### PR TITLE
fix(provider): start unreachable cooldown on provider-caused dial resets

### DIFF
--- a/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.spec.ts
+++ b/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.spec.ts
@@ -17,13 +17,21 @@ describe(ProviderConnectionTracker.name, () => {
     expect(tracker.shouldSkipDial("provider-a")).toBe(true);
   });
 
-  it.each(["ECONNRESET", "ETIMEDOUT", "EPIPE"])("never starts a cooldown for %s", errno => {
+  it.each(["ETIMEDOUT", "EPIPE"])("never starts a cooldown for %s", errno => {
     const { tracker, fail } = setup({ failureThreshold: 1 });
 
     fail("provider-a", errno);
     fail("provider-a", errno);
 
     expect(tracker.shouldSkipDial("provider-a")).toBe(false);
+  });
+
+  it("starts a cooldown when the dial is reset", () => {
+    const { tracker, fail } = setup({ failureThreshold: 1 });
+
+    fail("provider-a", "ECONNRESET");
+
+    expect(tracker.shouldSkipDial("provider-a")).toBe(true);
   });
 
   it("allows exactly one probe per cooldown window, even when asked concurrently", () => {

--- a/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
+++ b/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
@@ -2,14 +2,12 @@ import type { LoggerService } from "@akashnetwork/logging";
 import { LRUCache } from "lru-cache";
 
 /**
- * Errnos that mean the host itself is not there: no route, no DNS, nothing listening. They stay true for as
- * long as the provider is down, so re-dialing on every request only buys another connect timeout.
- *
- * ECONNRESET, ETIMEDOUT and EPIPE are deliberately absent. The proxy destroys its own request when the
- * per-attempt timeout fires and a client abort does the same, both surfacing as ECONNRESET, so treating them
- * as unreachable would let one slow poll blind every other caller on a healthy provider.
+ * Errnos that mean the host is not there: no route, no DNS, nothing listening, or the dial reset before a
+ * response existed. ECONNRESET is only trustworthy because ProviderProxy never reports a destroy it caused
+ * itself: its own per-attempt timeout and client aborts also surface as ECONNRESET, and counting those would
+ * let one slow poll blind every other caller on a healthy provider.
  */
-const UNREACHABLE_ERRNOS = ["EHOSTUNREACH", "ENETUNREACH", "ENOTFOUND", "EAI_AGAIN", "ECONNREFUSED"];
+const UNREACHABLE_ERRNOS = ["EHOSTUNREACH", "ENETUNREACH", "ENOTFOUND", "EAI_AGAIN", "ECONNREFUSED", "ECONNRESET"];
 
 /** Floor for how long a tracked provider is kept in memory. Eviction is a memory backstop, never a decision. */
 const MIN_STATE_RETENTION_MS = 10 * 60 * 1000;

--- a/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
+++ b/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
@@ -1,12 +1,7 @@
 import type { LoggerService } from "@akashnetwork/logging";
 import { LRUCache } from "lru-cache";
 
-/**
- * Errnos that mean the host is not there: no route, no DNS, nothing listening, or the dial reset before a
- * response existed. ECONNRESET is only trustworthy because ProviderProxy never reports a destroy it caused
- * itself: its own per-attempt timeout, client aborts and shared-agent teardowns all surface as ECONNRESET
- * too, and counting those would let one slow poll blind every other caller on a healthy provider.
- */
+/** ECONNRESET is listed only because ProviderProxy never reports a destroy it caused itself (its own per-attempt timeouts, client aborts and shared-agent teardowns all surface as ECONNRESET too). */
 const UNREACHABLE_ERRNOS = ["EHOSTUNREACH", "ENETUNREACH", "ENOTFOUND", "EAI_AGAIN", "ECONNREFUSED", "ECONNRESET"];
 
 /** Floor for how long a tracked provider is kept in memory. Eviction is a memory backstop, never a decision. */

--- a/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
+++ b/apps/provider-proxy/src/services/ProviderConnectionTracker/ProviderConnectionTracker.ts
@@ -4,8 +4,8 @@ import { LRUCache } from "lru-cache";
 /**
  * Errnos that mean the host is not there: no route, no DNS, nothing listening, or the dial reset before a
  * response existed. ECONNRESET is only trustworthy because ProviderProxy never reports a destroy it caused
- * itself: its own per-attempt timeout and client aborts also surface as ECONNRESET, and counting those would
- * let one slow poll blind every other caller on a healthy provider.
+ * itself: its own per-attempt timeout, client aborts and shared-agent teardowns all surface as ECONNRESET
+ * too, and counting those would let one slow poll blind every other caller on a healthy provider.
  */
 const UNREACHABLE_ERRNOS = ["EHOSTUNREACH", "ENETUNREACH", "ENOTFOUND", "EAI_AGAIN", "ECONNREFUSED", "ECONNRESET"];
 

--- a/apps/provider-proxy/src/services/ProviderProxy.spec.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.spec.ts
@@ -1,3 +1,4 @@
+import type { X509Certificate } from "node:crypto";
 import { EventEmitter } from "node:events";
 import type { ClientRequest, IncomingMessage } from "node:http";
 import https from "node:https";
@@ -102,9 +103,40 @@ describe(ProviderProxy.name, () => {
     expect(connectionTracker.recordUnreachable).not.toHaveBeenCalled();
   });
 
+  it("records nothing for a dial killed by another request's certificate teardown", async () => {
+    const { proxy, connectionTracker, certificateValidator } = setup();
+    certificateValidator.validate.mockResolvedValue({ ok: false, code: "expired" });
+    const { collateralRequest } = stubCertRejectedDialThenPendingDial();
+
+    const rejected = proxy.connect("https://provider.example.com:8443/status", { method: "GET", providerAddress: "akash1provider" });
+    const collateral = proxy.connect("https://provider.example.com:8443/status", { method: "GET", providerAddress: "akash1provider" });
+    await expect(rejected).resolves.toEqual({ ok: false, code: "invalidCertificate", reason: "expired" });
+    collateralRequest.emit("error", Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }));
+
+    await expect(collateral).resolves.toMatchObject({ ok: false, code: "connectionError" });
+    expect(connectionTracker.recordUnreachable).not.toHaveBeenCalled();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  function stubCertRejectedDialThenPendingDial() {
+    const rejectedRequest = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(), destroy: vi.fn(), reusedSocket: false });
+    const collateralRequest = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(), destroy: vi.fn(), reusedSocket: false });
+    const socket = Object.assign(Object.create(TLSSocket.prototype) as TLSSocket, {
+      authorized: false,
+      getPeerX509Certificate: vi.fn().mockReturnValue(mock<X509Certificate>())
+    });
+    const response = Object.assign(new EventEmitter(), { socket, destroy: vi.fn(), pause: vi.fn(), resume: vi.fn() });
+    const requests = [rejectedRequest, collateralRequest];
+    vi.spyOn(https, "request").mockImplementation((_url, _options, callback) => {
+      const request = requests.shift();
+      if (request === rejectedRequest) setImmediate(() => (callback as ((res: IncomingMessage) => void) | undefined)?.(response as unknown as IncomingMessage));
+      return request as unknown as ClientRequest;
+    });
+    return { collateralRequest };
+  }
 
   function stubDial() {
     const request = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(), destroy: vi.fn(), reusedSocket: false });
