### PR TITLE
refactor(deployment): resolve an sdl reference from one flat set of secrets

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -96,7 +96,7 @@ ${Array.from({ length: 40 }, () => `      - FILLER=${"z".repeat(4096)}`).join("\
 /** A valid SDL with nothing in it worth sealing, so a write that must state a token has null to state. */
 const SDL_WITHOUT_SECRETS = sdlAround("");
 
-/** Short enough to survive `js-yaml` truncating the line it quotes, so a partial leak of it is still detectable. */
+/** `js-yaml` trims the end of the line it quotes and never the start, so it is the variable name below that carries the leak assertion: this value survives untruncated at ten characters but would not at thirty-two. */
 const MALFORMED_SDL_VALUE = faker.string.alphanumeric(10);
 
 /** Not YAML at all, and carrying an env value, because a `js-yaml` message quotes the lines around the one it failed on. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -18,8 +18,9 @@ import type { DeploymentSettingRepository } from "@src/deployment/repositories/d
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-import type { ReceivedSdlSecrets, SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import type { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
@@ -301,17 +302,16 @@ describe(DeploymentWriterService.name, () => {
     });
 
     it("resolves the manifest from the values the intake handed back", async () => {
-      const byService = { web: { TOKEN: "resolved" } };
-      const { service, sdlService } = setup({ received: { supplied: { TOKEN: "resolved" }, byService } });
+      const received = { TOKEN: "resolved" };
+      const { service, sdlService } = setup({ received });
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
 
-      expect(sdlService.generateResolvedManifest).toHaveBeenCalledWith(expect.objectContaining({ secrets: byService }));
+      expect(sdlService.generateResolvedManifest).toHaveBeenCalledWith(expect.objectContaining({ secrets: received }));
     });
 
     it("seals what the client supplied together with the credentials it took out itself, against the dseq it just minted", async () => {
-      const supplied = { TOKEN: "resolved" };
-      const { service, sdlSecretsService } = setup({ received: { supplied, byService: { web: supplied } } });
+      const { service, sdlSecretsService } = setup({ received: { TOKEN: "resolved" } });
       vi.spyOn(Date, "now").mockReturnValue(1748400000000);
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
@@ -334,8 +334,7 @@ describe(DeploymentWriterService.name, () => {
     });
 
     it("refuses a supplied name the console derives for the same deployment, before minting a dseq", async () => {
-      const supplied = { s0_c_password: "resolved" };
-      const { service, deploymentSettingRepository, signerService } = setup({ received: { supplied, byService: { web: supplied } } });
+      const { service, deploymentSettingRepository, signerService } = setup({ received: { s0_c_password: "resolved" } });
       const dateNow = vi.spyOn(Date, "now");
 
       await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 })).rejects.toMatchObject({
@@ -367,8 +366,8 @@ describe(DeploymentWriterService.name, () => {
     });
 
     it("seals once for the whole create", async () => {
-      const supplied = Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`SECRET_${index}`, "value"]));
-      const { service, sdlSecretsService } = setup({ received: { supplied, byService: { web: supplied, worker: supplied } } });
+      const received = Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`SECRET_${index}`, "value"]));
+      const { service, sdlSecretsService } = setup({ received });
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
 
@@ -492,7 +491,7 @@ describe(DeploymentWriterService.name, () => {
     });
 
     it("says nothing about a supplied value in what it logs", async () => {
-      const { service, logger } = setup({ received: { supplied: { TOKEN: ENV_VALUE }, byService: { web: { TOKEN: ENV_VALUE } } } });
+      const { service, logger } = setup({ received: { TOKEN: ENV_VALUE } });
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
 
@@ -1184,7 +1183,7 @@ describe(DeploymentWriterService.name, () => {
     transactionRuns?: boolean;
     compensationEnqueued?: boolean;
     manifestVersion?: Uint8Array;
-    received?: ReceivedSdlSecrets;
+    received?: SdlSecrets;
     sealedSecrets?: string | null;
   }) {
     const signerService = mock<ManagedSignerService>();
@@ -1216,7 +1215,7 @@ describe(DeploymentWriterService.name, () => {
     const sdlSecretsService = mock<SdlSecretsService>();
     /** Real rather than doubled, because what every stored-sdl assertion below measures is the document this produces. */
     const sdlSecretsDerivationService = new SdlSecretsDerivationService(new SdlReferenceService());
-    sdlSecretsService.receive.mockResolvedValue({ ok: true, value: input?.received ?? { supplied: {}, byService: {} } });
+    sdlSecretsService.receive.mockResolvedValue({ ok: true, value: input?.received ?? {} });
     sdlSecretsService.sealForStorage.mockResolvedValue(input?.sealedSecrets ?? null);
 
     walletReaderService.getWalletByUserId.mockResolvedValue(wallet);

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -19,8 +19,7 @@ import {
   unbackedDeploymentSettingKeyFor
 } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
-import { MAX_ECHOED_REFERENCE_LENGTH, type NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-import type { ReceivedSdlSecrets } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import { MAX_ECHOED_REFERENCE_LENGTH } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
 import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
@@ -70,11 +69,11 @@ export class DeploymentWriterService {
 
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const depositInDollars = this.deploymentConfig.get("DEPLOYMENT_DEFAULT_DEPOSIT");
-    const secrets = await this.#receiveSecrets(input);
-    const stored = this.#storedSecretsOf(secrets.supplied, derived);
+    const supplied = await this.#receiveSecrets(input);
+    const stored = this.#storedSecretsOf(supplied, derived);
 
     const dseq = Date.now().toString();
-    const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: secrets.byService, isTrialing: !!wallet.isTrialing });
+    const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: supplied, isTrialing: !!wallet.isTrialing });
     const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: stored });
 
     if (wallet.isTrialing) {
@@ -320,7 +319,7 @@ export class DeploymentWriterService {
   }
 
   /** Only the manifest version is taken from the resolved SDL: the resolved manifest itself must not leave this call. Runs before any lookup so a bad reference always answers 400 rather than racing a 404. */
-  async #resolveSdl(sdl: string, options: { secrets?: NamespacedSdlSecrets; isTrialing?: boolean }) {
+  async #resolveSdl(sdl: string, options: { secrets?: SdlSecrets; isTrialing?: boolean }) {
     const result = await this.sdlService.generateResolvedManifest({ sdl, ...options, secrets: options.secrets ?? {} });
 
     if (!result.ok) {
@@ -331,7 +330,7 @@ export class DeploymentWriterService {
   }
 
   /** Reports through the same channel every other reference mistake uses, so a missing value reads identically whether the intake or substitution found it. */
-  async #receiveSecrets(input: CreateDeploymentRequest["data"]): Promise<ReceivedSdlSecrets> {
+  async #receiveSecrets(input: CreateDeploymentRequest["data"]): Promise<SdlSecrets> {
     const parsed = this.sdlService.parse(input.sdl);
 
     if (!parsed.ok) {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -197,7 +197,7 @@ export class DeploymentWriterService {
 
   /** Runs before the document is measured, so that what the size guard bounds is exactly what gets stored. */
   #takeValuesOutOf(document: SDLInput, values: StoredSdlValues): SdlSecrets {
-    return this.sdlSecretsDerivationService.derive(document, { includeEnvValues: values === "every-value-sealed" }).secrets;
+    return this.sdlSecretsDerivationService.derive(document, { includeEnvValues: values === "every-value-sealed" });
   }
 
   /**

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
@@ -3,7 +3,7 @@ import { yaml } from "@akashnetwork/chain-sdk";
 import { faker } from "@faker-js/faker";
 import { describe, expect, it } from "vitest";
 
-import type { NamespacedSdlSecrets, SdlReferenceResolver } from "./sdl-reference.service";
+import type { SdlReferenceResolver } from "./sdl-reference.service";
 import { MAX_SDL_REFERENCE_NAME_LENGTH, SdlReferenceService } from "./sdl-reference.service";
 
 const VALID_NAMES = ["A", "a", "_", "_A", "A9", `A${"b".repeat(62)}`, `A${"b".repeat(63)}`];
@@ -113,7 +113,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["DATABASE_URL=ac-secret://DATABASE_URL"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { DATABASE_URL: "postgres://u:p@host/db" } } });
+      const errors = service.substitute(sdl, { secrets: { DATABASE_URL: "postgres://u:p@host/db" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["DATABASE_URL=postgres://u:p@host/db"]);
@@ -124,7 +124,7 @@ describe(SdlReferenceService.name, () => {
       const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"]);
       const env = sdl.services.web.env;
 
-      service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
+      service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(env).toBe(sdl.services.web.env);
       expect(env).toEqual(["TOKEN=resolved"]);
@@ -135,7 +135,7 @@ describe(SdlReferenceService.name, () => {
       const value = "a: b #c |x >y {z} [w] &anchor *alias \"q\" 's'\nsecond: line\n\t- dash";
       const sdl = sdlWithEnv(["WEIRD=ac-secret://WEIRD"]);
 
-      service.substitute(sdl, { secrets: { web: { WEIRD: value } } });
+      service.substitute(sdl, { secrets: { WEIRD: value } });
 
       expect(sdl.services.web.env).toEqual([`WEIRD=${value}`]);
     });
@@ -144,7 +144,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["PAIR=ac-secret://PAIR"]);
 
-      service.substitute(sdl, { secrets: { web: { PAIR: "a=b=c" } } });
+      service.substitute(sdl, { secrets: { PAIR: "a=b=c" } });
 
       expect(sdl.services.web.env).toEqual(["PAIR=a=b=c"]);
     });
@@ -153,7 +153,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["MIXED=prefix ac-secret://TOKEN", 'QUOTED="ac-secret://TOKEN"', "LISTED=ac,ac-secret://TOKEN"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["MIXED=prefix ac-secret://TOKEN", 'QUOTED="ac-secret://TOKEN"', "LISTED=ac,ac-secret://TOKEN"]);
@@ -162,7 +162,7 @@ describe(SdlReferenceService.name, () => {
     it("reports a value opening with a reference and trailing something else", () => {
       const { service } = setup();
 
-      const [error] = service.substitute(sdlWithEnv(["SUFFIX=ac-secret://TOKEN suffix"]), { secrets: { web: { TOKEN: "resolved" } } });
+      const [error] = service.substitute(sdlWithEnv(["SUFFIX=ac-secret://TOKEN suffix"]), { secrets: { TOKEN: "resolved" } });
 
       expect(error.message).toContain("reserved");
     });
@@ -171,7 +171,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["ac-secret://TOKEN"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["ac-secret://TOKEN"]);
@@ -181,7 +181,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["A=ac-secret://A"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { A: "ac-secret://B", B: "leaked" } } });
+      const errors = service.substitute(sdl, { secrets: { A: "ac-secret://B", B: "leaked" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["A=ac-secret://B"]);
@@ -203,46 +203,46 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["TOKEN=ac-var://TOKEN"]);
 
-      const [error] = service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
+      const [error] = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(error.message).toContain("unknown SDL Reference kind");
       expect(sdl.services.web.env).toEqual(["TOKEN=ac-var://TOKEN"]);
     });
 
-    it("gives each service its own value for the same name", () => {
+    it("gives every service that references one name the same value", () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["TOKEN=ac-secret://TOKEN"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "web-value" }, worker: { TOKEN: "worker-value" } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: "shared" } });
 
       expect(errors).toEqual([]);
-      expect(sdl.services.web.env).toEqual(["TOKEN=web-value"]);
-      expect(sdl.services.worker.env).toEqual(["TOKEN=worker-value"]);
+      expect(sdl.services.web.env).toEqual(["TOKEN=shared"]);
+      expect(sdl.services.worker.env).toEqual(["TOKEN=shared"]);
     });
 
-    it("reports a name one service supplies and another does not, naming the service that lacks it", () => {
+    it("names the service a missing value was referenced from", () => {
       const { service } = setup();
-      const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["TOKEN=ac-secret://TOKEN"]);
+      const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["OTHER=ac-secret://OTHER"]);
 
-      const [error] = service.substitute(sdl, { secrets: { web: { TOKEN: "web-value" } } });
+      const [error] = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
-      expect(error.message).toContain("ac-secret://TOKEN");
+      expect(error.message).toContain("ac-secret://OTHER");
       expect(error.message).toContain("worker");
       expect(error.instancePath).toBe("/services/worker/env/0");
-      expect(sdl.services.worker.env).toEqual(["TOKEN=ac-secret://TOKEN"]);
+      expect(sdl.services.worker.env).toEqual(["OTHER=ac-secret://OTHER"]);
     });
 
-    it("resolves one service while another service supplies no namespace at all", () => {
+    it("resolves one service while another references nothing", () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["PORT=8080"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "web-value" } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(errors).toEqual([]);
-      expect(sdl.services.web.env).toEqual(["TOKEN=web-value"]);
+      expect(sdl.services.web.env).toEqual(["TOKEN=resolved"]);
     });
 
-    it.each(["constructor", "__proto__", "toString", "hasOwnProperty"])("reports a missing namespace for the service name %j", serviceName => {
+    it.each(["constructor", "__proto__", "toString", "hasOwnProperty"])("reports a missing value for a service named %j", serviceName => {
       const { service } = setup();
       const sdl = yaml.raw<SDLInput>(sdlYaml(serviceYaml(serviceName, ["TOKEN=ac-secret://TOKEN"])));
 
@@ -260,16 +260,6 @@ describe(SdlReferenceService.name, () => {
 
       expect(error.message.length).toBeLessThan(300);
       expect(error.message).toContain(String(error.params.serviceName));
-    });
-
-    it.each([{ web: "supersecret" }, { web: ["item"] }])("reports a missing value for the non-object namespace %j", secrets => {
-      const { service } = setup();
-      const sdl = sdlWithEnv(["A=ac-secret://length"]);
-
-      const [error] = service.substitute(sdl, { secrets: secrets as unknown as NamespacedSdlSecrets });
-
-      expect(error.message).toContain("no value supplied");
-      expect(sdl.services.web.env).toEqual(["A=ac-secret://length"]);
     });
 
     it.each([42, null, { nested: true }, ["array"], true])("refuses a resolver's non-string value %j", resolved => {
@@ -313,7 +303,7 @@ describe(SdlReferenceService.name, () => {
       const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
       const sdl = sdlWithCredentials({ username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" });
 
-      const errors = service.substitute(sdl, { secrets: { web: { REG_USER: username, REG_PASS: password } } });
+      const errors = service.substitute(sdl, { secrets: { REG_USER: username, REG_PASS: password } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.credentials).toMatchObject({ username, password });
@@ -323,22 +313,21 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithCredentials({ password: "ac-secret://REG_PASS" });
 
-      service.substitute(sdl, { secrets: { web: { REG_PASS: faker.internet.password() } } });
+      service.substitute(sdl, { secrets: { REG_PASS: faker.internet.password() } });
 
       expect(sdl.services.web.credentials).toMatchObject({ host: "registry.example.test", email: "ops@example.test" });
     });
 
-    it("resolves a credential from its own service's namespace", () => {
+    it("resolves a credential in every service that references it", () => {
       const { service } = setup();
       const sdl = sdlWithCredentials({ password: "ac-secret://REG_PASS" }, { password: "ac-secret://REG_PASS" });
+      const password = faker.internet.password();
 
-      const [webPassword, workerPassword] = [faker.internet.password(), faker.internet.password()];
-
-      const errors = service.substitute(sdl, { secrets: { web: { REG_PASS: webPassword }, worker: { REG_PASS: workerPassword } } });
+      const errors = service.substitute(sdl, { secrets: { REG_PASS: password } });
 
       expect(errors).toEqual([]);
-      expect(sdl.services.web.credentials!.password).toBe(webPassword);
-      expect(sdl.services.worker.credentials!.password).toBe(workerPassword);
+      expect(sdl.services.web.credentials!.password).toBe(password);
+      expect(sdl.services.worker.credentials!.password).toBe(password);
     });
 
     it("quotes the reference of a credential it holds no value for, a reserved-prefix string being one no registry could accept anyway", () => {
@@ -366,7 +355,7 @@ describe(SdlReferenceService.name, () => {
       const password = `ac-dc-${faker.internet.password()}`;
       const sdl = sdlSharingOneCredentialsBlock("ac-secret://REG_PASS");
 
-      const errors = service.substitute(sdl, { secrets: { web: { REG_PASS: password }, worker: { REG_PASS: password } } });
+      const errors = service.substitute(sdl, { secrets: { REG_PASS: password } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.credentials!.password).toBe(password);
@@ -378,7 +367,7 @@ describe(SdlReferenceService.name, () => {
       const value = `ac-dc-${faker.string.alphanumeric(16)}`;
       const sdl = sdlSharingOneEnvList("TOKEN=ac-secret://TOKEN");
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: value }, worker: { TOKEN: value } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: value } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual([`TOKEN=${value}`]);
@@ -417,7 +406,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv([`A=ac-secret://${name}`]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { [name]: "resolved" } } });
+      const errors = service.substitute(sdl, { secrets: { [name]: "resolved" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["A=resolved"]);
@@ -427,7 +416,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const reference = `ac-secret://${name}`;
 
-      const [error] = service.substitute(sdlWithEnv([`A=${reference}`]), { secrets: { web: { [name]: "resolved" } } });
+      const [error] = service.substitute(sdlWithEnv([`A=${reference}`]), { secrets: { [name]: "resolved" } });
 
       expect(error.message).toContain("reserved");
     });
@@ -435,7 +424,7 @@ describe(SdlReferenceService.name, () => {
     it.each(RESERVED_VALUES)("rejects the reserved value %j", value => {
       const { service } = setup();
 
-      const [error] = service.substitute(sdlWithEnv([`A=${value}`]), { secrets: { web: { X: "resolved", TOKEN: "resolved" } } });
+      const [error] = service.substitute(sdlWithEnv([`A=${value}`]), { secrets: { X: "resolved", TOKEN: "resolved" } });
 
       expect(error.message).toContain("reserved");
       expect(error.message).toContain(value);
@@ -454,7 +443,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["UPPER=ac-secret://TOKEN", "LOWER=ac-secret://token"]);
 
-      service.substitute(sdl, { secrets: { web: { TOKEN: "upper", token: "lower" } } });
+      service.substitute(sdl, { secrets: { TOKEN: "upper", token: "lower" } });
 
       expect(sdl.services.web.env).toEqual(["UPPER=upper", "LOWER=lower"]);
     });
@@ -462,7 +451,7 @@ describe(SdlReferenceService.name, () => {
     it("reports a name whose case does not match the supplied one", () => {
       const { service } = setup();
 
-      const [error] = service.substitute(sdlWithEnv(["A=ac-secret://token"]), { secrets: { web: { TOKEN: "resolved" } } });
+      const [error] = service.substitute(sdlWithEnv(["A=ac-secret://token"]), { secrets: { TOKEN: "resolved" } });
 
       expect(error.message).toContain("ac-secret://token");
     });

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -63,7 +63,7 @@ export interface SdlReferenceResolver {
 /** One position in an SDL where a reference may stand, holding the write back so a caller of the walk never has to know how that position spells a value. */
 export interface SdlReferenceSlot {
   serviceName: string;
-  /** The service's place in the document rather than its name, because a name may spell anything and a reference name may not. */
+  /** Where the service falls in `Object.entries` order — not the document's own order, since an integer-like name sorts first — because a name may spell anything and a reference name may not. */
   serviceIndex: number;
   instancePath: string;
   /** The container the value lives on, so a caller can tell two positions apart from one position two services share through a YAML anchor. */

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -43,11 +43,8 @@ function readEnvDeclaration(entry: string): { key: string; value: string } | nul
   return valueStart === -1 ? null : { key: entry.slice(0, valueStart), value: entry.slice(valueStart + 1) };
 }
 
-/** One namespace per service, so two services can reference the same name and receive their own value. */
-export type NamespacedSdlSecrets = Record<string, SdlSecrets>;
-
 export interface SdlReferenceContext {
-  secrets: NamespacedSdlSecrets;
+  secrets: SdlSecrets;
 }
 
 export interface SdlReferenceTarget {
@@ -85,18 +82,14 @@ export interface SdlReferenceDeclaration extends SdlReferenceTarget {
 
 type SdlReferenceVisitor = (reference: SdlReferenceDeclaration, slot: SdlReferenceSlot) => ValidationError | undefined;
 
-/** A service or reference name may spell an `Object.prototype` member, and a bare lookup would answer such a name with an inherited function. */
+/** A reference name may spell an `Object.prototype` member, and a bare lookup would answer such a name with an inherited function. */
 export function ownValue<T>(record: Record<string, T>, key: string): T | undefined {
   return Object.hasOwn(record, key) ? record[key] : undefined;
 }
 
 const secretReferenceResolver: SdlReferenceResolver = {
   kind: "secret",
-  resolve: ({ serviceName, name }, { secrets }) => {
-    const namespace = ownValue(secrets, serviceName);
-
-    return typeof namespace === "object" && namespace !== null ? ownValue(namespace, name) : undefined;
-  }
+  resolve: ({ name }, { secrets }) => ownValue(secrets, name)
 };
 
 function referenceError(instancePath: string, message: string, params: Record<string, unknown>): ValidationError {

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -19,7 +19,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const token = faker.string.alphanumeric(24);
       const document = documentWith({ web: { env: [`API_TOKEN=${token}`] } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_e0: token });
       expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
@@ -42,7 +42,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const [web, worker] = [faker.string.alphanumeric(16), faker.string.alphanumeric(16)];
 
-      const { secrets } = service.derive(documentWith({ web: { env: [`PASSWORD=${web}`] }, worker: { env: [`PASSWORD=${worker}`] } }), {
+      const secrets = service.derive(documentWith({ web: { env: [`PASSWORD=${web}`] }, worker: { env: [`PASSWORD=${worker}`] } }), {
         includeEnvValues: true
       });
 
@@ -54,7 +54,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
       const document = documentWith({ web: { credentials: { host: REGISTRY_HOST, email: REGISTRY_EMAIL, username, password } } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_c_username: username, s0_c_password: password });
       expect(document.services.web.credentials).toEqual({
@@ -69,7 +69,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: ["EXPLICITLY_EMPTY=", "INHERITED_FROM_HOST"] } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_e0: "" });
       expect(document.services.web.env).toEqual(["EXPLICITLY_EMPTY=ac-secret://s0_e0", "INHERITED_FROM_HOST"]);
@@ -79,7 +79,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: ["API_TOKEN=ac-secret://API_TOKEN", `LOG_LEVEL=${faker.string.alphanumeric(5)}`] } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(Object.keys(secrets)).toEqual(["s0_e1"]);
       expect(document.services.web.env![0]).toBe("API_TOKEN=ac-secret://API_TOKEN");
@@ -88,20 +88,13 @@ describe(SdlSecretsDerivationService.name, () => {
     it("takes nothing from a document that carries no env and no credentials", () => {
       const { service } = setup();
 
-      expect(service.derive(documentWith({ web: {} }), { includeEnvValues: true })).toEqual({ secrets: {}, derivedCount: 0 });
+      expect(service.derive(documentWith({ web: {} }), { includeEnvValues: true })).toEqual({});
     });
 
     it.each([{ env: null }, {}])("leaves the service declaring %j untouched", overrides => {
       const { service } = setup();
 
-      expect(service.derive(documentWith({ web: overrides }), { includeEnvValues: true }).secrets).toEqual({});
-    });
-
-    it("reports how many positions it rewrote without reporting any of their values", () => {
-      const { service } = setup();
-      const document = documentWith({ web: { env: [`A=${faker.string.alphanumeric(8)}`, `B=${faker.string.alphanumeric(8)}`] } });
-
-      expect(service.derive(document, { includeEnvValues: true }).derivedCount).toBe(2);
+      expect(service.derive(documentWith({ web: overrides }), { includeEnvValues: true })).toEqual({});
     });
   });
 
@@ -111,7 +104,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const token = faker.string.alphanumeric(24);
       const document = documentWith({ web: { env: [`API_TOKEN=${token}`] } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: false });
+      const secrets = service.derive(document, { includeEnvValues: false });
 
       expect(secrets).toEqual({});
       expect(document.services.web.env).toEqual([`API_TOKEN=${token}`]);
@@ -124,10 +117,28 @@ describe(SdlSecretsDerivationService.name, () => {
         web: { env: [`LOG_LEVEL=${faker.string.alphanumeric(5)}`], credentials: { host: REGISTRY_HOST, username, password } }
       });
 
-      const { secrets } = service.derive(document, { includeEnvValues: false });
+      const secrets = service.derive(document, { includeEnvValues: false });
 
       expect(secrets).toEqual({ s0_c_username: username, s0_c_password: password });
       expect(document.services.web.credentials!.password).toBe("ac-secret://s0_c_password");
+    });
+
+    it("takes both halves from every service that declares its own credentials block, not only the first", () => {
+      const { service } = setup();
+      const web = { host: REGISTRY_HOST, username: faker.string.alphanumeric(10), password: faker.internet.password() };
+      const worker = { host: "other-registry.example.test", username: faker.string.alphanumeric(10), password: faker.internet.password() };
+      const document = documentWith({ web: { credentials: web }, worker: { credentials: worker } });
+
+      const secrets = service.derive(document, { includeEnvValues: false });
+
+      expect(secrets).toEqual({
+        s0_c_username: web.username,
+        s0_c_password: web.password,
+        s1_c_username: worker.username,
+        s1_c_password: worker.password
+      });
+      expect(document.services.web.credentials).toMatchObject({ username: "ac-secret://s0_c_username", password: "ac-secret://s0_c_password" });
+      expect(document.services.worker.credentials).toMatchObject({ username: "ac-secret://s1_c_username", password: "ac-secret://s1_c_password" });
     });
 
     it("leaves a credential that already names a secret alone", () => {
@@ -136,7 +147,7 @@ describe(SdlSecretsDerivationService.name, () => {
         web: { credentials: { host: REGISTRY_HOST, username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" } }
       });
 
-      expect(service.derive(document, { includeEnvValues: false }).secrets).toEqual({});
+      expect(service.derive(document, { includeEnvValues: false })).toEqual({});
     });
   });
 
@@ -145,7 +156,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: [`T=${value}`] } });
 
-      expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({});
+      expect(service.derive(document, { includeEnvValues: true })).toEqual({});
       expect(document.services.web.env).toEqual([`T=${value}`]);
     });
 
