### PR TITLE
chore: ensure check is created when PR cannot be found

### DIFF
--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -66,13 +66,6 @@ jobs:
             exit 0
           fi
 
-          if [ "${PR_NUMBER}" == "" ]; then
-            echo "run_scan=false" >> "$GITHUB_OUTPUT"
-            echo "report_check=false" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=PR head changed because of rebase/force push and associated PR cannot be found" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           echo "report_check=true" >> "$GITHUB_OUTPUT"
 
           if [ "${PARENT_WORKFLOW_CONCLUSION}" != "success" ]; then

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -82,7 +82,6 @@ jobs:
 
           if [[ "${PR_NUMBER}" == "" && "${PARENT_WORKFLOW_EVENT}" == "pull_request" ]]; then
             echo "run_scan=false" >> "$GITHUB_OUTPUT"
-            echo "report_check=false" >> "$GITHUB_OUTPUT"
             echo "skip_reason=PR head changed because of rebase/force push and associated PR cannot be found" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -66,6 +66,13 @@ jobs:
             exit 0
           fi
 
+          if [ "${PR_NUMBER}" == "" ]; then
+            echo "run_scan=false" >> "$GITHUB_OUTPUT"
+            echo "report_check=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=PR head changed because of rebase/force push and associated PR cannot be found" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           echo "report_check=true" >> "$GITHUB_OUTPUT"
 
           if [ "${PARENT_WORKFLOW_CONCLUSION}" != "success" ]; then


### PR DESCRIPTION
## Why

Ref CON-853

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->