@@ -136,8 +168,9 @@ describe(ProviderProxy.name, () => {
       shouldSkipDial: vi.fn().mockReturnValue(input.shouldSkipDial ?? false),
       getLastError: vi.fn().mockReturnValue(input.lastError)
     });
-    const proxy = new ProviderProxy(mock<CertificateValidator>(), undefined, connectionTracker);
+    const certificateValidator = mock<CertificateValidator>();
+    const proxy = new ProviderProxy(certificateValidator, undefined, connectionTracker);
 
-    return { proxy, connectionTracker };
+    return { proxy, connectionTracker, certificateValidator };
   }
 });

--- a/apps/provider-proxy/src/services/ProviderProxy.spec.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.spec.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
-import type { ClientRequest } from "node:http";
+import type { ClientRequest, IncomingMessage } from "node:http";
 import https from "node:https";
+import { TLSSocket } from "node:tls";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -42,9 +43,85 @@ describe(ProviderProxy.name, () => {
     expect(connectionTracker.recordUnreachable).not.toHaveBeenCalled();
   });
 
+  it("records unreachable when the provider resets the dial", async () => {
+    const { proxy, connectionTracker } = setup();
+    const request = stubDial();
+    const error = Object.assign(new Error("Client network socket disconnected before secure TLS connection was established"), { code: "ECONNRESET" });
+
+    const pending = proxy.connect("https://provider.example.com:8443/status", { method: "GET", providerAddress: "akash1provider" });
+    request.emit("error", error);
+
+    await expect(pending).resolves.toEqual({ ok: false, code: "connectionError", error });
+    expect(connectionTracker.recordUnreachable).toHaveBeenCalledWith("akash1provider|https://provider.example.com:8443", error, "ECONNRESET");
+  });
+
+  it("records nothing when its own per-attempt timeout kills the dial", async () => {
+    const { proxy, connectionTracker } = setup();
+    const request = stubDial();
+
+    const pending = proxy.connect("https://provider.example.com:8443/status", {
+      method: "GET",
+      providerAddress: "akash1provider",
+      timeout: 5_000
+    });
+    request.emit("timeout");
+    request.emit("error", Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }));
+
+    await expect(pending).resolves.toMatchObject({ ok: false, code: "connectionError" });
+    expect(request.destroy).toHaveBeenCalled();
+    expect(connectionTracker.recordUnreachable).not.toHaveBeenCalled();
+  });
+
+  it("records nothing when the client aborts the dial", async () => {
+    const { proxy, connectionTracker } = setup();
+    const request = stubDial();
+    const abortController = new AbortController();
+
+    const pending = proxy.connect("https://provider.example.com:8443/status", {
+      method: "GET",
+      providerAddress: "akash1provider",
+      signal: abortController.signal
+    });
+    abortController.abort();
+    request.emit("error", Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }));
+
+    await expect(pending).resolves.toMatchObject({ ok: false, code: "connectionError" });
+    expect(request.destroy).toHaveBeenCalled();
+    expect(connectionTracker.recordUnreachable).not.toHaveBeenCalled();
+  });
+
+  it("records nothing when the connection drops after the provider answered", async () => {
+    const { proxy, connectionTracker } = setup();
+    const { response } = stubDialWithTlsResponse();
+
+    const result = await proxy.connect("https://provider.example.com:8443/status", { method: "GET", providerAddress: "akash1provider" });
+    response.emit("error", Object.assign(new Error("aborted"), { code: "ECONNRESET" }));
+
+    expect(result).toMatchObject({ ok: true });
+    expect(connectionTracker.recordReachable).toHaveBeenCalledWith("akash1provider|https://provider.example.com:8443");
+    expect(connectionTracker.recordUnreachable).not.toHaveBeenCalled();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  function stubDial() {
+    const request = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(), destroy: vi.fn(), reusedSocket: false });
+    vi.spyOn(https, "request").mockImplementation(() => request as unknown as ClientRequest);
+    return request;
+  }
+
+  function stubDialWithTlsResponse() {
+    const request = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(), destroy: vi.fn(), reusedSocket: false });
+    const socket = Object.assign(Object.create(TLSSocket.prototype) as TLSSocket, { authorized: true });
+    const response = Object.assign(new EventEmitter(), { socket, destroy: vi.fn(), pause: vi.fn(), resume: vi.fn() });
+    vi.spyOn(https, "request").mockImplementation((_url, _options, callback) => {
+      setImmediate(() => (callback as ((res: IncomingMessage) => void) | undefined)?.(response as unknown as IncomingMessage));
+      return request as unknown as ClientRequest;
+    });
+    return { request, response };
+  }
 
   function stubDialFailure(error: Error) {
     const request = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(), destroy: vi.fn(), reusedSocket: false });

