### PR TITLE
refactor(deployment): retire a field nobody reads and three comments that mislead

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -96,7 +96,7 @@ ${Array.from({ length: 40 }, () => `      - FILLER=${"z".repeat(4096)}`).join("\
 /** A valid SDL with nothing in it worth sealing, so a write that must state a token has null to state. */
 const SDL_WITHOUT_SECRETS = sdlAround("");
 
-/** Short enough to survive `js-yaml` truncating the line it quotes, so a partial leak of it is still detectable. */
+/** `js-yaml` trims the end of the line it quotes and never the start, so it is the variable name below that carries the leak assertion: this value survives untruncated at ten characters but would not at thirty-two. */
 const MALFORMED_SDL_VALUE = faker.string.alphanumeric(10);
 
 /** Not YAML at all, and carrying an env value, because a `js-yaml` message quotes the lines around the one it failed on. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -197,7 +197,7 @@ export class DeploymentWriterService {
 
   /** Runs before the document is measured, so that what the size guard bounds is exactly what gets stored. */
   #takeValuesOutOf(document: SDLInput, values: StoredSdlValues): SdlSecrets {
-    return this.sdlSecretsDerivationService.derive(document, { includeEnvValues: values === "every-value-sealed" }).secrets;
+    return this.sdlSecretsDerivationService.derive(document, { includeEnvValues: values === "every-value-sealed" });
   }
 
   /**

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -63,7 +63,7 @@ export interface SdlReferenceResolver {
 /** One position in an SDL where a reference may stand, holding the write back so a caller of the walk never has to know how that position spells a value. */
 export interface SdlReferenceSlot {
   serviceName: string;
-  /** The service's place in the document rather than its name, because a name may spell anything and a reference name may not. */
+  /** Where the service falls in `Object.entries` order — not the document's own order, since an integer-like name sorts first — because a name may spell anything and a reference name may not. */
   serviceIndex: number;
   instancePath: string;
   /** The container the value lives on, so a caller can tell two positions apart from one position two services share through a YAML anchor. */

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -19,7 +19,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const token = faker.string.alphanumeric(24);
       const document = documentWith({ web: { env: [`API_TOKEN=${token}`] } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_e0: token });
       expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
@@ -42,7 +42,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const [web, worker] = [faker.string.alphanumeric(16), faker.string.alphanumeric(16)];
 
-      const { secrets } = service.derive(documentWith({ web: { env: [`PASSWORD=${web}`] }, worker: { env: [`PASSWORD=${worker}`] } }), {
+      const secrets = service.derive(documentWith({ web: { env: [`PASSWORD=${web}`] }, worker: { env: [`PASSWORD=${worker}`] } }), {
         includeEnvValues: true
       });
 
@@ -54,7 +54,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
       const document = documentWith({ web: { credentials: { host: REGISTRY_HOST, email: REGISTRY_EMAIL, username, password } } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_c_username: username, s0_c_password: password });
       expect(document.services.web.credentials).toEqual({
@@ -69,7 +69,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: ["EXPLICITLY_EMPTY=", "INHERITED_FROM_HOST"] } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_e0: "" });
       expect(document.services.web.env).toEqual(["EXPLICITLY_EMPTY=ac-secret://s0_e0", "INHERITED_FROM_HOST"]);
@@ -79,7 +79,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: ["API_TOKEN=ac-secret://API_TOKEN", `LOG_LEVEL=${faker.string.alphanumeric(5)}`] } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(Object.keys(secrets)).toEqual(["s0_e1"]);
       expect(document.services.web.env![0]).toBe("API_TOKEN=ac-secret://API_TOKEN");
@@ -88,20 +88,13 @@ describe(SdlSecretsDerivationService.name, () => {
     it("takes nothing from a document that carries no env and no credentials", () => {
       const { service } = setup();
 
-      expect(service.derive(documentWith({ web: {} }), { includeEnvValues: true })).toEqual({ secrets: {}, derivedCount: 0 });
+      expect(service.derive(documentWith({ web: {} }), { includeEnvValues: true })).toEqual({});
     });
 
     it.each([{ env: null }, {}])("leaves the service declaring %j untouched", overrides => {
       const { service } = setup();
 
-      expect(service.derive(documentWith({ web: overrides }), { includeEnvValues: true }).secrets).toEqual({});
-    });
-
-    it("reports how many positions it rewrote without reporting any of their values", () => {
-      const { service } = setup();
-      const document = documentWith({ web: { env: [`A=${faker.string.alphanumeric(8)}`, `B=${faker.string.alphanumeric(8)}`] } });
-
-      expect(service.derive(document, { includeEnvValues: true }).derivedCount).toBe(2);
+      expect(service.derive(documentWith({ web: overrides }), { includeEnvValues: true })).toEqual({});
     });
   });
 
@@ -111,7 +104,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const token = faker.string.alphanumeric(24);
       const document = documentWith({ web: { env: [`API_TOKEN=${token}`] } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: false });
+      const secrets = service.derive(document, { includeEnvValues: false });
 
       expect(secrets).toEqual({});
       expect(document.services.web.env).toEqual([`API_TOKEN=${token}`]);
@@ -124,10 +117,28 @@ describe(SdlSecretsDerivationService.name, () => {
         web: { env: [`LOG_LEVEL=${faker.string.alphanumeric(5)}`], credentials: { host: REGISTRY_HOST, username, password } }
       });
 
-      const { secrets } = service.derive(document, { includeEnvValues: false });
+      const secrets = service.derive(document, { includeEnvValues: false });
 
       expect(secrets).toEqual({ s0_c_username: username, s0_c_password: password });
       expect(document.services.web.credentials!.password).toBe("ac-secret://s0_c_password");
+    });
+
+    it("takes both halves from every service that declares its own credentials block, not only the first", () => {
+      const { service } = setup();
+      const web = { host: REGISTRY_HOST, username: faker.string.alphanumeric(10), password: faker.internet.password() };
+      const worker = { host: "other-registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
+      const document = documentWith({ web: { credentials: web }, worker: { credentials: worker } });
+
+      const secrets = service.derive(document, { includeEnvValues: false });
+
+      expect(secrets).toEqual({
+        s0_c_username: web.username,
+        s0_c_password: web.password,
+        s1_c_username: worker.username,
+        s1_c_password: worker.password
+      });
+      expect(document.services.web.credentials).toMatchObject({ username: "ac-secret://s0_c_username", password: "ac-secret://s0_c_password" });
+      expect(document.services.worker.credentials).toMatchObject({ username: "ac-secret://s1_c_username", password: "ac-secret://s1_c_password" });
     });
 
     it("leaves a credential that already names a secret alone", () => {
@@ -136,7 +147,7 @@ describe(SdlSecretsDerivationService.name, () => {
         web: { credentials: { host: REGISTRY_HOST, username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" } }
       });
 
-      expect(service.derive(document, { includeEnvValues: false }).secrets).toEqual({});
+      expect(service.derive(document, { includeEnvValues: false })).toEqual({});
     });
   });
 
@@ -145,7 +156,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: [`T=${value}`] } });
 
