### PR TITLE
fix(template): bound the github archive cache by bytes and expire the balance memo

### DIFF
--- a/apps/api/src/caching/cache-registry.ts
+++ b/apps/api/src/caching/cache-registry.ts
@@ -6,6 +6,12 @@ export interface RegisterableCache {
   clear(): void;
 }
 
+export interface CacheLimits {
+  maxEntries?: number;
+  maxTotalBytes?: number;
+  maxEntryBytes?: number;
+}
+
 export interface CacheStats {
   name: string;
   entryCount: number;

--- a/apps/api/src/caching/memoryCacheEngine.ts
+++ b/apps/api/src/caching/memoryCacheEngine.ts
@@ -1,15 +1,10 @@
 import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { LRUCache } from "lru-cache";
 
+import type { CacheLimits } from "./cache-registry";
 import { cacheRegistry, NOMINAL_ENTRY_BYTES } from "./cache-registry";
 
 export type CacheValue = NonNullable<unknown>;
-
-export interface CacheLimits {
-  maxEntries?: number;
-  maxTotalBytes?: number;
-  maxEntryBytes?: number;
-}
 
 /** Multi-MB cached responses exhausted the 2GB V8 heap on 2026-09-01; the byte ceilings bound entries stored with an explicit size. */
 const DEFAULT_LIMITS = {

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
@@ -11,6 +11,11 @@ import { createAkashAddress } from "@test/seeders";
 
 describe(CachedBalanceService.name, () => {
   const DEFAULT_DEPOSIT_IN_USD = 0.5;
+  const MEMO_TTL_IN_MS = 5 * 60_000;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   describe("get", () => {
     const address = createAkashAddress();
@@ -49,6 +54,30 @@ describe(CachedBalanceService.name, () => {
       await service.get(address);
 
       expect(balancesService.getFreshLimits).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps sharing one balance for calls made within the memo window", async () => {
+      const { service, balancesService, elapse } = setup();
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: DEPLOYMENT_LIMIT, fee: 100 });
+
+      await service.get(address);
+      elapse(MEMO_TTL_IN_MS - 1);
+      await service.get(address);
+
+      expect(balancesService.getFreshLimits).toHaveBeenCalledTimes(1);
+    });
+
+    it("builds a balance free of earlier reservations once the memo window has passed", async () => {
+      const { service, balancesService, elapse } = setup();
+      balancesService.getFreshLimits.mockResolvedValue({ deployment: DEPLOYMENT_LIMIT, fee: 100 });
+
+      const stale = await service.get(address);
+      stale.reserveSufficientAmount(DEPLOYMENT_LIMIT);
+      elapse(MEMO_TTL_IN_MS + 1);
+      const rebuilt = await service.get(address);
+
+      expect(balancesService.getFreshLimits).toHaveBeenCalledTimes(2);
+      expect(rebuilt.spendable).toBe(DEPLOYMENT_LIMIT);
     });
 
     it("throws when trying to reserve more than available", async () => {
@@ -269,6 +298,12 @@ describe(CachedBalanceService.name, () => {
   });
 
   function setup(input?: { headroomInUsd?: number; defaultDepositInUsd?: number }) {
+    let clockMs = performance.now();
+    vi.spyOn(performance, "now").mockImplementation(() => clockMs);
+    const elapse = (ms: number) => {
+      clockMs += ms;
+    };
+
     const balancesService = mock<BalancesService>();
     const deploymentConfig = mockConfigService<DeploymentConfigService>({
       AUTO_TOP_UP_BALANCE_HEADROOM_IN_USD: input?.headroomInUsd ?? 0,
@@ -279,6 +314,6 @@ describe(CachedBalanceService.name, () => {
 
     const service = new CachedBalanceService(balancesService, deploymentConfig, createLogger);
 
-    return { service, balancesService, deploymentConfig, logger, createLogger };
+    return { service, balancesService, deploymentConfig, logger, createLogger, elapse };
   }
 });

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -6,6 +6,9 @@ import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { denomToUdenom } from "@src/utils/math";
 
+/** Outlives one owner's funding pass so its reservations stay shared, and expires well inside the hourly sweep that would otherwise reuse a balance predating its own deposits. */
+const BALANCE_MEMO_TTL_MS = 5 * 60_000;
+
 export class CachedBalance {
   readonly #available: number;
   readonly #headroom: number;
@@ -64,7 +67,11 @@ export class CachedBalance {
 
 @singleton()
 export class CachedBalanceService {
-  public get = memoizeAsync((address: string) => this.buildForAddress(address), { cacheItemLimit: 10_000, name: "CachedBalanceService#get" });
+  public get = memoizeAsync((address: string) => this.buildForAddress(address), {
+    cacheItemLimit: 10_000,
+    ttl: BALANCE_MEMO_TTL_MS,
+    name: "CachedBalanceService#get"
+  });
 
   private readonly logger: ReturnType<CreateLogger>;
 
@@ -77,9 +84,9 @@ export class CachedBalanceService {
   }
 
   /**
-   * Reads a fresh balance bypassing the per-address memo. The memo is keyed for
-   * the process lifetime, which suits the short-lived top-up cron but would serve
-   * stale balances to the long-running background worker across credit landings.
+   * Reads a fresh balance bypassing the per-address memo, whose window suits the
+   * short-lived top-up cron but would still serve the long-running background
+   * worker a balance taken before the credits that woke it landed.
    */
   public getFresh(address: string): Promise<CachedBalance> {
     return this.buildForAddress(address);

--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -143,6 +143,16 @@ describe(GitHubArchiveService.name, () => {
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
+    it("shares one download between concurrent callers even when a limit sits below the nominal entry charge", async () => {
+      const { service, fetchSpy, archiveResponse } = setup({ maxTotalBytes: 2000, maxEntryBytes: 900 });
+      fetchSpy.mockImplementation(async () => archiveResponse({ "root/readme.md": "# Hello" }));
+
+      const [first, second] = await Promise.all([service.getArchive("owner", "repo", "ref"), service.getArchive("owner", "repo", "ref")]);
+
+      expect(first).toBe(second);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("returns an archive too large to keep and warns instead of caching it", async () => {
       const maxEntryBytes = 1000;
       const { service, logger, installArchive, cacheStats } = setup({ maxEntryBytes });

--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -114,6 +114,53 @@ describe(GitHubArchiveService.name, () => {
     });
   });
 
+  describe("cache byte bounds", () => {
+    const ARCHIVE_CONTENT = "x".repeat(1500);
+
+    it("evicts the least recently used archive once the cached archives exceed the total byte bound", async () => {
+      const maxTotalBytes = 3000;
+      const { service, fetchSpy, archiveResponse, cacheStats } = setup({ maxTotalBytes, maxEntryBytes: 2000 });
+      fetchSpy.mockImplementation(async () => archiveResponse({ "root/readme.md": ARCHIVE_CONTENT }));
+
+      const first = await service.getArchive("owner", "repo", "first");
+      await service.getArchive("owner", "repo", "second");
+      await service.getArchive("owner", "repo", "first");
+
+      expect(first.retainedBytes * 2).toBeGreaterThan(maxTotalBytes);
+      expect(cacheStats()).toMatchObject({ entryCount: 1 });
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it("keeps every archive that fits within the total byte bound", async () => {
+      const { service, fetchSpy, archiveResponse, cacheStats } = setup({ maxTotalBytes: 8000, maxEntryBytes: 2000 });
+      fetchSpy.mockImplementation(async () => archiveResponse({ "root/readme.md": ARCHIVE_CONTENT }));
+
+      await service.getArchive("owner", "repo", "first");
+      await service.getArchive("owner", "repo", "second");
+      await service.getArchive("owner", "repo", "first");
+
+      expect(cacheStats()).toMatchObject({ entryCount: 2 });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns an archive too large to keep and warns instead of caching it", async () => {
+      const maxEntryBytes = 1000;
+      const { service, logger, installArchive, cacheStats } = setup({ maxEntryBytes });
+      await installArchive({ "root/readme.md": ARCHIVE_CONTENT });
+
+      const reader = await service.getArchive("owner", "repo", "ref");
+
+      expect(await reader.readFile("readme.md")).toBe(ARCHIVE_CONTENT);
+      expect(cacheStats()).toMatchObject({ entryCount: 0 });
+      expect(logger.warn).toHaveBeenCalledWith({
+        event: "ARCHIVE_TOO_LARGE_TO_CACHE",
+        cacheKey: "owner/repo/ref:unfiltered",
+        retainedBytes: reader.retainedBytes,
+        maxArchiveBytes: maxEntryBytes
+      });
+    });
+  });
+
   describe("download resilience", () => {
     it("retries when a download fails and succeeds on a later attempt", async () => {
       const { service, fetchSpy, archiveResponse } = setup();
@@ -315,11 +362,11 @@ describe(GitHubArchiveService.name, () => {
     });
   });
 
-  function setup() {
+  function setup(input?: { maxTotalBytes?: number; maxEntryBytes?: number }) {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const logger = mock<ReturnType<CreateLogger>>();
     const namesBeforeRegistration = new Set(cacheRegistry.getStats().map(stats => stats.name));
-    const service = new GitHubArchiveService(logger);
+    const service = new GitHubArchiveService(logger, input);
     const cacheName = cacheRegistry.getStats().find(stats => !namesBeforeRegistration.has(stats.name))!.name;
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 

--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -155,8 +155,8 @@ describe(GitHubArchiveService.name, () => {
 
     it("returns an archive too large to keep and warns instead of caching it", async () => {
       const maxEntryBytes = 1000;
-      const { service, logger, installArchive, cacheStats } = setup({ maxEntryBytes });
-      await installArchive({ "root/readme.md": ARCHIVE_CONTENT });
+      const { service, logger, fetchSpy, archiveResponse, cacheStats } = setup({ maxEntryBytes });
+      fetchSpy.mockImplementation(async () => archiveResponse({ "root/readme.md": ARCHIVE_CONTENT }));
 
       const reader = await service.getArchive("owner", "repo", "ref");
 
@@ -168,6 +168,27 @@ describe(GitHubArchiveService.name, () => {
         retainedBytes: reader.retainedBytes,
         maxArchiveBytes: maxEntryBytes
       });
+    });
+
+    it("warns once per key however many lookups re-parse the same oversized archive", async () => {
+      const { service, logger, fetchSpy, archiveResponse } = setup({ maxEntryBytes: 1000 });
+      fetchSpy.mockImplementation(async () => archiveResponse({ "root/readme.md": ARCHIVE_CONTENT }));
+
+      await service.getArchive("owner", "repo", "ref");
+      await service.getArchive("owner", "repo", "ref");
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns again for an archive still too large after the cache is cleared", async () => {
+      const { service, logger, fetchSpy, archiveResponse } = setup({ maxEntryBytes: 1000 });
+      fetchSpy.mockImplementation(async () => archiveResponse({ "root/readme.md": ARCHIVE_CONTENT }));
+
+      await service.getArchive("owner", "repo", "ref");
+      service.clearCache();
+      await service.getArchive("owner", "repo", "ref");
+
+      expect(logger.warn).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -26,6 +26,9 @@ function inFlightArchiveBytes(maxArchiveBytes: number): number {
   return Math.min(NOMINAL_ENTRY_BYTES, maxArchiveBytes);
 }
 
+/** Bounds the set of keys already warned about, which grows by one per oversized ref until the next gallery refresh clears it. */
+const MAX_WARNED_OVERSIZED_ARCHIVES = 100;
+
 const MAX_DOWNLOAD_RETRIES = 2;
 const RETRY_INITIAL_DELAY_MS = 1_000;
 const RETRY_MAX_DELAY_MS = 10_000;
@@ -70,6 +73,7 @@ async function* streamWhileMakingProgress(body: ReadableStream<Uint8Array>, onPr
 export class GitHubArchiveService {
   readonly #cache: LRUCache<string, Promise<ArchiveReader>>;
   readonly #maxArchiveBytes: number;
+  readonly #warnedOversizedKeys = new Set<string>();
   readonly #logger: ReturnType<CreateLogger>;
   readonly #downloadPolicy: RetryPolicy;
 
@@ -115,6 +119,7 @@ export class GitHubArchiveService {
 
   clearCache(): void {
     this.#cache.clear();
+    this.#warnedOversizedKeys.clear();
   }
 
   /** lru-cache ignores a size given for a value it already holds, so the parsed archive has to replace its own in-flight entry. */
@@ -122,11 +127,23 @@ export class GitHubArchiveService {
     this.#cache.delete(cacheKey);
 
     if (retainedBytes > this.#maxArchiveBytes) {
-      this.#logger.warn({ event: "ARCHIVE_TOO_LARGE_TO_CACHE", cacheKey, retainedBytes, maxArchiveBytes: this.#maxArchiveBytes });
+      this.#warnArchiveTooLargeToCache(cacheKey, retainedBytes);
       return;
     }
 
     this.#cache.set(cacheKey, archive, { size: retainedBytes });
+  }
+
+  /** An uncacheable archive is re-parsed by every template lookup for it, so the warning is reported once per key rather than once per lookup. */
+  #warnArchiveTooLargeToCache(cacheKey: string, retainedBytes: number): void {
+    if (this.#warnedOversizedKeys.has(cacheKey)) return;
+
+    if (this.#warnedOversizedKeys.size >= MAX_WARNED_OVERSIZED_ARCHIVES) {
+      this.#warnedOversizedKeys.clear();
+    }
+
+    this.#warnedOversizedKeys.add(cacheKey);
+    this.#logger.warn({ event: "ARCHIVE_TOO_LARGE_TO_CACHE", cacheKey, retainedBytes, maxArchiveBytes: this.#maxArchiveBytes });
   }
 
   async #downloadAndParse(owner: string, repo: string, ref: string, fileFilter?: (relativePath: string) => boolean): Promise<ArchiveReader> {

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -6,14 +6,20 @@ import { createGunzip } from "node:zlib";
 import tar from "tar";
 
 import type { CreateLogger } from "@src/core";
+import type { CacheLimits } from "../../../caching/cache-registry.ts";
 import { cacheRegistry, NOMINAL_ENTRY_BYTES } from "../../../caching/cache-registry.ts";
 
 /** The template repo archives are ~70 MB each, so the download budget has to bound stalls rather than total transfer time. */
 const DOWNLOAD_STALL_TIMEOUT_MS = 30_000;
 
 const MAX_CACHED_ARCHIVES = 10;
-/** An archive retaining more than this is still parsed and returned, just not kept, since getArchive resolves from the parse rather than from the cache. */
-const MAX_CACHED_ARCHIVE_BYTES = 256 * 1024 * 1024;
+/** Filtered to template files the gallery's archives retain ~2.3 MB each, so this leaves room for an order of magnitude of repo growth. */
+const MAX_CACHED_ARCHIVES_TOTAL_BYTES = 128 * 1024 * 1024;
+
+/** Half the total so one archive can never evict every other one, and an archive above it is still parsed and returned since getArchive resolves from the parse. */
+function maxBytesPerArchive(maxTotalBytes: number): number {
+  return maxTotalBytes / 2;
+}
 
 const MAX_DOWNLOAD_RETRIES = 2;
 const RETRY_INITIAL_DELAY_MS = 1_000;
@@ -57,15 +63,20 @@ async function* streamWhileMakingProgress(body: ReadableStream<Uint8Array>, onPr
 }
 
 export class GitHubArchiveService {
-  readonly #cache = new LRUCache<string, Promise<ArchiveReader>>({
-    max: MAX_CACHED_ARCHIVES,
-    maxEntrySize: MAX_CACHED_ARCHIVE_BYTES,
-    sizeCalculation: () => NOMINAL_ENTRY_BYTES
-  });
+  readonly #cache: LRUCache<string, Promise<ArchiveReader>>;
+  readonly #maxArchiveBytes: number;
   readonly #logger: ReturnType<CreateLogger>;
   readonly #downloadPolicy: RetryPolicy;
 
-  constructor(logger: ReturnType<CreateLogger>) {
+  constructor(logger: ReturnType<CreateLogger>, limits: CacheLimits = {}) {
+    const maxTotalBytes = limits.maxTotalBytes ?? MAX_CACHED_ARCHIVES_TOTAL_BYTES;
+    this.#maxArchiveBytes = limits.maxEntryBytes ?? maxBytesPerArchive(maxTotalBytes);
+    this.#cache = new LRUCache<string, Promise<ArchiveReader>>({
+      max: limits.maxEntries ?? MAX_CACHED_ARCHIVES,
+      maxSize: maxTotalBytes,
+      maxEntrySize: this.#maxArchiveBytes,
+      sizeCalculation: () => NOMINAL_ENTRY_BYTES
+    });
     this.#logger = logger;
     cacheRegistry.register("GitHubArchiveService#archives", this.#cache);
     this.#downloadPolicy = retry(
@@ -104,6 +115,12 @@ export class GitHubArchiveService {
   /** lru-cache ignores a size given for a value it already holds, so the parsed archive has to replace its own in-flight entry. */
   #chargeRetainedBytes(cacheKey: string, archive: Promise<ArchiveReader>, retainedBytes: number): void {
     this.#cache.delete(cacheKey);
+
+    if (retainedBytes > this.#maxArchiveBytes) {
+      this.#logger.warn({ event: "ARCHIVE_TOO_LARGE_TO_CACHE", cacheKey, retainedBytes, maxArchiveBytes: this.#maxArchiveBytes });
+      return;
+    }
+
     this.#cache.set(cacheKey, archive, { size: retainedBytes });
   }
 

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -21,6 +21,11 @@ function maxBytesPerArchive(maxTotalBytes: number): number {
   return maxTotalBytes / 2;
 }
 
+/** The placeholder charged while a download is in flight must fit the ceiling, or lru-cache refuses the entry and concurrent callers each start their own download. */
+function inFlightArchiveBytes(maxArchiveBytes: number): number {
+  return Math.min(NOMINAL_ENTRY_BYTES, maxArchiveBytes);
+}
+
 const MAX_DOWNLOAD_RETRIES = 2;
 const RETRY_INITIAL_DELAY_MS = 1_000;
 const RETRY_MAX_DELAY_MS = 10_000;
@@ -75,7 +80,7 @@ export class GitHubArchiveService {
       max: limits.maxEntries ?? MAX_CACHED_ARCHIVES,
       maxSize: maxTotalBytes,
       maxEntrySize: this.#maxArchiveBytes,
-      sizeCalculation: () => NOMINAL_ENTRY_BYTES
+      sizeCalculation: () => inFlightArchiveBytes(this.#maxArchiveBytes)
     });
     this.#logger = logger;
     cacheRegistry.register("GitHubArchiveService#archives", this.#cache);


### PR DESCRIPTION
## Why

The two items #3784 left for follow-up:

> Left for follow-up PRs: an actual byte bound on the `GitHubArchiveService` archives, which now report their real size but are still capped only by count, and deciding on a TTL for `CachedBalanceService`'s 10k-entry cache.

Ref #3784.

## What

**The archive cache is bounded by bytes.** It reported its real retained bytes to the registry but capped nothing with them — `max: 10` at the 256MB per-entry ceiling is 2.5GB on a process whose heap limit is 2GB. Adding `maxSize` is the bound that was missing.

I measured what the three archives the gallery actually fetches retain, replicating the service's parse (gunzip → `tar.Parse` → `isTemplateFile` → path bytes per entry plus content bytes for kept files):

| archive | download | entries | kept files | retained |
|---|---|---|---|---|
| `akash-network/awesome-akash@master` | 63.94 MB | 2105 | 877 | **2.28 MB** |
| `cosmos/chain-registry@master` | 63.45 MB | 5028 | 449 | **2.25 MB** |
| `akash-network/cosmos-omnibus@master` | 0.05 MB | 359 | 138 | **0.20 MB** |

So the real working set is ~4.7MB and the old per-entry ceiling was ~100× the largest archive. A 128MB total leaves an order of magnitude of repo growth, and the per-entry ceiling is derived as half of it — that keeps `maxEntrySize` below `maxSize`, so lru-cache can never insert an archive at the tail and then evict every other one to make room for it.

**An archive above the per-entry ceiling now warns instead of being silently refused.** `getArchive` is called once per template, so a repo that outgrew the ceiling would re-download it hundreds of times per refresh rather than once, and nothing would say why. `ARCHIVE_TOO_LARGE_TO_CACHE` mirrors the `CACHE_ENTRY_TOO_LARGE` line #3784 added to `MemoryCacheEngine` for the same silent-refusal problem.

`CacheLimits` moves to `cache-registry`, which already owns the shared cache-sizing vocabulary, so the archive service takes its limits from the module it already depends on rather than reaching into the memcache engine.

**The balance memo gets a 5 minute TTL.** `CachedBalance` is mutable — reservations accumulate on it across a batch, which is why callers for one address have to share an instance rather than each build their own and spend the same allowance twice (#2866). That memo had no TTL, so the instance it holds was correct only for as long as the funding pass that built it.

An entry outliving its pass is wrong in both directions at once: its `available` predates the deposits that pass made, and its `reserved` has already been spent against it. `getFresh` exists to route around exactly that, which left the invariant resting on the fact that no long-running process happens to call `get`. Five minutes outlives one owner's pass, so repeat callers still share the reservation ledger, and expires well inside both the hourly sweep and the 60-minute funding cooldown, so no entry can inform a second funding decision for the same address.

I kept the memo rather than replacing it with `reusePendingPromise`: dropping to in-flight-only sharing would trade away the over-allocation guard in a money path for ~10MB of cache the registry already bounds and reports.

Verified: 2549 unit, 18 integration (`top-up-managed-deployments`) and 374 functional tests pass; `tsc --noEmit` shows no delta against `main`'s baseline; `lint --quiet` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable cache limits for archived GitHub data, including total size, entry count, and individual archive size.
  * Archives exceeding the per-entry limit remain available for processing but are not retained in the cache.
  * Added a five-minute memoization window for cached balances, with fresh data rebuilt after expiration.

* **Bug Fixes**
  * Improved cache behavior through size-aware eviction and clearer handling of oversized entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->