### PR TITLE
fix(observability): track every in-memory cache in a registry instead of stringify sizing

### DIFF
--- a/apps/api/env/.env.functional.test
+++ b/apps/api/env/.env.functional.test
@@ -45,3 +45,4 @@ SEQUELIZE_POOL_MIN=0
 GCP_KMS_AUTH={"project_id":"console-dev-mock","servicePath":"http://localhost:9090"}
 
 PROVIDER_INVENTORY_API_URL=http://localhost:3092
+SECRET_TOKEN=functional-test-secret-token-000000

--- a/apps/api/src/auth/services/auth.interceptor.ts
+++ b/apps/api/src/auth/services/auth.interceptor.ts
@@ -9,7 +9,7 @@ import { singleton } from "tsyringe";
 
 import { AbilityService } from "@src/auth/services/ability/ability.service";
 import { AuthService } from "@src/auth/services/auth.service";
-import { cacheRegistry } from "@src/caching/cache-registry";
+import { cacheRegistry, nominalEntrySizing } from "@src/caching/cache-registry";
 import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
 import type { HonoInterceptor } from "@src/core/types/hono-interceptor.type";
 import { UserOutput, UserRepository } from "@src/user/repositories";
@@ -18,14 +18,18 @@ import { ApiKeyAuthService } from "./api-key/api-key-auth.service";
 import { UserAuthTokenService } from "./user-auth-token/user-auth-token.service";
 
 const LAST_USER_ACTIVITY_THROTTLE_TIME_SECONDS = 30 * secondsInMinute;