@@ -155,7 +166,7 @@ describe(SdlSecretsDerivationService.name, () => {
         const { service } = setup();
         const document = documentWith({ web: { env: [`T=${value}`] } });
 
-        expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({ s0_e0: value });
+        expect(service.derive(document, { includeEnvValues: true })).toEqual({ s0_e0: value });
         expect(document.services.web.env).toEqual(["T=ac-secret://s0_e0"]);
       }
     );
@@ -164,7 +175,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: ["T=ac-secret://T"] }, worker: { env: ["T=ac-secret://T"] } });
 
-      expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({});
+      expect(service.derive(document, { includeEnvValues: true })).toEqual({});
       expect(document.services.web.env).toEqual(["T=ac-secret://T"]);
       expect(document.services.worker.env).toEqual(["T=ac-secret://T"]);
     });
@@ -174,7 +185,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const url = `postgres://u:${faker.internet.password()}@h:5432/db?ssl=true&a=b`;
       const document = documentWith({ web: { env: [`DATABASE_URL=${url}`] } });
 
-      expect(service.derive(document, { includeEnvValues: true }).secrets).toEqual({ s0_e0: url });
+      expect(service.derive(document, { includeEnvValues: true })).toEqual({ s0_e0: url });
       expect(document.services.web.env).toEqual(["DATABASE_URL=ac-secret://s0_e0"]);
     });
   });
