### PR TITLE
refactor(deployment): stop sdlForStorage dropping values nothing asks it to drop

### DIFF
--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -140,6 +140,70 @@ describe(SdlSecretsDerivationService.name, () => {
     });
   });
 
+  describe("whether a value already names a secret, which the grammar decides and not the prefix", () => {
+    it.each(["ac-secret://TOKEN", "ac-secret://PROD_DB", "ac-var://MODE"])("leaves %j where it stands, the grammar accepting it whole", value => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: [`T=${value}`] } });
+
+      expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({});
+      expect(document.services.web.env).toEqual([`T=${value}`]);
+    });
+
+    it.each(["ac-dc", "prefix-ac-secret://T", "ac-secret://T suffix", "ac-secret://T\n", `ac-${"z".repeat(17)}://T`])(
+      "takes %j out, the grammar refusing it as a reference",
+      value => {
+        const { service } = setup();
+        const document = documentWith({ web: { env: [`T=${value}`] } });
+
+        expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({ s0_e0: value });
+        expect(document.services.web.env).toEqual(["T=ac-secret://s0_e0"]);
+      }
+    );
+
+    it("leaves the reference of every service that carries one", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["T=ac-secret://T"] }, worker: { env: ["T=ac-secret://T"] } });
+
+      expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({});
+      expect(document.services.web.env).toEqual(["T=ac-secret://T"]);
+      expect(document.services.worker.env).toEqual(["T=ac-secret://T"]);
+    });
+
+    it("takes a value containing an equals sign whole, splitting only on the first", () => {
+      const { service } = setup();
+      const url = `postgres://u:${faker.internet.password()}@h:5432/db?ssl=true&a=b`;
+      const document = documentWith({ web: { env: [`DATABASE_URL=${url}`] } });
+
+      expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({ s0_e0: url });
+      expect(document.services.web.env).toEqual(["DATABASE_URL=ac-secret://s0_e0"]);
+    });
+  });
+
+  describe("a copy of a value the document made for itself", () => {
+    it("rewrites the env declaration an aliased list is shared through, and the copy in args with it", () => {
+      const { service } = setup();
+      const token = faker.string.alphanumeric(12);
+      const document = yaml.raw<SDLInput>(sdlSharingOneListBetweenEnvAndArgs(`API_TOKEN=${token}`));
+
+      const { secrets } = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e0: token });
+      expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
+      expect(document.services.web.args).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
+    });
+
+    it("leaves a value typed out a second time in args, which the env declaration cannot reach", () => {
+      const { service } = setup();
+      const token = faker.string.alphanumeric(12);
+      const document = documentWith({ web: { env: [`API_TOKEN=${token}`], args: [`--token=${token}`] } });
+
+      service.derive(document, { includeEnvValues: true });
+
+      expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
+      expect(document.services.web.args).toEqual([`--token=${token}`]);
+    });
+  });
+
   describe("a node two services share through a yaml anchor", () => {
     it("mints one name for one shared credentials block rather than one per service", () => {
       const { service } = setup();
@@ -270,6 +334,10 @@ describe(SdlSecretsDerivationService.name, () => {
         deployment: Object.fromEntries(names.map(name => [name, { dcloud: { profile: name, count: 1 } }]))
       })
     );
+  }
+
+  function sdlSharingOneListBetweenEnvAndArgs(entry: string) {
+    return `version: "2.0"\nservices:\n  web:\n    image: ${IMAGE}\n    env: &shared\n      - ${JSON.stringify(entry)}\n    args: *shared\n`;
   }
 
   function sdlSharingCredentials(password: string) {

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
@@ -11,7 +11,7 @@ import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-import { dropSdlValues, parseSdlForStorage, sdlForStorage } from "./sdl-for-storage";
+import { parseSdlForStorage, sdlForStorage } from "./sdl-for-storage";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
@@ -20,60 +20,15 @@ const IMAGE = "ghcr.io/akash-network/hello-akash-world:2.1.0";
 /** Generous enough that every test but the size ones is measuring stripping rather than the limit. */
 const MAX_LENGTH = 128 * 1024;
 
-/** A caller that takes nothing out of the parsed document, leaving it to be stored as it arrived. */
+/** A caller that takes nothing out, so a test can measure what parsing, serializing and the size bound do to a document on their own. */
 const TAKING_NOTHING_OUT = () => {};
 
 describe(sdlForStorage.name, () => {
-  describe("an env value, when the caller drops every value", () => {
-    it("keeps the variable name and drops its value", () => {
-      const token = faker.string.alphanumeric(24);
-
-      const stripped = storedWithoutValues(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }));
-
-      expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
-    });
-
-    it("drops a value that itself contains an equals sign", () => {
-      const password = faker.internet.password();
-
-      const stripped = storedWithoutValues(sdlWith({ web: { env: [`DATABASE_URL=postgres://u:${password}@h:5432/db?ssl=true&a=b`] } }));
-
-      expect(stripped.services.web.env).toEqual(["DATABASE_URL="]);
-    });
-
-    it("leaves an entry that names no value alone", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["INHERITED_FROM_HOST"] } }));
-
-      expect(stripped.services.web.env).toEqual(["INHERITED_FROM_HOST"]);
-    });
-
-    it("leaves an explicitly null env list alone", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: null } }));
-
-      expect(stripped.services.web.env).toBeNull();
-    });
-
-    it("leaves a service that declares no env alone", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: {} }));
-
-      expect(stripped.services.web).not.toHaveProperty("env");
-    });
-
-    it("strips the env of every service, not only the first", () => {
-      const stripped = storedWithoutValues(
-        sdlWith({ web: { env: [`A=${faker.string.alphanumeric(8)}`] }, worker: { env: [`B=${faker.string.alphanumeric(8)}`] } })
-      );
-
-      expect(stripped.services.web.env).toEqual(["A="]);
-      expect(stripped.services.worker.env).toEqual(["B="]);
-    });
-  });
-
-  describe("an env value, when the caller takes nothing out", () => {
+  describe("a document nothing was taken out of", () => {
     it("keeps the value exactly as submitted", () => {
       const token = faker.string.alphanumeric(24);
 
-      const kept = storedWithValues(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }));
+      const kept = storedDocumentOf(sdlWith({ web: { env: [`API_TOKEN=${token}`] } }));
 
       expect(kept.services.web.env).toEqual([`API_TOKEN=${token}`]);
     });
@@ -82,7 +37,7 @@ describe(sdlForStorage.name, () => {
       const password = faker.internet.password();
       const url = `postgres://u:${password}@h:5432/db?ssl=true&a=b`;
 
-      const kept = storedWithValues(sdlWith({ web: { env: [`DATABASE_URL=${url}`] } }));
+      const kept = storedDocumentOf(sdlWith({ web: { env: [`DATABASE_URL=${url}`] } }));
 
       expect(kept.services.web.env).toEqual([`DATABASE_URL=${url}`]);
     });
@@ -90,13 +45,13 @@ describe(sdlForStorage.name, () => {
     it("keeps a value carrying yaml metacharacters byte-identical", () => {
       const value = "a: b #c |x >y {z} [w] &anchor *alias \"q\" 's'\nsecond: line\t- dash";
 
-      const kept = storedWithValues(sdlWith({ web: { env: [`WEIRD=${value}`] } }));
+      const kept = storedDocumentOf(sdlWith({ web: { env: [`WEIRD=${value}`] } }));
 
       expect(kept.services.web.env).toEqual([`WEIRD=${value}`]);
     });
 
     it("keeps an entry that names no value distinct from one whose value is empty", () => {
-      const kept = storedWithValues(sdlWith({ web: { env: ["INHERITED_FROM_HOST", "EXPLICITLY_EMPTY="] } }));
+      const kept = storedDocumentOf(sdlWith({ web: { env: ["INHERITED_FROM_HOST", "EXPLICITLY_EMPTY="] } }));
 
       expect(kept.services.web.env).toEqual(["INHERITED_FROM_HOST", "EXPLICITLY_EMPTY="]);
     });
@@ -104,7 +59,7 @@ describe(sdlForStorage.name, () => {
     it("keeps a reference beside an ordinary value", () => {
       const token = faker.string.alphanumeric(24);
 
-      const kept = storedWithValues(sdlWith({ web: { env: ["SECRET=ac-secret://SECRET", `PLAIN=${token}`, "INHERITED_FROM_HOST"] } }));
+      const kept = storedDocumentOf(sdlWith({ web: { env: ["SECRET=ac-secret://SECRET", `PLAIN=${token}`, "INHERITED_FROM_HOST"] } }));
 
       expect(kept.services.web.env).toEqual(["SECRET=ac-secret://SECRET", `PLAIN=${token}`, "INHERITED_FROM_HOST"]);
     });
@@ -112,7 +67,7 @@ describe(sdlForStorage.name, () => {
     it("keeps the env of every service, not only the first", () => {
       const [first, second] = [faker.string.alphanumeric(8), faker.string.alphanumeric(8)];
 
-      const kept = storedWithValues(sdlWith({ web: { env: [`A=${first}`] }, worker: { env: [`B=${second}`] } }));
+      const kept = storedDocumentOf(sdlWith({ web: { env: [`A=${first}`] }, worker: { env: [`B=${second}`] } }));
 
       expect(kept.services.web.env).toEqual([`A=${first}`]);
       expect(kept.services.worker.env).toEqual([`B=${second}`]);
@@ -124,99 +79,7 @@ describe(sdlForStorage.name, () => {
         worker: { env: [`DATABASE_URL=postgres://u:${faker.internet.password()}@h:5432/db?ssl=true`] }
       });
 
-      expect(storedWithValues(submitted)).toEqual(yaml.raw<SDLInput>(submitted));
-    });
-  });
-
-  describe("a value that refers to a secret rather than carrying one", () => {
-    it("keeps a whole sdl reference", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["API_TOKEN=ac-secret://API_TOKEN"] } }));
-
-      expect(stripped.services.web.env).toEqual(["API_TOKEN=ac-secret://API_TOKEN"]);
-    });
-
-    it("keeps a reference whose name differs from the variable it is assigned to", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["DATABASE_URL=ac-secret://PROD_DB"] } }));
-
-      expect(stripped.services.web.env).toEqual(["DATABASE_URL=ac-secret://PROD_DB"]);
-    });
-
-    it("keeps a reference of a kind no resolver is registered for", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["MODE=ac-var://MODE"] } }));
-
-      expect(stripped.services.web.env).toEqual(["MODE=ac-var://MODE"]);
-    });
-
-    it("keeps the reference of every service that carries one", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["T=ac-secret://T"] }, worker: { env: ["T=ac-secret://T"] } }));
-
-      expect(stripped.services.web.env).toEqual(["T=ac-secret://T"]);
-      expect(stripped.services.worker.env).toEqual(["T=ac-secret://T"]);
-    });
-
-    it("drops a value that merely opens with the reserved prefix", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["MODE=ac-dc"] } }));
-
-      expect(stripped.services.web.env).toEqual(["MODE="]);
-    });
-
-    it("drops a reference embedded in a larger value", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["T=prefix-ac-secret://T"] } }));
-
-      expect(stripped.services.web.env).toEqual(["T="]);
-    });
-
-    it("drops a value that is a reference followed by anything else", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["T=ac-secret://T suffix"] } }));
-
-      expect(stripped.services.web.env).toEqual(["T="]);
-    });
-
-    it("drops a value that is a reference followed by a line terminator", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["T=ac-secret://T\n"] } }));
-
-      expect(stripped.services.web.env).toEqual(["T="]);
-    });
-
-    it("drops a value naming a kind longer than the grammar allows", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: [`T=ac-${"z".repeat(17)}://T`] } }));
-
-      expect(stripped.services.web.env).toEqual(["T="]);
-    });
-
-    it("keeps a reference while dropping an ordinary value beside it", () => {
-      const token = faker.string.alphanumeric(24);
-
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["SECRET=ac-secret://SECRET", `PLAIN=${token}`, "INHERITED_FROM_HOST"] } }));
-
-      expect(stripped.services.web.env).toEqual(["SECRET=ac-secret://SECRET", "PLAIN=", "INHERITED_FROM_HOST"]);
-    });
-  });
-
-  describe("private registry credentials", () => {
-    it("removes the whole block, not just the password", () => {
-      const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
-
-      const stored = storedWithoutValues(sdlWith({ web: { credentials } }));
-
-      expect(stored.services.web).not.toHaveProperty("credentials");
-    });
-
-    it("removes the block of every service that declares one", () => {
-      const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
-
-      const stored = storedWithoutValues(sdlWith({ web: { credentials }, worker: { credentials } }));
-
-      expect(stored.services.web).not.toHaveProperty("credentials");
-      expect(stored.services.worker).not.toHaveProperty("credentials");
-    });
-
-    it("leaves the block alone for a caller taking nothing out, which is a caller taking the credentials itself", () => {
-      const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
-
-      const stored = storedWithValues(sdlWith({ web: { credentials } }));
-
-      expect(stored.services.web.credentials).toMatchObject(credentials);
+      expect(storedDocumentOf(submitted)).toEqual(yaml.raw<SDLInput>(submitted));
     });
   });
 