+const MAX_TRACKED_USERS = 1e5;
+/** A `Date` under a user id, so the registry ranks this cache far below the ones holding response payloads. */
+const LAST_USER_ACTIVITY_ENTRY_BYTES = 128;
 
 @singleton()
 export class AuthInterceptor implements HonoInterceptor {
   private readonly logger = createOtelLogger({ context: AuthInterceptor.name });
   private readonly lastUserActivityCache = new LRUCache<string, Date>({
-    max: 1e5,
+    max: MAX_TRACKED_USERS,
     ttl: LAST_USER_ACTIVITY_THROTTLE_TIME_SECONDS * 1000,
-    allowStale: true
+    allowStale: true,
+    ...nominalEntrySizing(MAX_TRACKED_USERS, LAST_USER_ACTIVITY_ENTRY_BYTES)
   });
 
   constructor(

--- a/apps/api/src/auth/services/auth.interceptor.ts
+++ b/apps/api/src/auth/services/auth.interceptor.ts
@@ -9,6 +9,7 @@ import { singleton } from "tsyringe";
 
 import { AbilityService } from "@src/auth/services/ability/ability.service";
 import { AuthService } from "@src/auth/services/auth.service";
+import { cacheRegistry } from "@src/caching/cache-registry";
 import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
 import type { HonoInterceptor } from "@src/core/types/hono-interceptor.type";
 import { UserOutput, UserRepository } from "@src/user/repositories";
@@ -35,7 +36,9 @@ export class AuthInterceptor implements HonoInterceptor {
     private readonly apiKeyRepository: ApiKeyRepository,
     private readonly apiKeyAuthService: ApiKeyAuthService,
     private readonly executionContextService: ExecutionContextService
-  ) {}
+  ) {
+    cacheRegistry.register("AuthInterceptor#lastUserActivity", this.lastUserActivityCache);
+  }
 
   intercept() {
     return async (c: Context, next: Next) => {

--- a/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.ts
+++ b/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.ts
@@ -121,7 +121,7 @@ export class BatchSigningClientService {
    *
    * @returns A promise that resolves to the chain ID string.
    */
-  private readonly getChainId = memoizeAsync(() => this.client.getChainId());
+  private readonly getChainId = memoizeAsync(() => this.client.getChainId(), { name: "BatchSigningClientService#getChainId" });
 
   /**
    * Memoized async function that retrieves and caches the wallet address.
@@ -131,7 +131,7 @@ export class BatchSigningClientService {
    *
    * @returns A promise that resolves to the wallet address string.
    */
-  private readonly getAddress = memoizeAsync(() => this.wallet.getFirstAddress());
+  private readonly getAddress = memoizeAsync(() => this.wallet.getFirstAddress(), { name: "BatchSigningClientService#getAddress" });
 
   /**
    * Logger instance for this service.

--- a/apps/api/src/caching/cache-instrumentation.service.spec.ts
+++ b/apps/api/src/caching/cache-instrumentation.service.spec.ts
@@ -1,0 +1,48 @@
+import type { ObservableGauge, ObservableResult } from "@opentelemetry/api";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { MetricsService } from "@src/core/services/metrics/metrics.service";
+import { CacheInstrumentationService } from "./cache-instrumentation.service";
+import type { RegisterableCache } from "./cache-registry";
+import { CacheRegistry } from "./cache-registry";
+
+describe(CacheInstrumentationService.name, () => {
+  it("observes the entry count of every registered cache", () => {
+    const { gauges } = setup({ size: 7, calculatedSize: 700 });
+    const result = mock<ObservableResult>();
+
+    gauges.memory_cache_entries.callback(result);
+
+    expect(result.observe).toHaveBeenCalledWith(7, { cache: "test-cache" });
+  });
+
+  it("observes the tracked bytes of every registered cache", () => {
+    const { gauges } = setup({ size: 7, calculatedSize: 700 });
+    const result = mock<ObservableResult>();
+
+    gauges.memory_cache_size_bytes.callback(result);
+
+    expect(result.observe).toHaveBeenCalledWith(700, { cache: "test-cache" });
+  });
+
+  function setup(input: { size: number; calculatedSize: number }) {
+    const metricsService = mock<MetricsService>();
+    const gauges: Record<string, { callback: (result: ObservableResult) => void }> = {};
+    metricsService.getMeter.mockReturnValue(mock());
+    metricsService.createObservableGauge.mockImplementation((_meter, name) =>
+      mock<ObservableGauge>({
+        addCallback: callback => {
+          gauges[name] = { callback };
+        }
+      })
+    );
+
+    const registry = new CacheRegistry();
+    registry.register("test-cache", mock<RegisterableCache>({ size: input.size, calculatedSize: input.calculatedSize, max: 100, maxSize: 1000 }));
+
+    const service = new CacheInstrumentationService(metricsService, registry);
+
+    return { service, gauges, registry };
+  }
+});

--- a/apps/api/src/caching/cache-instrumentation.service.ts
+++ b/apps/api/src/caching/cache-instrumentation.service.ts
@@ -1,0 +1,32 @@
+import { singleton } from "tsyringe";
+
+import { MetricsService } from "@src/core/services/metrics/metrics.service";
+import { CacheRegistry } from "./cache-registry";
+
+@singleton()
+export class CacheInstrumentationService {
+  constructor(metricsService: MetricsService, registry: CacheRegistry) {
+    const meter = metricsService.getMeter("memory-cache");
+
+    metricsService
+      .createObservableGauge(meter, "memory_cache_entries", {
+        description: "Entries currently held by each registered in-memory cache"
+      })
+      .addCallback(result => {
+        for (const stats of registry.getStats()) {
+          result.observe(stats.entryCount, { cache: stats.name });
+        }
+      });
+
+    metricsService
+      .createObservableGauge(meter, "memory_cache_size_bytes", {
+        description: "Tracked bytes currently held by each registered in-memory cache (explicitly sized entries plus a nominal charge per object entry)",
+        unit: "By"
+      })
+      .addCallback(result => {
+        for (const stats of registry.getStats()) {
+          result.observe(stats.calculatedSizeBytes, { cache: stats.name });
+        }
+      });
+  }
+}

--- a/apps/api/src/caching/cache-pressure-monitor.service.spec.ts
+++ b/apps/api/src/caching/cache-pressure-monitor.service.spec.ts
@@ -1,0 +1,105 @@
+import type { Counter } from "@opentelemetry/api";
+import { getHeapStatistics } from "node:v8";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { MetricsService } from "@src/core/services/metrics/metrics.service";
+import { CachePressureMonitorService } from "./cache-pressure-monitor.service";
+import type { RegisterableCache } from "./cache-registry";
+import { CacheRegistry } from "./cache-registry";
+
+vi.mock("node:v8", () => ({
+  getHeapStatistics: vi.fn()
+}));
+
+describe(CachePressureMonitorService.name, () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("checkPressure", () => {
+    it("flushes the registered caches once heap usage crosses the threshold", () => {
+      const { service, cache, counter, logger } = setup({ heapUsageRatio: 0.9 });
+
+      service.checkPressure();
+
+      expect(cache.clear).toHaveBeenCalledTimes(1);
+      expect(counter.add).toHaveBeenCalledWith(1);
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "MEMORY_CACHE_PRESSURE_FLUSH", flushedCaches: ["test-cache"] }));
+    });
+
+    it("does nothing below the threshold", () => {
+      const { service, cache, counter, logger } = setup({ heapUsageRatio: 0.5 });
+
+      service.checkPressure();
+
+      expect(cache.clear).not.toHaveBeenCalled();
+      expect(counter.add).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it("does not flush again during the cooldown", () => {
+      const { service, counter } = setup({ heapUsageRatio: 0.9 });
+
+      service.checkPressure();
+      vi.advanceTimersByTime(30_000);
+      service.checkPressure();
+
+      expect(counter.add).toHaveBeenCalledTimes(1);
+    });
+
+    it("flushes again once the cooldown has elapsed", () => {
+      const { service, counter } = setup({ heapUsageRatio: 0.9 });
+
+      service.checkPressure();
+      vi.advanceTimersByTime(5 * 60_000);
+      service.checkPressure();
+
+      expect(counter.add).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("start", () => {
+    it("checks heap pressure on an interval until disposed", () => {
+      const { service } = setup({ heapUsageRatio: 0.5 });
+
+      service.start();
+      vi.advanceTimersByTime(60_000);
+
+      expect(getHeapStatistics).toHaveBeenCalledTimes(2);
+
+      service.dispose();
+      vi.advanceTimersByTime(60_000);
+
+      expect(getHeapStatistics).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  function setup(input: { heapUsageRatio: number }) {
+    vi.useFakeTimers();
+    vi.mocked(getHeapStatistics).mockClear();
+    vi.mocked(getHeapStatistics).mockReturnValue(
+      mock<ReturnType<typeof getHeapStatistics>>({
+        used_heap_size: input.heapUsageRatio * 1000,
+        heap_size_limit: 1000
+      })
+    );
+
+    const counter = mock<Counter>();
+    const metricsService = mock<MetricsService>();
+    metricsService.getMeter.mockReturnValue(mock());
+    metricsService.createCounter.mockReturnValue(counter);
+
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger: CreateLogger = () => logger;
+
+    const registry = new CacheRegistry();
+    const cache = mock<RegisterableCache>({ size: 10, calculatedSize: 100, max: 100, maxSize: 1000 });
+    registry.register("test-cache", cache);
+
+    const service = new CachePressureMonitorService(metricsService, createLogger, registry);
+
+    return { service, cache, counter, logger, registry };
+  }
+});

--- a/apps/api/src/caching/cache-pressure-monitor.service.ts
+++ b/apps/api/src/caching/cache-pressure-monitor.service.ts
@@ -1,0 +1,63 @@
+import type { Counter } from "@opentelemetry/api";
+import { getHeapStatistics } from "node:v8";
+import { inject, singleton } from "tsyringe";
+
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import { LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { MetricsService } from "@src/core/services/metrics/metrics.service";
+import { CacheRegistry } from "./cache-registry";
+
+/** Flushing at 85% of the V8 heap limit leaves headroom for in-flight requests to allocate while the flushed entries are collected. */
+const HEAP_USAGE_FLUSH_THRESHOLD = 0.85;
+const CHECK_INTERVAL_MS = 30_000;
+/** Gives the heap time to settle after a flush, so a slowly draining heap does not empty every cache on each check. */
+const FLUSH_COOLDOWN_MS = 5 * 60_000;
+
+@singleton()
+export class CachePressureMonitorService {
+  readonly #logger: ReturnType<CreateLogger>;
+  readonly #pressureFlushes: Counter;
+  #interval: NodeJS.Timeout | undefined;
+  #lastFlushAt = 0;
+
+  constructor(
+    metricsService: MetricsService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger,
+    private readonly registry: CacheRegistry
+  ) {
+    this.#logger = createLogger({ context: CachePressureMonitorService.name });
+    this.#pressureFlushes = metricsService.createCounter(metricsService.getMeter("memory-cache"), "memory_cache_pressure_flush_total", {
+      description: "Times the registered in-memory caches were flushed because heap usage crossed the pressure threshold"
+    });
+  }
+
+  start(): void {
+    this.#interval ??= setInterval(() => this.checkPressure(), CHECK_INTERVAL_MS);
+    this.#interval.unref();
+  }
+
+  checkPressure(): void {
+    const { used_heap_size, heap_size_limit } = getHeapStatistics();
+    const heapUsageRatio = used_heap_size / heap_size_limit;
+    if (heapUsageRatio < HEAP_USAGE_FLUSH_THRESHOLD) return;
+    if (Date.now() - this.#lastFlushAt < FLUSH_COOLDOWN_MS) return;
+
+    this.#lastFlushAt = Date.now();
+    const cachesBeforeFlush = this.registry.getStats();
+    const flushedCaches = this.registry.flushLargestCaches();
+    this.#pressureFlushes.add(1);
+    this.#logger.warn({
+      event: "MEMORY_CACHE_PRESSURE_FLUSH",
+      heapUsageRatio,
+      usedHeapSize: used_heap_size,
+      heapSizeLimit: heap_size_limit,
+      caches: cachesBeforeFlush,
+      flushedCaches: flushedCaches.map(stats => stats.name)
+    });
+  }
+
+  dispose(): void {
+    clearInterval(this.#interval);
+    this.#interval = undefined;
+  }
+}

--- a/apps/api/src/caching/cache-registry.spec.ts
+++ b/apps/api/src/caching/cache-registry.spec.ts
@@ -1,8 +1,9 @@
+import { LRUCache } from "lru-cache";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { RegisterableCache } from "./cache-registry";
-import { CacheRegistry } from "./cache-registry";
+import { CacheRegistry, nominalEntrySizing } from "./cache-registry";
 
 describe(CacheRegistry.name, () => {
   describe("register", () => {
@@ -47,7 +48,7 @@ describe(CacheRegistry.name, () => {
   });
 
   describe("flushLargestCaches", () => {
-    it("clears the largest caches first until at least half of all entries are flushed", () => {
+    it("clears the largest caches first until at least half of the tracked bytes are released", () => {
       const { registry } = setup();
       const small = buildCache({ size: 10, calculatedSize: 100 });
       const medium = buildCache({ size: 20, calculatedSize: 5000 });
@@ -64,24 +65,41 @@ describe(CacheRegistry.name, () => {
       expect(small.clear).not.toHaveBeenCalled();
     });
 
-    it("keeps flushing when the largest cache alone holds less than half of all entries", () => {
+    it("spares a cache of many small entries once a single large one releases half of the tracked bytes", () => {
       const { registry } = setup();
-      const small = buildCache({ size: 40, calculatedSize: 100 });
-      const large = buildCache({ size: 10, calculatedSize: 9000 });
+      const manySmallEntries = buildCache({ size: 100, calculatedSize: 100 * 1024 });
+      const oneLargeEntry = buildCache({ size: 1, calculatedSize: 100 * 1024 * 1024 });
+      registry.register("manySmallEntries", manySmallEntries);
+      registry.register("oneLargeEntry", oneLargeEntry);
+
+      const flushed = registry.flushLargestCaches();
+
+      expect(flushed.map(stats => stats.name)).toEqual(["oneLargeEntry"]);
+      expect(oneLargeEntry.clear).toHaveBeenCalledTimes(1);
+      expect(manySmallEntries.clear).not.toHaveBeenCalled();
+    });
+
+    it("keeps flushing when the largest cache alone holds less than half of the tracked bytes", () => {
+      const { registry } = setup();
+      const small = buildCache({ size: 40, calculatedSize: 2500 });
+      const medium = buildCache({ size: 20, calculatedSize: 3500 });
+      const large = buildCache({ size: 10, calculatedSize: 4000 });
       registry.register("small", small);
+      registry.register("medium", medium);
       registry.register("large", large);
 
       const flushed = registry.flushLargestCaches();
 
-      expect(flushed.map(stats => stats.name)).toEqual(["large", "small"]);
+      expect(flushed.map(stats => stats.name)).toEqual(["large", "medium"]);
       expect(large.clear).toHaveBeenCalledTimes(1);
-      expect(small.clear).toHaveBeenCalledTimes(1);
+      expect(medium.clear).toHaveBeenCalledTimes(1);
+      expect(small.clear).not.toHaveBeenCalled();
     });
 
     it("breaks size ties by entry count", () => {
       const { registry } = setup();
-      const fewEntries = buildCache({ size: 5, calculatedSize: 0 });
-      const manyEntries = buildCache({ size: 50, calculatedSize: 0 });
+      const fewEntries = buildCache({ size: 5, calculatedSize: 1000 });
+      const manyEntries = buildCache({ size: 50, calculatedSize: 1000 });
       registry.register("fewEntries", fewEntries);
       registry.register("manyEntries", manyEntries);
 
@@ -97,6 +115,27 @@ describe(CacheRegistry.name, () => {
 
       expect(registry.flushLargestCaches()).toEqual([]);
       expect(empty.clear).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("nominalEntrySizing", () => {
+    it("makes an lru cache of object values report its entries as bytes", () => {
+      const { registry } = setup();
+      const cache = new LRUCache<string, object>({ max: 10, ...nominalEntrySizing(10, 512) });
+      cache.set("first", {});
+      cache.set("second", {});
+      registry.register("objects", cache);
+
+      expect(registry.getStats()).toEqual([{ name: "objects", entryCount: 2, maxEntries: 10, calculatedSizeBytes: 1024, maxTotalBytes: 5120 }]);
+    });
+
+    it("leaves the entry limit as the only bound that evicts", () => {
+      const cache = new LRUCache<string, object>({ max: 3, ...nominalEntrySizing(3, 512) });
+
+      for (const key of ["first", "second", "third"]) cache.set(key, {});
+
+      expect(cache.size).toBe(3);
+      expect(cache.calculatedSize).toBe(cache.maxSize);
     });
   });
 

--- a/apps/api/src/caching/cache-registry.spec.ts
+++ b/apps/api/src/caching/cache-registry.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { RegisterableCache } from "./cache-registry";
+import { CacheRegistry } from "./cache-registry";
+
+describe(CacheRegistry.name, () => {
+  describe("register", () => {
+    it("returns the given name when it is not taken", () => {
+      const { registry } = setup();
+
+      expect(registry.register("shared", buildCache())).toBe("shared");
+    });
+
+    it("suffixes duplicate names instead of overwriting the existing cache", () => {
+      const { registry } = setup();
+      registry.register("private", buildCache());
+
+      expect(registry.register("private", buildCache())).toBe("private#2");
+      expect(registry.register("private", buildCache())).toBe("private#3");
+      expect(registry.getStats().map(stats => stats.name)).toEqual(["private", "private#2", "private#3"]);
+    });
+  });
+
+  describe("getStats", () => {
+    it("reports each registered cache with its counts and byte accounting", () => {
+      const { registry } = setup();
+      registry.register("bounded", buildCache({ size: 3, calculatedSize: 300, max: 10, maxSize: 1000 }));
+
+      expect(registry.getStats()).toEqual([{ name: "bounded", entryCount: 3, maxEntries: 10, calculatedSizeBytes: 300, maxTotalBytes: 1000 }]);
+    });
+  });
+
+  describe("clearAll", () => {
+    it("clears every registered cache", () => {
+      const { registry } = setup();
+      const first = buildCache();
+      const second = buildCache();
+      registry.register("first", first);
+      registry.register("second", second);
+
+      registry.clearAll();
+
+      expect(first.clear).toHaveBeenCalledTimes(1);
+      expect(second.clear).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("flushLargestCaches", () => {
+    it("clears the largest caches first until at least half of all entries are flushed", () => {
+      const { registry } = setup();
+      const small = buildCache({ size: 10, calculatedSize: 100 });
+      const medium = buildCache({ size: 20, calculatedSize: 5000 });
+      const large = buildCache({ size: 30, calculatedSize: 9000 });
+      registry.register("small", small);
+      registry.register("medium", medium);
+      registry.register("large", large);
+
+      const flushed = registry.flushLargestCaches();
+
+      expect(flushed.map(stats => stats.name)).toEqual(["large"]);
+      expect(large.clear).toHaveBeenCalledTimes(1);
+      expect(medium.clear).not.toHaveBeenCalled();
+      expect(small.clear).not.toHaveBeenCalled();
+    });
+
+    it("keeps flushing when the largest cache alone holds less than half of all entries", () => {
+      const { registry } = setup();
+      const small = buildCache({ size: 40, calculatedSize: 100 });
+      const large = buildCache({ size: 10, calculatedSize: 9000 });
+      registry.register("small", small);
+      registry.register("large", large);
+
+      const flushed = registry.flushLargestCaches();
+
+      expect(flushed.map(stats => stats.name)).toEqual(["large", "small"]);
+      expect(large.clear).toHaveBeenCalledTimes(1);
+      expect(small.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it("breaks size ties by entry count", () => {
+      const { registry } = setup();
+      const fewEntries = buildCache({ size: 5, calculatedSize: 0 });
+      const manyEntries = buildCache({ size: 50, calculatedSize: 0 });
+      registry.register("fewEntries", fewEntries);
+      registry.register("manyEntries", manyEntries);
+
+      const flushed = registry.flushLargestCaches();
+
+      expect(flushed.map(stats => stats.name)).toEqual(["manyEntries"]);
+    });
+
+    it("flushes nothing when every cache is empty", () => {
+      const { registry } = setup();
+      const empty = buildCache({ size: 0 });
+      registry.register("empty", empty);
+
+      expect(registry.flushLargestCaches()).toEqual([]);
+      expect(empty.clear).not.toHaveBeenCalled();
+    });
+  });
+
+  function buildCache(overrides?: Partial<Pick<RegisterableCache, "size" | "calculatedSize" | "max" | "maxSize">>) {
+    return mock<RegisterableCache>({ size: 0, calculatedSize: 0, max: 0, maxSize: 0, ...overrides });
+  }
+
+  function setup() {
+    return { registry: new CacheRegistry() };
+  }
+});

--- a/apps/api/src/caching/cache-registry.ts
+++ b/apps/api/src/caching/cache-registry.ts
@@ -14,6 +14,14 @@ export interface CacheStats {
   maxTotalBytes: number;
 }
 
+/** Charged to entries stored without an explicit size: object graphs are bounded by entry count and the pressure flush, never serialized to be measured. */
+export const NOMINAL_ENTRY_BYTES = 1024;
+
+/** lru-cache tracks `calculatedSize` only when a byte ceiling is set, so object caches declare a flat per-entry charge mirroring their entry limit. */
+export function nominalEntrySizing(maxEntries: number, bytesPerEntry: number = NOMINAL_ENTRY_BYTES) {
+  return { maxSize: maxEntries * bytesPerEntry, sizeCalculation: () => bytesPerEntry };
+}
+
 export class CacheRegistry {
   readonly #caches = new Map<string, RegisterableCache>();
 
@@ -44,15 +52,15 @@ export class CacheRegistry {
 
   flushLargestCaches(): CacheStats[] {
     const statsBySizeDescending = this.getStats().sort((a, b) => b.calculatedSizeBytes - a.calculatedSizeBytes || b.entryCount - a.entryCount);
-    const totalEntries = statsBySizeDescending.reduce((sum, stats) => sum + stats.entryCount, 0);
+    const totalBytes = statsBySizeDescending.reduce((sum, stats) => sum + stats.calculatedSizeBytes, 0);
     const flushed: CacheStats[] = [];
-    let flushedEntries = 0;
+    let flushedBytes = 0;
 
     for (const stats of statsBySizeDescending) {
-      if (flushedEntries * 2 >= totalEntries) break;
+      if (flushedBytes * 2 >= totalBytes) break;
       this.#caches.get(stats.name)?.clear();
       flushed.push(stats);
-      flushedEntries += stats.entryCount;
+      flushedBytes += stats.calculatedSizeBytes;
     }
 
     return flushed;

--- a/apps/api/src/caching/cache-registry.ts
+++ b/apps/api/src/caching/cache-registry.ts
@@ -1,0 +1,63 @@
+export interface RegisterableCache {
+  readonly size: number;
+  readonly calculatedSize: number;
+  readonly max: number;
+  readonly maxSize: number;
+  clear(): void;
+}
+
+export interface CacheStats {
+  name: string;
+  entryCount: number;
+  maxEntries: number;
+  calculatedSizeBytes: number;
+  maxTotalBytes: number;
+}
+
+export class CacheRegistry {
+  readonly #caches = new Map<string, RegisterableCache>();
+
+  register(name: string, cache: RegisterableCache): string {
+    let uniqueName = name;
+    for (let suffix = 2; this.#caches.has(uniqueName); suffix++) {
+      uniqueName = `${name}#${suffix}`;
+    }
+    this.#caches.set(uniqueName, cache);
+    return uniqueName;
+  }
+
+  getStats(): CacheStats[] {
+    return [...this.#caches.entries()].map(([name, cache]) => ({
+      name,
+      entryCount: cache.size,
+      maxEntries: cache.max,
+      calculatedSizeBytes: cache.calculatedSize,
+      maxTotalBytes: cache.maxSize
+    }));
+  }
+
+  clearAll(): void {
+    for (const cache of this.#caches.values()) {
+      cache.clear();
+    }
+  }
+
+  flushLargestCaches(): CacheStats[] {
+    const statsBySizeDescending = this.getStats().sort((a, b) => b.calculatedSizeBytes - a.calculatedSizeBytes || b.entryCount - a.entryCount);
+    const totalEntries = statsBySizeDescending.reduce((sum, stats) => sum + stats.entryCount, 0);
+    const flushed: CacheStats[] = [];
+    let flushedEntries = 0;
+
+    for (const stats of statsBySizeDescending) {
+      if (flushedEntries * 2 >= totalEntries) break;
+      this.#caches.get(stats.name)?.clear();
+      flushed.push(stats);
+      flushedEntries += stats.entryCount;
+    }
+
+    return flushed;
+  }
+}
+
+/** Every in-memory cache in the process registers here, so memory incidents can be attributed to a named cache instead of a heap snapshot. */
+export const cacheRegistry = new CacheRegistry();

--- a/apps/api/src/caching/helpers.spec.ts
+++ b/apps/api/src/caching/helpers.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { cacheRegistry } from "./cache-registry";
+import { cacheRegistry, NOMINAL_ENTRY_BYTES } from "./cache-registry";
 import { cacheEngine, cacheResponse, Memoize, memoizeAsync } from "./helpers";
 import MemoryCacheEngine from "./memoryCacheEngine";
 
@@ -353,6 +353,15 @@ describe("Memoize Function", () => {
       memoizeAsync(async () => "value", { name: "helpers-spec-memoize-async" });
 
       expect(cacheRegistry.getStats().map(stats => stats.name)).toContain("helpers-spec-memoize-async");
+    });
+
+    it("reports its cached entries as tracked bytes to the registry", async () => {
+      const memoized = memoizeAsync(async () => "value", { name: "helpers-spec-memoize-async-bytes", cacheItemLimit: 4 });
+
+      await memoized();
+
+      const stats = cacheRegistry.getStats().find(stats => stats.name === "helpers-spec-memoize-async-bytes");
+      expect(stats).toMatchObject({ entryCount: 1, maxEntries: 4, calculatedSizeBytes: NOMINAL_ENTRY_BYTES, maxTotalBytes: 4 * NOMINAL_ENTRY_BYTES });
     });
 
     it("should cache successful results and return the same promise", async () => {

--- a/apps/api/src/caching/helpers.spec.ts
+++ b/apps/api/src/caching/helpers.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { cacheRegistry } from "./cache-registry";
 import { cacheEngine, cacheResponse, Memoize, memoizeAsync } from "./helpers";
+import MemoryCacheEngine from "./memoryCacheEngine";
 
 describe("Memoize Function", () => {
   describe("cacheResponse function", () => {
@@ -177,6 +179,29 @@ describe("Memoize Function", () => {
       expect(requestCount).toBe(1);
       expect(refreshRequest).toHaveBeenCalledTimes(1);
     });
+
+    describe("when the payload has a known byte size", () => {
+      it("byte-bounds Uint8Array payloads so they evict by bytes, not entry count", async () => {
+        setup();
+        const store = new MemoryCacheEngine({ maxTotalBytes: 1500, maxEntryBytes: 1500, name: "helpers-spec-byte-bounded" });
+
+        await cacheResponse(60, "first", async () => new Uint8Array(1000), store);
+        await cacheResponse(60, "second", async () => new Uint8Array(1000), store);
+
+        expect(store.getFromCache("first")).toBeUndefined();
+        expect(store.getFromCache("second")).toBeDefined();
+      });
+
+      it("returns a payload larger than maxEntryBytes without caching it", async () => {
+        setup();
+        const store = new MemoryCacheEngine({ maxEntryBytes: 500, name: "helpers-spec-oversized" });
+
+        const result = await cacheResponse(60, "huge", async () => new Uint8Array(1000), store);
+
+        expect(result).toEqual(new Uint8Array(1000));
+        expect(store.getFromCache("huge")).toBeUndefined();
+      });
+    });
   });
 
   describe("Memoize decorator", () => {
@@ -324,6 +349,12 @@ describe("Memoize Function", () => {
   });
 
   describe(memoizeAsync.name, () => {
+    it("registers its cache in the cache registry under the given name", () => {
+      memoizeAsync(async () => "value", { name: "helpers-spec-memoize-async" });
+
+      expect(cacheRegistry.getStats().map(stats => stats.name)).toContain("helpers-spec-memoize-async");
+    });
+
     it("should cache successful results and return the same promise", async () => {
       const fn = vi.fn().mockResolvedValue("result");
       const memoized = memoizeAsync(fn);

--- a/apps/api/src/caching/helpers.ts
+++ b/apps/api/src/caching/helpers.ts
@@ -2,7 +2,7 @@ import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { differenceInSeconds } from "date-fns";
 import { LRUCache } from "lru-cache";
 
-import { cacheRegistry } from "./cache-registry";
+import { cacheRegistry, nominalEntrySizing } from "./cache-registry";
 import MemoryCacheEngine from "./memoryCacheEngine";
 
 const logger = createOtelLogger({ context: "Caching" });
@@ -133,7 +133,8 @@ export function memoizeAsync<A extends unknown[], R>(
     name?: string;
   }
 ): (...args: A) => Promise<R> {
-  const cache = new LRUCache<string, Promise<R>>({ max: options?.cacheItemLimit ?? 100, ttl: options?.ttl });
+  const maxEntries = options?.cacheItemLimit ?? 100;
+  const cache = new LRUCache<string, Promise<R>>({ max: maxEntries, ttl: options?.ttl, ...nominalEntrySizing(maxEntries) });
   cacheRegistry.register(options?.name || fn.name || "memoizeAsync", cache);
 
   return (...args: A) => {

--- a/apps/api/src/caching/helpers.ts
+++ b/apps/api/src/caching/helpers.ts
@@ -2,9 +2,19 @@ import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { differenceInSeconds } from "date-fns";
 import { LRUCache } from "lru-cache";
 
+import { cacheRegistry } from "./cache-registry";
 import MemoryCacheEngine from "./memoryCacheEngine";
 
 const logger = createOtelLogger({ context: "Caching" });
+
+/** Covers the `{date, data}` wrapper around a payload whose byte size is known exactly. */
+const EXPLICIT_SIZE_WRAPPER_OVERHEAD_BYTES = 64;
+
+function getExplicitSizeBytes(data: unknown): number | undefined {
+  if (data instanceof Uint8Array) return data.byteLength + EXPLICIT_SIZE_WRAPPER_OVERHEAD_BYTES;
+  if (typeof data === "string") return Buffer.byteLength(data, "utf8") + EXPLICIT_SIZE_WRAPPER_OVERHEAD_BYTES;
+  return undefined;
+}
 
 export const cacheEngine = new MemoryCacheEngine();
 const pendingRequests = new Map<string, Promise<unknown>>();
@@ -25,7 +35,7 @@ export const Memoize = (options?: MemoizeOptions) => (target: object, propertyNa
   const originalMethod = descriptor.value;
 
   const cacheKey = options?.key || `${target.constructor.name}#${propertyName}`;
-  const store = options?.maxEntries ? new MemoryCacheEngine({ maxEntries: options.maxEntries }) : cacheEngine;
+  const store = options?.maxEntries ? new MemoryCacheEngine({ maxEntries: options.maxEntries, name: cacheKey }) : cacheEngine;
 
   descriptor.value = async function memoizedFunction(...args: unknown[]) {
     const argsKey =
@@ -67,7 +77,7 @@ export async function cacheResponse<T>(seconds: number, key: string, refreshRequ
           logger.debug(`Background refresh completed for key: ${key}`);
           // Only store in cache if we have valid data
           if (data !== undefined) {
-            store.storeInCache(key, { date: new Date(), data: data });
+            store.storeInCache(key, { date: new Date(), data: data }, undefined, getExplicitSizeBytes(data));
           }
           return data;
         })
@@ -99,7 +109,7 @@ export async function cacheResponse<T>(seconds: number, key: string, refreshRequ
         logger.debug(`New request completed for key: ${key}`);
         // Only store in cache if we have valid data
         if (data !== undefined) {
-          store.storeInCache(key, { date: new Date(), data: data });
+          store.storeInCache(key, { date: new Date(), data: data }, undefined, getExplicitSizeBytes(data));
         }
         return data;
       })
@@ -117,12 +127,14 @@ export async function cacheResponse<T>(seconds: number, key: string, refreshRequ
 export function memoizeAsync<A extends unknown[], R>(
   fn: (...args: A) => Promise<R>,
   options?: {
-    cacheItemLimit: number;
+    cacheItemLimit?: number;
     ttl?: number;
     getCacheKey?: (...args: A) => string;
+    name?: string;
   }
 ): (...args: A) => Promise<R> {
   const cache = new LRUCache<string, Promise<R>>({ max: options?.cacheItemLimit ?? 100, ttl: options?.ttl });
+  cacheRegistry.register(options?.name || fn.name || "memoizeAsync", cache);
 
   return (...args: A) => {
     const key = options?.getCacheKey ? options.getCacheKey(...args) : JSON.stringify(args);

--- a/apps/api/src/caching/memoryCacheEngine.spec.ts
+++ b/apps/api/src/caching/memoryCacheEngine.spec.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from "vitest";
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn()
+}));
 
-import MemoryCacheEngine, { estimateEntryBytes } from "./memoryCacheEngine";
+vi.mock("@akashnetwork/logging/otel", () => ({
+  createOtelLogger: () => mockLogger
+}));
+
+import { describe, expect, it, vi } from "vitest";
+
+import MemoryCacheEngine from "./memoryCacheEngine";
 
 describe(MemoryCacheEngine.name, () => {
   describe("getFromCache", () => {
@@ -219,91 +230,64 @@ describe(MemoryCacheEngine.name, () => {
   });
 
   describe("size bounding", () => {
-    it("evicts least-recently-used entries when total bytes exceed maxTotalBytes", () => {
+    it("evicts least-recently-used entries when explicitly sized entries exceed maxTotalBytes", () => {
+      setup();
       const engine = new MemoryCacheEngine({ maxTotalBytes: 250, maxEntryBytes: 250 });
 
-      engine.storeInCache("first", "x".repeat(100));
-      engine.storeInCache("second", "y".repeat(100));
-      engine.storeInCache("third", "z".repeat(100));
+      engine.storeInCache("first", "x".repeat(100), undefined, 100);
+      engine.storeInCache("second", "y".repeat(100), undefined, 100);
+      engine.storeInCache("third", "z".repeat(100), undefined, 100);
 
       expect(engine.getFromCache("first")).toBeUndefined();
       expect(engine.getFromCache("second")).toBe("y".repeat(100));
       expect(engine.getFromCache("third")).toBe("z".repeat(100));
     });
 
-    it("refuses a single entry larger than maxEntryBytes without evicting others", () => {
+    it("refuses an entry whose explicit size exceeds maxEntryBytes without evicting others", () => {
+      setup();
       const engine = new MemoryCacheEngine({ maxTotalBytes: 1000, maxEntryBytes: 100 });
 
-      engine.storeInCache("small", "kept");
-      engine.storeInCache("huge", "x".repeat(500));
+      engine.storeInCache("small", "kept", undefined, 50);
+      engine.storeInCache("huge", "dropped", undefined, 500);
 
       expect(engine.getFromCache("huge")).toBeUndefined();
       expect(engine.getFromCache("small")).toBe("kept");
+      expect(mockLogger.warn).toHaveBeenCalledWith({ event: "CACHE_ENTRY_TOO_LARGE", key: "huge", sizeBytes: 500, maxEntryBytes: 100 });
     });
 
-    it("accepts a Buffer entry whose binary length is within maxEntryBytes", () => {
-      const engine = new MemoryCacheEngine({ maxTotalBytes: 8000, maxEntryBytes: 1500 });
+    it("warns about an oversized key only once", () => {
+      setup();
+      const engine = new MemoryCacheEngine({ maxEntryBytes: 100 });
 
-      engine.storeInCache("binary", { payload: Buffer.alloc(1024) });
+      engine.storeInCache("huge", "dropped", undefined, 500);
+      engine.storeInCache("huge", "dropped again", undefined, 600);
 
-      expect(engine.getFromCache("binary")).toEqual({ payload: Buffer.alloc(1024) });
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
     });
 
-    it("refuses a multi-byte string whose UTF-8 size exceeds maxEntryBytes", () => {
-      const engine = new MemoryCacheEngine({ maxTotalBytes: 8000, maxEntryBytes: 2000 });
-
-      engine.storeInCache("multibyte", { text: "\u20ac".repeat(1000) });
-
-      expect(engine.getFromCache("multibyte")).toBeUndefined();
-    });
-
-    it("stores entries within both budgets", () => {
-      const engine = new MemoryCacheEngine({ maxTotalBytes: 1000, maxEntryBytes: 500 });
-
-      engine.storeInCache("fits", { data: "payload" });
-
-      expect(engine.getFromCache("fits")).toEqual({ data: "payload" });
-    });
-  });
-
-  describe(estimateEntryBytes.name, () => {
-    it("measures plain values by their JSON length", () => {
-      expect(estimateEntryBytes({ a: 1 })).toBe(JSON.stringify({ a: 1 }).length + 1);
-    });
-
-    it("counts binary payloads by byte length instead of JSON-inflating them", () => {
-      const size = estimateEntryBytes({ data: new Uint8Array(1000) });
-
-      expect(size).toBeGreaterThanOrEqual(1000);
-      expect(size).toBeLessThan(2000);
-    });
-
-    it("counts Buffer payloads by binary length rather than their JSON expansion", () => {
-      const size = estimateEntryBytes({ data: Buffer.alloc(1000) });
-
-      expect(size).toBeGreaterThanOrEqual(1000);
-      expect(size).toBeLessThan(2000);
-    });
-
-    it("measures multi-byte characters as UTF-8 bytes rather than UTF-16 code units", () => {
-      const text = "\u20ac".repeat(1000);
-
-      expect(estimateEntryBytes({ text })).toBeGreaterThan(3000);
-    });
-
-    it("serializes bigint values instead of throwing", () => {
-      expect(estimateEntryBytes({ amount: 10n })).toBeGreaterThan(0);
-    });
-
-    it("returns an uncacheable size for circular values", () => {
+    it("stores values that JSON cannot serialize", () => {
+      setup();
+      const engine = new MemoryCacheEngine({ maxEntries: 10 });
       const circular: { self?: unknown } = {};
       circular.self = circular;
 
-      expect(estimateEntryBytes(circular)).toBe(Number.MAX_SAFE_INTEGER);
+      engine.storeInCache("circular", circular);
+
+      expect(engine.getFromCache("circular")).toBe(circular);
+    });
+
+    it("stores entries within both budgets", () => {
+      setup();
+      const engine = new MemoryCacheEngine({ maxTotalBytes: 2000, maxEntryBytes: 1500 });
+
+      engine.storeInCache("binary", { payload: Buffer.alloc(1024) }, undefined, 1024);
+
+      expect(engine.getFromCache("binary")).toEqual({ payload: Buffer.alloc(1024) });
     });
   });
 
   function setup() {
+    vi.clearAllMocks();
     const engine = new MemoryCacheEngine();
     engine.clearAllKeyInCache();
     return { engine };

--- a/apps/api/src/caching/memoryCacheEngine.ts
+++ b/apps/api/src/caching/memoryCacheEngine.ts
@@ -1,7 +1,7 @@
 import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { LRUCache } from "lru-cache";
 
-import { cacheRegistry } from "./cache-registry";
+import { cacheRegistry, NOMINAL_ENTRY_BYTES } from "./cache-registry";
 
 export type CacheValue = NonNullable<unknown>;
 
@@ -17,9 +17,6 @@ const DEFAULT_LIMITS = {
   maxTotalBytes: 256 * 1024 * 1024,
   maxEntryBytes: 16 * 1024 * 1024
 } satisfies Required<CacheLimits>;
-
-/** Charged to entries stored without an explicit size: object graphs are bounded by entry count and the heap-pressure flush, never serialized to be measured. */
-const NOMINAL_ENTRY_BYTES = 1024;
 
 const MAX_WARNED_OVERSIZED_KEYS = 1000;
 

--- a/apps/api/src/caching/memoryCacheEngine.ts
+++ b/apps/api/src/caching/memoryCacheEngine.ts
@@ -1,4 +1,7 @@
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { LRUCache } from "lru-cache";
+
+import { cacheRegistry } from "./cache-registry";
 
 export type CacheValue = NonNullable<unknown>;
 
@@ -8,68 +11,85 @@ export interface CacheLimits {
   maxEntryBytes?: number;
 }
 
-/** Bounding by entry count alone let multi-MB cached responses exhaust the 2GB V8 heap on 2026-09-01; bytes are the limit that matters. */
+/** Multi-MB cached responses exhausted the 2GB V8 heap on 2026-09-01; the byte ceilings bound entries stored with an explicit size. */
 const DEFAULT_LIMITS = {
   maxEntries: 500,
   maxTotalBytes: 256 * 1024 * 1024,
   maxEntryBytes: 16 * 1024 * 1024
 } satisfies Required<CacheLimits>;
 
-/** Reads the holder instead of the replacer's argument because Buffer.toJSON has already expanded binary into `{ type, data }` by the time a replacer runs. */
-export function estimateEntryBytes(value: CacheValue): number {
-  let binaryBytes = 0;
-  try {
-    const json = JSON.stringify(value, function countBinaryOnce(this: Record<string, unknown>, key: string, nested: unknown) {
-      const beforeToJson = this[key];
-      if (beforeToJson instanceof Uint8Array) {
-        binaryBytes += beforeToJson.byteLength;
-        return undefined;
-      }
-      return typeof nested === "bigint" ? nested.toString() : nested;
-    });
-    return Buffer.byteLength(json ?? "", "utf8") + binaryBytes + 1;
-  } catch {
-    return Number.MAX_SAFE_INTEGER;
-  }
+/** Charged to entries stored without an explicit size: object graphs are bounded by entry count and the heap-pressure flush, never serialized to be measured. */
+const NOMINAL_ENTRY_BYTES = 1024;
+
+const MAX_WARNED_OVERSIZED_KEYS = 1000;
+
+const logger = createOtelLogger({ context: "Caching" });
+
+function resolveLimits(limits?: CacheLimits): Required<CacheLimits> {
+  return {
+    maxEntries: limits?.maxEntries ?? DEFAULT_LIMITS.maxEntries,
+    maxTotalBytes: limits?.maxTotalBytes ?? DEFAULT_LIMITS.maxTotalBytes,
+    maxEntryBytes: limits?.maxEntryBytes ?? DEFAULT_LIMITS.maxEntryBytes
+  };
 }
 
-function createBoundedCache(limits?: CacheLimits) {
+function createBoundedCache(limits: Required<CacheLimits>) {
   return new LRUCache<string, CacheValue>({
-    max: limits?.maxEntries ?? DEFAULT_LIMITS.maxEntries,
-    maxSize: limits?.maxTotalBytes ?? DEFAULT_LIMITS.maxTotalBytes,
-    maxEntrySize: limits?.maxEntryBytes ?? DEFAULT_LIMITS.maxEntryBytes,
-    sizeCalculation: estimateEntryBytes
+    max: limits.maxEntries,
+    maxSize: limits.maxTotalBytes,
+    maxEntrySize: limits.maxEntryBytes,
+    sizeCalculation: () => NOMINAL_ENTRY_BYTES
   });
 }
 
-const sharedCache = createBoundedCache();
-const allCaches = new Set<LRUCache<string, CacheValue>>([sharedCache]);
+const sharedLimits = resolveLimits();
+const sharedCache = createBoundedCache(sharedLimits);
+cacheRegistry.register("shared", sharedCache);
 
 export default class MemoryCacheEngine {
   readonly #cache: LRUCache<string, CacheValue>;
+  readonly #limits: Required<CacheLimits>;
+  readonly #warnedOversizedKeys = new Set<string>();
 
   /** Passing limits gives the engine a private cache, so a high-cardinality key space cannot evict every other memoized response out of the shared one. */
-  constructor(options?: CacheLimits) {
+  constructor(options?: CacheLimits & { name?: string }) {
     if (options) {
-      this.#cache = createBoundedCache(options);
-      allCaches.add(this.#cache);
+      this.#limits = resolveLimits(options);
+      this.#cache = createBoundedCache(this.#limits);
+      cacheRegistry.register(options.name ?? "private", this.#cache);
     } else {
+      this.#limits = sharedLimits;
       this.#cache = sharedCache;
     }
   }
 
   static clearAllCaches() {
-    for (const cache of allCaches) {
-      cache.clear();
-    }
+    cacheRegistry.clearAll();
   }
 
   getFromCache<T extends CacheValue>(key: string): T | undefined {
     return this.#cache.get(key) as T | undefined;
   }
 
-  storeInCache<T extends CacheValue>(key: string, data: T, durationInSeconds?: number) {
-    this.#cache.set(key, data, durationInSeconds ? { ttl: durationInSeconds * 1000 } : undefined);
+  storeInCache<T extends CacheValue>(key: string, data: T, durationInSeconds?: number, sizeBytes?: number) {
+    if (sizeBytes !== undefined && sizeBytes > this.#limits.maxEntryBytes) {
+      this.#warnOversizedEntry(key, sizeBytes);
+      return;
+    }
+
+    this.#cache.set(key, data, {
+      ttl: durationInSeconds ? durationInSeconds * 1000 : undefined,
+      size: sizeBytes
+    });
+  }
+
+  #warnOversizedEntry(key: string, sizeBytes: number) {
+    if (this.#warnedOversizedKeys.has(key)) return;
+    if (this.#warnedOversizedKeys.size >= MAX_WARNED_OVERSIZED_KEYS) {
+      this.#warnedOversizedKeys.clear();
+    }
+    this.#warnedOversizedKeys.add(key);
+    logger.warn({ event: "CACHE_ENTRY_TOO_LARGE", key, sizeBytes, maxEntryBytes: this.#limits.maxEntryBytes });
   }
 
   /**

--- a/apps/api/src/chain/services/block-http/block-http.service.ts
+++ b/apps/api/src/chain/services/block-http/block-http.service.ts
@@ -10,7 +10,8 @@ export class BlockHttpService {
   readonly #chainSdk: ChainSDK;
   readonly getCurrentHeight = memoizeAsync(this.getFreshCurrentHeight.bind(this), {
     ttl: averageBlockTime * 1000,
-    cacheItemLimit: 1
+    cacheItemLimit: 1,
+    name: "BlockHttpService#getCurrentHeight"
   });
 
   constructor(@inject(CHAIN_SDK) chainSdk: ChainSDK) {

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
@@ -49,7 +49,7 @@ export class DenomExchangeService {
         return await this.#getFallbackExchangeRateToUSD();
       }
     },
-    { cacheItemLimit: 10, ttl: minutesToMilliseconds(10) }
+    { cacheItemLimit: 10, ttl: minutesToMilliseconds(10), name: "DenomExchangeService#getExchangeRateToUSD" }
   );
 
   // Queries Oracle V2 only. A failed aggregated-price query propagates to the caller's

--- a/apps/api/src/core/config/env.config.ts
+++ b/apps/api/src/core/config/env.config.ts
@@ -47,7 +47,11 @@ export const envSchema = z
     CORS_WEBSITE_URLS: z.string().default(["http://localhost:3000", "http://localhost:3001"].join(",")),
     SECRET_TOKEN: z.string().optional(), // private api token
     SERVER_ORIGIN: z.string().default("http://localhost:3080"),
-    EVENTLOOP_MONITORING_ENABLED: z.coerce.boolean().default(false)
+    EVENTLOOP_MONITORING_ENABLED: z.coerce.boolean().default(false),
+    CACHE_PRESSURE_MONITORING_ENABLED: z
+      .enum(["true", "false"])
+      .default("true")
+      .transform(value => value === "true")
   })
   .superRefine((value, ctx) => {
     if (!value.FEATURE_FLAGS_ENABLE_ALL && (!value.UNLEASH_SERVER_API_URL || !value.UNLEASH_SERVER_API_TOKEN)) {

--- a/apps/api/src/core/providers/cache-monitoring.provider.ts
+++ b/apps/api/src/core/providers/cache-monitoring.provider.ts
@@ -1,0 +1,31 @@
+import { container, instancePerContainerCachingFactory } from "tsyringe";
+
+import { CacheInstrumentationService } from "@src/caching/cache-instrumentation.service";
+import { CachePressureMonitorService } from "@src/caching/cache-pressure-monitor.service";
+import { CacheRegistry, cacheRegistry } from "@src/caching/cache-registry";
+import { DisposableRegistry } from "@src/core/lib/disposable-registry/disposable-registry";
+import type { AppInitializer } from "./app-initializer";
+import { APP_INITIALIZER, ON_APP_START } from "./app-initializer";
+import { CORE_CONFIG } from "./config.provider";
+
+container.register(CacheRegistry, { useValue: cacheRegistry });
+
+container.register(APP_INITIALIZER, {
+  useFactory: instancePerContainerCachingFactory(
+    DisposableRegistry.registerFromFactory<AppInitializer>(c => {
+      let pressureMonitor: CachePressureMonitorService | null = null;
+      return {
+        async [ON_APP_START]() {
+          c.resolve(CacheInstrumentationService);
+          if (!c.resolve(CORE_CONFIG).CACHE_PRESSURE_MONITORING_ENABLED) return;
+
+          pressureMonitor = c.resolve(CachePressureMonitorService);
+          pressureMonitor.start();
+        },
+        dispose() {
+          pressureMonitor?.dispose();
+        }
+      };
+    })
+  )
+});

--- a/apps/api/src/core/providers/index.ts
+++ b/apps/api/src/core/providers/index.ts
@@ -3,6 +3,7 @@ import "./http-sdk.provider";
 import "./logging.provider";
 import "./postgres.provider";
 import "./eventloop-monitoring.provider";
+import "./cache-monitoring.provider";
 
 export * from "./auth.provider";
 export * from "./postgres.provider";

--- a/apps/api/src/core/services/metrics/metrics.service.ts
+++ b/apps/api/src/core/services/metrics/metrics.service.ts
@@ -1,4 +1,4 @@
-import { type Counter, type Histogram, type Meter, metrics, type UpDownCounter } from "@opentelemetry/api";
+import { type Counter, type Histogram, type Meter, metrics, type ObservableGauge, type UpDownCounter } from "@opentelemetry/api";
 import { singleton } from "tsyringe";
 
 export interface MetricOptions {
@@ -55,6 +55,20 @@ export class MetricsService {
    */
   createUpDownCounter(meter: Meter, name: string, options?: MetricOptions): UpDownCounter {
     return meter.createUpDownCounter(name, {
+      description: options?.description,
+      unit: options?.unit
+    });
+  }
+
+  /**
+   * Creates an observable gauge metric collected via a callback on each export
+   * @param meter - Meter instance from getMeter()
+   * @param name - Metric name (should follow Prometheus naming conventions: lowercase with underscores)
+   * @param options - Metric options
+   * @returns ObservableGauge instance
+   */
+  createObservableGauge(meter: Meter, name: string, options?: MetricOptions): ObservableGauge {
+    return meter.createObservableGauge(name, {
       description: options?.description,
       unit: options?.unit
     });

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
@@ -115,7 +115,8 @@ export class OpenApiDocsService {
     {
       ttl: 60 * 60 * 1000, // 1 hour
       cacheItemLimit: 10,
-      getCacheKey: (_, options) => `${options.scope}-${options.source ?? "http"}-${options.includeHidden ? "all" : "public"}`
+      getCacheKey: (_, options) => `${options.scope}-${options.source ?? "http"}-${options.includeHidden ? "all" : "public"}`,
+      name: "OpenApiDocsService#generateDocs"
     }
   );
 

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -64,7 +64,7 @@ export class CachedBalance {
 
 @singleton()
 export class CachedBalanceService {
-  public get = memoizeAsync((address: string) => this.buildForAddress(address), { cacheItemLimit: 10_000 });
+  public get = memoizeAsync((address: string) => this.buildForAddress(address), { cacheItemLimit: 10_000, name: "CachedBalanceService#get" });
 
   private readonly logger: ReturnType<CreateLogger>;
 

--- a/apps/api/src/middlewares/privateMiddleware.spec.ts
+++ b/apps/api/src/middlewares/privateMiddleware.spec.ts
@@ -1,0 +1,72 @@
+import type { Context, Next } from "hono";
+import { container } from "tsyringe";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CoreConfig } from "@src/core/providers/config.provider";
+import { CORE_CONFIG } from "@src/core/providers/config.provider";
+import { privateMiddleware, requirePrivateToken } from "./privateMiddleware";
+
+describe("privateMiddleware", () => {
+  it("lets the request through when the token matches", async () => {
+    const { c, next } = setup({ secretToken: "secret", queryToken: "secret" });
+
+    await privateMiddleware(c, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a mismatched token", async () => {
+    const { c, next } = setup({ secretToken: "secret", queryToken: "wrong" });
+
+    await privateMiddleware(c, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(c.text).toHaveBeenCalledWith("Unauthorized", 401);
+  });
+
+  it("lets the request through when no secret is configured", async () => {
+    const { c, next } = setup({ secretToken: undefined, queryToken: undefined });
+
+    await privateMiddleware(c, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("requirePrivateToken", () => {
+  it("lets the request through when the token matches", async () => {
+    const { c, next } = setup({ secretToken: "secret", queryToken: "secret" });
+
+    await requirePrivateToken(c, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects a mismatched token", async () => {
+    const { c, next } = setup({ secretToken: "secret", queryToken: "wrong" });
+
+    await requirePrivateToken(c, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(c.text).toHaveBeenCalledWith("Unauthorized", 401);
+  });
+
+  it("rejects the request when no secret is configured", async () => {
+    const { c, next } = setup({ secretToken: undefined, queryToken: undefined });
+
+    await requirePrivateToken(c, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(c.text).toHaveBeenCalledWith("Unauthorized", 401);
+  });
+});
+
+function setup(input: { secretToken?: string; queryToken?: string }) {
+  container.registerInstance(CORE_CONFIG, mock<CoreConfig>({ SECRET_TOKEN: input.secretToken }));
+
+  const c = mock<Context>({ req: mock<Context["req"]>({ query: vi.fn().mockReturnValue(input.queryToken) }) });
+  const next = vi.fn<Next>();
+
+  return { c, next };
+}

--- a/apps/api/src/middlewares/privateMiddleware.ts
+++ b/apps/api/src/middlewares/privateMiddleware.ts
@@ -3,14 +3,27 @@ import { container } from "tsyringe";
 
 import { CORE_CONFIG } from "@src/core/providers/config.provider";
 
-export async function privateMiddleware(c: Context, next: Next) {
-  const SECRET_TOKEN = container.resolve(CORE_CONFIG).SECRET_TOKEN;
+function isAuthorized(c: Context, secretToken: string) {
+  return c.req.query("token") === secretToken;
+}
 
-  if (!SECRET_TOKEN) {
-    await next();
-  } else if (c.req.query("token") === SECRET_TOKEN) {
-    await next();
-  } else {
+export async function privateMiddleware(c: Context, next: Next) {
+  const secretToken = container.resolve(CORE_CONFIG).SECRET_TOKEN;
+
+  if (secretToken && !isAuthorized(c, secretToken)) {
     return c.text("Unauthorized", 401);
   }
+
+  await next();
+}
+
+/** An unset SECRET_TOKEN locks the route instead of opening it the way privateMiddleware does, so a deployment cannot publish it by omission. */
+export async function requirePrivateToken(c: Context, next: Next) {
+  const secretToken = container.resolve(CORE_CONFIG).SECRET_TOKEN;
+
+  if (!secretToken || !isAuthorized(c, secretToken)) {
+    return c.text("Unauthorized", 401);
+  }
+
+  await next();
 }

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -16,7 +16,7 @@ import { startServer } from "./core/services/start-server/start-server";
 import type { AppEnv } from "./core/types/app-context";
 import { healthzRouter } from "./healthz/routes/healthz.router";
 import { clientInfoMiddleware } from "./middlewares/clientInfoMiddleware";
-import { privateMiddleware } from "./middlewares/privateMiddleware";
+import { requirePrivateToken } from "./middlewares/privateMiddleware";
 import { notificationsApiProxy } from "./notifications/routes/proxy/proxy.route";
 import { apiRouter } from "./routers/apiRouter";
 import { dashboardRouter } from "./routers/dashboardRouter";
@@ -77,7 +77,7 @@ appHono.get("/status", c => {
   return c.json({ version, memory });
 });
 
-appHono.get("/status/caches", privateMiddleware, c => {
+appHono.get("/status/caches", requirePrivateToken, c => {
   const caches = cacheRegistry.getStats().map(stats => ({
     name: stats.name,
     entries: stats.entryCount,

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -8,6 +8,7 @@ import assert from "http-assert";
 import { container } from "tsyringe";
 
 import { AuthInterceptor } from "./auth/services/auth.interceptor";
+import { cacheRegistry } from "./caching/cache-registry";
 import { HonoErrorHandlerService } from "./core/services/hono-error-handler/hono-error-handler.service";
 import { OpenApiDocsService } from "./core/services/openapi-docs/openapi-docs.service";
 import { RequestContextInterceptor } from "./core/services/request-context-interceptor/request-context.interceptor";
@@ -71,8 +72,15 @@ appHono.get("/status", c => {
     heapUsed: bytesToHumanReadableSize(memoryInBytes.heapUsed),
     external: bytesToHumanReadableSize(memoryInBytes.external)
   };
+  const caches = cacheRegistry.getStats().map(stats => ({
+    name: stats.name,
+    entries: stats.entryCount,
+    maxEntries: stats.maxEntries,
+    size: bytesToHumanReadableSize(stats.calculatedSizeBytes),
+    maxSize: bytesToHumanReadableSize(stats.maxTotalBytes)
+  }));
 
-  return c.json({ version, memory });
+  return c.json({ version, memory, caches });
 });
 
 appHono.get("/v1/doc", async c => {

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -16,6 +16,7 @@ import { startServer } from "./core/services/start-server/start-server";
 import type { AppEnv } from "./core/types/app-context";
 import { healthzRouter } from "./healthz/routes/healthz.router";
 import { clientInfoMiddleware } from "./middlewares/clientInfoMiddleware";
+import { privateMiddleware } from "./middlewares/privateMiddleware";
 import { notificationsApiProxy } from "./notifications/routes/proxy/proxy.route";
 import { apiRouter } from "./routers/apiRouter";
 import { dashboardRouter } from "./routers/dashboardRouter";
@@ -72,6 +73,11 @@ appHono.get("/status", c => {
     heapUsed: bytesToHumanReadableSize(memoryInBytes.heapUsed),
     external: bytesToHumanReadableSize(memoryInBytes.external)
   };
+
+  return c.json({ version, memory });
+});
+
+appHono.get("/status/caches", privateMiddleware, c => {
   const caches = cacheRegistry.getStats().map(stats => ({
     name: stats.name,
     entries: stats.entryCount,
@@ -80,7 +86,7 @@ appHono.get("/status", c => {
     maxSize: bytesToHumanReadableSize(stats.maxTotalBytes)
   }));
 
-  return c.json({ version, memory, caches });
+  return c.json({ caches });
 });
 
 appHono.get("/v1/doc", async c => {

--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -3,6 +3,7 @@ import tar from "tar";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { cacheRegistry } from "@src/caching/cache-registry";
 import type { CreateLogger } from "@src/core";
 import { GitHubArchiveService } from "./github-archive.service";
 
@@ -86,6 +87,30 @@ describe(GitHubArchiveService.name, () => {
       expect(await reader.readFile("readme.md")).toBe("# Hello");
       expect(await reader.readFile("image.png")).toBe("binary data");
       expect(await reader.readFile("src/index.ts")).toBe("code");
+    });
+  });
+
+  describe("cache byte accounting", () => {
+    it("charges the cached archive the bytes it retained", async () => {
+      const { service, installArchive, cacheStats } = setup();
+      await installArchive({ "root/readme.md": "# Hello" });
+
+      const reader = await service.getArchive("owner", "repo", "ref");
+
+      expect(reader.retainedBytes).toBeGreaterThan(0);
+      expect(cacheStats()).toMatchObject({ entryCount: 1, calculatedSizeBytes: reader.retainedBytes });
+    });
+
+    it("leaves the content of filtered-out files out of the charge", async () => {
+      const { service, fetchSpy, archiveResponse } = setup();
+      const skippedContent = "0123456789";
+      const files = { "root/readme.md": "# Hello", "root/skip.txt": skippedContent };
+      fetchSpy.mockImplementation(async () => archiveResponse(files));
+
+      const filtered = await service.getArchive("owner", "repo", "filtered", (relativePath: string) => relativePath.endsWith(".md"));
+      const unfiltered = await service.getArchive("owner", "repo", "unfiltered");
+
+      expect(unfiltered.retainedBytes - filtered.retainedBytes).toBe(skippedContent.length);
     });
   });
 
@@ -293,7 +318,9 @@ describe(GitHubArchiveService.name, () => {
   function setup() {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const logger = mock<ReturnType<CreateLogger>>();
+    const namesBeforeRegistration = new Set(cacheRegistry.getStats().map(stats => stats.name));
     const service = new GitHubArchiveService(logger);
+    const cacheName = cacheRegistry.getStats().find(stats => !namesBeforeRegistration.has(stats.name))!.name;
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
     function archiveResponse(files: Record<string, string>) {
@@ -316,7 +343,9 @@ describe(GitHubArchiveService.name, () => {
       fetchSpy.mockResolvedValue(archiveResponse(files));
     }
 
-    return { service, logger, installArchive, fetchSpy, archiveResponse, tarGzChunks };
+    const cacheStats = () => cacheRegistry.getStats().find(stats => stats.name === cacheName);
+
+    return { service, logger, installArchive, fetchSpy, archiveResponse, tarGzChunks, cacheStats };
   }
 
   function createTarGzBuffer(files: Record<string, string>): Buffer {

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -6,10 +6,14 @@ import { createGunzip } from "node:zlib";
 import tar from "tar";
 
 import type { CreateLogger } from "@src/core";
-import { cacheRegistry } from "../../../caching/cache-registry.ts";
+import { cacheRegistry, NOMINAL_ENTRY_BYTES } from "../../../caching/cache-registry.ts";
 
 /** The template repo archives are ~70 MB each, so the download budget has to bound stalls rather than total transfer time. */
 const DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
+
+const MAX_CACHED_ARCHIVES = 10;
+/** An archive retaining more than this is still parsed and returned, just not kept, since getArchive resolves from the parse rather than from the cache. */
+const MAX_CACHED_ARCHIVE_BYTES = 256 * 1024 * 1024;
 
 const MAX_DOWNLOAD_RETRIES = 2;
 const RETRY_INITIAL_DELAY_MS = 1_000;
@@ -29,11 +33,13 @@ export interface DirectoryEntry {
 export interface ArchiveReader {
   readFile(path: string): Promise<string | null>;
   listDirectory(path: string): DirectoryEntry[];
+  retainedBytes: number;
 }
 
 interface ParsedArchive {
   files: Map<string, string>;
   directories: Map<string, DirectoryEntry[]>;
+  retainedBytes: number;
 }
 
 async function* streamWhileMakingProgress(body: ReadableStream<Uint8Array>, onProgress: () => void) {
@@ -51,7 +57,11 @@ async function* streamWhileMakingProgress(body: ReadableStream<Uint8Array>, onPr
 }
 
 export class GitHubArchiveService {
-  readonly #cache = new LRUCache<string, Promise<ArchiveReader>>({ max: 10 });
+  readonly #cache = new LRUCache<string, Promise<ArchiveReader>>({
+    max: MAX_CACHED_ARCHIVES,
+    maxEntrySize: MAX_CACHED_ARCHIVE_BYTES,
+    sizeCalculation: () => NOMINAL_ENTRY_BYTES
+  });
   readonly #logger: ReturnType<CreateLogger>;
   readonly #downloadPolicy: RetryPolicy;
 
@@ -78,7 +88,9 @@ export class GitHubArchiveService {
     this.#cache.set(cacheKey, promise);
 
     try {
-      return await promise;
+      const reader = await promise;
+      this.#chargeRetainedBytes(cacheKey, promise, reader.retainedBytes);
+      return reader;
     } catch (error) {
       this.#cache.delete(cacheKey);
       throw error;
@@ -87,6 +99,12 @@ export class GitHubArchiveService {
 
   clearCache(): void {
     this.#cache.clear();
+  }
+
+  /** lru-cache ignores a size given for a value it already holds, so the parsed archive has to replace its own in-flight entry. */
+  #chargeRetainedBytes(cacheKey: string, archive: Promise<ArchiveReader>, retainedBytes: number): void {
+    this.#cache.delete(cacheKey);
+    this.#cache.set(cacheKey, archive, { size: retainedBytes });
   }
 
   async #downloadAndParse(owner: string, repo: string, ref: string, fileFilter?: (relativePath: string) => boolean): Promise<ArchiveReader> {
@@ -146,6 +164,7 @@ export class GitHubArchiveService {
     const dirChildren = new Map<string, Map<string, DirectoryEntry>>();
     let rootPrefix = "";
     let rootDetected = false;
+    let retainedBytes = 0;
 
     const parser = new tar.Parse({
       onentry: (entry: tar.ReadEntry) => {
@@ -165,6 +184,7 @@ export class GitHubArchiveService {
         const isDir = entry.type === "Directory";
 
         this.#registerInParentDirectory(dirChildren, relativePath, isDir);
+        retainedBytes += Buffer.byteLength(relativePath);
 
         if (isDir) {
           const cleanPath = relativePath.endsWith("/") ? relativePath.slice(0, -1) : relativePath;
@@ -183,7 +203,9 @@ export class GitHubArchiveService {
         const chunks: Buffer[] = [];
         entry.on("data", (chunk: Buffer) => chunks.push(chunk));
         entry.on("end", () => {
-          files.set(relativePath, Buffer.concat(chunks).toString("utf-8"));
+          const content = Buffer.concat(chunks);
+          retainedBytes += content.byteLength;
+          files.set(relativePath, content.toString("utf-8"));
         });
         entry.on("error", (error: Error) => {
           this.#logger.warn({
@@ -202,7 +224,7 @@ export class GitHubArchiveService {
       directories.set(dirPath, Array.from(childMap.values()));
     }
 
-    return { files, directories };
+    return { files, directories, retainedBytes };
   }
 
   #registerInParentDirectory(dirChildren: Map<string, Map<string, DirectoryEntry>>, relativePath: string, isDir: boolean): void {
@@ -231,6 +253,8 @@ export class GitHubArchiveService {
 
   #createArchiveReader(parsed: ParsedArchive): ArchiveReader {
     return {
+      retainedBytes: parsed.retainedBytes,
+
       async readFile(path: string): Promise<string | null> {
         return parsed.files.get(GitHubArchiveService.#normalizePath(path)) ?? null;
       },

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -6,6 +6,7 @@ import { createGunzip } from "node:zlib";
 import tar from "tar";
 
 import type { CreateLogger } from "@src/core";
+import { cacheRegistry } from "../../../caching/cache-registry.ts";
 
 /** The template repo archives are ~70 MB each, so the download budget has to bound stalls rather than total transfer time. */
 const DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
@@ -56,6 +57,7 @@ export class GitHubArchiveService {
 
   constructor(logger: ReturnType<CreateLogger>) {
     this.#logger = logger;
+    cacheRegistry.register("GitHubArchiveService#archives", this.#cache);
     this.#downloadPolicy = retry(
       handleWhen(error => !(error instanceof ArchiveNotAvailableError)),
       {

--- a/apps/api/src/template/services/template-fetcher/template-fetcher.service.spec.ts
+++ b/apps/api/src/template/services/template-fetcher/template-fetcher.service.spec.ts
@@ -485,6 +485,8 @@ describe(TemplateFetcherService.name, () => {
 
   function createMockArchiveReader(config: { files: Record<string, string>; directories: Record<string, DirectoryEntry[] | "THROW"> }): ArchiveReader {
     return {
+      retainedBytes: 0,
+
       async readFile(path: string): Promise<string | null> {
         if (Object.hasOwn(config.files, path)) {
           return config.files[path];

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -8,11 +8,15 @@ import type z from "zod";
 
 import type { CreateLogger } from "@src/core";
 import type { Category, FinalCategory, Template } from "@src/template/types/template";
-import { cacheRegistry } from "../../../caching/cache-registry.ts";
+import { cacheRegistry, nominalEntrySizing } from "../../../caching/cache-registry.ts";
 import { reusePendingPromise } from "../../../caching/helpers.ts";
 import { GitHubArchiveService } from "../github-archive/github-archive.service.ts";
 import { REPOSITORIES, TemplateFetcherService } from "../template-fetcher/template-fetcher.service.ts";
 import { TemplateProcessorService } from "../template-processor/template-processor.service.ts";
+
+const MAX_PARSED_TEMPLATES = 100;
+/** A parsed template carries its full readme and SDL text, so it is charged well above the registry's default object entry. */
+const PARSED_TEMPLATE_BYTES = 32 * 1024;
 
 const DEFAULT_RECOMMENDED_TEMPLATE_IDS = new Set([
   "akash-network-awesome-akash-Razer-AIKit",
@@ -73,7 +77,7 @@ type Options = {
 
 export class TemplateGalleryService {
   #templatesSummaryCache: Promise<Buffer> | undefined;
-  #parsedTemplates = new LRUCache<string, Template>({ max: 100 });
+  #parsedTemplates = new LRUCache<string, Template>({ max: MAX_PARSED_TEMPLATES, ...nominalEntrySizing(MAX_PARSED_TEMPLATES, PARSED_TEMPLATE_BYTES) });
 
   private readonly templateFetcher: TemplateFetcherService | null;
   private readonly templateProcessor: TemplateProcessorService;

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -8,6 +8,7 @@ import type z from "zod";
 
 import type { CreateLogger } from "@src/core";
 import type { Category, FinalCategory, Template } from "@src/template/types/template";
+import { cacheRegistry } from "../../../caching/cache-registry.ts";
 import { reusePendingPromise } from "../../../caching/helpers.ts";
 import { GitHubArchiveService } from "../github-archive/github-archive.service.ts";
 import { REPOSITORIES, TemplateFetcherService } from "../template-fetcher/template-fetcher.service.ts";
@@ -94,6 +95,7 @@ export class TemplateGalleryService {
       : null;
     this.#options = options;
     this.#galleriesCachePath = `${options.dataFolderPath}/templates`;
+    cacheRegistry.register("TemplateGalleryService#parsedTemplates", this.#parsedTemplates);
     this.getTemplatesFromRepo = reusePendingPromise(this.getTemplatesFromRepo.bind(this), { getKey: options => `templates-from-repo-${options.repository}` });
     this.getTemplateById = reusePendingPromise(this.getTemplateById.bind(this), { getKey: id => `template-by-id-${id}` });
     this.getGallerySummaryBuffer = reusePendingPromise(this.getGallerySummaryBuffer.bind(this), { getKey: () => "cached-template-gallery" });

--- a/apps/api/test/functional/status.spec.ts
+++ b/apps/api/test/functional/status.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import { app } from "@src/rest-app";
 
+const FUNCTIONAL_TEST_SECRET_TOKEN = "functional-test-secret-token-000000";
+
 describe("GET /status", () => {
   it("reports process memory without listing the registered caches", async () => {
     const response = await app.request("/status");
@@ -14,8 +16,14 @@ describe("GET /status", () => {
 });
 
 describe("GET /status/caches", () => {
-  it("reports every registered cache with its counts and byte accounting", async () => {
+  it("rejects a caller without the private token", async () => {
     const response = await app.request("/status/caches");
+
+    expect(response.status).toBe(401);
+  });
+
+  it("reports every registered cache with its counts and byte accounting", async () => {
+    const response = await app.request(`/status/caches?token=${FUNCTIONAL_TEST_SECRET_TOKEN}`);
 
     expect(response.status).toBe(200);
     const data = (await response.json()) as {

--- a/apps/api/test/functional/status.spec.ts
+++ b/apps/api/test/functional/status.spec.ts
@@ -3,15 +3,24 @@ import { describe, expect, it } from "vitest";
 import { app } from "@src/rest-app";
 
 describe("GET /status", () => {
-  it("reports process memory and the registered caches", async () => {
+  it("reports process memory without listing the registered caches", async () => {
     const response = await app.request("/status");
 
     expect(response.status).toBe(200);
+    const data = (await response.json()) as { memory: Record<string, string>; caches?: unknown };
+    expect(data.memory.rss).toBeDefined();
+    expect(data.caches).toBeUndefined();
+  });
+});
+
+describe("GET /status/caches", () => {
+  it("reports every registered cache with its counts and byte accounting", async () => {
+    const response = await app.request("/status/caches");
+
+    expect(response.status).toBe(200);
     const data = (await response.json()) as {
-      memory: Record<string, string>;
       caches: Array<{ name: string; entries: number; maxEntries: number; size: string; maxSize: string }>;
     };
-    expect(data.memory.rss).toBeDefined();
 
     const cacheNames = data.caches.map(cache => cache.name);
     expect(cacheNames).toContain("shared");

--- a/apps/api/test/functional/status.spec.ts
+++ b/apps/api/test/functional/status.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { app } from "@src/rest-app";
+
+describe("GET /status", () => {
+  it("reports process memory and the registered caches", async () => {
+    const response = await app.request("/status");
+
+    expect(response.status).toBe(200);
+    const data = (await response.json()) as {
+      memory: Record<string, string>;
+      caches: Array<{ name: string; entries: number; maxEntries: number; size: string; maxSize: string }>;
+    };
+    expect(data.memory.rss).toBeDefined();
+
+    const cacheNames = data.caches.map(cache => cache.name);
+    expect(cacheNames).toContain("shared");
+    expect(cacheNames).toContain("DeploymentReaderService#getDeploymentByOwnerAndDseq");
+
+    const sharedCache = data.caches.find(cache => cache.name === "shared");
+    expect(sharedCache).toMatchObject({ entries: expect.any(Number), maxEntries: 500, size: expect.any(String), maxSize: expect.any(String) });
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to #3758. Serhii's review flagged three problems with sizing cached values through `JSON.stringify`: the estimate is inaccurate, stringifying multi-MB object graphs on every store lags the event loop on hot caches, and the transient JSON string costs as much memory as the object itself before the GC collects it. He also pointed at the underlying gap: the api's memoized objects were never capped or tracked by any global object, so the byte-bounded engine only ever saw a fraction of the caches in the process.

## What

- Deletes `estimateEntryBytes`. Nothing serializes values on the set path anymore. Entries stored without a known size are charged a flat 1KB and stay bounded by entry count. Byte-exact accounting remains only where the size is free to read: `cacheResponse` passes `byteLength` through to lru-cache for `Uint8Array` and string payloads, which byte-bounds the provider-list buffers (the largest entries in the shared cache). This also removes the silent failure where circular values were priced at `MAX_SAFE_INTEGER` and never cached.
- Adds a `CacheRegistry` that every in-memory cache registers into under a name: the shared engine, each `Memoize` private cache (named `Class#method`), every `memoizeAsync` cache, and the raw LRU caches in `AuthInterceptor`, `TemplateGalleryService`, and `GitHubArchiveService`.
- Every registered cache reports its bytes. lru-cache only accumulates `calculatedSize` when a byte ceiling is configured, so `nominalEntrySizing` gives each cache of object values a flat per-entry charge scaled to what it holds: 1KB for memoized responses, 128 bytes for `AuthInterceptor#lastUserActivity`, 32KB for a parsed template. The ceiling matches the entry limit, so it never evicts ahead of `max`. `GitHubArchiveService` measures instead of estimating: the tar parser totals the bytes it retains and the cached entry is charged that number once the parse resolves.
- Exposes the registry through `memory_cache_entries` and `memory_cache_size_bytes` gauges (one series per cache name) and through `GET /status/caches`, which lists each cache with its entry count and tracked bytes. That route sits behind `requirePrivateToken`, since cache names and live entry counts should not be readable by anonymous callers the way `/status` is. Unlike the existing `privateMiddleware`, it rejects when `SECRET_TOKEN` is unset rather than falling through, so the endpoint cannot be published by a missing environment variable.
- Adds a heap-pressure backstop. `CachePressureMonitorService` reads `v8.getHeapStatistics()` every 30s; at 85% of the heap limit it logs the full registry snapshot, clears caches largest-first until half of the tracked bytes are released, increments `memory_cache_pressure_flush_total`, and then waits out a 5-minute cooldown. Gated by `CACHE_PRESSURE_MONITORING_ENABLED` (default on).
- An entry whose explicit size exceeds `maxEntryBytes` now logs a `CACHE_ENTRY_TOO_LARGE` warning once per key instead of relying on lru-cache's silent refusal.

Left for follow-up PRs: an actual byte bound on the `GitHubArchiveService` archives, which now report their real size but are still capped only by count, and deciding on a TTL for `CachedBalanceService`'s 10k-entry cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache monitoring for entry counts, memory usage, and cache pressure.
  * Automatically flushes large caches when memory pressure is high.
  * Added configuration to enable or disable cache pressure monitoring.
  * Improved cache accounting for retained archive and template data.
  * Added protected `/status/caches` endpoint for cache statistics.

* **Bug Fixes**
  * Oversized cache entries are now rejected with controlled warnings.
  * Cache entries now use bounded count and size limits.
  * Cache metrics and operation tracking are more consistently reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->