@@ -185,7 +196,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const token = faker.string.alphanumeric(12);
       const document = yaml.raw<SDLInput>(sdlSharingOneListBetweenEnvAndArgs(`API_TOKEN=${token}`));
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_e0: token });
       expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
@@ -210,7 +221,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const password = faker.internet.password();
       const document = yaml.raw<SDLInput>(sdlSharingCredentials(password));
 
-      const { secrets } = service.derive(document, { includeEnvValues: false });
+      const secrets = service.derive(document, { includeEnvValues: false });
 
       expect(Object.keys(secrets)).toEqual(["s0_c_username", "s0_c_password"]);
       expect(secrets.s0_c_password).toBe(password);
@@ -223,7 +234,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const token = faker.string.alphanumeric(20);
       const document = yaml.raw<SDLInput>(sdlSharingEnv(`API_TOKEN=${token}`));
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(secrets).toEqual({ s0_e0: token });
       expect(document.services.web.env).toEqual(["API_TOKEN=ac-secret://s0_e0"]);
@@ -239,7 +250,7 @@ describe(SdlSecretsDerivationService.name, () => {
         "a-service-name-the-grammar-would-refuse.42": { env: [`B=${faker.string.alphanumeric(8)}`] }
       });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
 
       expect(Object.keys(secrets)).toHaveLength(4);
       Object.keys(secrets).forEach(name => expect(isSdlReference(`ac-secret://${name}`)).toBe(true));