-      expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({});
+      expect(service.derive(document, { includeEnvValues: true })).toEqual({});
       expect(document.services.web.env).toEqual([`T=${value}`]);
     });
 
@@ -155,7 +166,7 @@ describe(SdlSecretsDerivationService.name, () => {
         const { service } = setup();
         const document = documentWith({ web: { env: [`T=${value}`] } });
 
-        expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({ s0_e0: value });
+        expect(service.derive(document, { includeEnvValues: true })).toEqual({ s0_e0: value });
         expect(document.services.web.env).toEqual(["T=ac-secret://s0_e0"]);
       }
     );
@@ -164,7 +175,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: ["T=ac-secret://T"] }, worker: { env: ["T=ac-secret://T"] } });
 
-      expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({});
+      expect(service.derive(document, { includeEnvValues: true })).toEqual({});
       expect(document.services.web.env).toEqual(["T=ac-secret://T"]);
       expect(document.services.worker.env).toEqual(["T=ac-secret://T"]);
     });
@@ -174,7 +185,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const url = `postgres://u:${faker.internet.password()}@h:5432/db?ssl=true&a=b`;
       const document = documentWith({ web: { env: [`DATABASE_URL=${url}`] } });
 
-      expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({ s0_e0: url });
+      expect(service.derive(document, { includeEnvValues: true })).toEqual({ s0_e0: url });
       expect(document.services.web.env).toEqual(["DATABASE_URL=ac-secret://s0_e0"]);
     });
   });
@@ -185,7 +196,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const token = faker.string.alphanumeric(12);
       const document = yaml.raw<SDLInput>(sdlSharingOneListBetweenEnvAndArgs(`API_TOKEN=${token}`));
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_e0: token });
       expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
@@ -210,7 +221,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const password = faker.internet.password();
       const document = yaml.raw<SDLInput>(sdlSharingCredentials(password));
 
-      const { secrets } = service.derive(document, { includeEnvValues: false });
+      const secrets = service.derive(document, { includeEnvValues: false });
 
       expect(Object.keys(secrets)).toEqual(["s0_c_username", "s0_c_password"]);
       expect(secrets.s0_c_password).toBe(password);
