### PR TITLE
fix(observability): cap unbounded cache key spaces on anonymous routes

### DIFF
--- a/apps/api/src/address/services/address/address.service.spec.ts
+++ b/apps/api/src/address/services/address/address.service.spec.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 
-import { cacheEngine } from "@src/caching/helpers";
+import MemoryCacheEngine from "@src/caching/memoryCacheEngine";
 import type { TransactionService } from "@src/transaction/services/transaction/transaction.service";
 import type { ValidatorRepository } from "@src/validator/repositories/validator/validator.repository";
 import { AddressService } from "./address.service";
@@ -240,7 +240,7 @@ describe(AddressService.name, () => {
     validatorRepository: MockProxy<ValidatorRepository>;
     service: AddressService;
   } {
-    cacheEngine.clearAllKeyInCache();
+    MemoryCacheEngine.clearAllCaches();
 
     const transactionService = mock<TransactionService>();
     const cosmosHttpService = mock<CosmosHttpService>();

--- a/apps/api/src/address/services/address/address.service.ts
+++ b/apps/api/src/address/services/address/address.service.ts
@@ -21,7 +21,7 @@ export class AddressService {
     private readonly validatorRepository: ValidatorRepository
   ) {}
 
-  @Memoize({ ttlInSeconds: averageBlockTime })
+  @Memoize({ ttlInSeconds: averageBlockTime, maxEntries: 500 })
   async getAddressDetails(address: string): Promise<GetAddressResponse> {
     const [balancesResponse, delegationsResponse, rewardsResponse, redelegationsResponse, latestTransactions] = await Promise.all([
       this.cosmosHttpService.getBankBalancesByAddress(address),

--- a/apps/api/src/billing/services/balances/balances.service.ts
+++ b/apps/api/src/billing/services/balances/balances.service.ts
@@ -100,7 +100,7 @@ export class BalancesService {
     }, 0);
   }
 
-  @Memoize({ ttlInSeconds: averageBlockTime })
+  @Memoize({ ttlInSeconds: averageBlockTime, maxEntries: 500 })
   async getFullBalanceMemoized(address: string): Promise<GetBalancesResponseOutput> {
     return this.getFullBalance(address);
   }

--- a/apps/api/src/block/services/akash-block/akash-block.service.ts
+++ b/apps/api/src/block/services/akash-block/akash-block.service.ts
@@ -14,7 +14,7 @@ export class AkashBlockService {
     return await this.akashBlockRepository.getBlocks(limit);
   }
 
-  @Memoize({ ttlInSeconds: 60 })
+  @Memoize({ ttlInSeconds: 60, maxEntries: 500 })
   async getBlockWithTransactionsByHeight(height: number): Promise<GetBlockByHeightResponse | null> {
     return await this.akashBlockRepository.getBlockWithTransactionsByHeight(height);
   }

--- a/apps/api/src/dashboard/services/stats/stats.service.spec.ts
+++ b/apps/api/src/dashboard/services/stats/stats.service.spec.ts
@@ -968,6 +968,16 @@ describe(StatsService.name, () => {
       expect(statsRepository.findClosedLeases).toHaveBeenCalledTimes(1);
     });
 
+    it("distinguishes an owner containing '#' from a dseq filter", async () => {
+      const { service, statsRepository } = setup();
+      statsRepository.findClosedLeases.mockResolvedValue([]);
+
+      await service.getLeasesDuration("akash1owner#123", buildLeasesDurationQuery());
+      await service.getLeasesDuration("akash1owner", buildLeasesDurationQuery({ dseq: "123" }));
+
+      expect(statsRepository.findClosedLeases).toHaveBeenCalledTimes(2);
+    });
+
     it("fetches fresh results when the owner or query differs", async () => {
       const { service, statsRepository } = setup();
       statsRepository.findClosedLeases.mockResolvedValue([]);

--- a/apps/api/src/dashboard/services/stats/stats.service.spec.ts
+++ b/apps/api/src/dashboard/services/stats/stats.service.spec.ts
@@ -1,4 +1,4 @@
-import type { AkashBlock as Block, Provider } from "@akashnetwork/database/dbSchemas/akash";
+import type { AkashBlock as Block, Lease, Provider } from "@akashnetwork/database/dbSchemas/akash";
 import type { Day } from "@akashnetwork/database/dbSchemas/base";
 import type { CosmosHttpService } from "@akashnetwork/http-sdk";
 import { describe, expect, it } from "vitest";
@@ -6,6 +6,7 @@ import { mock } from "vitest-mock-extended";
 
 import { cacheEngine } from "@src/caching/helpers";
 import type { DenomExchangeService } from "@src/chain/services/denom-exchange/denom-exchange.service";
+import type { LeasesDurationQuery } from "@src/dashboard/http-schemas/leases-duration/leases-duration.schema";
 import type { StatsRepository } from "../../repositories/stats";
 import { StatsService } from "./stats.service";
 import { isValidGraphDataName } from "./stats.types";
@@ -917,6 +918,75 @@ describe(StatsService.name, () => {
       expect(denomExchangeService.getExchangeRateToUSD).not.toHaveBeenCalled();
     });
   });
+
+  describe("getLeasesDuration", () => {
+    it("maps closed leases to durations with totals", async () => {
+      const { service, statsRepository } = setup();
+      const closedLease = {
+        dseq: "123",
+        oseq: 1,
+        gseq: 1,
+        providerAddress: "akash1provider",
+        createdHeight: 100,
+        closedHeight: 300,
+        createdBlock: { datetime: new Date("2024-01-01T00:00:00Z") },
+        closedBlock: { datetime: new Date("2024-01-15T00:00:00Z") }
+      };
+      statsRepository.findClosedLeases.mockResolvedValue([closedLease] as unknown as Lease[]);
+
+      const result = await service.getLeasesDuration("akash1owner", buildLeasesDurationQuery());
+
+      expect(result).toEqual({
+        leaseCount: 1,
+        totalDurationInSeconds: 1209600,
+        totalDurationInHours: 336,
+        leases: [
+          {
+            dseq: "123",
+            oseq: 1,
+            gseq: 1,
+            provider: "akash1provider",
+            startHeight: 100,
+            startDate: "2024-01-01T00:00:00.000Z",
+            closedHeight: 300,
+            closedDate: "2024-01-15T00:00:00.000Z",
+            durationInBlocks: 200,
+            durationInSeconds: 1209600,
+            durationInHours: 336
+          }
+        ]
+      });
+    });
+
+    it("serves a repeated owner and query from cache", async () => {
+      const { service, statsRepository } = setup();
+      statsRepository.findClosedLeases.mockResolvedValue([]);
+
+      await service.getLeasesDuration("akash1owner", buildLeasesDurationQuery());
+      await service.getLeasesDuration("akash1owner", buildLeasesDurationQuery());
+
+      expect(statsRepository.findClosedLeases).toHaveBeenCalledTimes(1);
+    });
+
+    it("fetches fresh results when the owner or query differs", async () => {
+      const { service, statsRepository } = setup();
+      statsRepository.findClosedLeases.mockResolvedValue([]);
+
+      await service.getLeasesDuration("akash1owner", buildLeasesDurationQuery());
+      await service.getLeasesDuration("akash1owner", buildLeasesDurationQuery({ dseq: "123" }));
+      await service.getLeasesDuration("akash1other", buildLeasesDurationQuery());
+
+      expect(statsRepository.findClosedLeases).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  function buildLeasesDurationQuery(overrides?: Partial<LeasesDurationQuery>): LeasesDurationQuery {
+    return {
+      startDate: new Date("2024-01-01T00:00:00Z"),
+      endDate: new Date("2024-02-01T00:00:00Z"),
+      ...overrides
+    };
+  }
 
   function setup() {
     cacheEngine.clearAllKeyInCache();

--- a/apps/api/src/dashboard/services/stats/stats.service.ts
+++ b/apps/api/src/dashboard/services/stats/stats.service.ts
@@ -576,7 +576,7 @@ export class StatsService {
     {
       cacheItemLimit: 500,
       ttl: minutesToSeconds(5) * 1000,
-      getCacheKey: (owner, query) => [owner, query.dseq, query.startDate.toISOString(), query.endDate.toISOString()].join("#"),
+      getCacheKey: (owner, query) => JSON.stringify([owner, query.dseq, query.startDate.toISOString(), query.endDate.toISOString()]),
       name: "StatsService#getLeasesDuration"
     }
   );

--- a/apps/api/src/dashboard/services/stats/stats.service.ts
+++ b/apps/api/src/dashboard/services/stats/stats.service.ts
@@ -576,7 +576,8 @@ export class StatsService {
     {
       cacheItemLimit: 500,
       ttl: minutesToSeconds(5) * 1000,
-      getCacheKey: (owner, query) => [owner, query.dseq, query.startDate.toISOString(), query.endDate.toISOString()].join("#")
+      getCacheKey: (owner, query) => [owner, query.dseq, query.startDate.toISOString(), query.endDate.toISOString()].join("#"),
+      name: "StatsService#getLeasesDuration"
     }
   );
 

--- a/apps/api/src/dashboard/services/stats/stats.service.ts
+++ b/apps/api/src/dashboard/services/stats/stats.service.ts
@@ -5,7 +5,7 @@ import { differenceInSeconds, minutesToSeconds, subHours } from "date-fns";
 import uniqBy from "lodash/uniqBy";
 import { singleton } from "tsyringe";
 
-import { Memoize } from "@src/caching/helpers";
+import { Memoize, memoizeAsync } from "@src/caching/helpers";
 import { DenomExchangeService } from "@src/chain/services/denom-exchange/denom-exchange.service";
 import type { BmeDashboardDataResponse, BmePeriodData } from "@src/dashboard/http-schemas/bme-dashboard-data/bme-dashboard-data.schema";
 import { BmeStatusHistoryResponse } from "@src/dashboard/http-schemas/bme-status-history/bme-status-history.schema";
@@ -571,7 +571,16 @@ export class StatsService {
     return amount * marketData.price;
   }
 
-  async getLeasesDuration(owner: LeasesDurationParams["owner"], query: LeasesDurationQuery): Promise<LeasesDurationResponse> {
+  readonly getLeasesDuration = memoizeAsync(
+    (owner: LeasesDurationParams["owner"], query: LeasesDurationQuery) => this.getLeasesDurationUncached(owner, query),
+    {
+      cacheItemLimit: 500,
+      ttl: minutesToSeconds(5) * 1000,
+      getCacheKey: (owner, query) => [owner, query.dseq, query.startDate.toISOString(), query.endDate.toISOString()].join("#")
+    }
+  );
+
+  private async getLeasesDurationUncached(owner: LeasesDurationParams["owner"], query: LeasesDurationQuery): Promise<LeasesDurationResponse> {
     const closedLeases = await this.statsRepository.findClosedLeases(owner, query);
 
     const leases = closedLeases.map(x => ({

--- a/apps/api/src/deployment/services/fallback-deployment-reader/fallback-deployment-reader.service.ts
+++ b/apps/api/src/deployment/services/fallback-deployment-reader/fallback-deployment-reader.service.ts
@@ -3,6 +3,7 @@ import { inject, singleton } from "tsyringe";
 
 import { USDC_IBC_DENOMS } from "@src/billing/config/network.config";
 import { cacheResponse, Memoize } from "@src/caching/helpers";
+import MemoryCacheEngine from "@src/caching/memoryCacheEngine";
 import type { CoreConfig } from "@src/core/providers/config.provider";
 import { CORE_CONFIG } from "@src/core/providers/config.provider";
 import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
@@ -17,6 +18,8 @@ export const UNKNOWN_DB_PLACEHOLDER = "unknown_value";
 export class FallbackDeploymentReaderService {
   readonly #coreConfig: CoreConfig;
 
+  readonly #listCache = new MemoryCacheEngine({ maxEntries: 500, name: "FallbackDeploymentReaderService#findAll" });
+
   constructor(
     private readonly deploymentRepository: DeploymentRepository,
     @inject(CORE_CONFIG) coreConfig: CoreConfig
@@ -25,7 +28,12 @@ export class FallbackDeploymentReaderService {
   }
 
   async findAll(params: DatabaseDeploymentListParams): Promise<RestAkashDeploymentListResponse> {
-    return cacheResponse(averageBlockTime, `FallbackDeploymentReaderService#findAll#${JSON.stringify(params)}`, () => this.findAllUncached(params));
+    return cacheResponse(
+      averageBlockTime,
+      `FallbackDeploymentReaderService#findAll#${JSON.stringify(params)}`,
+      () => this.findAllUncached(params),
+      this.#listCache
+    );
   }
 
   private async findAllUncached(params: DatabaseDeploymentListParams): Promise<RestAkashDeploymentListResponse> {
@@ -100,7 +108,7 @@ export class FallbackDeploymentReaderService {
     };
   }
 
-  @Memoize({ ttlInSeconds: averageBlockTime })
+  @Memoize({ ttlInSeconds: averageBlockTime, maxEntries: 500 })
   async findByOwnerAndDseq(owner: string, dseq: string): Promise<RestAkashDeploymentInfoResponse | null> {
     const deployment = await this.deploymentRepository.findByIdWithGroups(owner, dseq);
 

--- a/apps/api/src/gpu/services/gpu.service.spec.ts
+++ b/apps/api/src/gpu/services/gpu.service.spec.ts
@@ -13,7 +13,7 @@ describe(GpuService.name, () => {
   describe("getGpuModels", () => {
     it("fetches the provider-config catalog and returns the formatted vendor list", async () => {
       const { service, httpClient } = setup({
-        "10de": { name: "nvidia", devices: { d1: { name: "rtx4090", memory_size: "24Gi", interface: "PCIe" } } }
+        catalog: { "10de": { name: "nvidia", devices: { d1: { name: "rtx4090", memory_size: "24Gi", interface: "PCIe" } } } }
       });
 
       const [vendor] = await service.getGpuModels();
@@ -24,14 +24,38 @@ describe(GpuService.name, () => {
     });
   });
 
-  function setup(catalog: ProviderConfigGpusType) {
+  describe("getGpuBreakdown", () => {
+    it("serves a repeated query from cache", async () => {
+      const { service, gpuRepository } = setup();
+      gpuRepository.getGpuBreakdown.mockResolvedValue([]);
+
+      await service.getGpuBreakdown({ vendor: "nvidia" });
+      await service.getGpuBreakdown({ vendor: "nvidia" });
+
+      expect(gpuRepository.getGpuBreakdown).toHaveBeenCalledTimes(1);
+    });
+
+    it("fetches fresh results when the filters differ", async () => {
+      const { service, gpuRepository } = setup();
+      gpuRepository.getGpuBreakdown.mockResolvedValue([]);
+
+      await service.getGpuBreakdown({});
+      await service.getGpuBreakdown({ vendor: "nvidia" });
+      await service.getGpuBreakdown({ model: "nvidia" });
+
+      expect(gpuRepository.getGpuBreakdown).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  function setup(input?: { catalog?: ProviderConfigGpusType }) {
     cacheEngine.clearAllKeyInCache();
     const httpClient = mock<HttpClient>();
     const response = mock<AxiosResponse<ProviderConfigGpusType>>();
-    response.data = catalog;
+    response.data = input?.catalog ?? {};
     httpClient.get.mockResolvedValue(response);
 
-    const service = new GpuService(mock<GpuRepository>(), new GpuFormattingService(), httpClient);
-    return { service, httpClient };
+    const gpuRepository = mock<GpuRepository>();
+    const service = new GpuService(gpuRepository, new GpuFormattingService(), httpClient);
+    return { service, httpClient, gpuRepository };
   }
 });

--- a/apps/api/src/gpu/services/gpu.service.spec.ts
+++ b/apps/api/src/gpu/services/gpu.service.spec.ts
@@ -35,6 +35,16 @@ describe(GpuService.name, () => {
       expect(gpuRepository.getGpuBreakdown).toHaveBeenCalledTimes(1);
     });
 
+    it("distinguishes filter values that contain '#' characters", async () => {
+      const { service, gpuRepository } = setup();
+      gpuRepository.getGpuBreakdown.mockResolvedValue([]);
+
+      await service.getGpuBreakdown({ vendor: "a", model: "b#c" });
+      await service.getGpuBreakdown({ vendor: "a#b", model: "c" });
+
+      expect(gpuRepository.getGpuBreakdown).toHaveBeenCalledTimes(2);
+    });
+
     it("fetches fresh results when the filters differ", async () => {
       const { service, gpuRepository } = setup();
       gpuRepository.getGpuBreakdown.mockResolvedValue([]);

--- a/apps/api/src/gpu/services/gpu.service.ts
+++ b/apps/api/src/gpu/services/gpu.service.ts
@@ -90,6 +90,7 @@ export class GpuService {
   readonly getGpuBreakdown = memoizeAsync((query: GpuBreakdownQuery) => this.gpuRepository.getGpuBreakdown(query), {
     cacheItemLimit: 500,
     ttl: minutesToSeconds(5) * 1000,
-    getCacheKey: query => [query.vendor, query.model].join("#")
+    getCacheKey: query => [query.vendor, query.model].join("#"),
+    name: "GpuService#getGpuBreakdown"
   });
 }

--- a/apps/api/src/gpu/services/gpu.service.ts
+++ b/apps/api/src/gpu/services/gpu.service.ts
@@ -2,7 +2,7 @@ import type { HttpClient } from "@akashnetwork/http-sdk";
 import { minutesToSeconds } from "date-fns";
 import { inject, singleton } from "tsyringe";
 
-import { Memoize } from "@src/caching/helpers";
+import { Memoize, memoizeAsync } from "@src/caching/helpers";
 import type { ProviderConfigGpusType } from "@src/types/gpu";
 import { type GpuBreakdownQuery } from "../http-schemas/gpu.schema";
 import { GPU_MODELS_HTTP_CLIENT } from "../providers/gpu-models-client.provider";
@@ -87,8 +87,9 @@ export class GpuService {
     return this.gpuFormattingService.mapProviderConfig(response.data);
   }
 
-  @Memoize({ ttlInSeconds: minutesToSeconds(5) })
-  async getGpuBreakdown(query: GpuBreakdownQuery) {
-    return await this.gpuRepository.getGpuBreakdown(query);
-  }
+  readonly getGpuBreakdown = memoizeAsync((query: GpuBreakdownQuery) => this.gpuRepository.getGpuBreakdown(query), {
+    cacheItemLimit: 500,
+    ttl: minutesToSeconds(5) * 1000,
+    getCacheKey: query => [query.vendor, query.model].join("#")
+  });
 }

--- a/apps/api/src/gpu/services/gpu.service.ts
+++ b/apps/api/src/gpu/services/gpu.service.ts
@@ -90,7 +90,7 @@ export class GpuService {
   readonly getGpuBreakdown = memoizeAsync((query: GpuBreakdownQuery) => this.gpuRepository.getGpuBreakdown(query), {
     cacheItemLimit: 500,
     ttl: minutesToSeconds(5) * 1000,
-    getCacheKey: query => [query.vendor, query.model].join("#"),
+    getCacheKey: query => JSON.stringify([query.vendor, query.model]),
     name: "GpuService#getGpuBreakdown"
   });
 }

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -217,7 +217,7 @@ export class ProviderService {
     });
   }
 
-  @Memoize({ ttlInSeconds: 30 })
+  @Memoize({ ttlInSeconds: 30, maxEntries: 500 })
   async getProvider(address: string) {
     const nowUtc = toUTC(new Date());
     const provider = await this.providerRepository.getProviderByAddressWithAttributes(address);

--- a/apps/api/src/transaction/services/transaction/transaction.service.ts
+++ b/apps/api/src/transaction/services/transaction/transaction.service.ts
@@ -15,12 +15,12 @@ export class TransactionService {
     return await this.transactionRepository.getTransactions(limit);
   }
 
-  @Memoize({ ttlInSeconds: 60 })
+  @Memoize({ ttlInSeconds: 60, maxEntries: 500 })
   async getTransactionByHash(hash: string): Promise<GetTransactionByHashResponse | null> {
     return await this.transactionRepository.getTransactionByHash(hash);
   }
 
-  @Memoize({ ttlInSeconds: averageBlockTime })
+  @Memoize({ ttlInSeconds: averageBlockTime, maxEntries: 500 })
   async getTransactionsByAddress(address: string, skip: number = -1, limit: number = -1): Promise<GetAddressTransactionsResponse> {
     return await this.transactionRepository.getTransactionsByAddress(address, skip === -1 ? undefined : skip, limit === -1 ? undefined : limit);
   }

--- a/apps/api/src/validator/services/validator/validator.service.ts
+++ b/apps/api/src/validator/services/validator/validator.service.ts
@@ -38,7 +38,7 @@ export class ValidatorService {
     return sortedValidators;
   }
 
-  @Memoize({ ttlInSeconds: 60 })
+  @Memoize({ ttlInSeconds: 60, maxEntries: 500 })
   public async getByAddress(address: string): Promise<GetValidatorByAddressResponse | null> {
     let cosmosResponse: RestCosmosStakingValidatorResponse;
     try {

--- a/apps/api/test/setup-functional-tests.ts
+++ b/apps/api/test/setup-functional-tests.ts
@@ -4,6 +4,7 @@ import { container } from "tsyringe";
 import { afterAll, afterEach, beforeAll, beforeEach, expect } from "vitest";
 
 import { cacheEngine } from "@src/caching/helpers";
+import MemoryCacheEngine from "@src/caching/memoryCacheEngine";
 import { RAW_APP_CONFIG } from "@src/core/providers/raw-app-config.provider";
 import { TestDatabaseService } from "./services/test-database.service";
 
@@ -16,7 +17,7 @@ const dbService = new TestDatabaseService(testPath!);
  */
 export function clearCache(keyOrPrefix?: string) {
   if (!keyOrPrefix) {
-    cacheEngine.clearAllKeyInCache();
+    MemoryCacheEngine.clearAllCaches();
   } else if (keyOrPrefix.includes("*")) {
     // Handle wildcard patterns if needed in the future
     const prefix = keyOrPrefix.replace("*", "");
@@ -37,7 +38,7 @@ export function clearCache(keyOrPrefix?: string) {
 container.register(RAW_APP_CONFIG, { useValue: process.env });
 
 beforeAll(async () => {
-  cacheEngine.clearAllKeyInCache();
+  MemoryCacheEngine.clearAllCaches();
   await dbService.setup();
 }, 20000);
 
@@ -48,15 +49,15 @@ afterAll(async () => {
     // could be disposed in tests
   }
   await dbService.teardown();
-  cacheEngine.clearAllKeyInCache();
+  MemoryCacheEngine.clearAllCaches();
 }, 20000);
 
 beforeEach(() => {
-  cacheEngine.clearAllKeyInCache();
+  MemoryCacheEngine.clearAllCaches();
 });
 
 afterEach(() => {
-  cacheEngine.clearAllKeyInCache();
+  MemoryCacheEngine.clearAllCaches();
 });
 
 expect.extend({

--- a/apps/api/test/setup-integration-tests.ts
+++ b/apps/api/test/setup-integration-tests.ts
@@ -3,14 +3,14 @@ import "reflect-metadata";
 import { container } from "tsyringe";
 import { afterAll, afterEach, beforeAll, beforeEach, expect } from "vitest";
 
-import { cacheEngine } from "@src/caching/helpers";
+import MemoryCacheEngine from "@src/caching/memoryCacheEngine";
 import { TestDatabaseService } from "./services/test-database.service";
 
 const testPath = expect.getState().testPath;
 const dbService = new TestDatabaseService(testPath!);
 
 beforeAll(async () => {
-  cacheEngine.clearAllKeyInCache();
+  MemoryCacheEngine.clearAllCaches();
   await dbService.setup();
 }, 20_000);
 
@@ -21,13 +21,13 @@ afterAll(async () => {
     // could be disposed in tests
   }
   await dbService.teardown();
-  cacheEngine.clearAllKeyInCache();
+  MemoryCacheEngine.clearAllCaches();
 }, 20_000);
 
 beforeEach(() => {
-  cacheEngine.clearAllKeyInCache();
+  MemoryCacheEngine.clearAllCaches();
 });
 
 afterEach(() => {
-  cacheEngine.clearAllKeyInCache();
+  MemoryCacheEngine.clearAllCaches();
 });


### PR DESCRIPTION
## Why

The Sep 3 API abuse incident (an anonymous bot polling per-address/per-dseq endpoints at ~295K req/day) showed that memoized responses keyed by caller-controlled arguments (address, tx hash, dseq, block height, pagination params) share one LRU with every other cached response. A crawler sweeping distinct keys can evict the expensive hot entries (provider list, network capacity, chain stats) out of the shared cache and amplify DB load — the same pressure pattern behind the 2026-09-01 heap incident. Cloudflare rate limits now blunt single-IP abuse, but the origin should stay resilient when the next bot shows up distributed across many IPs.

## What

- Every `@Memoize` method on an anonymous route whose arguments form an unbounded key space now uses a capped private cache (`maxEntries: 500`, same pattern #3753 introduced for the deployment lookup): transactions by hash and by address, address details, balances, validator by address, provider by address, block by height, and the `/akash/deployment/{version}/deployments` fallback reader (both `info` via `@Memoize` and `list` via a private `MemoryCacheEngine` passed to `cacheResponse`).
- `GET /v1/leases-duration/{owner}` — previously uncached and one of the most expensive anonymous queries — is now memoized with `memoizeAsync` (500-entry LRU, 5-minute TTL) keyed by owner, dseq, and date range, following the `cached-balance.service.ts` pattern.
- `GET /v1/gpu-breakdown` had a correctness bug: the `Memoize` key builder drops non-primitive arguments, so every vendor/model filter combination shared a single cache entry for 5 minutes and could return another filter's results. It now uses `memoizeAsync` keyed by vendor and model, which also bounds its key space.
- Functional and integration test setups clear all registered caches between tests (`MemoryCacheEngine.clearAllCaches()` from #3784) instead of only the shared engine, so private caches cannot leak state across tests.

Pre-existing local test failures unrelated to this change (fail identically on `origin/main`): `sign-and-broadcast-tx.spec.ts` functional suite and the `markAsActive`/`markAsUsed` throttle integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved response times and resource usage for address, balance, block, provider, transaction, validator, deployment, GPU, and dashboard statistics queries through bounded caching.
  * Added caching for lease-duration statistics and GPU breakdown results, reducing repeated requests while keeping data refreshed through existing expiration periods.
  * Added safeguards to limit cached results and maintain consistent application performance during higher usage.

* **Bug Fixes**
  * Improved cache separation for certain dashboard and GPU queries to prevent different requests from sharing incorrect results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->