### PR TITLE
chore: skip security-scan if associated pr cannot be found

### DIFF
--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -54,13 +54,22 @@ jobs:
 
       - name: Decide whether to run scan
         id: decide
-        run: | # shell
+        env:
+          PR_NUMBER: ${{ steps.associated_pr.outputs.number }}
+        run: |
           # A cancelled CI run is superseded by a newer one whose own scan reports this commit's verdict;
           # reporting here as well would race that scan for the same check name on the same commit.
           if [ "${PARENT_WORKFLOW_CONCLUSION}" == "cancelled" ]; then
             echo "run_scan=false" >> "$GITHUB_OUTPUT"
             echo "report_check=false" >> "$GITHUB_OUTPUT"
             echo "skip_reason=Upstream CI was cancelled, so the superseding CI run reports instead" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${PR_NUMBER}" == "" ]; then
+            echo "run_scan=false" >> "$GITHUB_OUTPUT"
+            echo "report_check=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=PR head changed because of rebase/force push and associated PR cannot be found" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -66,13 +66,6 @@ jobs:
             exit 0
           fi
 
-          if [ "${PR_NUMBER}" == "" ]; then
-            echo "run_scan=false" >> "$GITHUB_OUTPUT"
-            echo "report_check=false" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=PR head changed because of rebase/force push and associated PR cannot be found" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           echo "report_check=true" >> "$GITHUB_OUTPUT"
 
           if [ "${PARENT_WORKFLOW_CONCLUSION}" != "success" ]; then
@@ -84,6 +77,13 @@ jobs:
           if [[ "${PARENT_WORKFLOW_EVENT}" != "pull_request" && "${PARENT_WORKFLOW_EVENT}" != "push" ]]; then
             echo "run_scan=false" >> "$GITHUB_OUTPUT"
             echo "skip_reason=Upstream CI was not triggered by pull_request or push (event=${PARENT_WORKFLOW_EVENT})" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${PR_NUMBER}" == "" && "${PARENT_WORKFLOW_EVENT}" == "pull_request" ]]; then
+            echo "run_scan=false" >> "$GITHUB_OUTPUT"
+            echo "report_check=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=PR head changed because of rebase/force push and associated PR cannot be found" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 


### PR DESCRIPTION
## Why

ref CON-863 

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Security scanning now continues for push-triggered workflows, even when no associated pull request exists.
  * Pull request workflows without an associated pull request skip scanning and check reporting, with a clear rebase or force-push explanation.
  * Pull request information is now correctly passed between workflow steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->