@@ -249,7 +260,7 @@ describe(SdlSecretsDerivationService.name, () => {
       const { service } = setup();
       const document = documentWith({ web: { env: Array.from({ length: 5000 }, (_, index) => `SETTING_${index}=v`) } });
 
-      const { secrets } = service.derive(document, { includeEnvValues: true });
+      const secrets = service.derive(document, { includeEnvValues: true });
       const longest = Object.keys(secrets).reduce((longestSoFar, name) => Math.max(longestSoFar, name.length), 0);
 
       expect(Object.keys(secrets)).toHaveLength(5000);
@@ -287,7 +298,7 @@ describe(SdlSecretsDerivationService.name, () => {
     ];
     const rewritten = documentWith({ web: { env: values.map((value, index) => `V${index}=${value}`) } });
 
-    const { secrets } = service.derive(rewritten, { includeEnvValues: true });
+    const secrets = service.derive(rewritten, { includeEnvValues: true });
     const reparsed = yaml.raw<SDLInput>(dump(rewritten, { lineWidth: -1 }));
     const byService = Object.fromEntries(Object.keys(reparsed.services).map(serviceName => [serviceName, secrets]));
 
@@ -307,7 +318,7 @@ describe(SdlSecretsDerivationService.name, () => {
     const submitted = documentWith(services);
     const rewritten = documentWith(services);
 
-    const { secrets } = service.derive(rewritten, { includeEnvValues: true });
+    const secrets = service.derive(rewritten, { includeEnvValues: true });
     const byService = Object.fromEntries(Object.keys(rewritten.services).map(serviceName => [serviceName, secrets]));
 
     expect(sdlReferenceService.substitute(rewritten, { secrets: byService })).toEqual([]);

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -300,9 +300,8 @@ describe(SdlSecretsDerivationService.name, () => {
 
     const secrets = service.derive(rewritten, { includeEnvValues: true });
     const reparsed = yaml.raw<SDLInput>(dump(rewritten, { lineWidth: -1 }));
-    const byService = Object.fromEntries(Object.keys(reparsed.services).map(serviceName => [serviceName, secrets]));
 
-    expect(sdlReferenceService.substitute(reparsed, { secrets: byService })).toEqual([]);
+    expect(sdlReferenceService.substitute(reparsed, { secrets })).toEqual([]);
     expect(reparsed.services.web.env).toEqual(values.map((value, index) => `V${index}=${value}`));
   });
 
@@ -319,9 +318,8 @@ describe(SdlSecretsDerivationService.name, () => {
     const rewritten = documentWith(services);
 
     const secrets = service.derive(rewritten, { includeEnvValues: true });
-    const byService = Object.fromEntries(Object.keys(rewritten.services).map(serviceName => [serviceName, secrets]));
 
-    expect(sdlReferenceService.substitute(rewritten, { secrets: byService })).toEqual([]);
+    expect(sdlReferenceService.substitute(rewritten, { secrets })).toEqual([]);
     expect(rewritten).toEqual(submitted);
   });
 

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -8,59 +8,31 @@ import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/s
 /** The kind every derived reference is written as, because a derived value is a secret like any other and nothing downstream needs to know it was not supplied. */
 const DERIVED_REFERENCE_KIND = "secret";
 
-export interface DerivedSdlSecrets {
-  /** Name to value, in the shape `sealForStorage` seals and the stored token carries. */
-  secrets: SdlSecrets;
-  /** How many positions were rewritten, for a log line that has to say something without saying a value. */
-  derivedCount: number;
-}
-
-const NOTHING_DERIVED: DerivedSdlSecrets = { secrets: {}, derivedCount: 0 };
-
-/**
- * Takes the values a submitted SDL carries in the clear out of the document and hands them back as
- * secrets, leaving an `ac-secret://NAME` reference in each place one stood. This is what lets a client
- * that names none of its secrets still have them stored as ciphertext rather than as text, and what keeps
- * the definition it leaves behind resolvable instead of blanked.
- *
- * `includeEnvValues` is the difference between the two callers. A request that sealed its values has
- * already said which of them are secret, so only a private registry credential is taken — that is a
- * secret whatever it holds, and there is no ordinary reading of it. A request that sealed nothing has
- * said nothing, so every value in `env` is taken as well.
- *
- * A value that is already a whole reference is left alone. It names a secret rather than carrying one,
- * and inventing a value for a name the author asked to be handed would turn a missing-value refusal into
- * a deployment configured with the literal text of its own reference.
- *
- * Mutates the document it is given, which must therefore be a copy the caller keeps to itself: the
- * manifest is generated from the submitted SDL and has to see the real values, so a document with
- * references written into it can only ever be the one being stored.
- */
+/** Takes the values a submitted SDL carries in the clear out of the document and hands them back as secrets, leaving an `ac-secret://NAME` reference where each one stood. */
 @singleton()
 export class SdlSecretsDerivationService {
   constructor(private readonly sdlReferenceService: SdlReferenceService) {}
 
-  derive(document: SDLInput, options: { includeEnvValues: boolean }): DerivedSdlSecrets {
-    const slots = this.sdlReferenceService.slotsOf(document).filter(slot => this.#isDerivable(slot, options));
-
-    if (slots.length === 0) return NOTHING_DERIVED;
-
+  /** Mutates the document it is given, which must therefore be a copy the caller keeps to itself: the manifest is generated from the submitted SDL and has to see the real values. */
+  derive(document: SDLInput, options: { includeEnvValues: boolean }): SdlSecrets {
     const secrets: SdlSecrets = {};
-    const namesByNode = new Map<object, Map<string, string>>();
+    const takenByNode = new Map<object, Set<string>>();
 
-    for (const slot of slots) {
-      const namesInNode = namesByNode.get(slot.node) ?? new Map<string, string>();
-      namesByNode.set(slot.node, namesInNode);
+    for (const slot of this.sdlReferenceService.slotsOf(document)) {
+      if (!this.#isDerivable(slot, options)) continue;
 
-      if (namesInNode.has(slot.position)) continue;
+      const takenInNode = takenByNode.get(slot.node) ?? new Set<string>();
+      takenByNode.set(slot.node, takenInNode);
+
+      if (takenInNode.has(slot.position)) continue;
 
       const name = `s${slot.serviceIndex}_${slot.position}`;
-      namesInNode.set(slot.position, name);
+      takenInNode.add(slot.position);
       secrets[name] = slot.value;
       slot.replace(`ac-${DERIVED_REFERENCE_KIND}://${name}`);
     }
 
-    return { secrets, derivedCount: Object.keys(secrets).length };
+    return secrets;
   }
 
   #isDerivable(slot: SdlReferenceSlot, options: { includeEnvValues: boolean }): boolean {

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
@@ -25,16 +25,16 @@ function sdlWith(services: Record<string, string[]>): SDLInput {
 
 describe(SdlSecretsService.name, () => {
   describe("receive", () => {
-    it("hands a referenced value to the service that referenced it", async () => {
+    it("returns the value a reference names", async () => {
       const { service } = setup({ supplied: { TOKEN: "resolved" } });
 
       const result = await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
 
       expect(result.ok).toBe(true);
-      expect(receivedOf(result).byService).toEqual({ web: { TOKEN: "resolved" } });
+      expect(receivedOf(result)).toEqual({ TOKEN: "resolved" });
     });
 
-    it("hands one supplied value to every service that references it", async () => {
+    it("accepts one value several services reference", async () => {
       const { service } = setup({ supplied: { TOKEN: "shared" } });
 
       const result = await service.receive({
@@ -43,10 +43,10 @@ describe(SdlSecretsService.name, () => {
         sealedSecrets: SEAL
       });
 
-      expect(receivedOf(result).byService).toEqual({ web: { TOKEN: "shared" }, worker: { TOKEN: "shared" }, cron: { TOKEN: "shared" } });
+      expect(receivedOf(result)).toEqual({ TOKEN: "shared" });
     });
 
-    it("hands a service only the names it references", async () => {
+    it("accepts names referenced from different services", async () => {
       const { service } = setup({ supplied: { TOKEN: "one", DATABASE_URL: "two" } });
 
       const result = await service.receive({
@@ -55,10 +55,10 @@ describe(SdlSecretsService.name, () => {
         sealedSecrets: SEAL
       });
 
-      expect(receivedOf(result).byService).toEqual({ web: { TOKEN: "one" }, db: { DATABASE_URL: "two" } });
+      expect(receivedOf(result)).toEqual({ TOKEN: "one", DATABASE_URL: "two" });
     });
 
-    it("hands nothing to a service that references nothing", async () => {
+    it("accepts a document whose other service references nothing", async () => {
       const { service } = setup({ supplied: { TOKEN: "resolved" } });
 
       const result = await service.receive({
@@ -67,20 +67,7 @@ describe(SdlSecretsService.name, () => {
         sealedSecrets: SEAL
       });
 
-      expect(Object.keys(receivedOf(result).byService)).toEqual(["web"]);
-    });
-
-    it("keeps what the client sealed unchanged, for storage", async () => {
-      const supplied = { TOKEN: "one", DATABASE_URL: "two" };
-      const { service } = setup({ supplied });
-
-      const result = await service.receive({
-        sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN", "DATABASE_URL=ac-secret://DATABASE_URL"] }),
-        rawSdl: RAW_SDL,
-        sealedSecrets: SEAL
-      });
-
-      expect(receivedOf(result).supplied).toEqual(supplied);
+      expect(receivedOf(result)).toEqual({ TOKEN: "resolved" });
     });
 
     it("names a reference it holds no value for", async () => {
@@ -147,12 +134,12 @@ describe(SdlSecretsService.name, () => {
       expect(JSON.stringify(errorsOf(result))).not.toContain(value);
     });
 
-    it("resolves a name spelling an Object.prototype member from what was supplied for it", async () => {
+    it("accepts a name spelling an Object.prototype member supplied for it", async () => {
       const { service } = setup({ supplied: JSON.parse('{"constructor":"resolved"}') as SdlSecrets });
 
       const result = await service.receive({ sdl: sdlWith({ web: ["C=ac-secret://constructor"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
 
-      expect(receivedOf(result).byService).toEqual({ web: { constructor: "resolved" } });
+      expect(result.ok).toBe(true);
     });
 
     it("refuses a reference whose name spells an Object.prototype member nothing was supplied for", async () => {
@@ -168,7 +155,7 @@ describe(SdlSecretsService.name, () => {
 
       const result = await service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL });
 
-      expect(receivedOf(result)).toEqual({ supplied: {}, byService: {} });
+      expect(receivedOf(result)).toEqual({});
       expect(unsealerService.open).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
@@ -4,7 +4,7 @@ import { inject, singleton } from "tsyringe";
 
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { jsonEncodedBytes } from "@src/deployment/config/sdl-secrets.config";
-import type { NamespacedSdlSecrets, SdlReferenceDeclaration } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { SdlReferenceDeclaration } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import {
   MAX_ECHOED_REFERENCE_LENGTH,
   MAX_SDL_REFERENCE_NAME_LENGTH,
@@ -20,16 +20,10 @@ import { DeploymentConfigService } from "../deployment-config/deployment-config.
 /** The kind of SDL Reference a sealed payload answers. Other kinds resolve from elsewhere and are none of this service's business. */
 const SECRET_REFERENCE_KIND = "secret";
 
-export interface ReceivedSdlSecrets {
-  /** What the client sealed, unchanged, because this is what gets re-sealed for storage: one flat name-to-value map per deployment. */
-  supplied: SdlSecrets;
-  /** The same values indexed by the service that referenced them, which is the shape resolution reads. */
-  byService: NamespacedSdlSecrets;
-}
+/** What the client sealed, unchanged: the one flat name-to-value map a deployment has, which is both what resolution reads and what gets re-sealed for storage. */
+export type ReceiveSdlSecretsResult = { ok: true; value: SdlSecrets } | { ok: false; value: ValidationError[] };
 
-export type ReceiveSdlSecretsResult = { ok: true; value: ReceivedSdlSecrets } | { ok: false; value: ValidationError[] };
-
-const NOTHING_SUPPLIED: ReceivedSdlSecrets = { supplied: {}, byService: {} };
+const NOTHING_SUPPLIED: SdlSecrets = {};
 
 function unreferencedNameError(name: string): ValidationError {
   const echoed = name.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
@@ -69,7 +63,7 @@ export class SdlSecretsService {
     const supplied = await this.unsealerService.open({ seal: input.sealedSecrets, sdl: input.rawSdl });
     this.#assertWithinLimits(supplied);
 
-    const { byService, errors } = this.#assignToServices(declarations, supplied);
+    const errors = this.#mismatchesBetween(declarations, supplied);
 
     if (errors.length > 0) return { ok: false, value: errors };
 
@@ -77,10 +71,10 @@ export class SdlSecretsService {
       event: "SDL_SECRETS_RECEIVED",
       suppliedCount: Object.keys(supplied).length,
       referencedNames: [...new Set(declarations.map(declaration => declaration.name))],
-      serviceCount: Object.keys(byService).length
+      serviceCount: new Set(declarations.map(declaration => declaration.serviceName)).size
     });
 
-    return { ok: true, value: { supplied, byService } };
+    return { ok: true, value: supplied };
   }
 
   /** Returns null when nothing was supplied, so a create always has a value to write and a retry cannot inherit an abandoned attempt's token. */
@@ -96,30 +90,25 @@ export class SdlSecretsService {
     return sealed;
   }
 
-  /** Namespaces are built from the walk rather than by copying everything to every service, so a service that references nothing is handed nothing. */
-  #assignToServices(declarations: SdlReferenceDeclaration[], supplied: SdlSecrets) {
-    const byService: NamespacedSdlSecrets = Object.create(null);
+  /** Both directions are reported from one pass, so a request that gets each side wrong hears about both at once. */
+  #mismatchesBetween(declarations: SdlReferenceDeclaration[], supplied: SdlSecrets): ValidationError[] {
     const errors: ValidationError[] = [];
     const referenced = new Set<string>();
 
     for (const declaration of declarations) {
-      const value = ownValue(supplied, declaration.name);
-
-      if (typeof value !== "string") {
-        errors.push(missingSdlReferenceValueError(declaration));
+      if (typeof ownValue(supplied, declaration.name) === "string") {
+        referenced.add(declaration.name);
         continue;
       }
 
-      const namespace = (byService[declaration.serviceName] ??= Object.create(null) as SdlSecrets);
-      namespace[declaration.name] = value;
-      referenced.add(declaration.name);
+      errors.push(missingSdlReferenceValueError(declaration));
     }
 
     for (const name of Object.keys(supplied)) {
       if (!referenced.has(name)) errors.push(unreferencedNameError(name));
     }
 
-    return { byService, errors };
+    return errors;
   }
 
   /** Every bound is measured as `jsonEncodedBytes`, matching the seal budget, because a raw-length check would let a payload pass here and die on the body limit. */

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -679,7 +679,7 @@ describe(SdlService.name, () => {
     it("returns a manifest carrying the resolved value", async () => {
       const { service } = setup();
 
-      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
+      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { TOKEN: "resolved" } });
 
       expect(result.ok).toBe(true);
       expect(resolvedOf(result).manifest.groups[0].services[0].env).toEqual(["TOKEN=resolved"]);
@@ -691,7 +691,7 @@ describe(SdlService.name, () => {
 
       const result = await service.generateResolvedManifest({
         sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
-        secrets: { web: { REG_USER: username, REG_PASS: password } }
+        secrets: { REG_USER: username, REG_PASS: password }
       });
 
       expect(result.ok).toBe(true);
@@ -704,7 +704,7 @@ describe(SdlService.name, () => {
 
       const substituted = await service.generateResolvedManifest({
         sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
-        secrets: { web: { REG_USER: username, REG_PASS: password } }
+        secrets: { REG_USER: username, REG_PASS: password }
       });
       const inline = await service.generateResolvedManifest({ sdl: SDL_WITH_CREDENTIALS(username, password), secrets: {} });
 
@@ -716,7 +716,7 @@ describe(SdlService.name, () => {
 
       const result = await service.generateResolvedManifest({
         sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
-        secrets: { web: { REG_USER: faker.string.alphanumeric(10), REG_PASS: "short" } }
+        secrets: { REG_USER: faker.string.alphanumeric(10), REG_PASS: "short" }
       });
 
       expect(result.ok).toBe(false);
@@ -726,7 +726,7 @@ describe(SdlService.name, () => {
     it("hashes an sdl with a substituted value exactly as one carrying that value inline", async () => {
       const { service } = setup();
 
-      const substituted = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
+      const substituted = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { TOKEN: "resolved" } });
       const inline = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=resolved"), secrets: {} });
 
       expect(versionOf(substituted)).toEqual(versionOf(inline));
@@ -736,8 +736,8 @@ describe(SdlService.name, () => {
       const { service } = setup();
       const sdl = SDL_WITH_ENV("TOKEN=ac-secret://TOKEN");
 
-      const first = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "one" } } });
-      const second = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "two" } } });
+      const first = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "one" } });
+      const second = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "two" } });
 
       expect(versionOf(first)).not.toEqual(versionOf(second));
     });
@@ -746,8 +746,8 @@ describe(SdlService.name, () => {
       const { service } = setup();
       const sdl = SDL_WITH_ENV("TOKEN=ac-secret://TOKEN");
 
-      const first = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "resolved" } } });
-      const second = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "resolved" } } });
+      const first = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "resolved" } });
+      const second = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "resolved" } });
 
       expect(versionOf(first)).toEqual(versionOf(second));
     });
@@ -764,7 +764,7 @@ describe(SdlService.name, () => {
     it("returns errors for an unrecognized kind", async () => {
       const { service } = setup();
 
-      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-var://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
+      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-var://TOKEN"), secrets: { TOKEN: "resolved" } });
 
       expect(errorsOf(result)[0].message).toContain("ac-var://TOKEN");
     });

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -5,8 +5,8 @@ import { singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
-import type { NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import { sdlRequestsGpuInterconnect } from "@src/deployment/utils/gpu-interconnect/gpu-interconnect";
 import { findTrialResourceViolation } from "@src/deployment/utils/group-resources/group-resources";
 
@@ -46,7 +46,7 @@ export class SdlService {
   }
 
   /** The only path that substitutes SDL References, and the only caller of the substitution walk, so a resolved manifest exists nowhere a caller has not asked for one. */
-  async generateResolvedManifest(input: { sdl: string; secrets: NamespacedSdlSecrets; isTrialing?: boolean }): Promise<GenerateResolvedManifestResult> {
+  async generateResolvedManifest(input: { sdl: string; secrets: SdlSecrets; isTrialing?: boolean }): Promise<GenerateResolvedManifestResult> {
     const parsed = this.parse(input.sdl);
 
     if (!parsed.ok) return parsed;

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -692,9 +692,8 @@ describe("Deployment sealed secrets", () => {
 
   function resolvedDocumentOf(storedSdl: string, secrets: Record<string, string>) {
     const document = yaml.raw<SDLInput>(storedSdl);
-    const byService = Object.fromEntries(Object.keys(document.services).map(serviceName => [serviceName, secrets]));
 
-    expect(container.resolve(SdlReferenceService).substitute(document, { secrets: byService })).toEqual([]);
+    expect(container.resolve(SdlReferenceService).substitute(document, { secrets })).toEqual([]);
 
     return document;
   }

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -187,6 +187,31 @@ describe("Deployment sealed secrets", () => {
     await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({ REG_USER: username, REG_PASS: password });
   });
 
+  it("stores a reference for every service's own registry credentials, with neither service's value in the clear", async () => {
+    const { apiKey, user } = await persistedUser();
+    const web = { host: REGISTRY_HOST, username: faker.string.alphanumeric(10), password: randomUUID() };
+    const worker = { host: "other-registry.example.test", username: faker.string.alphanumeric(10), password: randomUUID() };
+
+    const response = await postDeployment(apiKey, sdlWith({ web: ["LOG_LEVEL=debug"], worker: ["LOG_LEVEL=debug"] }, { web, worker }));
+
+    expect(response.status).toBe(201);
+    const setting = await settingOf(user, response);
+    expect(setting!.sdl).toContain("username: ac-secret://s0_c_username");
+    expect(setting!.sdl).toContain("username: ac-secret://s1_c_username");
+    expect(setting!.sdl).not.toContain(web.password);
+    expect(setting!.sdl).not.toContain(worker.password);
+    expect(setting!.sdl).not.toContain(web.username);
+    expect(setting!.sdl).not.toContain(worker.username);
+    await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({
+      s0_e0: "debug",
+      s1_e0: "debug",
+      s0_c_username: web.username,
+      s0_c_password: web.password,
+      s1_c_username: worker.username,
+      s1_c_password: worker.password
+    });
+  });
+
   it("stores a credential the client left in the clear as a reference, with its value only in the token", async () => {
     const { apiKey, user } = await persistedUser();
     const [username, password] = [faker.string.alphanumeric(10), randomUUID()];

--- a/apps/api/test/mocks/sdl-secrets-kms.mock.ts
+++ b/apps/api/test/mocks/sdl-secrets-kms.mock.ts
@@ -12,12 +12,7 @@ export const SDL_SECRETS_KID = "sdl-secrets.v1";
 
 const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 
-/**
- * Doubles the one third-party boundary the sealed-secrets path crosses, backed by a real RSA key so a
- * seal is genuinely opened rather than waved through, and registers it at module scope so nothing has
- * resolved the real target before the first request. Every create that carries an env value now unwraps
- * a data encryption key, so any spec exercising `POST /v1/deployments` needs this.
- */
+/** Every create carrying an env value unwraps a data key, so any spec exercising `POST /v1/deployments` must call this or reach the real Cloud KMS: it doubles that boundary with a real RSA key, registered at module scope so nothing resolves the real target first. */
 export function registerFakeSdlSecretsKms() {
   const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 3072 });
   const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
@@ -44,11 +39,7 @@ export function registerFakeSdlSecretsKms() {
   return { client, publicKey };
 }
 
-/**
- * Warms the sealing key the way the boot initializer does, because wrapping a new data encryption key
- * peeks at the cache rather than waiting on it — so a spec that skips this gets a 503 on its first
- * create for a user, exactly as an instance whose boot-time warm-up failed would.
- */
+/** A spec that skips this gets a 503 on its first create for a user, exactly as an instance whose boot-time warm-up failed would, because wrapping a new data key peeks at the sealing key cache rather than waiting on it. */
 export async function warmSealingKeyAsBootWould() {
   await container.resolve(SdlSecretsSealingKeyService).getSealingKey();
 }


### PR DESCRIPTION
## Why

Part of CON-863.

A deployment's secrets arrive as **one flat name-to-value map**, and the intake fanned them out into a namespace per service that resolution then read back through the service's name. The fan-out differentiated nothing — every service referencing a name received the same value, because a flat payload has no second value to give it.

**Stack position — PR 8 of 8, the new tip.** Targets PR 7 (`refactor/deployment-drop-dead-field-and-comments`). Nothing sits on this one, and nothing below it changes.

## What

### The namespace was a re-projection of the map it was built from

`#assignToServices` looked each declaration up with `ownValue(supplied, declaration.name)` — a flat lookup. Both refusals it produced (a reference with no value, a value nothing references) were already decided by that lookup; `byService` was built alongside them and cast no vote. The only thing that ever read it back was `secretReferenceResolver`, through the service name.

### What the second key level did add was a matching requirement

`byService` was keyed by service names read from the parse the intake performs. Substitution runs against a **second, independent parse** of the same text — the writer passes the raw string on and `SdlService` re-parses it. Two parses agreeing on their keys held by determinism alone, over names the reference grammar does not constrain at all, which is why `ownValue` and `Object.create(null)` guarded a hop that existed only to be guarded.

### The isolation it looked like it gave comes from the walk

"A service is handed only the names it references" reads like least privilege, but substitution is position-driven: it asks a resolver only for a name standing at a slot in *that* service, and nothing iterates the context. A flat map cannot reach a service that references nothing, because substitution only writes where a reference already stands.

The derivation service already spells this the better way — it folds the service into the *name*, `s{serviceIndex}_{position}`, and never needed a map level to keep two services apart.

### What changes

`receive` returns what the client sealed, so the writer hands one object to resolution and to storage instead of choosing between `supplied` and `byService`. `NamespacedSdlSecrets` goes; `SdlReferenceContext.secrets` is the flat map. The assignment pass becomes `#mismatchesBetween`, which reports both directions and builds nothing. `SDL_SECRETS_RECEIVED` keeps `serviceCount`, now counted off the declarations rather than off the map.

The specs lose the fan-out **three of them performed to call `substitute` at all** — the same `Object.fromEntries(Object.keys(services).map(name => [name, secrets]))` line in the writer's spec, the derivation service's spec and the sealed-secrets functional spec, each re-deriving a namespace from the flat secrets it actually had.

Two tests lose their subject and are rewritten rather than deleted: "gives each service its own value for the same name" becomes the flat truth it always described, and the non-object-namespace case goes (its `as unknown as` cast with it), the non-string guard being covered by the probe resolver.

Unit, functional and the sealed-secrets suites pass; `tsc` shows the same 43 pre-existing errors as the base, none in touched files.
