### PR TITLE
fix(notifications): serve the new wordmark as png in both email colour schemes

### DIFF
--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
@@ -12,9 +12,10 @@ describe(renderEmailLayout.name, () => {
 
   it("renders both logo variants for light and dark mode", () => {
     const { html } = setup({});
-    expect(html).toContain("https://console-cdn.akash.network/akashconsole-light.png");
-    expect(html).toContain("https://console-cdn.akash.network/akashconsole-dark.svg");
+    expect(html).toContain("https://console-cdn.akash.network/akashconsole-logo.png");
+    expect(html).toContain("https://console-cdn.akash.network/akashconsole-logo-dark.png");
     expect(html).toContain("@media (prefers-color-scheme: dark)");
+    expect(html).not.toContain(".svg");
   });
 
   it("renders the subject as the title and headline", () => {

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
@@ -1,7 +1,7 @@
 import escape from "lodash/escape";
 
-const LOGO_LIGHT_URL = "https://console-cdn.akash.network/akashconsole-light.png";
-const LOGO_DARK_URL = "https://console-cdn.akash.network/akashconsole-dark.svg";
+const LOGO_LIGHT_URL = "https://console-cdn.akash.network/akashconsole-logo.png";
+const LOGO_DARK_URL = "https://console-cdn.akash.network/akashconsole-logo-dark.png";
 
 /** The subject is user-controlled for alert emails, so it is escaped; content must already be sanitized by the caller. */
 export function renderEmailLayout({ subject, content }: { subject: string; content: string }): string {
@@ -38,8 +38,8 @@ export function renderEmailLayout({ subject, content }: { subject: string; conte
     <tr><td align="center" style="padding:40px 16px;">
       <table role="presentation" width="600" cellpadding="0" cellspacing="0" class="card" style="max-width:600px;width:100%;background-color:#ffffff;border:1px solid #e4e4e7;border-radius:12px;overflow:hidden;">
         <tr><td class="header-border" style="padding:24px 40px;border-bottom:1px solid #f0f0f1;">
-          <img src="${LOGO_LIGHT_URL}" alt="Akash Console" width="170" height="19" class="logo-light" style="display:inline-block;border:0;" />
-          <img src="${LOGO_DARK_URL}" alt="Akash Console" width="170" height="19" class="logo-dark" style="display:none;border:0;" />
+          <img src="${LOGO_LIGHT_URL}" alt="Akash Console" width="173" height="19" class="logo-light" style="display:inline-block;border:0;" />
+          <img src="${LOGO_DARK_URL}" alt="Akash Console" width="173" height="19" class="logo-dark" style="display:none;border:0;" />
         </td></tr>
         <tr><td style="padding:36px 40px;">
           <h1 class="heading" style="margin:0 0 24px 0;font-size:24px;line-height:1.3;font-weight:700;color:#18181b;">${escapedSubject}</h1>


### PR DESCRIPTION
## Why

Denis reviewed the new branded email layout from #3759 and asked for the Akash Console logo in black, the way it looks in the app. New wordmark files were uploaded to the same CDN path under different names, so this points the layout at them.

Two things get fixed along the way:

The dark-mode logo was an SVG. Gmail, Outlook and Yahoo all strip SVG from `img` sources, so anyone reading in dark mode has been getting a broken image since the layout shipped. Both variants are PNG now.

The old art was 170x19 and displayed at 170x19, so it rendered soft on any retina screen. The new files are 1497x164.

## What

- `LOGO_LIGHT_URL` now points at `akashconsole-logo.png`, the black wordmark Denis asked for
- `LOGO_DARK_URL` now points at `akashconsole-logo-dark.png` instead of the SVG
- Display size goes from `170x19` to `173x19`. The new art is 9.13:1 where the old was 8.95:1, so keeping 170 would have squashed it about 2% vertically. Both `img` tags carry the same size, otherwise the logo jumps when a client switches scheme.
- The spec gained `expect(html).not.toContain(".svg")` so the SVG-in-email problem can't come back unnoticed

All four new files were checked against the CDN before this was written: both PNGs return 200, are 1497x164, and are RGBA with real transparency. `akashconsole-logo.png` is the black wordmark and `akashconsole-logo-dark.png` is the white one, so the existing light/dark toggle keeps working unchanged.

Nothing else in the repo references these URLs. A grep for `console-cdn.akash.network` returns only this file and its spec.

## Notes

The Novu workflow template for `transactional-mailer` lives in the Novu dashboard rather than in this repo. If it carries its own header or logo, this PR doesn't touch it and it will need a separate look.