--- a/apps/provider-proxy/src/services/ProviderProxy.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.ts
@@ -20,6 +20,8 @@ export class ProviderProxy {
   readonly #agentsCache = new LRUCache<string, https.Agent>({
     max: 1_000_000
   });
+  /** Destroying a shared agent aborts every concurrent dial to that provider with ECONNRESET, which must not count as the provider being unreachable. */
+  readonly #tornDownAgents = new WeakSet<https.Agent>();
   readonly #certificateValidator: CertificateValidator;
   readonly #networkLookup?: NetworkLookup;
   readonly #connectionTracker?: ProviderConnectionTracker;
@@ -94,6 +96,7 @@ export class ProviderProxy {
                 selfDestroyed = true;
                 res.destroy();
                 req.destroy();
+                if (requestOptions.agent) this.#tornDownAgents.add(requestOptions.agent);
                 requestOptions.agent?.destroy();
                 return;
               }
@@ -123,7 +126,8 @@ export class ProviderProxy {
         req.on(
           "error",
           propagateTracingContext(error => {
-            if (!selfDestroyed) this.recordUnreachable(trackerKey, error);
+            const destroyedByProxy = selfDestroyed || (requestOptions.agent !== undefined && this.#tornDownAgents.has(requestOptions.agent));
+            if (!destroyedByProxy) this.recordUnreachable(trackerKey, error);
             resolve({ ok: false, code: "connectionError", error });
           })
         );

--- a/apps/provider-proxy/src/services/ProviderProxy.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.ts
@@ -43,6 +43,7 @@ export class ProviderProxy {
     }
 
     return new Promise<ProxyConnectionResult>((resolve, reject) => {
+      let selfDestroyed = false;
       const { agentCacheKey, ...requestOptions } = this.getRequestOptions(options);
       const req = https.request(
         url,
@@ -52,7 +53,6 @@ export class ProviderProxy {
             res.on(
               "error",
               propagateTracingContext(error => {
-                this.recordUnreachable(trackerKey, error);
                 resolve({ ok: false, code: "connectionError", error });
               })
             );
@@ -91,6 +91,7 @@ export class ProviderProxy {
                 this.#agentsCache.delete(agentCacheKey);
                 resolve({ ok: false, code: "invalidCertificate", reason: validationResult.code });
                 req.off("error", reject);
+                selfDestroyed = true;
                 res.destroy();
                 req.destroy();
                 requestOptions.agent?.destroy();
@@ -111,6 +112,7 @@ export class ProviderProxy {
         options.signal.addEventListener(
           "abort",
           () => {
+            selfDestroyed = true;
             req.destroy();
           },
           { once: true }
@@ -121,16 +123,14 @@ export class ProviderProxy {
         req.on(
           "error",
           propagateTracingContext(error => {
-            this.recordUnreachable(trackerKey, error);
+            if (!selfDestroyed) this.recordUnreachable(trackerKey, error);
             resolve({ ok: false, code: "connectionError", error });
           })
         );
         req.on(
           "timeout",
           propagateTracingContext(() => {
-            // here we are just notified that response take more than specified in request options timeout
-            // then we manually destroy request and it drops connection and
-            // on('error') handler is called with Error code = ECONNRESET
+            selfDestroyed = true;
             req.destroy();
           })
         );


### PR DESCRIPTION
## Why

Yesterday's 5xx alert on provider-proxy-mainnet came from a provider that resets the TCP dial before the TLS handshake completes. That failure mode never enters the unreachable cooldown: ECONNRESET is excluded from `UNREACHABLE_ERRNOS` because the proxy's own per-attempt timeout and client aborts also surface as ECONNRESET, and counting those would let one slow poll blind every caller on a healthy provider.

The result is an asymmetry. A host that refuses connections (ECONNREFUSED) is short-circuited in milliseconds once the breaker opens, while a host that resets them pays the full retry loop on every request: 4 dials and 11s on yesterday's lease-status poll, up to ~61s against a host that black-holes instead of resetting. The expensive failure mode was the one the breaker never suppressed.

## What

The ambiguity lives in the proxy, not the errno: both self-inflicted ECONNRESET cases are our own `req.destroy()` calls. `connect()` now sets a `selfDestroyed` flag before every destroy it initiates (per-attempt timeout, client abort, invalid-cert teardown) and reports a dial failure to the tracker only when the flag is unset. With that guarantee in place, ECONNRESET joins `UNREACHABLE_ERRNOS`. Threshold and cooldown are unchanged: 3 failures, 60s.

Recording also moves out of the response error handler. Once headers have arrived the host has answered, and a provider-caused reset mid-body is indistinguishable there from our own mid-stream timeout (both land on the response as ECONNRESET, verified empirically on Node 24.14.1). Reachability is decided at the dial only. Without this, listing ECONNRESET would resurrect the exact blinding scenario the old exclusion guarded against.

In production this means a provider that resets dials costs 3 recorded failures, then every caller short-circuits it for 60s per window, the same as ECONNREFUSED today. A provider that answers headers can never be cooled down by a mid-stream drop, ours or theirs.

Covered by 5 new unit tests across `ProviderProxy` and `ProviderConnectionTracker`; the functional suite already exercises the changed paths ("responds with 502 if provider host hangs up connection") and passes unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider availability tracking for connection resets and unreachable providers.
  * Prevented client-request timeouts, cancellations, certificate validation failures, and post-response connection issues from being incorrectly reported as provider outages.
  * Added coverage for provider-side connection failures and intentional request termination scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->