@@ -224,6 +87,7 @@ describe(sdlForStorage.name, () => {
     it("is handed a document still carrying every value and credential, so it has something to take", () => {
       const credentials = { host: "registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
       const token = faker.string.alphanumeric(24);
+
       const { document } = parseSdlForStorage(sdlWith({ web: { env: [`API_TOKEN=${token}`], credentials } }));
 
       expect(document!.services.web.env).toEqual([`API_TOKEN=${token}`]);
@@ -253,51 +117,30 @@ describe(sdlForStorage.name, () => {
 
   describe("a value that is also an ordinary part of the SDL", () => {
     it("keeps a service whose name another service's env value happens to equal", () => {
-      const stripped = storedWithoutValues(sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: { env: ["MYSQL_DATABASE=wordpress"] } }));
+      const stored = storedDocumentOf(sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: { env: ["MYSQL_DATABASE=wordpress"] } }));
 
-      expect(Object.keys(stripped.services)).toEqual(["wordpress", "db"]);
-      expect(stripped.services.db.image).toBe(IMAGE);
-      expect(Object.keys(stripped.deployment)).toEqual(["wordpress", "db"]);
-      expect(Object.keys(stripped.profiles.compute)).toEqual(["wordpress", "db"]);
+      expect(Object.keys(stored.services)).toEqual(["wordpress", "db"]);
+      expect(stored.services.db.image).toBe(IMAGE);
+      expect(Object.keys(stored.deployment)).toEqual(["wordpress", "db"]);
+      expect(Object.keys(stored.profiles.compute)).toEqual(["wordpress", "db"]);
     });
 
     it("keeps a placement denom an env value happens to equal", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["DENOM=uakt"] } }));
+      const stored = storedDocumentOf(sdlWith({ web: { env: ["DENOM=uakt"] } }));
 
-      expect(stripped.profiles.placement.dcloud.pricing.web.denom).toBe("uakt");
+      expect(stored.profiles.placement.dcloud.pricing.web.denom).toBe("uakt");
     });
 
     it("keeps an image an env value happens to equal", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { image: "nginx", env: ["IMAGE_NAME=nginx"] } }));
