### PR TITLE
fix(sdl): convert a uakt price ceiling into the grant denom

### DIFF
--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
@@ -124,6 +124,48 @@ describe(DenomExchangeService.name, () => {
         priceChangePercentage24: 0
       });
     });
+
+    it("serves a usable price from the cache instead of querying the oracle again", async () => {
+      const { service, getAggregatedPriceV2 } = setup({});
+
+      await service.getExchangeRateToUSD("akt");
+      const second = await service.getExchangeRateToUSD("akt");
+
+      expect(second.price).toBe(0.56);
+      expect(getAggregatedPriceV2).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries the oracle rather than serving an unavailable price the previous call left behind", async () => {
+      const { service, getAggregatedPriceV2 } = setup({ oracleThrows: true, latestAktPrice: null });
+
+      expect((await service.getExchangeRateToUSD("akt")).price).toBe(0);
+      await service.getExchangeRateToUSD("akt");
+
+      expect(getAggregatedPriceV2).toHaveBeenCalledTimes(2);
+    });
+
+    it("recovers on the next call once the oracle answers again", async () => {
+      const { service, getAggregatedPriceV2 } = setup({ oracleThrows: true, latestAktPrice: null });
+
+      expect((await service.getExchangeRateToUSD("akt")).price).toBe(0);
+      getAggregatedPriceV2.mockResolvedValue({ aggregatedPrice: { medianPrice: "0.56" }, priceHealth: { isHealthy: true } });
+
+      expect((await service.getExchangeRateToUSD("akt")).price).toBe(0.56);
+    });
+
+    it("reports an unavailable rate so a cached zero is not mistaken for a real price", async () => {
+      const { service, logger } = setup({ oracleThrows: true, latestAktPrice: null });
+
+      await service.getExchangeRateToUSD("akt");
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "EXCHANGE_RATE_UNAVAILABLE", denom: "akt" }));
+    });
+
+    it("propagates a failure that is not an unavailable price", async () => {
+      const { service } = setup({ oracleThrows: true, dbThrows: true });
+
+      await expect(service.getExchangeRateToUSD("akt")).rejects.toThrow("day table unreachable");
+    });
   });
 
   it("creates the logger with the service context", () => {
@@ -139,6 +181,7 @@ describe(DenomExchangeService.name, () => {
     oracleThrows?: boolean;
     v2HistoryThrows?: boolean;
     latestAktPrice?: number | null;
+    dbThrows?: boolean;
   }) {
     const aggregatedPriceResponse = {
       aggregatedPrice: { medianPrice: "0.56" },
@@ -164,6 +207,10 @@ describe(DenomExchangeService.name, () => {
 
     const dayRepository = mock<DayRepository>();
     dayRepository.getLatestAktPrice.mockResolvedValue("latestAktPrice" in input ? input.latestAktPrice! : 1.23);
+
+    if (input.dbThrows) {
+      dayRepository.getLatestAktPrice.mockRejectedValue(new Error("day table unreachable"));
+    }
 
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
@@ -6,6 +6,11 @@ import { CHAIN_SDK, type ChainSDK } from "@src/chain/providers/chain-sdk.provide
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { DayRepository } from "@src/gpu/repositories/day.repository";
 
+const UNAVAILABLE_PRICE = 0;
+
+/** memoizeAsync drops only a rejected promise, so an unusable rate rejects to stay out of the 10 minute cache and be retried on the next call. */
+class UnavailableExchangeRateError extends Error {}
+
 @singleton()
 export class DenomExchangeService {
   readonly #chainSdk: ChainSDK;
@@ -18,39 +23,60 @@ export class DenomExchangeService {
     this.#dayRepository = dayRepository;
   }
 
-  getExchangeRateToUSD = memoizeAsync(
+  async getExchangeRateToUSD(denom: "akt" | "akash-network") {
+    try {
+      return await this.#cachedExchangeRateToUSD(denom);
+    } catch (error) {
+      if (error instanceof UnavailableExchangeRateError) return this.#rateOf(UNAVAILABLE_PRICE);
+
+      throw error;
+    }
+  }
+
+  #cachedExchangeRateToUSD = memoizeAsync(
     async (denom: "akt" | "akash-network") => {
-      const legacyToNewMapping: Record<string, string> = {
-        "akash-network": "akt"
-      };
-      const mappedDenom = legacyToNewMapping[denom] ?? denom;
+      const rate = await this.#loadExchangeRateToUSD(denom);
 
-      try {
-        const { oracleRate, rate24hAgo } = await this.#fetchOracleRate(mappedDenom);
-
-        if (!oracleRate.priceHealth?.isHealthy) {
-          this.#logger.warn({ event: "ORACLE_PRICE_UNHEALTHY", denom: mappedDenom });
-          return await this.#getFallbackExchangeRateToUSD();
-        }
-
-        const price = parseFloat(oracleRate.aggregatedPrice?.medianPrice ?? "0");
-        const price24hAgo = rate24hAgo.prices[0]?.state?.price ? parseFloat(rate24hAgo.prices[0].state.price) : price;
-
-        return {
-          price,
-          volume: 0,
-          marketCap: 0,
-          marketCapRank: 0,
-          priceChange24h: price - price24hAgo,
-          priceChangePercentage24: price24hAgo ? ((price - price24hAgo) / price24hAgo) * 100 : 0
-        };
-      } catch (error) {
-        this.#logger.warn({ event: "ORACLE_RPC_FAILED", denom: mappedDenom, error });
-        return await this.#getFallbackExchangeRateToUSD();
+      if (!Number.isFinite(rate.price) || rate.price <= UNAVAILABLE_PRICE) {
+        this.#logger.warn({ event: "EXCHANGE_RATE_UNAVAILABLE", denom });
+        throw new UnavailableExchangeRateError();
       }
+
+      return rate;
     },
     { cacheItemLimit: 10, ttl: minutesToMilliseconds(10), name: "DenomExchangeService#getExchangeRateToUSD" }
   );
+
+  async #loadExchangeRateToUSD(denom: "akt" | "akash-network") {
+    const legacyToNewMapping: Record<string, string> = {
+      "akash-network": "akt"
+    };
+    const mappedDenom = legacyToNewMapping[denom] ?? denom;
+
+    try {
+      const { oracleRate, rate24hAgo } = await this.#fetchOracleRate(mappedDenom);
+
+      if (!oracleRate.priceHealth?.isHealthy) {
+        this.#logger.warn({ event: "ORACLE_PRICE_UNHEALTHY", denom: mappedDenom });
+        return await this.#getFallbackExchangeRateToUSD();
+      }
+
+      const price = parseFloat(oracleRate.aggregatedPrice?.medianPrice ?? "0");
+      const price24hAgo = rate24hAgo.prices[0]?.state?.price ? parseFloat(rate24hAgo.prices[0].state.price) : price;
+
+      return {
+        price,
+        volume: 0,
+        marketCap: 0,
+        marketCapRank: 0,
+        priceChange24h: price - price24hAgo,
+        priceChangePercentage24: price24hAgo ? ((price - price24hAgo) / price24hAgo) * 100 : 0
+      };
+    } catch (error) {
+      this.#logger.warn({ event: "ORACLE_RPC_FAILED", denom: mappedDenom, error });
+      return await this.#getFallbackExchangeRateToUSD();
+    }
+  }
 
   // Queries Oracle V2 only. A failed aggregated-price query propagates to the caller's
   // CoinGecko/DB fallback; a failed 24h-history query is swallowed (see below).
@@ -77,8 +103,12 @@ export class DenomExchangeService {
   async #getFallbackExchangeRateToUSD() {
     const aktPrice = await this.#dayRepository.getLatestAktPrice();
 
+    return this.#rateOf(aktPrice ?? UNAVAILABLE_PRICE);
+  }
+
+  #rateOf(price: number) {
     return {
-      price: aktPrice ?? 0,
+      price,
       volume: 0,
       marketCap: 0,
       marketCapRank: 0,

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -487,6 +487,15 @@ describe(SdlService.name, () => {
       });
     });
 
+    it("rejects an sdl priced in usdc", async () => {
+      const { result } = await setup({ sdl: VALID_SDL.replace("denom: uakt", "denom: uusdc"), deploymentGrantDenom: "uact" });
+
+      expect(result).toMatchObject({
+        ok: false,
+        value: [expect.objectContaining({ message: expect.stringContaining("should be one of: uakt, uact") })]
+      });
+    });
+
     it("rejects the sdl when the akt price needed to convert its ceiling is unavailable", async () => {
       const { result } = await setup({ sdl: VALID_SDL, deploymentGrantDenom: "uact", aktToUsdRate: 0 });
 

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -524,10 +524,14 @@ describe(SdlService.name, () => {
     });
 
     it("converts a price shared through a yaml alias exactly once", async () => {
-      const { result } = await setup({ sdl: SDL_WITH_ALIASED_PRICE, deploymentGrantDenom: "uact", aktToUsdRate: 0.325 });
+      const { result, denomExchangeService } = await setup({ sdl: SDL_WITH_ALIASED_PRICE, deploymentGrantDenom: "uact", aktToUsdRate: 0.325 });
 
       expect(result.ok).toBe(true);
-      expect(getPrice(result, "westcoast")).toMatchObject({ denom: "uact", amount: "325" });
+      expect(getGroupSpec(result, "westcoast").resources.map(resource => resource.price)).toMatchObject([
+        { denom: "uact", amount: "325" },
+        { denom: "uact", amount: "325" }
+      ]);
+      expect(denomExchangeService.getExchangeRateToUSD).toHaveBeenCalledTimes(1);
     });
 
     it("does not replace denom or look up a rate when deploymentGrantDenom is uakt", async () => {

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -478,6 +478,15 @@ describe(SdlService.name, () => {
       expect(denomExchangeService.getExchangeRateToUSD).not.toHaveBeenCalled();
     });
 
+    it("rejects an sdl priced in a denom the grant cannot restate", async () => {
+      const { result } = await setup({ sdl: VALID_SDL.replace("denom: uakt", "denom: uatom"), deploymentGrantDenom: "uact" });
+
+      expect(result).toMatchObject({
+        ok: false,
+        value: [expect.objectContaining({ message: expect.stringContaining("should be one of: uakt, uact") })]
+      });
+    });
+
     it("rejects the sdl when the akt price needed to convert its ceiling is unavailable", async () => {
       const { result } = await setup({ sdl: VALID_SDL, deploymentGrantDenom: "uact", aktToUsdRate: 0 });
 

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -496,6 +496,15 @@ describe(SdlService.name, () => {
       });
     });
 
+    it("rejects the sdl when the akt price lookup fails instead of throwing", async () => {
+      const { result } = await setup({ sdl: VALID_SDL, deploymentGrantDenom: "uact", aktToUsdRateError: new Error("oracle and day table are both down") });
+
+      expect(result).toMatchObject({
+        ok: false,
+        value: [expect.objectContaining({ keyword: "pricing", message: expect.stringContaining("the AKT price is unavailable") })]
+      });
+    });
+
     it("does not append auditors when allowedAuditors is empty", async () => {
       const { result } = await setup({ sdl: VALID_SDL, allowedAuditors: [] });
 
@@ -808,6 +817,7 @@ describe(SdlService.name, () => {
     trialMaxCpu?: number;
     trialMaxMemoryGi?: number;
     aktToUsdRate?: number;
+    aktToUsdRateError?: Error;
   }) {
     const config = mock<BillingConfig>({
       DEPLOYMENT_GRANT_DENOM: input?.deploymentGrantDenom ?? "uakt",
@@ -821,9 +831,11 @@ describe(SdlService.name, () => {
     });
     const blockedGpuService = new BlockedGpuService(blockedGpuConfig);
     const denomExchangeService = mock<DenomExchangeService>({
-      getExchangeRateToUSD: vi.fn().mockResolvedValue({ price: input?.aktToUsdRate ?? 1 })
+      getExchangeRateToUSD: input?.aktToUsdRateError
+        ? vi.fn().mockRejectedValue(input.aktToUsdRateError)
+        : vi.fn().mockResolvedValue({ price: input?.aktToUsdRate ?? 1 })
     });
-    const createLogger = (() => mock<ReturnType<CreateLogger>>()) as unknown as CreateLogger;
+    const createLogger: CreateLogger = () => mock<ReturnType<CreateLogger>>();
     const service = new SdlService(config, blockedGpuService, new SdlReferenceService(), denomExchangeService, createLogger);
     const result = await service.generateManifest(input?.sdl ?? VALID_SDL, { isTrialing: input?.isTrialing });
 

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -45,6 +45,59 @@ deployment:
       count: 1
 `;
 
+const SDL_WITH_ALIASED_PRICE = `
+version: "2.0"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+  api:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+    api:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      pricing:
+        web: &price
+          denom: uakt
+          amount: 1000
+        api: *price
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+  api:
+    westcoast:
+      profile: api
+      count: 1
+`;
+
 const SDL_WITH_RESOURCES = (cpuUnits: number, memorySize: string) => `
 version: "2.0"
 services:
@@ -465,6 +518,13 @@ describe(SdlService.name, () => {
 
     it("converts the price ceiling at the akt price when deploymentGrantDenom differs from uakt", async () => {
       const { result } = await setup({ sdl: VALID_SDL, deploymentGrantDenom: "uact", aktToUsdRate: 0.325 });
+
+      expect(result.ok).toBe(true);
+      expect(getPrice(result, "westcoast")).toMatchObject({ denom: "uact", amount: "325" });
+    });
+
+    it("converts a price shared through a yaml alias exactly once", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_ALIASED_PRICE, deploymentGrantDenom: "uact", aktToUsdRate: 0.325 });
 
       expect(result.ok).toBe(true);
       expect(getPrice(result, "westcoast")).toMatchObject({ denom: "uact", amount: "325" });

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -1,9 +1,11 @@
 import { faker } from "@faker-js/faker";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfig } from "@src/billing/providers";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { DenomExchangeService } from "@src/chain/services/denom-exchange/denom-exchange.service";
+import type { CreateLogger } from "@src/core";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlService } from "./sdl.service";
@@ -407,33 +409,33 @@ deployment:
 
 describe(SdlService.name, () => {
   describe("generateManifest", () => {
-    it("parses SDL containing template variables without throwing", () => {
-      const { result } = setup({ sdl: SDL_WITH_VARS });
+    it("parses SDL containing template variables without throwing", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_VARS });
 
       expect(result.ok).toBe(true);
     });
 
-    it("adds auditor to signedBy anyOf when not present", () => {
+    it("adds auditor to signedBy anyOf when not present", async () => {
       const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
-      const { result } = setup({ sdl: VALID_SDL, allowedAuditors: [auditor] });
+      const { result } = await setup({ sdl: VALID_SDL, allowedAuditors: [auditor] });
 
       expect(result.ok).toBe(true);
       expect(getSignedBy(result, "westcoast").anyOf).toContain(auditor);
     });
 
-    it("does not duplicate auditor if already present in anyOf", () => {
+    it("does not duplicate auditor if already present in anyOf", async () => {
       const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
-      const { result } = setup({ sdl: SDL_WITH_AUDITOR(auditor), allowedAuditors: [auditor] });
+      const { result } = await setup({ sdl: SDL_WITH_AUDITOR(auditor), allowedAuditors: [auditor] });
 
       expect(result.ok).toBe(true);
       const anyOfCount = getSignedBy(result, "westcoast").anyOf.filter((a: string) => a === auditor).length;
       expect(anyOfCount).toBe(1);
     });
 
-    it("adds multiple auditors to signedBy anyOf", () => {
+    it("adds multiple auditors to signedBy anyOf", async () => {
       const auditor1 = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
       const auditor2 = "akash1another7awdyj3n2sav7xfx76adc6dnmlx64";
-      const { result } = setup({ sdl: VALID_SDL, allowedAuditors: [auditor1, auditor2] });
+      const { result } = await setup({ sdl: VALID_SDL, allowedAuditors: [auditor1, auditor2] });
 
       expect(result.ok).toBe(true);
       const anyOf = getSignedBy(result, "westcoast").anyOf;
@@ -441,10 +443,10 @@ describe(SdlService.name, () => {
       expect(anyOf).toContain(auditor2);
     });
 
-    it("preserves existing signedBy allOf when adding anyOf", () => {
+    it("preserves existing signedBy allOf when adding anyOf", async () => {
       const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
       const existingAllOf = "akash1existingauditor";
-      const { result } = setup({ sdl: SDL_WITH_ALLOF(existingAllOf), allowedAuditors: [auditor] });
+      const { result } = await setup({ sdl: SDL_WITH_ALLOF(existingAllOf), allowedAuditors: [auditor] });
 
       expect(result.ok).toBe(true);
       const signedBy = getSignedBy(result, "westcoast");
@@ -452,44 +454,54 @@ describe(SdlService.name, () => {
       expect(signedBy.allOf).toContain(existingAllOf);
     });
 
-    it("applies auditor requirement to all placement profiles", () => {
+    it("applies auditor requirement to all placement profiles", async () => {
       const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
-      const { result } = setup({ sdl: MULTI_PLACEMENT_SDL, allowedAuditors: [auditor] });
+      const { result } = await setup({ sdl: MULTI_PLACEMENT_SDL, allowedAuditors: [auditor] });
 
       expect(result.ok).toBe(true);
       expect(getSignedBy(result, "westcoast").anyOf).toContain(auditor);
       expect(getSignedBy(result, "eastcoast").anyOf).toContain(auditor);
     });
 
-    it("replaces denom in pricing when deploymentGrantDenom differs from uakt", () => {
-      const { result } = setup({ sdl: VALID_SDL, deploymentGrantDenom: "uact" });
+    it("converts the price ceiling at the akt price when deploymentGrantDenom differs from uakt", async () => {
+      const { result } = await setup({ sdl: VALID_SDL, deploymentGrantDenom: "uact", aktToUsdRate: 0.325 });
 
       expect(result.ok).toBe(true);
-      expect(getPrice(result, "westcoast").denom).toBe("uact");
+      expect(getPrice(result, "westcoast")).toMatchObject({ denom: "uact", amount: "325" });
     });
 
-    it("does not replace denom when deploymentGrantDenom is uakt", () => {
-      const { result } = setup({ sdl: VALID_SDL, deploymentGrantDenom: "uakt" });
+    it("does not replace denom or look up a rate when deploymentGrantDenom is uakt", async () => {
+      const { result, denomExchangeService } = await setup({ sdl: VALID_SDL, deploymentGrantDenom: "uakt" });
 
       expect(result.ok).toBe(true);
-      expect(getPrice(result, "westcoast").denom).toBe("uakt");
+      expect(getPrice(result, "westcoast")).toMatchObject({ denom: "uakt", amount: "1000" });
+      expect(denomExchangeService.getExchangeRateToUSD).not.toHaveBeenCalled();
     });
 
-    it("does not append auditors when allowedAuditors is empty", () => {
-      const { result } = setup({ sdl: VALID_SDL, allowedAuditors: [] });
+    it("rejects the sdl when the akt price needed to convert its ceiling is unavailable", async () => {
+      const { result } = await setup({ sdl: VALID_SDL, deploymentGrantDenom: "uact", aktToUsdRate: 0 });
+
+      expect(result).toMatchObject({
+        ok: false,
+        value: [expect.objectContaining({ keyword: "pricing", message: expect.stringContaining("the AKT price is unavailable") })]
+      });
+    });
+
+    it("does not append auditors when allowedAuditors is empty", async () => {
+      const { result } = await setup({ sdl: VALID_SDL, allowedAuditors: [] });
 
       expect(result.ok).toBe(true);
       expect(getSignedBy(result, "westcoast").anyOf).toEqual([]);
     });
 
-    it("returns error result for invalid SDL", () => {
-      const { result } = setup({ sdl: "invalid" });
+    it("returns error result for invalid SDL", async () => {
+      const { result } = await setup({ sdl: "invalid" });
 
       expect(result.ok).toBeFalsy();
     });
 
-    it("returns error result with message for malformed YAML", () => {
-      const { result } = setup({ sdl: "key: value\n  bad_indent: true" });
+    it("returns error result with message for malformed YAML", async () => {
+      const { result } = await setup({ sdl: "key: value\n  bad_indent: true" });
 
       expect(result).toMatchObject({
         ok: false,
@@ -497,8 +509,8 @@ describe(SdlService.name, () => {
       });
     });
 
-    it("rejects SDL that requests a blocked GPU model for trialing wallets", () => {
-      const { result } = setup({ sdl: SDL_WITH_GPU("nvidia", "h100"), blockedGpuModels: ["nvidia/h100"], isTrialing: true });
+    it("rejects SDL that requests a blocked GPU model for trialing wallets", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_GPU("nvidia", "h100"), blockedGpuModels: ["nvidia/h100"], isTrialing: true });
 
       expect(result).toMatchObject({
         ok: false,
@@ -506,26 +518,26 @@ describe(SdlService.name, () => {
       });
     });
 
-    it("does not enforce blocked GPU models for non-trialing wallets", () => {
-      const { result } = setup({ sdl: SDL_WITH_GPU("nvidia", "h100"), blockedGpuModels: ["nvidia/h100"], isTrialing: false });
+    it("does not enforce blocked GPU models for non-trialing wallets", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_GPU("nvidia", "h100"), blockedGpuModels: ["nvidia/h100"], isTrialing: false });
 
       expect(result.ok).toBe(true);
     });
 
-    it("allows SDL that requests a non-blocked GPU model", () => {
-      const { result } = setup({ sdl: SDL_WITH_GPU("nvidia", "rtx-4090"), blockedGpuModels: ["nvidia/h100"], isTrialing: true });
+    it("allows SDL that requests a non-blocked GPU model", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_GPU("nvidia", "rtx-4090"), blockedGpuModels: ["nvidia/h100"], isTrialing: true });
 
       expect(result.ok).toBe(true);
     });
 
-    it("does not enforce GPU block when the configured set is empty", () => {
-      const { result } = setup({ sdl: SDL_WITH_GPU("nvidia", "h100"), blockedGpuModels: [], isTrialing: true });
+    it("does not enforce GPU block when the configured set is empty", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_GPU("nvidia", "h100"), blockedGpuModels: [], isTrialing: true });
 
       expect(result.ok).toBe(true);
     });
 
-    it("rejects SDL that requests an implicit GPU interconnect for trialing wallets", () => {
-      const { result } = setup({ sdl: SDL_WITH_GPU_INTERCONNECT("[]"), blockedGpuModels: ["nvidia/h100"], isTrialing: true });
+    it("rejects SDL that requests an implicit GPU interconnect for trialing wallets", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_GPU_INTERCONNECT("[]"), blockedGpuModels: ["nvidia/h100"], isTrialing: true });
 
       expect(result).toMatchObject({
         ok: false,
@@ -533,8 +545,8 @@ describe(SdlService.name, () => {
       });
     });
 
-    it("rejects SDL that requests an explicit GPU interconnect group for trialing wallets", () => {
-      const { result } = setup({ sdl: SDL_WITH_GPU_INTERCONNECT("{ group: pair0 }"), blockedGpuModels: ["nvidia/h100"], isTrialing: true });
+    it("rejects SDL that requests an explicit GPU interconnect group for trialing wallets", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_GPU_INTERCONNECT("{ group: pair0 }"), blockedGpuModels: ["nvidia/h100"], isTrialing: true });
 
       expect(result).toMatchObject({
         ok: false,
@@ -542,20 +554,20 @@ describe(SdlService.name, () => {
       });
     });
 
-    it("does not enforce the interconnect block for non-trialing wallets", () => {
-      const { result } = setup({ sdl: SDL_WITH_GPU_INTERCONNECT("[]"), blockedGpuModels: ["nvidia/h100"], isTrialing: false });
+    it("does not enforce the interconnect block for non-trialing wallets", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_GPU_INTERCONNECT("[]"), blockedGpuModels: ["nvidia/h100"], isTrialing: false });
 
       expect(result.ok).toBe(true);
     });
 
-    it("allows a trialing interconnect SDL when the GPU trial restriction is inactive", () => {
-      const { result } = setup({ sdl: SDL_WITH_GPU_INTERCONNECT("[]"), blockedGpuModels: [], isTrialing: true });
+    it("allows a trialing interconnect SDL when the GPU trial restriction is inactive", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_GPU_INTERCONNECT("[]"), blockedGpuModels: [], isTrialing: true });
 
       expect(result.ok).toBe(true);
     });
 
-    it("rejects trial SDL that exceeds the CPU cap", () => {
-      const { result } = setup({ sdl: SDL_WITH_RESOURCES(16, "24Gi"), isTrialing: true, trialMaxCpu: 4, trialMaxMemoryGi: 32 });
+    it("rejects trial SDL that exceeds the CPU cap", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_RESOURCES(16, "24Gi"), isTrialing: true, trialMaxCpu: 4, trialMaxMemoryGi: 32 });
 
       expect(result).toMatchObject({
         ok: false,
@@ -563,8 +575,8 @@ describe(SdlService.name, () => {
       });
     });
 
-    it("rejects trial SDL that exceeds the memory cap", () => {
-      const { result } = setup({ sdl: SDL_WITH_RESOURCES(2, "24Gi"), isTrialing: true, trialMaxCpu: 4, trialMaxMemoryGi: 16 });
+    it("rejects trial SDL that exceeds the memory cap", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_RESOURCES(2, "24Gi"), isTrialing: true, trialMaxCpu: 4, trialMaxMemoryGi: 16 });
 
       expect(result).toMatchObject({
         ok: false,
@@ -572,41 +584,41 @@ describe(SdlService.name, () => {
       });
     });
 
-    it("allows trial SDL within the resource caps", () => {
-      const { result } = setup({ sdl: SDL_WITH_RESOURCES(4, "16Gi"), isTrialing: true, trialMaxCpu: 4, trialMaxMemoryGi: 16 });
+    it("allows trial SDL within the resource caps", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_RESOURCES(4, "16Gi"), isTrialing: true, trialMaxCpu: 4, trialMaxMemoryGi: 16 });
 
       expect(result.ok).toBe(true);
     });
 
-    it("does not enforce resource caps for non-trialing wallets", () => {
-      const { result } = setup({ sdl: SDL_WITH_RESOURCES(16, "24Gi"), isTrialing: false, trialMaxCpu: 4, trialMaxMemoryGi: 16 });
+    it("does not enforce resource caps for non-trialing wallets", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_RESOURCES(16, "24Gi"), isTrialing: false, trialMaxCpu: 4, trialMaxMemoryGi: 16 });
 
       expect(result.ok).toBe(true);
     });
 
-    it("does not enforce resource caps when they are configured to zero", () => {
-      const { result } = setup({ sdl: SDL_WITH_RESOURCES(16, "24Gi"), isTrialing: true, trialMaxCpu: 0, trialMaxMemoryGi: 0 });
+    it("does not enforce resource caps when they are configured to zero", async () => {
+      const { result } = await setup({ sdl: SDL_WITH_RESOURCES(16, "24Gi"), isTrialing: true, trialMaxCpu: 0, trialMaxMemoryGi: 0 });
 
       expect(result.ok).toBe(true);
     });
 
     describe("confidential compute (tee)", () => {
-      it("projects a cpu tee selection into the manifest sent to the provider", () => {
-        const { result } = setup({ sdl: SDL_WITH_TEE("cpu") });
+      it("projects a cpu tee selection into the manifest sent to the provider", async () => {
+        const { result } = await setup({ sdl: SDL_WITH_TEE("cpu") });
 
         expect(result.ok).toBe(true);
         expect(getManifestService(result, "westcoast", "web").params?.tee).toEqual({ type: "cpu", attestation: true });
       });
 
-      it("projects a cpu-gpu tee selection into the manifest when gpu resources are present", () => {
-        const { result } = setup({ sdl: SDL_WITH_TEE_AND_GPU("cpu-gpu") });
+      it("projects a cpu-gpu tee selection into the manifest when gpu resources are present", async () => {
+        const { result } = await setup({ sdl: SDL_WITH_TEE_AND_GPU("cpu-gpu") });
 
         expect(result.ok).toBe(true);
         expect(getManifestService(result, "westcoast", "web").params?.tee).toEqual({ type: "cpu-gpu", attestation: true });
       });
 
-      it("rejects a cpu-gpu tee selection without gpu resources", () => {
-        const { result } = setup({ sdl: SDL_WITH_TEE("cpu-gpu") });
+      it("rejects a cpu-gpu tee selection without gpu resources", async () => {
+        const { result } = await setup({ sdl: SDL_WITH_TEE("cpu-gpu") });
 
         expect(result).toMatchObject({
           ok: false,
@@ -614,8 +626,8 @@ describe(SdlService.name, () => {
         });
       });
 
-      it("leaves manifest service params untouched when no tee is selected", () => {
-        const { result } = setup({ sdl: VALID_SDL });
+      it("leaves manifest service params untouched when no tee is selected", async () => {
+        const { result } = await setup({ sdl: VALID_SDL });
 
         expect(result.ok).toBe(true);
         expect(getManifestService(result, "westcoast", "web").params?.tee).toBeUndefined();
@@ -623,15 +635,15 @@ describe(SdlService.name, () => {
     });
 
     describe("sdl references", () => {
-      it("keeps a recognized sdl reference verbatim in the manifest", () => {
-        const { result } = setup({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN") });
+      it("keeps a recognized sdl reference verbatim in the manifest", async () => {
+        const { result } = await setup({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN") });
 
         expect(result.ok).toBe(true);
         expect(getManifestService(result, "westcoast", "web").env).toEqual(["TOKEN=ac-secret://TOKEN"]);
       });
 
-      it("rejects an unknown sdl reference kind naming the offending value", () => {
-        const { result } = setup({ sdl: SDL_WITH_ENV("TOKEN=ac-var://TOKEN") });
+      it("rejects an unknown sdl reference kind naming the offending value", async () => {
+        const { result } = await setup({ sdl: SDL_WITH_ENV("TOKEN=ac-var://TOKEN") });
 
         expect(result).toMatchObject({
           ok: false,
@@ -639,8 +651,8 @@ describe(SdlService.name, () => {
         });
       });
 
-      it("rejects a value merely beginning with the reserved prefix", () => {
-        const { result } = setup({ sdl: SDL_WITH_ENV("MODE=ac-dc") });
+      it("rejects a value merely beginning with the reserved prefix", async () => {
+        const { result } = await setup({ sdl: SDL_WITH_ENV("MODE=ac-dc") });
 
         expect(result).toMatchObject({
           ok: false,
@@ -648,14 +660,14 @@ describe(SdlService.name, () => {
         });
       });
 
-      it("accepts a value merely containing a reference", () => {
-        const { result } = setup({ sdl: SDL_WITH_ENV("MODE=see ac-secret://TOKEN") });
+      it("accepts a value merely containing a reference", async () => {
+        const { result } = await setup({ sdl: SDL_WITH_ENV("MODE=see ac-secret://TOKEN") });
 
         expect(result.ok).toBe(true);
       });
 
-      it("keeps a recognized registry credential reference verbatim in the manifest", () => {
-        const { result } = setup({ sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS") });
+      it("keeps a recognized registry credential reference verbatim in the manifest", async () => {
+        const { result } = await setup({ sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS") });
 
         expect(result.ok).toBe(true);
         expect(getManifestService(result, "westcoast", "web").credentials).toMatchObject({
@@ -664,8 +676,8 @@ describe(SdlService.name, () => {
         });
       });
 
-      it("rejects a registry credential merely beginning with the reserved prefix", () => {
-        const { result } = setup({ sdl: SDL_WITH_CREDENTIALS(faker.string.alphanumeric(10), "ac-dc-forever") });
+      it("rejects a registry credential merely beginning with the reserved prefix", async () => {
+        const { result } = await setup({ sdl: SDL_WITH_CREDENTIALS(faker.string.alphanumeric(10), "ac-dc-forever") });
 
         expect(result).toMatchObject({
           ok: false,
@@ -677,7 +689,7 @@ describe(SdlService.name, () => {
 
   describe("generateResolvedManifest", () => {
     it("returns a manifest carrying the resolved value", async () => {
-      const { service } = setup();
+      const { service } = await setup();
 
       const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
 
@@ -686,7 +698,7 @@ describe(SdlService.name, () => {
     });
 
     it("returns a manifest carrying the resolved registry credential", async () => {
-      const { service } = setup();
+      const { service } = await setup();
       const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
 
       const result = await service.generateResolvedManifest({
@@ -699,7 +711,7 @@ describe(SdlService.name, () => {
     });
 
     it("hashes an sdl with a substituted registry credential exactly as one carrying it inline", async () => {
-      const { service } = setup();
+      const { service } = await setup();
       const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
 
       const substituted = await service.generateResolvedManifest({
@@ -712,7 +724,7 @@ describe(SdlService.name, () => {
     });
 
     it("refuses a resolved registry credential the schema rejects, which the unresolved reference passed", async () => {
-      const { service } = setup();
+      const { service } = await setup();
 
       const result = await service.generateResolvedManifest({
         sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
@@ -724,7 +736,7 @@ describe(SdlService.name, () => {
     });
 
     it("hashes an sdl with a substituted value exactly as one carrying that value inline", async () => {
-      const { service } = setup();
+      const { service } = await setup();
 
       const substituted = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
       const inline = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=resolved"), secrets: {} });
@@ -733,7 +745,7 @@ describe(SdlService.name, () => {
     });
 
     it("hashes two different resolved values differently", async () => {
-      const { service } = setup();
+      const { service } = await setup();
       const sdl = SDL_WITH_ENV("TOKEN=ac-secret://TOKEN");
 
       const first = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "one" } } });
@@ -743,7 +755,7 @@ describe(SdlService.name, () => {
     });
 
     it("returns the same manifest version for the same input twice", async () => {
-      const { service } = setup();
+      const { service } = await setup();
       const sdl = SDL_WITH_ENV("TOKEN=ac-secret://TOKEN");
 
       const first = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "resolved" } } });
@@ -753,7 +765,7 @@ describe(SdlService.name, () => {
     });
 
     it("returns errors rather than throwing when a reference has no value", async () => {
-      const { service } = setup();
+      const { service } = await setup();
 
       const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: {} });
 
@@ -762,7 +774,7 @@ describe(SdlService.name, () => {
     });
 
     it("returns errors for an unrecognized kind", async () => {
-      const { service } = setup();
+      const { service } = await setup();
 
       const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-var://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
 
@@ -770,7 +782,7 @@ describe(SdlService.name, () => {
     });
 
     it("returns errors for an sdl that is not valid yaml", async () => {
-      const { service } = setup();
+      const { service } = await setup();
 
       const result = await service.generateResolvedManifest({ sdl: "services: [", secrets: {} });
 
@@ -778,7 +790,7 @@ describe(SdlService.name, () => {
     });
   });
 
-  function setup(input?: {
+  async function setup(input?: {
     sdl?: string;
     allowedAuditors?: string[];
     deploymentGrantDenom?: BillingConfig["DEPLOYMENT_GRANT_DENOM"];
@@ -786,6 +798,7 @@ describe(SdlService.name, () => {
     isTrialing?: boolean;
     trialMaxCpu?: number;
     trialMaxMemoryGi?: number;
+    aktToUsdRate?: number;
   }) {
     const config = mock<BillingConfig>({
       DEPLOYMENT_GRANT_DENOM: input?.deploymentGrantDenom ?? "uakt",
@@ -798,28 +811,32 @@ describe(SdlService.name, () => {
       MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: input?.blockedGpuModels ?? []
     });
     const blockedGpuService = new BlockedGpuService(blockedGpuConfig);
-    const service = new SdlService(config, blockedGpuService, new SdlReferenceService());
-    const result = service.generateManifest(input?.sdl ?? VALID_SDL, { isTrialing: input?.isTrialing });
+    const denomExchangeService = mock<DenomExchangeService>({
+      getExchangeRateToUSD: vi.fn().mockResolvedValue({ price: input?.aktToUsdRate ?? 1 })
+    });
+    const createLogger = (() => mock<ReturnType<CreateLogger>>()) as unknown as CreateLogger;
+    const service = new SdlService(config, blockedGpuService, new SdlReferenceService(), denomExchangeService, createLogger);
+    const result = await service.generateManifest(input?.sdl ?? VALID_SDL, { isTrialing: input?.isTrialing });
 
-    return { service, result };
+    return { service, result, denomExchangeService };
   }
 
-  function getGroupSpec(result: ReturnType<SdlService["generateManifest"]>, placementName: string) {
+  function getGroupSpec(result: Awaited<ReturnType<SdlService["generateManifest"]>>, placementName: string) {
     if (!result.ok) throw new Error("Expected ok result");
     const groupSpec = result.value.groupSpecs.find(gs => gs.name === placementName);
     if (!groupSpec) throw new Error(`Placement "${placementName}" not found`);
     return groupSpec;
   }
 
-  function getSignedBy(result: ReturnType<SdlService["generateManifest"]>, placementName: string) {
+  function getSignedBy(result: Awaited<ReturnType<SdlService["generateManifest"]>>, placementName: string) {
     return getGroupSpec(result, placementName).requirements!.signedBy!;
   }
 
-  function getPrice(result: ReturnType<SdlService["generateManifest"]>, placementName: string) {
+  function getPrice(result: Awaited<ReturnType<SdlService["generateManifest"]>>, placementName: string) {
     return getGroupSpec(result, placementName).resources[0].price!;
   }
 
-  function getManifestService(result: ReturnType<SdlService["generateManifest"]>, groupName: string, serviceName: string) {
+  function getManifestService(result: Awaited<ReturnType<SdlService["generateManifest"]>>, groupName: string, serviceName: string) {
     if (!result.ok) throw new Error("Expected ok result");
     const group = result.value.groups.find(g => g.name === groupName);
     if (!group) throw new Error(`Manifest group "${groupName}" not found`);

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -1,14 +1,17 @@
 import type { GenerateManifestResult, Manifest, SDLInput, ValidationError } from "@akashnetwork/chain-sdk";
 import { generateManifest, generateManifestVersion, yaml } from "@akashnetwork/chain-sdk";
 import { YAMLException } from "js-yaml";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { DenomExchangeService } from "@src/chain/services/denom-exchange/denom-exchange.service";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import type { NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { sdlRequestsGpuInterconnect } from "@src/deployment/utils/gpu-interconnect/gpu-interconnect";
 import { findTrialResourceViolation } from "@src/deployment/utils/group-resources/group-resources";
+import { restatePricesInGrantDenom } from "@src/deployment/utils/price-denom/price-denom";
 
 export type SdlParseResult = { ok: true; value: SDLInput } | { ok: false; value: ValidationError[] };
 export type SdlManifest = Extract<GenerateManifestResult, { ok: true }>["value"];
@@ -23,17 +26,21 @@ export type GenerateResolvedManifestResult = { ok: true; value: ResolvedSdl } | 
 @singleton()
 export class SdlService {
   readonly #config: BillingConfig;
+  readonly #logger: ReturnType<CreateLogger>;
 
   constructor(
     @InjectBillingConfig() config: BillingConfig,
     private readonly blockedGpuService: BlockedGpuService,
-    private readonly sdlReferenceService: SdlReferenceService
+    private readonly sdlReferenceService: SdlReferenceService,
+    private readonly denomExchangeService: DenomExchangeService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.#config = config;
+    this.#logger = createLogger({ context: SdlService.name });
   }
 
   /** SDL References are validated here and never substituted, so no caller of this can hand a resolved value back to a client. */
-  generateManifest(rawSDL: string, options: { isTrialing?: boolean } = {}): GenerateManifestResult {
+  async generateManifest(rawSDL: string, options: { isTrialing?: boolean } = {}): Promise<GenerateManifestResult> {
     const parsed = this.parse(rawSDL);
 
     if (!parsed.ok) return parsed;
@@ -55,7 +62,7 @@ export class SdlService {
 
     if (referenceErrors.length > 0) return { ok: false, value: referenceErrors };
 
-    const manifest = this.generateManifestFrom(parsed.value, { isTrialing: input.isTrialing });
+    const manifest = await this.generateManifestFrom(parsed.value, { isTrialing: input.isTrialing });
 
     if (!manifest.ok) return { ok: false, value: manifest.value };
 
@@ -74,20 +81,34 @@ export class SdlService {
   }
 
   /** The one entry point that skips SDL Reference validation, because both its callers have already validated or substituted every reference. */
-  generateManifestFrom(potentiallyInvalidSDL: SDLInput, options: { isTrialing?: boolean } = {}): GenerateManifestResult {
+  async generateManifestFrom(potentiallyInvalidSDL: SDLInput, options: { isTrialing?: boolean } = {}): Promise<GenerateManifestResult> {
     const deploymentGrantDenom = this.#config.DEPLOYMENT_GRANT_DENOM;
     const sdlPlacement =
       potentiallyInvalidSDL?.profiles?.placement && typeof potentiallyInvalidSDL?.profiles?.placement === "object"
         ? potentiallyInvalidSDL.profiles.placement
         : {};
 
-    Object.values(sdlPlacement).forEach(profile => {
-      if (typeof profile !== "object" || !profile || !profile.pricing || typeof profile.pricing !== "object") return;
-      Object.values(profile.pricing).forEach(price => {
-        if (typeof price !== "object" || !price || price.denom === deploymentGrantDenom) return;
-        price.denom = deploymentGrantDenom;
-      });
+    const restatement = await restatePricesInGrantDenom(sdlPlacement, {
+      grantDenom: deploymentGrantDenom,
+      loadAktToUsdRate: () => this.#loadAktToUsdRate()
     });
+
+    if (!restatement.ok) {
+      this.#logger.warn({ event: "SDL_PRICE_RESTATEMENT_FAILED", deploymentGrantDenom, aktToUsdRate: restatement.aktToUsdRate });
+
+      return {
+        ok: false,
+        value: [
+          {
+            schemaPath: "",
+            instancePath: "/profiles/placement",
+            keyword: "pricing",
+            params: {},
+            message: `Unable to convert SDL pricing to ${deploymentGrantDenom}: the AKT price is unavailable. Price your SDL in ${deploymentGrantDenom} and try again`
+          }
+        ]
+      };
+    }
 
     const allowedAuditors = this.#config.MANAGED_WALLET_LEASE_ALLOWED_AUDITORS;
     if (allowedAuditors && allowedAuditors.length > 0) {
@@ -157,6 +178,12 @@ export class SdlService {
 
   async generateManifestVersion(manifest: Manifest): Promise<Uint8Array> {
     return generateManifestVersion(manifest);
+  }
+
+  async #loadAktToUsdRate(): Promise<number> {
+    const { price } = await this.denomExchangeService.getExchangeRateToUSD("akt");
+
+    return price;
   }
 
   #appendAuditorRequirement(placement: SDLInput["profiles"]["placement"], allowedAuditors: string[]): void {

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -23,6 +23,9 @@ export interface ResolvedSdl {
 
 export type GenerateResolvedManifestResult = { ok: true; value: ResolvedSdl } | { ok: false; value: ValidationError[] };
 
+/** DenomExchangeService already reports a missing rate as 0, so a lookup that throws is rejected by the same guard rather than escaping as a 500. */
+const UNAVAILABLE_AKT_TO_USD_RATE = 0;
+
 @singleton()
 export class SdlService {
   readonly #config: BillingConfig;
@@ -181,9 +184,15 @@ export class SdlService {
   }
 
   async #loadAktToUsdRate(): Promise<number> {
-    const { price } = await this.denomExchangeService.getExchangeRateToUSD("akt");
+    try {
+      const { price } = await this.denomExchangeService.getExchangeRateToUSD("akt");
 
-    return price;
+      return price;
+    } catch (error) {
+      this.#logger.warn({ event: "AKT_EXCHANGE_RATE_LOOKUP_FAILED", error });
+
+      return UNAVAILABLE_AKT_TO_USD_RATE;
+    }
   }
 
   #appendAuditorRequirement(placement: SDLInput["profiles"]["placement"], allowedAuditors: string[]): void {

--- a/apps/api/src/deployment/utils/price-denom/price-denom.spec.ts
+++ b/apps/api/src/deployment/utils/price-denom/price-denom.spec.ts
@@ -40,38 +40,39 @@ describe("restatePricesInGrantDenom", () => {
     expect(loadAktToUsdRate).toHaveBeenCalledTimes(1);
   });
 
-  it("restates a dollar ceiling into uakt without a rate, since only real networks grant in dollars", async () => {
+  it("leaves every price alone when the grant already pays in uakt", async () => {
     const placement = placementWith({ web: { denom: "uact", amount: 50 } });
     const loadAktToUsdRate = vi.fn();
 
-    await restatePricesInGrantDenom(placement, { grantDenom: "uakt", loadAktToUsdRate });
+    const result = await restatePricesInGrantDenom(placement, { grantDenom: "uakt", loadAktToUsdRate });
 
-    expect(placement.westcoast.pricing.web).toEqual({ denom: "uakt", amount: 50 });
+    expect(result).toEqual({ ok: true });
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uact", amount: 50 });
     expect(loadAktToUsdRate).not.toHaveBeenCalled();
   });
 
-  it("restates a denom already pegged to the dollar without a rate or an amount change", async () => {
+  it("leaves a usdc price for sdl validation to reject", async () => {
     const placement = placementWith({ web: { denom: "uusdc", amount: 26 } });
     const loadAktToUsdRate = vi.fn();
 
     const result = await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate });
 
     expect(result).toEqual({ ok: true });
-    expect(placement.westcoast.pricing.web).toEqual({ denom: "uact", amount: 26 });
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uusdc", amount: 26 });
     expect(loadAktToUsdRate).not.toHaveBeenCalled();
   });
 
-  it("restates the legacy ibc usdc denom without a rate", async () => {
+  it("leaves the legacy ibc usdc denom for sdl validation to reject", async () => {
     const placement = placementWith({ web: { denom: "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1", amount: 26 } });
     const loadAktToUsdRate = vi.fn();
 
     await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate });
 
-    expect(placement.westcoast.pricing.web).toEqual({ denom: "uact", amount: 26 });
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1", amount: 26 });
     expect(loadAktToUsdRate).not.toHaveBeenCalled();
   });
 
-  it("leaves a denom pegged to neither akt nor the dollar for sdl validation to reject", async () => {
+  it("leaves a denom the grant cannot restate for sdl validation to reject", async () => {
     const placement = placementWith({ web: { denom: "uatom", amount: 100 } });
     const loadAktToUsdRate = vi.fn();
 

--- a/apps/api/src/deployment/utils/price-denom/price-denom.spec.ts
+++ b/apps/api/src/deployment/utils/price-denom/price-denom.spec.ts
@@ -1,0 +1,116 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { describe, expect, it, vi } from "vitest";
+
+import { restatePricesInGrantDenom } from "./price-denom";
+
+describe("restatePricesInGrantDenom", () => {
+  it("converts a uakt ceiling into the grant denom at the akt price", async () => {
+    const placement = placementWith({ web: { denom: "uakt", amount: 55 } });
+
+    const result = await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate: async () => 0.325 });
+
+    expect(result).toEqual({ ok: true });
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uact", amount: 18 });
+  });
+
+  it("rounds a converted ceiling up so it never lands under the price the user asked for", async () => {
+    const placement = placementWith({ web: { denom: "uakt", amount: 3 } });
+
+    await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate: async () => 1.1 });
+
+    expect(placement.westcoast.pricing.web.amount).toBe(4);
+  });
+
+  it("converts a ceiling stated as a string", async () => {
+    const placement = placementWith({ web: { denom: "uakt", amount: "1000" } });
+
+    await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate: async () => 0.5 });
+
+    expect(placement.westcoast.pricing.web.amount).toBe(500);
+  });
+
+  it("converts every uakt ceiling from a single rate lookup", async () => {
+    const placement = placementWith({ web: { denom: "uakt", amount: 100 }, api: { denom: "uakt", amount: 200 } });
+    const loadAktToUsdRate = vi.fn().mockResolvedValue(0.5);
+
+    await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate });
+
+    expect(placement.westcoast.pricing.web.amount).toBe(50);
+    expect(placement.westcoast.pricing.api.amount).toBe(100);
+    expect(loadAktToUsdRate).toHaveBeenCalledTimes(1);
+  });
+
+  it("restates a dollar ceiling into uakt without a rate, since only real networks grant in dollars", async () => {
+    const placement = placementWith({ web: { denom: "uact", amount: 50 } });
+    const loadAktToUsdRate = vi.fn();
+
+    await restatePricesInGrantDenom(placement, { grantDenom: "uakt", loadAktToUsdRate });
+
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uakt", amount: 50 });
+    expect(loadAktToUsdRate).not.toHaveBeenCalled();
+  });
+
+  it("restates a denom already pegged to the dollar without a rate or an amount change", async () => {
+    const placement = placementWith({ web: { denom: "uusdc", amount: 26 } });
+    const loadAktToUsdRate = vi.fn();
+
+    const result = await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate });
+
+    expect(result).toEqual({ ok: true });
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uact", amount: 26 });
+    expect(loadAktToUsdRate).not.toHaveBeenCalled();
+  });
+
+  it("leaves a price already in the grant denom alone", async () => {
+    const placement = placementWith({ web: { denom: "uact", amount: 100000 } });
+    const loadAktToUsdRate = vi.fn();
+
+    await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate });
+
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uact", amount: 100000 });
+    expect(loadAktToUsdRate).not.toHaveBeenCalled();
+  });
+
+  it("reports the unusable rate and leaves the price untouched when the akt price is unavailable", async () => {
+    const placement = placementWith({ web: { denom: "uakt", amount: 55 } });
+
+    const result = await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate: async () => 0 });
+
+    expect(result).toEqual({ ok: false, aktToUsdRate: 0 });
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uakt", amount: 55 });
+  });
+
+  it("reports failure when the akt price is not a finite number", async () => {
+    const placement = placementWith({ web: { denom: "uakt", amount: 55 } });
+
+    const result = await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate: async () => NaN });
+
+    expect(result).toMatchObject({ ok: false });
+  });
+
+  it("leaves an amount that is not a number to downstream validation", async () => {
+    const placement = placementWith({ web: { denom: "uakt", amount: "not-a-number" } });
+
+    await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate: async () => 0.5 });
+
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uact", amount: "not-a-number" });
+  });
+
+  it("tolerates a placement without pricing", async () => {
+    const placement = { westcoast: {} } as unknown as SDLInput["profiles"]["placement"];
+
+    const result = await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate: async () => 0.5 });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("tolerates a missing placement", async () => {
+    const result = await restatePricesInGrantDenom(undefined, { grantDenom: "uact", loadAktToUsdRate: async () => 0.5 });
+
+    expect(result).toEqual({ ok: true });
+  });
+
+  function placementWith(pricing: Record<string, { denom: string; amount: string | number }>) {
+    return { westcoast: { pricing } } as unknown as SDLInput["profiles"]["placement"];
+  }
+});

--- a/apps/api/src/deployment/utils/price-denom/price-denom.spec.ts
+++ b/apps/api/src/deployment/utils/price-denom/price-denom.spec.ts
@@ -61,6 +61,36 @@ describe("restatePricesInGrantDenom", () => {
     expect(loadAktToUsdRate).not.toHaveBeenCalled();
   });
 
+  it("restates the legacy ibc usdc denom without a rate", async () => {
+    const placement = placementWith({ web: { denom: "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1", amount: 26 } });
+    const loadAktToUsdRate = vi.fn();
+
+    await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate });
+
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uact", amount: 26 });
+    expect(loadAktToUsdRate).not.toHaveBeenCalled();
+  });
+
+  it("leaves a denom pegged to neither akt nor the dollar for sdl validation to reject", async () => {
+    const placement = placementWith({ web: { denom: "uatom", amount: 100 } });
+    const loadAktToUsdRate = vi.fn();
+
+    const result = await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate });
+
+    expect(result).toEqual({ ok: true });
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uatom", amount: 100 });
+    expect(loadAktToUsdRate).not.toHaveBeenCalled();
+  });
+
+  it("converts a uakt ceiling even when another service prices in a denom it cannot restate", async () => {
+    const placement = placementWith({ web: { denom: "uakt", amount: 100 }, api: { denom: "uatom", amount: 100 } });
+
+    await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate: async () => 0.5 });
+
+    expect(placement.westcoast.pricing.web).toEqual({ denom: "uact", amount: 50 });
+    expect(placement.westcoast.pricing.api).toEqual({ denom: "uatom", amount: 100 });
+  });
+
   it("leaves a price already in the grant denom alone", async () => {
     const placement = placementWith({ web: { denom: "uact", amount: 100000 } });
     const loadAktToUsdRate = vi.fn();

--- a/apps/api/src/deployment/utils/price-denom/price-denom.spec.ts
+++ b/apps/api/src/deployment/utils/price-denom/price-denom.spec.ts
@@ -29,6 +29,15 @@ describe("restatePricesInGrantDenom", () => {
     expect(placement.westcoast.pricing.web.amount).toBe(500);
   });
 
+  it("converts a price node shared by two services exactly once", async () => {
+    const shared = { denom: "uakt", amount: 55 };
+    const placement = { westcoast: { pricing: { web: shared, api: shared } } } as unknown as SDLInput["profiles"]["placement"];
+
+    await restatePricesInGrantDenom(placement, { grantDenom: "uact", loadAktToUsdRate: async () => 0.325 });
+
+    expect(shared).toEqual({ denom: "uact", amount: 18 });
+  });
+
   it("converts every uakt ceiling from a single rate lookup", async () => {
     const placement = placementWith({ web: { denom: "uakt", amount: 100 }, api: { denom: "uakt", amount: 200 } });
     const loadAktToUsdRate = vi.fn().mockResolvedValue(0.5);

--- a/apps/api/src/deployment/utils/price-denom/price-denom.ts
+++ b/apps/api/src/deployment/utils/price-denom/price-denom.ts
@@ -1,7 +1,5 @@
 import type { SDLInput } from "@akashnetwork/chain-sdk";
 
-import { USDC_IBC_DENOMS } from "@src/billing/config/network.config";
-
 type SdlPlacement = SDLInput["profiles"]["placement"];
 type PriceCoin = SdlPlacement[string]["pricing"][string];
 
@@ -9,54 +7,37 @@ export type GrantDenom = PriceCoin["denom"];
 export type PriceRestatement = { ok: true } | { ok: false; aktToUsdRate: number };
 
 const AKT_DENOM = "uakt";
-const DOLLAR_PEGGED_DENOMS: readonly string[] = ["uact", "uusdc", USDC_IBC_DENOMS.mainnetId, USDC_IBC_DENOMS.sandboxId];
 
 /** Managed deployments pay out of a grant in a single denom, so a uakt ceiling is restated in it through the AKT price rather than swapped over. */
 export async function restatePricesInGrantDenom(
   placement: SdlPlacement | undefined,
   options: { grantDenom: GrantDenom; loadAktToUsdRate: () => Promise<number> }
 ): Promise<PriceRestatement> {
-  const prices = findPrices(placement).filter(price => price.denom !== options.grantDenom && isRestatable(price));
+  if (options.grantDenom === AKT_DENOM) return { ok: true };
 
-  if (prices.length === 0) return { ok: true };
+  const aktPrices = findPrices(placement).filter(price => price.denom === AKT_DENOM);
 
-  if (!prices.some(isAktPriced)) {
-    restate(prices, { grantDenom: options.grantDenom });
-    return { ok: true };
-  }
+  if (aktPrices.length === 0) return { ok: true };
 
   const aktToUsdRate = await options.loadAktToUsdRate();
 
   if (!Number.isFinite(aktToUsdRate) || aktToUsdRate <= 0) return { ok: false, aktToUsdRate };
 
-  restate(prices, { grantDenom: options.grantDenom, aktToUsdRate });
+  for (const price of aktPrices) {
+    price.amount = convertedAmount(price.amount, aktToUsdRate);
+    price.denom = options.grantDenom;
+  }
 
   return { ok: true };
 }
 
-function restate(prices: PriceCoin[], options: { grantDenom: GrantDenom; aktToUsdRate?: number }): void {
-  for (const price of prices) {
-    if (options.aktToUsdRate !== undefined) price.amount = convertedAmount(price, options.aktToUsdRate);
-    price.denom = options.grantDenom;
-  }
-}
-
-function isAktPriced(price: PriceCoin): boolean {
-  return price.denom === AKT_DENOM;
-}
-
-/** A denom worth neither a fraction of AKT nor a fraction of a dollar is left for SDL validation to reject, rather than restated into a ceiling it cannot mean. */
-function isRestatable(price: PriceCoin): boolean {
-  return isAktPriced(price) || DOLLAR_PEGGED_DENOMS.includes(price.denom);
-}
-
 /** Rounds up so a converted ceiling never lands under the one the user stated. */
-function convertedAmount(price: PriceCoin, aktToUsdRate: number): PriceCoin["amount"] {
-  const amount = Number(price.amount);
+function convertedAmount(amount: PriceCoin["amount"], aktToUsdRate: number): PriceCoin["amount"] {
+  const parsedAmount = Number(amount);
 
-  if (!isAktPriced(price) || !Number.isFinite(amount)) return price.amount;
+  if (!Number.isFinite(parsedAmount)) return amount;
 
-  return Math.ceil(amount * aktToUsdRate);
+  return Math.ceil(parsedAmount * aktToUsdRate);
 }
 
 function findPrices(placement: SdlPlacement | undefined): PriceCoin[] {

--- a/apps/api/src/deployment/utils/price-denom/price-denom.ts
+++ b/apps/api/src/deployment/utils/price-denom/price-denom.ts
@@ -15,9 +15,9 @@ export async function restatePricesInGrantDenom(
 ): Promise<PriceRestatement> {
   if (options.grantDenom === AKT_DENOM) return { ok: true };
 
-  const aktPrices = findPrices(placement).filter(price => price.denom === AKT_DENOM);
+  const aktPrices = new Set(findPrices(placement).filter(price => price.denom === AKT_DENOM));
 
-  if (aktPrices.length === 0) return { ok: true };
+  if (aktPrices.size === 0) return { ok: true };
 
   const aktToUsdRate = await options.loadAktToUsdRate();
 
@@ -40,6 +40,7 @@ function convertedAmount(amount: PriceCoin["amount"], aktToUsdRate: number): Pri
   return Math.ceil(parsedAmount * aktToUsdRate);
 }
 
+/** A YAML alias resolves to the one price object it points at, so the walk can return it once per service that references it. */
 function findPrices(placement: SdlPlacement | undefined): PriceCoin[] {
   if (!placement || typeof placement !== "object") return [];
 

--- a/apps/api/src/deployment/utils/price-denom/price-denom.ts
+++ b/apps/api/src/deployment/utils/price-denom/price-denom.ts
@@ -1,5 +1,7 @@
 import type { SDLInput } from "@akashnetwork/chain-sdk";
 
+import { USDC_IBC_DENOMS } from "@src/billing/config/network.config";
+
 type SdlPlacement = SDLInput["profiles"]["placement"];
 type PriceCoin = SdlPlacement[string]["pricing"][string];
 
@@ -7,13 +9,14 @@ export type GrantDenom = PriceCoin["denom"];
 export type PriceRestatement = { ok: true } | { ok: false; aktToUsdRate: number };
 
 const AKT_DENOM = "uakt";
+const DOLLAR_PEGGED_DENOMS: readonly string[] = ["uact", "uusdc", USDC_IBC_DENOMS.mainnetId, USDC_IBC_DENOMS.sandboxId];
 
 /** Managed deployments pay out of a grant in a single denom, so a uakt ceiling is restated in it through the AKT price rather than swapped over. */
 export async function restatePricesInGrantDenom(
   placement: SdlPlacement | undefined,
   options: { grantDenom: GrantDenom; loadAktToUsdRate: () => Promise<number> }
 ): Promise<PriceRestatement> {
-  const prices = findPrices(placement).filter(price => price.denom !== options.grantDenom);
+  const prices = findPrices(placement).filter(price => price.denom !== options.grantDenom && isRestatable(price));
 
   if (prices.length === 0) return { ok: true };
 
@@ -40,6 +43,11 @@ function restate(prices: PriceCoin[], options: { grantDenom: GrantDenom; aktToUs
 
 function isAktPriced(price: PriceCoin): boolean {
   return price.denom === AKT_DENOM;
+}
+
+/** A denom worth neither a fraction of AKT nor a fraction of a dollar is left for SDL validation to reject, rather than restated into a ceiling it cannot mean. */
+function isRestatable(price: PriceCoin): boolean {
+  return isAktPriced(price) || DOLLAR_PEGGED_DENOMS.includes(price.denom);
 }
 
 /** Rounds up so a converted ceiling never lands under the one the user stated. */

--- a/apps/api/src/deployment/utils/price-denom/price-denom.ts
+++ b/apps/api/src/deployment/utils/price-denom/price-denom.ts
@@ -1,0 +1,62 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+
+type SdlPlacement = SDLInput["profiles"]["placement"];
+type PriceCoin = SdlPlacement[string]["pricing"][string];
+
+export type GrantDenom = PriceCoin["denom"];
+export type PriceRestatement = { ok: true } | { ok: false; aktToUsdRate: number };
+
+const AKT_DENOM = "uakt";
+
+/** Managed deployments pay out of a grant in a single denom, so a uakt ceiling is restated in it through the AKT price rather than swapped over. */
+export async function restatePricesInGrantDenom(
+  placement: SdlPlacement | undefined,
+  options: { grantDenom: GrantDenom; loadAktToUsdRate: () => Promise<number> }
+): Promise<PriceRestatement> {
+  const prices = findPrices(placement).filter(price => price.denom !== options.grantDenom);
+
+  if (prices.length === 0) return { ok: true };
+
+  if (!prices.some(isAktPriced)) {
+    restate(prices, { grantDenom: options.grantDenom });
+    return { ok: true };
+  }
+
+  const aktToUsdRate = await options.loadAktToUsdRate();
+
+  if (!Number.isFinite(aktToUsdRate) || aktToUsdRate <= 0) return { ok: false, aktToUsdRate };
+
+  restate(prices, { grantDenom: options.grantDenom, aktToUsdRate });
+
+  return { ok: true };
+}
+
+function restate(prices: PriceCoin[], options: { grantDenom: GrantDenom; aktToUsdRate?: number }): void {
+  for (const price of prices) {
+    if (options.aktToUsdRate !== undefined) price.amount = convertedAmount(price, options.aktToUsdRate);
+    price.denom = options.grantDenom;
+  }
+}
+
+function isAktPriced(price: PriceCoin): boolean {
+  return price.denom === AKT_DENOM;
+}
+
+/** Rounds up so a converted ceiling never lands under the one the user stated. */
+function convertedAmount(price: PriceCoin, aktToUsdRate: number): PriceCoin["amount"] {
+  const amount = Number(price.amount);
+
+  if (!isAktPriced(price) || !Number.isFinite(amount)) return price.amount;
+
+  return Math.ceil(amount * aktToUsdRate);
+}
+
+function findPrices(placement: SdlPlacement | undefined): PriceCoin[] {
+  if (!placement || typeof placement !== "object") return [];
+
+  return Object.values(placement).flatMap(profile => {
+    if (!profile || typeof profile !== "object" || !profile.pricing || typeof profile.pricing !== "object") return [];
+
+    return Object.values(profile.pricing).filter((price): price is PriceCoin => !!price && typeof price === "object");
+  });
+}

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
@@ -437,7 +437,7 @@ describe(sdlForStorage.name, () => {
     const config = mock<BillingConfig>({ DEPLOYMENT_GRANT_DENOM: "uakt", MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: [] });
     const blockedGpuService = new BlockedGpuService(mockConfigService<BillingConfigService>({ MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: [] }));
     const denomExchangeService = mock<DenomExchangeService>();
-    const createLogger = (() => mock<ReturnType<CreateLogger>>()) as unknown as CreateLogger;
+    const createLogger: CreateLogger = () => mock<ReturnType<CreateLogger>>();
 
     return new SdlService(config, blockedGpuService, new SdlReferenceService(), denomExchangeService, createLogger).generateManifest(rawSdl);
   }

--- a/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
+++ b/apps/api/src/deployment/utils/sdl-for-storage/sdl-for-storage.spec.ts
@@ -7,6 +7,8 @@ import { mock } from "vitest-mock-extended";
 
 import type { BillingConfig } from "@src/billing/providers";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { DenomExchangeService } from "@src/chain/services/denom-exchange/denom-exchange.service";
+import type { CreateLogger } from "@src/core";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
@@ -264,26 +266,26 @@ describe(sdlForStorage.name, () => {
   });
 
   describe("the stored output", () => {
-    it("stays an SDL the manifest generator still accepts", () => {
+    it("stays an SDL the manifest generator still accepts", async () => {
       const submitted = sdlWith({ web: { env: [`API_TOKEN=${faker.string.alphanumeric(12)}`] } });
 
-      expect(manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED)).ok).toBe(true);
+      expect((await manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED))).ok).toBe(true);
     });
 
-    it("stays an SDL the manifest generator accepts when an env value equals the service name", () => {
+    it("stays an SDL the manifest generator accepts when an env value equals the service name", async () => {
       const submitted = sdlWith({ wordpress: { env: ["WORDPRESS_DB_HOST=db"] }, db: {} });
 
-      expect(manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED)).ok).toBe(true);
+      expect((await manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED))).ok).toBe(true);
     });
 
-    it("stays an SDL the manifest generator accepts when an env value equals the denom", () => {
+    it("stays an SDL the manifest generator accepts when an env value equals the denom", async () => {
       const submitted = sdlWith({ web: { env: ["DENOM=uakt"] } });
 
-      expect(manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED)).ok).toBe(true);
+      expect((await manifestFrom(storedSdlOf(submitted, SECRETS_NOT_DECLARED))).ok).toBe(true);
     });
 
-    it("still generates a manifest for an SDL that declares no env at all", () => {
-      expect(manifestFrom(storedSdlOf(sdlWith({ web: {} }), SECRETS_NOT_DECLARED)).ok).toBe(true);
+    it("still generates a manifest for an SDL that declares no env at all", async () => {
+      expect((await manifestFrom(storedSdlOf(sdlWith({ web: {} }), SECRETS_NOT_DECLARED))).ok).toBe(true);
     });
 
     it("stores an already stored SDL as the same thing again", () => {
@@ -434,7 +436,9 @@ describe(sdlForStorage.name, () => {
   function manifestFrom(rawSdl: string) {
     const config = mock<BillingConfig>({ DEPLOYMENT_GRANT_DENOM: "uakt", MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: [] });
     const blockedGpuService = new BlockedGpuService(mockConfigService<BillingConfigService>({ MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: [] }));
+    const denomExchangeService = mock<DenomExchangeService>();
+    const createLogger = (() => mock<ReturnType<CreateLogger>>()) as unknown as CreateLogger;
 
-    return new SdlService(config, blockedGpuService, new SdlReferenceService()).generateManifest(rawSdl);
+    return new SdlService(config, blockedGpuService, new SdlReferenceService(), denomExchangeService, createLogger).generateManifest(rawSdl);
   }
 });

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -740,7 +740,7 @@ describe("Deployments API", () => {
     it("records an sdl that is still a deployable SDL", async () => {
       const { setting } = await createDeploymentWithSecrets();
 
-      expect(container.resolve(SdlService).generateManifest(setting?.sdl ?? "").ok).toBe(true);
+      expect((await container.resolve(SdlService).generateManifest(setting?.sdl ?? "")).ok).toBe(true);
     });
 
     it("records the manifest version it commits on chain", async () => {
@@ -1279,7 +1279,7 @@ describe("Deployments API", () => {
     it("records an sdl that is still a deployable SDL", async () => {
       const { setting } = await updateDeploymentWithSecrets();
 
-      expect(container.resolve(SdlService).generateManifest(setting?.sdl ?? "").ok).toBe(true);
+      expect((await container.resolve(SdlService).generateManifest(setting?.sdl ?? "")).ok).toBe(true);
     });
 
     it("returns 400 naming the offending value for an unrecognized ac- kind", async () => {
@@ -1325,7 +1325,7 @@ describe("Deployments API", () => {
     it("commits the manifest version of the very manifest it sends the providers", async () => {
       const { userApiKeySecret, user, dseq } = await setupUpdatableDeployment();
       const sdlService = container.resolve(SdlService);
-      const manifest = sdlService.generateManifest(fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8"));
+      const manifest = await sdlService.generateManifest(fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8"));
       const { groups } = (manifest as Extract<typeof manifest, { ok: true }>).value;
 
       await putDeployment({ userApiKeySecret, dseq, sdlMock: "hello-world-sdl.yml" });


### PR DESCRIPTION
## Why

Fixes #2956

A user set a price limit of 55 uakt/block through the managed wallet API and got bids at 26 uusdc/block, roughly 80 uakt at the time. The managed wallet rewrites the SDL's placement pricing to the denom its grant pays out, but only the denom moved: 55 uakt/block went on chain as 55 uact/block, and the bid filter then compared provider bids against a ceiling that meant something else.

Console's own SDL builder already prices in uact, so this hits SDLs written by hand or copied from the docs and the template repos, which price in uakt.

## What

`SdlService` now restates the amount along with the denom. A uakt ceiling is multiplied by the AKT price — uakt is AKT×10⁻⁶ and uact is USD×10⁻⁶, so the multiplier is exactly the AKT/USD rate — and rounded up so it never lands under what the user asked for. With the reporter's numbers, 55 uakt at AKT ≈ $0.325 becomes 18 uact, and the 26 uact bid is rejected.

- The rate comes from `DenomExchangeService` (oracle, memoized for 10 minutes, falling back to the `day` table). It is only fetched when the SDL actually prices in uakt, so the Console path adds no oracle call and no latency.
- If no usable rate comes back, the SDL is rejected with a 400 naming the grant denom instead of falling back to the plain swap. That fallback is the bug, and it would be invisible.
- A price already in the grant denom keeps its amount as before.
- Any other denom is no longer rewritten at all. It used to be swapped over with its amount intact, which was only ever true of dollar-pegged denoms; now the SDL schema rejects it by name (`"denom" ... should be one of: uakt, uact`). This covers USDC: deployments no longer price in it, so a `uusdc` or IBC USDC SDL is rejected rather than relabeled into a ceiling it never meant.
- `generateManifest` and `generateManifestFrom` are async now, since the rate is loaded inside them. The only production caller was already async.

The conversion runs on the parsed SDL, not on the document we store, so the stored SDL keeps the user's original pricing. Prices are not part of the manifest hash, so manifest versions are unaffected.

Left out on purpose: deploy-web still shows the raw uakt number when importing such an SDL, and the API response doesn't tell the caller which ceiling it ended up using. Both are worth their own issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment manifest generation when AKT/USD exchange-rate data is unavailable.
  - Corrected AKT price conversion, including upward rounding and consistent handling of repeated prices.
  - Unsupported denominations, including USDC, remain available for SDL validation.
  - Improved handling of malformed deployment inputs and invalid pricing values.

- **Reliability**
  - Improved manifest generation for confidential compute, secrets, references, trial resource restrictions, and deterministic results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