@@ -223,7 +234,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const token = faker.string.alphanumeric(20);
       const document = yaml.raw<SDLInput>(sdlSharingEnv(`API_TOKEN=${token}`));
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_e0: token });
       expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
@@ -239,7 +250,7 @@ describe(SdlSecretsDerivationService.name, () => {
         "a-service-name-the-grammar-would-refuse.42": { env: [`B=${faker.string.alphanumeric(8)}`] }
       });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(Object.keys(secrets)).toHaveLength(4);
       Object.keys(secrets).forEach(name => expect(isSdlReference(`ac-secret://${name}`)).toBe(true));
@@ -249,7 +260,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: Array.from({ length: 5000 }, (_, index) => `SETTING_${index}=v`) } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
       const longest = Object.keys(secrets).reduce((longestSoFar, name) => Math.max(longestSoFar, name.length), 0);
 
       expect(Object.keys(secrets)).toHaveLength(5000);
@@ -287,7 +298,7 @@ describe(SdlSecretsDerivationService.name, () => {
     ];
     const rewritten = documentWith({ web: { env: values.map((value, index) => `V${index}=${value}`) } });
 
-    const { secrets } = service.derive(rewritten, { includeEnvValues: true });
+    const secrets = service.derive(rewritten, { includeEnvValues: true });
     const reparsed = yaml.raw<SDLInput>(dump(rewritten, { lineWidth: -1 }));
     const byService = Object.fromEntries(Object.keys(reparsed.services).map(serviceName => [serviceName, secrets]));
 
@@ -307,7 +318,7 @@ describe(SdlSecretsDerivationService.name, () => {
     const submitted = documentWith(services);
     const rewritten = documentWith(services);
 
-    const { secrets } = service.derive(rewritten, { includeEnvValues: true });
+    const secrets = service.derive(rewritten, { includeEnvValues: true });
     const byService = Object.fromEntries(Object.keys(rewritten.services).map(serviceName => [serviceName, secrets]));
 
     expect(sdlReferenceService.substitute(rewritten, { secrets: byService })).toEqual([]);

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -8,59 +8,31 @@ import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/s
 /** The kind every derived reference is written as, because a derived value is a secret like any other and nothing downstream needs to know it was not supplied. */
 const DERIVED_REFERENCE_KIND = "secret";
 
-export interface DerivedSdlSecrets {
-  /** Name to value, in the shape `sealForStorage` seals and the stored token carries. */
-  secrets: SdlSecrets;
-  /** How many positions were rewritten, for a log line that has to say something without saying a value. */
-  derivedCount: number;
-}
-
-const NOTHING_DERIVED: DerivedSdlSecrets = { secrets: {}, derivedCount: 0 };
-
-/**
- * Takes the values a submitted SDL carries in the clear out of the document and hands them back as
- * secrets, leaving an `ac-secret://NAME` reference in each place one stood. This is what lets a client
- * that names none of its secrets still have them stored as ciphertext rather than as text, and what keeps
- * the definition it leaves behind resolvable instead of blanked.
- *
- * `includeEnvValues` is the difference between the two callers. A request that sealed its values has
- * already said which of them are secret, so only a private registry credential is taken — that is a
- * secret whatever it holds, and there is no ordinary reading of it. A request that sealed nothing has
- * said nothing, so every value in `env` is taken as well.
- *
- * A value that is already a whole reference is left alone. It names a secret rather than carrying one,
- * and inventing a value for a name the author asked to be handed would turn a missing-value refusal into
- * a deployment configured with the literal text of its own reference.
- *
- * Mutates the document it is given, which must therefore be a copy the caller keeps to itself: the
- * manifest is generated from the submitted SDL and has to see the real values, so a document with
- * references written into it can only ever be the one being stored.
- */
+/** Takes the values a submitted SDL carries in the clear out of the document and hands them back as secrets, leaving an `ac-secret://NAME` reference where each one stood. */
 @singleton()
 export class SdlSecretsDerivationService {
   constructor(private readonly sdlReferenceService: SdlReferenceService) {}
 
-  derive(document: SDLInput, options: { includeEnvValues: boolean }): DerivedSdlSecrets {
-    const slots = this.sdlReferenceService.slotsOf(document).filter(slot => this.#isDerivable(slot, options));
-
-    if (slots.length === 0) return NOTHING_DERIVED;
-
+  /** Mutates the document it is given, which must therefore be a copy the caller keeps to itself: the manifest is generated from the submitted SDL and has to see the real values. */
+  derive(document: SDLInput, options: { includeEnvValues: boolean }): SdlSecrets {
     const secrets: SdlSecrets = {};
-    const namesByNode = new Map<object, Map<string, string>>();
+    const takenByNode = new Map<object, Set<string>>();
 
-    for (const slot of slots) {
-      const namesInNode = namesByNode.get(slot.node) ?? new Map<string, string>();
-      namesByNode.set(slot.node, namesInNode);
+    for (const slot of this.sdlReferenceService.slotsOf(document)) {
+      if (!this.#isDerivable(slot, options)) continue;
 
-      if (namesInNode.has(slot.position)) continue;
+      const takenInNode = takenByNode.get(slot.node) ?? new Set<string>();
+      takenByNode.set(slot.node, takenInNode);
+
+      if (takenInNode.has(slot.position)) continue;
 
       const name = `s${slot.serviceIndex}_${slot.position}`;
-      namesInNode.set(slot.position, name);
+      takenInNode.add(slot.position);
       secrets[name] = slot.value;
       slot.replace(`ac-${DERIVED_REFERENCE_KIND}://${name}`);
     }
 
-    return { secrets, derivedCount: Object.keys(secrets).length };
+    return secrets;
   }
 
   #isDerivable(slot: SdlReferenceSlot, options: { includeEnvValues: boolean }): boolean {

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -187,6 +187,31 @@ describe("Deployment sealed secrets", () => {
     await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({ REG_USER: username, REG_PASS: password });
   });
 
+  it("stores a reference for every service's own registry credentials, with neither service's value in the clear", async () => {
+    const { apiKey, user } = await persistedUser();
+    const web = { host: REGISTRY_HOST, username: faker.string.alphanumeric(10), password: randomUUID() };
+    const worker = { host: "other-registry.example.test", username: faker.string.alphanumeric(10), password: randomUUID() };
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["LOG_LEVEL=debug"], worker: ["LOG_LEVEL=debug"] }, { web, worker }));
+
+    expect(response.status).toBe(201);
+    const setting = await settingOf(user, response);
+    expect(setting!.sdl).toContain("username: ac-secret://s0_c_username");
+    expect(setting!.sdl).toContain("username: ac-secret://s1_c_username");
+    expect(setting!.sdl).not.toContain(web.password);
+    expect(setting!.sdl).not.toContain(worker.password);
+    expect(setting!.sdl).not.toContain(web.username);
+    expect(setting!.sdl).not.toContain(worker.username);
+    await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({
+      s0_e0: "debug",
+      s1_e0: "debug",
+      s0_c_username: web.username,
+      s0_c_password: web.password,
+      s1_c_username: worker.username,
+      s1_c_password: worker.password
+    });
+  });
+
   it("stores a credential the client left in the clear as a reference, with its value only in the token", async () => {
     const { apiKey, user } = await persistedUser();
     const [username, password] = [faker.string.alphanumeric(10), randomUUID()];

--- a/apps/api/test/mocks/sdl-secrets-kms.mock.ts
+++ b/apps/api/test/mocks/sdl-secrets-kms.mock.ts
@@ -12,12 +12,7 @@ export const SDL_SECRETS_KID = "sdl-secrets.v1";
 
 const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 
-/**
- * Doubles the one third-party boundary the sealed-secrets path crosses, backed by a real RSA key so a
- * seal is genuinely opened rather than waved through, and registers it at module scope so nothing has
- * resolved the real target before the first request. Every create that carries an env value now unwraps
- * a data encryption key, so any spec exercising `POST /v1/deployments` needs this.
- */
+/** Every create carrying an env value unwraps a data key, so any spec exercising `POST /v1/deployments` must call this or reach the real Cloud KMS: it doubles that boundary with a real RSA key, registered at module scope so nothing resolves the real target first. */
 export function registerFakeSdlSecretsKms() {
   const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
   const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
@@ -44,11 +39,7 @@ export function registerFakeSdlSecretsKms() {
   return { client, publicKey };
 }
 
-/**
- * Warms the sealing key the way the boot initializer does, because wrapping a new data encryption key
- * peeks at the cache rather than waiting on it — so a spec that skips this gets a 503 on its first
- * create for a user, exactly as an instance whose boot-time warm-up failed would.
- */
+/** A spec that skips this gets a 503 on its first create for a user, exactly as an instance whose boot-time warm-up failed would, because wrapping a new data key peeks at the sealing key cache rather than waiting on it. */
 export async function warmSealingKeyAsBootWould() {
   await container.resolve(SdlSecretsSealingKeyService).getSealingKey();
 }


### PR DESCRIPTION
## Why

Part of CON-863.

Review findings from the six PRs below, collected here rather than amended into each. Each belongs to a PR that is already reviewed and clear, and the files carrying them — the deployment writer's spec and the derivation service's spec — are the two that every later PR also edits. Rebasing to place four small fixes would put conflict resolution in spec files on the critical path, which is the one place a mistake silently drops a test, and would invalidate a clearance already given.

The trade is deliberate: **a nit fixed one PR later, against a rebase that could cost a test.**

**Stack position — PR 7 of 7, the tip.** Targets PR 6 (`refactor/deployment-retire-sdl-value-dropping`). Nothing sits on this one.

## What

### A field justified by a consumer nobody wrote

`derivedCount` goes. Its comment promised "a log line that has to say something without saying a value", and no such line was ever written; nothing read the field but its own assertion.

Checking whether the gap was real turned out to matter: **`SDL_SECRETS_SEALED` already reports a count with the owner and the dseq**, for derived and supplied values alike. So the field's stated purpose was already served elsewhere. What is genuinely missing is the *split* between derived and supplied, and that is left unwritten rather than justified by a field — a second log line is worth adding when something needs the distinction. `derive` now returns the map itself.

The dedupe map admits what it is: its inner value was never read, only `has` and `size`, so `Map<object, Set<string>>` says "these positions in this node are taken" instead of implying a lookup nobody performs.

### Three comments that were wrong, not merely long

**The worst defended the wrong invariant.** The malformed-SDL fixture's comment credited the *value's* length for keeping the leak assertion sharp. What actually keeps it sharp is the *variable name*: `js-yaml` trims the end of the line it quotes and never the start, so the name survives at every length while the value stops surviving past about thirty characters. Verified at 10/16/20/24/32/64/200. Believing the comment, someone lengthening the value would have concluded the value assertion still bit when only the name assertion did — **a booby trap on exactly the test that caught a real leak** (PR 2's parse-error cause chain).

**`serviceIndex` claimed to be the service's place in the document.** It is its place in `Object.entries` order, which is not the same thing: an integer-like service name sorts first, so `{ web, "2" }` numbers `"2"` as zero. Verified. Nothing breaks — names stay grammatical, unique and deterministic either way — but the comment misleads anyone reasoning about the numbering.

**The derivation service's class comment was nineteen lines** against a one-line cap, the largest instance in the stack of a rule applied minimally two PRs earlier. It says what the service does in one line now; the constraint worth keeping — that it mutates a document which must therefore be the caller's private copy, because the manifest is generated from the submitted SDL — moves to a one-line note on the method it constrains. The KMS test double loses two multi-paragraph blocks for the same reason, tests being allowed none.

### A gap PR 6's mapping table claimed a home for and did not have

Retiring the value-dropping mode deleted the only case asserting that **two distinct `credentials` nodes** in one document are both handled. Every surviving credentials case is single-service, and the shared-anchor case exercises one node reached twice — the opposite property.

So this passed the entire suite — 2452 unit and 383 functional tests — while storing the second service's registry credentials in the clear:

```ts
if (slot.valueIsAlwaysSecret) return slot.serviceIndex === 0;
return options.includeEnvValues;
```

That is precisely the leak A1 exists to prevent, reaching `deployment_settings.sdl` and `GET /v1/deployments/{dseq}`. The behaviour was always correct — the real code derives all four names and rewrites both blocks — so this was a missing assertion, not a bug. Now covered at unit level (two services, each with its own credentials, asserting all four derived names and both blocks referenced) **and** functional level, because a unit test alone would not have caught a plaintext credential reaching the database. Mutation-verified with the exact mutation above: both tests fail, and nothing else did.

### The KMS double gets its instructions back

PR 6's comment compression cut the two clauses that were instructions rather than narration: which specs must register the double, and that skipping the sealing-key warm-up answers the first create for a user with a 503, exactly as an instance whose boot-time warm-up failed would. Every env-carrying create now unwraps a data key, so those were the only place in the repo saying when a spec needs either helper and what failure it gets if it does not. One line each, naming the 503.

**Size:** 163 lines by the labeler filter (81 insertions, 82 deletions).

**Validation:** `eslint --quiet` clean; `tsc --noEmit` at 42 errors, byte-identical to the baseline at the base branch tip; unit **180 files / 2452 tests**, functional **35 / 383**, integration **31 / 379** — all green, zero skipped. Mutation-verified after the fixes: a pre-rewrite size measurement fails both new size tests, removing the per-node dedupe fails 2, restoring the parse-error cause chain fails 4.

**Demo:** see PR 4. `showboat verify` re-run against this commit — exit 0, every captured output still matching.