+      const stored = storedDocumentOf(sdlWith({ web: { image: "nginx", env: ["IMAGE_NAME=nginx"] } }));
 
-      expect(stripped.services.web.image).toBe("nginx");
+      expect(stored.services.web.image).toBe("nginx");
     });
 
     it("keeps a map key an env value happens to equal", () => {
-      const stripped = storedWithoutValues(sdlWith({ web: { env: ["PROFILE=dcloud"] } }));
+      const stored = storedDocumentOf(sdlWith({ web: { env: ["PROFILE=dcloud"] } }));
 
-      expect(stripped.profiles.placement).toHaveProperty("dcloud");
-    });
-  });
-
-  describe("a copy of a value the SDL made for itself", () => {
-    it("keeps the copy an aliased env list left in args, stripping only where the value is declared", () => {
-      const token = faker.string.alphanumeric(12);
-      const sharedEnv = [`API_TOKEN=${token}`];
-
-      const stripped = storedWithoutValues(dump(sdlDocument({ web: { env: sharedEnv, args: sharedEnv } })));
-
-      expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
-      expect(stripped.services.web.args).toEqual(["API_TOKEN="]);
-    });
-
-    it("keeps a value typed out a second time in args, which the env declaration cannot reach", () => {
-      const token = faker.string.alphanumeric(12);
-
-      const stripped = storedWithoutValues(sdlWith({ web: { env: [`API_TOKEN=${token}`], args: [`--token=${token}`] } }));
-
-      expect(stripped.services.web.env).toEqual(["API_TOKEN="]);
-      expect(stripped.services.web.args).toEqual([`--token=${token}`]);
+      expect(stored.profiles.placement).toHaveProperty("dcloud");
     });
   });
 
@@ -371,10 +214,10 @@ describe(sdlForStorage.name, () => {
     });
 
     it("stores a document with no anchors that fits, without consulting the estimate", () => {
-      const stripped = storedFrom(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }), MAX_LENGTH);
+      const stored = storedFrom(sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } }), MAX_LENGTH);
 
-      expect(stripped.sdl).toContain("API_TOKEN=");
-      expect(stripped.length).toBe(stripped.sdl?.length);
+      expect(stored.sdl).toContain("API_TOKEN=");
+      expect(stored.length).toBe(stored.sdl?.length);
     });
 
     it("measures a document with no anchors by serializing it exactly", () => {
@@ -387,29 +230,49 @@ describe(sdlForStorage.name, () => {
     });
 
     it("stores a document whose scalars merely contain an ampersand and an asterisk", () => {
-      const submitted = sdlWith({ web: { args: ["sh", "-c", "start && tail -f *.log"], env: [`TOKEN=${faker.string.alphanumeric(8)}&x*y`] } });
+      const entry = `TOKEN=${faker.string.alphanumeric(8)}&x*y`;
+      const submitted = sdlWith({ web: { args: ["sh", "-c", "start && tail -f *.log"], env: [entry] } });
 
-      const stripped = storedWithoutValues(submitted);
+      const stored = storedDocumentOf(submitted);
 
-      expect(stripped.services.web.args).toEqual(["sh", "-c", "start && tail -f *.log"]);
-      expect(stripped.services.web.env).toEqual(["TOKEN="]);
+      expect(stored.services.web.args).toEqual(["sh", "-c", "start && tail -f *.log"]);
+      expect(stored.services.web.env).toEqual([entry]);
     });
 
     it("returns a document that fits", () => {
       expect(storedFrom(sdlWith({ web: {} }), MAX_LENGTH).sdl).toContain("services:");
     });
 
-    it("refuses a document only the values it keeps put past the limit", () => {
-      const submitted = sdlWith({ web: { env: [`BLOB=${"x".repeat(4096)}`] } });
+    it("refuses a document only the rewrite puts past the limit, against the bound production uses", () => {
+      const env = Array.from({ length: 5000 }, (_, index) => `S${index}=v`);
+      const submitted = sdlWith({ web: { env } });
 
-      expect(storedFrom(submitted, 2048, TAKING_NOTHING_OUT).sdl).toBeNull();
-      expect(storedFrom(submitted, 2048).sdl).not.toBeNull();
+      const stored = storedFrom(submitted, SDL_MAX_LENGTH, document => {
+        document.services.web.env = env.map((entry, index) => `${entry.slice(0, entry.indexOf("="))}=ac-secret://s0_e${index}`);
+      });
+
+      expect(storedSdlOf(submitted).length).toBeLessThan(SDL_MAX_LENGTH);
+      expect(stored.sdl).toBeNull();
+      expect(stored.length).toBeGreaterThan(SDL_MAX_LENGTH);
+    });
+
+    it("stores a document only the rewrite brings inside the limit, against the bound production uses", () => {
+      const env = Array.from({ length: 200 }, (_, index) => `BLOB${index}=${"x".repeat(800)}`);
+      const submitted = sdlWith({ web: { env } });
+
+      const stored = storedFrom(submitted, SDL_MAX_LENGTH, document => {
+        document.services.web.env = env.map((entry, index) => `${entry.slice(0, entry.indexOf("="))}=ac-secret://s0_e${index}`);
+      });
+
+      expect(storedFrom(submitted, SDL_MAX_LENGTH).length).toBeGreaterThan(SDL_MAX_LENGTH);
+      expect(stored.sdl).toContain("BLOB0=ac-secret://s0_e0");
+      expect(stored.length).toBeLessThan(SDL_MAX_LENGTH);
     });
 
     it("stores an env-heavy sdl of a realistic size against the bound production uses", () => {
       const env = Array.from({ length: 200 }, (_, index) => `SETTING_${index}=${faker.string.alphanumeric(48)}`);
 
-      const { sdl, length } = storedFrom(sdlWith({ web: { env } }), SDL_MAX_LENGTH, TAKING_NOTHING_OUT);
+      const { sdl, length } = storedFrom(sdlWith({ web: { env } }), SDL_MAX_LENGTH);
 
       expect(sdl).not.toBeNull();
       expect(length).toBeLessThan(SDL_MAX_LENGTH / 4);
@@ -418,21 +281,17 @@ describe(sdlForStorage.name, () => {
 
   type ServiceOverrides = Record<string, unknown>;
 
-  function storedWithoutValues(rawSdl: string) {
-    return yaml.raw<SDLInput>(storedSdlOf(rawSdl, dropSdlValues));
+  function storedDocumentOf(rawSdl: string) {
+    return yaml.raw<SDLInput>(storedSdlOf(rawSdl));
   }
 
-  function storedWithValues(rawSdl: string) {
-    return yaml.raw<SDLInput>(storedSdlOf(rawSdl, TAKING_NOTHING_OUT));
-  }
-
-  function storedSdlOf(rawSdl: string, takeValuesOut: (document: SDLInput) => void = dropSdlValues): string {
-    const { sdl } = storedFrom(rawSdl, MAX_LENGTH, takeValuesOut);
+  function storedSdlOf(rawSdl: string): string {
+    const { sdl } = storedFrom(rawSdl, MAX_LENGTH);
     expect(sdl).not.toBeNull();
     return sdl as string;
   }
 
-  function storedFrom(rawSdl: string, maxLength: number, takeValuesOut: (document: SDLInput) => void = dropSdlValues) {
+  function storedFrom(rawSdl: string, maxLength: number, takeValuesOut: (document: SDLInput) => void = TAKING_NOTHING_OUT) {
     const parsed = parseSdlForStorage(rawSdl);
 
     if (parsed.document === null) {

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.ts
@@ -2,10 +2,6 @@ import type { SDLInput } from "@akashnetwork/chain-sdk";
 import { yaml } from "@akashnetwork/chain-sdk";
 import { dump } from "js-yaml";
 
-import { isSdlReference } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-
-type SdlServiceDefinition = SDLInput["services"][string];
-
 /** Why a document was not stored, so a caller can report which without reading a parse error, whose message quotes the line it failed on. */
 export type StoredSdlRefusal = "unparseable" | "too-large";
 
@@ -44,53 +40,11 @@ export function sdlForStorage(parsed: StorableSdl, maxLength: number): StoredSdl
   return stored.length > maxLength ? { sdl: null, length: stored.length } : { sdl: stored, length: stored.length };
 }
 
-/** Keeps nothing of what a document carries in the clear, for a caller with nowhere to put it: an `env` value goes and the credentials block with it. */
-export function dropSdlValues(document: SDLInput): void {
-  for (const service of serviceDefinitionsOf(document)) {
-    dropEnvValues(service);
-    delete service.credentials;
-  }
-}
-
 /** Reads `line` and `column` and nothing else, because the other fields of a `js-yaml` mark quote the document that failed to parse. */
 function positionOf(error: unknown): StoredSdlPosition | undefined {
   const mark = (error as { mark?: { line?: unknown; column?: unknown } })?.mark;
 
   return typeof mark?.line === "number" && typeof mark?.column === "number" ? { line: mark.line + 1, column: mark.column + 1 } : undefined;
-}
-
-function serviceDefinitionsOf(sdl: SDLInput | undefined): SdlServiceDefinition[] {
-  const services = sdl?.services;
-
-  if (!services || typeof services !== "object") {
-    return [];
-  }
-
-  return Object.values(services).filter((service): service is SdlServiceDefinition => !!service && typeof service === "object");
-}
-
-/** A non-list `env` is left alone rather than failing, because the manifest generator the caller runs first already rejects that shape. */
-function dropEnvValues(service: SdlServiceDefinition): void {
-  const env = service.env;
-
-  if (!Array.isArray(env)) {
-    return;
-  }
-
-  env.forEach((entry, index) => {
-    if (typeof entry === "string") {
-      env[index] = withoutValue(entry);
-    }
-  });
-}
-
-/** Keeps the variable name and drops its value, unless the entry declares no value or names one by reference. */
-function withoutValue(entry: string): string {
-  const valueStart = entry.indexOf("=");
-
-  if (valueStart === -1) return entry;
-
-  return isSdlReference(entry.slice(valueStart + 1)) ? entry : entry.slice(0, valueStart + 1);
 }
 
 function mayShareNodesOf(rawSdl: string): boolean {


### PR DESCRIPTION
## Why

Part of CON-863.

Once update started sealing what it takes out (PR 5), `sdlForStorage` had no caller left for the half of it that blanks `env` values and deletes the `credentials` block. What that leaves is not merely unused: **it is a mode a future caller could pass to lose values instead of sealing them**, which is the same shape as the ordering bug PR 4 removed from the writer's type.

**Stack position — PR 6 of 7.** Targets PR 5 (`feat/deployment-seal-derived-secrets-on-update`). PR 7 (`refactor/deployment-drop-dead-field-and-comments`) sits on this one.

## What

The function is now what its name says: parse the submitted text, hand the document to the caller that takes its secrets out, and store what is left once it is known to fit. `rewrite` is required rather than optional for the same reason — a document stored with nothing taken out of it is a document holding its own secrets in the clear, and there is no longer a way to ask for one.

The util went from 215 to 158 lines; its spec from 50 tests to 30, with 12 more in the derivation service's, which is where the questions they answer are now decided.

### Every retired assertion has a home

The reference-grammar cases are **ported** rather than summarised, because whether a value is a whole reference is the one decision that used to live in two places. `derivation:N` = `sdl-secrets-derivation.service.spec.ts:N`; `reference:N` = `sdl-reference.service.spec.ts:N`.

| Retired test | Disposition |
|---|---|
| keeps the variable name and drops its value | deleted, covered by `derivation:17` |
| drops a value that itself contains an equals sign | **ported** → `derivation:172` |
| leaves an entry that names no value alone | deleted, covered by `derivation:68` |
| leaves an explicitly null env list alone | deleted, covered by `derivation:94` (`{ env: null }`) |
| leaves a service that declares no env alone | deleted, covered by `derivation:94` (`{}`) |
| strips the env of every service, not only the first | deleted, covered by `derivation:28` |
| keeps a whole sdl reference | **ported** → `derivation:144` (`ac-secret://TOKEN`) |
| keeps a reference whose name differs from its variable | **ported** → `derivation:144` (`ac-secret://PROD_DB`) |
| keeps a reference of a kind no resolver is registered for | **ported** → `derivation:144` (`ac-var://MODE`) |
| keeps the reference of every service that carries one | **ported** → `derivation:163` |
| drops a value that merely opens with the reserved prefix | **ported** → `derivation:152` (`ac-dc`); grammar at `reference:31` |
| drops a reference embedded in a larger value | **ported** → `derivation:152`; grammar at `reference:534` |
| drops a value that is a reference followed by anything else | **ported** → `derivation:152`; grammar at `reference:162` |
| drops a value that is a reference followed by a line terminator | **ported** → `derivation:152`; grammar at `reference:435` |
| drops a value naming a kind longer than the grammar allows | **ported** → `derivation:152`; grammar at `reference:435` |
| keeps a reference while dropping an ordinary value beside it | deleted, covered by `derivation:78` |
| removes the whole credentials block (×2 modes) | deleted — behaviour gone as of PR 4; replaced by `derivation:52`, `derivation:120` and the functional assertions |
| removes the credentials block of **every service** (×2 modes) | deleted — and this is the one home that did **not** hold. See below. |
| keeps the copy an aliased env list left in args | **ported** → `derivation:183`, sharpened: one node, so both places are rewritten |
| keeps a value typed out a second time in args | **ported** → `derivation:195` |
| refuses a document only the values it keeps put past the limit | deleted — the mode comparison no longer exists; covered by "measures what the rewrite left rather than what arrived" |

Nine cases ported, eleven deleted with a home that holds.

**One did not, and review caught it.** The deleted `removes the block of every service that declares one` asserted **two distinct `credentials` nodes in one document, both handled**. Every case I mapped it to is single-service, and the shared-anchor case exercises one node reached twice — the opposite property. So the multi-node property was untested, and deriving only the first service's credentials passed the whole suite while storing the second service's username and password in the clear in `deployment_settings.sdl`. The behaviour was always correct; the assertion was missing. **PR 7 closes it** at unit and functional level, mutation-verified. Flagging it here because this PR's table is what claimed the home.

### The size decision is now pinned in both directions

It was not, and the untested direction was the dangerous one. The existing 512-byte case only ever caught a guard that *refuses what it should store*, because its fixture was over that limit before any rewrite ran. A guard measuring the document as it arrived would have written a 173 KB document into a column bounded at 128 KiB and nothing would have gone red.

Two fixtures now, both against the bound production uses:

- 5000 × `S{i}=v` — arrives serializing to **79 KB** (fits), rewritten **173 KB** (must be refused)
- its mirror, 200 × 800-byte values — arrives at **163 KB** (over), rewritten **7 KB** (must be stored)

A guard reading the wrong document fails both. Verified by mutation.

What stays in this spec is what the util actually does: a rewrite is handed a document still carrying every value and credential, what it leaves behind is what gets stored, and what it leaves behind is also what gets measured. Alongside those, the parts that were never about dropping anything — the anchor-bomb estimator and its budget, the unparseable and too-large refusals, and the guarantee that a value which merely resembles some other part of the document survives.

`rewrite` is now a named type, `StoredSdlRewrite`, so the constraint it carries sits on the parameter rather than being asserted as a fact about rewrites in general: a rewrite must not make two keys share a node, because the alias guard decides on the pre-rewrite text and sharing introduced afterwards is never priced. True of the only rewrite there is — `derive` assigns strings through `slot.replace` — but that is a property of the caller, and the guard's whole value is that its safety argument holds without knowing anything about one.

**Size:** 424 lines by the labeler filter, most of it deletion (150 insertions, 274 deletions).

**Validation:** `eslint --quiet` clean; `tsc --noEmit` at 42 errors, byte-identical to the baseline at the base branch tip; unit, functional and integration all green.

**Demo:** see PR 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Deployment definitions now preserve submitted environment values and credentials when stored by default.
  * Values containing YAML-sensitive characters or equals signs are handled correctly.
  * Optional transformations remain supported, with rewritten documents continuing to observe storage-size limits.
* **Validation**
  * SDL secret references now undergo broader grammar validation, including malformed references, service-specific references, and aliases shared between environment variables and arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->