### PR TITLE
feat(notifications): render call-to-action buttons in transactional emails

### DIFF
--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
@@ -14,7 +14,10 @@ import type { DeploymentWriterService } from "@src/deployment/services/deploymen
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 import { CloseTrialDeployment, CloseTrialDeploymentHandler } from "./close-trial-deployment.handler";
 
+import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const PAYMENT_LINK = "https://console.akash.network/billing?payment=true";
 
 describe(CloseTrialDeploymentHandler.name, () => {
   it("logs warning and returns early when wallet is not found", async () => {
@@ -108,6 +111,7 @@ describe(CloseTrialDeploymentHandler.name, () => {
           dseq: payload.dseq,
           owner: wallet.address!,
           deploymentLifetimeInHours: 24,
+          paymentLink: PAYMENT_LINK,
           firstPurchaseBonus: "$resolved"
         }
       }),
@@ -317,8 +321,9 @@ describe(CloseTrialDeploymentHandler.name, () => {
       deploymentService: mock<DeploymentHttpService>({
         findByOwnerAndDseq: input?.findDeployment ?? vi.fn().mockResolvedValue({ deployment: { state: "active" } })
       }),
-      billingConfig: mock<BillingConfigService>({
-        get: vi.fn().mockReturnValue(input?.trialDeploymentLifetimeInHours ?? 24)
+      billingConfig: mockConfigService<BillingConfigService>({
+        TRIAL_DEPLOYMENT_CLEANUP_HOURS: input?.trialDeploymentLifetimeInHours ?? 24,
+        CONSOLE_WEB_PAYMENT_LINK: PAYMENT_LINK
       }),
       chainErrorService: new ChainErrorService(mock<BalanceHttpService>(), mock<BillingConfigService>(), mock<TxManagerService>())
     };

--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.ts
@@ -147,6 +147,7 @@ export class CloseTrialDeploymentHandler implements JobHandler<CloseTrialDeploym
           dseq: payload.dseq,
           owner: wallet.address!,
           deploymentLifetimeInHours: this.billingConfig.get("TRIAL_DEPLOYMENT_CLEANUP_HOURS"),
+          paymentLink: this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK"),
           firstPurchaseBonus: RESOLVED_MARKER
         }
       }),

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
@@ -13,7 +13,10 @@ import { NotificationJob } from "@src/notifications/services/notification-handle
 import { CloseTrialDeployment } from "../close-trial-deployment/close-trial-deployment.handler";
 import { TrialDeploymentLeaseCreatedHandler } from "./trial-deployment-lease-created.handler";
 
+import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const PAYMENT_LINK = "https://console.akash.network/billing?payment=true";
 
 describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   it("logs a warning when wallet is not found", async () => {
@@ -111,6 +114,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
           deploymentClosedAt: addHours(deploymentCreatedAt, trialDeploymentLifetimeInHours).toISOString(),
           dseq: payload.dseq,
           owner: wallet.address!,
+          paymentLink: PAYMENT_LINK,
           firstPurchaseBonus: "$resolved"
         }
       }),
@@ -223,8 +227,9 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
       jobQueueService: mock<JobQueueService>({
         enqueue: input?.enqueueJob ?? vi.fn().mockResolvedValue(undefined)
       }),
-      billingConfig: mock<BillingConfigService>({
-        get: vi.fn().mockReturnValue(input?.trialDeploymentLifetimeInHours ?? 24)
+      billingConfig: mockConfigService<BillingConfigService>({
+        TRIAL_DEPLOYMENT_CLEANUP_HOURS: input?.trialDeploymentLifetimeInHours ?? 24,
+        CONSOLE_WEB_PAYMENT_LINK: PAYMENT_LINK
       })
     };
 

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
@@ -72,6 +72,7 @@ export class TrialDeploymentLeaseCreatedHandler implements JobHandler<TrialDeplo
           deploymentClosedAt: addHours(deploymentCreatedAt, trialDeploymentLifetime).toISOString(),
           dseq: payload.dseq,
           owner: wallet.address!,
+          paymentLink: this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK"),
           firstPurchaseBonus: RESOLVED_MARKER
         }
       }),

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
@@ -171,7 +171,7 @@ describe(AutoReloadPauseService.name, () => {
       await service.recordDecline({ claim, user, decline: { isTerminal: false } });
 
       const notification = notificationService.createNotification.mock.calls[0][0];
-      expect(notification.payload.description).toContain('<a href="https://console.akash.network/billing">');
+      expect(notification.payload.actions).toEqual([{ label: "Update payment method", url: "https://console.akash.network/billing" }]);
     });
   });
 

--- a/apps/api/src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service.integration.ts
+++ b/apps/api/src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service.integration.ts
@@ -36,7 +36,7 @@ describe(ExpiringDeploymentsNotifierService.name, () => {
     expect(createNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: expect.objectContaining({
-          description: expect.stringContaining(`/deployments/${dseq}?tab=SETTINGS`)
+          actions: [expect.objectContaining({ url: expect.stringContaining(`/deployments/${dseq}?tab=SETTINGS`) })]
         })
       })
     );

--- a/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
+++ b/apps/api/src/deployment/services/unreachable-provider-deployments-notifier/unreachable-provider-deployments-notifier.service.spec.ts
@@ -49,7 +49,7 @@ describe(UnreachableProviderDeploymentsNotifierService.name, () => {
     );
     const [{ payload }] = notificationService.createNotification.mock.calls[0];
     expect(payload.description).toContain("<strong>dark</strong>");
-    expect(payload.description).toContain(`${DEPLOY_WEB_BASE_URL}/deployments/${DSEQ}`);
+    expect(payload.actions).toEqual([{ label: "Close the deployment", url: `${DEPLOY_WEB_BASE_URL}/deployments/${DSEQ}` }]);
   });
 
   it("claims the outage before sending so a repeat sweep cannot email twice", async () => {

--- a/apps/api/src/notifications/services/notification-templates/after-trial-ends-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/after-trial-ends-notification.ts
@@ -13,8 +13,9 @@ export function afterTrialEndsNotification(
     payload: {
       summary: "Add payment info to continue using Akash",
       description:
-        `Your trial period with Akash Network has ended. To keep using the platform and access all features, please add a payment method and top up your account by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>` +
-        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
+        `Your trial period with Akash Network has ended. To keep using the platform and access all features, please add a payment method and top up your account.` +
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus),
+      actions: [{ label: "Add credits", url: vars.paymentLink }]
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/auto-recharge-succeeded-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-recharge-succeeded-notification.spec.ts
@@ -19,7 +19,7 @@ describe(autoRechargeSucceededNotification.name, () => {
     expect(result.payload.summary).toBe("Your Akash account was recharged $50.00");
     expect(result.payload.description).toContain("$50.00");
     expect(result.payload.description).toContain("<strong>$120.50</strong>");
-    expect(result.payload.description).toContain('<a href="https://console.akash.network/billing">');
+    expect(result.payload.actions).toEqual([{ label: "View billing", url: "https://console.akash.network/billing" }]);
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 });

--- a/apps/api/src/notifications/services/notification-templates/auto-recharge-succeeded-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-recharge-succeeded-notification.ts
@@ -19,8 +19,8 @@ export function autoRechargeSucceededNotification(
       summary: `Your Akash account was recharged ${amount}`,
       description:
         `We automatically charged your default payment method ${amount} to keep your deployments running. ` +
-        `Your available balance is now <strong>${balance}</strong>. ` +
-        `<a href="${vars.billingUrl}">View your billing</a>.`
+        `Your available balance is now <strong>${balance}</strong>.`,
+      actions: [{ label: "View billing", url: vars.billingUrl }]
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-charge-failed-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-charge-failed-notification.spec.ts
@@ -16,7 +16,7 @@ describe(autoTopUpChargeFailedNotification.name, () => {
     expect(result.payload.summary).toBe("We couldn't charge your card");
     expect(result.payload.description).toContain("declined");
     expect(result.payload.description).toContain("try again");
-    expect(result.payload.description).toContain('<a href="https://console.akash.network/billing">');
+    expect(result.payload.actions).toEqual([{ label: "Update payment method", url: "https://console.akash.network/billing" }]);
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-charge-failed-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-charge-failed-notification.ts
@@ -13,8 +13,8 @@ export function autoTopUpChargeFailedNotification(user: UserOutput, vars: { char
       description:
         `Your card was declined, so we couldn't add credits to your account automatically. ` +
         `We'll try again a few more times over the next several hours. If it keeps failing we'll stop and send you another email. ` +
-        `Your deployments keep running on the credits you already have. ` +
-        `<a href="${vars.billingUrl}">Update your payment method</a> if the card needs fixing.`
+        `Your deployments keep running on the credits you already have.`,
+      actions: [{ label: "Update payment method", url: vars.billingUrl }]
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-paused-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-paused-notification.spec.ts
@@ -15,7 +15,7 @@ describe(autoTopUpPausedNotification.name, () => {
 
     expect(result.payload.summary).toBe("Auto top-up is paused");
     expect(result.payload.description).toContain("declined");
-    expect(result.payload.description).toContain('<a href="https://console.akash.network/billing">');
+    expect(result.payload.actions).toEqual([{ label: "Update payment method", url: "https://console.akash.network/billing" }]);
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-paused-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-paused-notification.ts
@@ -13,7 +13,8 @@ export function autoTopUpPausedNotification(user: UserOutput, vars: { pausedAt: 
       description:
         `Your card was declined several times, so we've stopped trying to charge it. ` +
         `Your deployments will keep running until your credits run out, but nothing will be added automatically. ` +
-        `<a href="${vars.billingUrl}">Update your payment method</a> and auto top-up starts again on its own.`
+        `Once you update your payment method, auto top-up starts again on its own.`,
+      actions: [{ label: "Update payment method", url: vars.billingUrl }]
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.spec.ts
@@ -21,4 +21,18 @@ describe(beforeCloseTrialDeploymentNotification.name, () => {
     expect(result.payload.description).toContain("10% in bonus credits");
     expect(result.payload.actions).toEqual([{ label: "Add credits", url: "https://console.akash.network/billing?payment=true" }]);
   });
+
+  it("omits the action when a job enqueued before paymentLink existed carries no link", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = beforeCloseTrialDeploymentNotification(user, {
+      deploymentClosedAt: "2025-10-22T07:58:47.770Z",
+      dseq: "123456",
+      owner: "akash1test",
+      firstPurchaseBonus: { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 }
+    } as Parameters<typeof beforeCloseTrialDeploymentNotification>[1]);
+
+    expect(result.payload.actions).toBeUndefined();
+    expect(result.payload.summary).toBe("Your Trial Deployment Ends Soon");
+  });
 });

--- a/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.spec.ts
@@ -12,11 +12,13 @@ describe(beforeCloseTrialDeploymentNotification.name, () => {
       deploymentClosedAt: "2025-10-22T07:58:47.770Z",
       dseq: "123456",
       owner: "akash1test",
+      paymentLink: "https://console.akash.network/billing?payment=true",
       firstPurchaseBonus: { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 }
     });
 
     expect(result.payload.summary).toBe("Your Trial Deployment Ends Soon");
     expect(result.payload.description).toContain("Your trial deployment will end");
     expect(result.payload.description).toContain("10% in bonus credits");
+    expect(result.payload.actions).toEqual([{ label: "Add credits", url: "https://console.akash.network/billing?payment=true" }]);
   });
 });

--- a/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.ts
@@ -8,7 +8,13 @@ import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
 
 export function beforeCloseTrialDeploymentNotification(
   user: UserOutput,
-  vars: { deploymentClosedAt: string; dseq: string; owner: string; firstPurchaseBonus: ResolvedValue<FirstPurchaseBonusOffer | null> }
+  vars: {
+    deploymentClosedAt: string;
+    dseq: string;
+    owner: string;
+    paymentLink: string;
+    firstPurchaseBonus: ResolvedValue<FirstPurchaseBonusOffer | null>;
+  }
 ): CreateNotificationInput {
   const deploymentClosedAt = new Date(vars.deploymentClosedAt);
   const timeLeft = deploymentClosedAt.getTime() < Date.now() ? "in a few seconds" : formatDistanceToNow(deploymentClosedAt, { addSuffix: true });
@@ -18,7 +24,8 @@ export function beforeCloseTrialDeploymentNotification(
       summary: "Your Trial Deployment Ends Soon",
       description:
         `Your trial deployment will end ${timeLeft}. To keep your deployment running, please add a payment method and top up your account before then.` +
-        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus),
+      actions: [{ label: "Add credits", url: vars.paymentLink }]
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.ts
@@ -5,6 +5,7 @@ import type { ResolvedValue } from "@src/notifications/services/notification-dat
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
 import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
+import { linkedActions } from "./notification-actions";
 
 export function beforeCloseTrialDeploymentNotification(
   user: UserOutput,
@@ -25,7 +26,7 @@ export function beforeCloseTrialDeploymentNotification(
       description:
         `Your trial deployment will end ${timeLeft}. To keep your deployment running, please add a payment method and top up your account before then.` +
         firstPurchaseBonusSentence(vars.firstPurchaseBonus),
-      actions: [{ label: "Add credits", url: vars.paymentLink }]
+      actions: linkedActions({ label: "Add credits", url: vars.paymentLink })
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/before-trial-ends-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-trial-ends-notification.ts
@@ -25,8 +25,9 @@ export function beforeTrialEndsNotification(
       description:
         `Your free trial with Akash Network will end ${timeLeft}. You still have $${vars.remainingCredits} in free credits available and, ` +
         `${vars.activeDeployments} deployments that will be lost when your free trial ends. ` +
-        `To retain the remaining free credits and to ensure your deployments keep running when the trial ends, purchase some credits today by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>.` +
-        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
+        `To retain the remaining free credits and to ensure your deployments keep running when the trial ends, purchase some credits today.` +
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus),
+      actions: [{ label: "Add credits", url: vars.paymentLink }]
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/credits-running-low-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/credits-running-low-notification.spec.ts
@@ -20,8 +20,10 @@ describe(creditsRunningLowNotification.name, () => {
     expect(result.payload.summary).toBe("Your Akash credits are running low");
     expect(result.payload.description).toContain("<strong>$12.50</strong>");
     expect(result.payload.description).toContain("about 2 days of current usage");
-    expect(result.payload.description).toContain('<a href="https://console.akash.network/billing?openPayment=true">Add credits</a>');
-    expect(result.payload.description).toContain('<a href="https://console.akash.network/billing">enable Auto Recharge</a>');
+    expect(result.payload.actions).toEqual([
+      { label: "Add credits", url: "https://console.akash.network/billing?openPayment=true" },
+      { label: "Enable Auto Recharge", url: "https://console.akash.network/billing" }
+    ]);
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 

--- a/apps/api/src/notifications/services/notification-templates/credits-running-low-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/credits-running-low-notification.ts
@@ -15,9 +15,11 @@ export function creditsRunningLowNotification(
       summary: "Your Akash credits are running low",
       description:
         `Your remaining credits are <strong>${balance}</strong>, about ${coverage} of current usage. ` +
-        `Add credits or turn on Auto Recharge to keep your deployments running. ` +
-        `<a href="${vars.paymentLink}">Add credits</a> or ` +
-        `<a href="${vars.billingUrl}">enable Auto Recharge</a>.`
+        `Add credits or turn on Auto Recharge to keep your deployments running.`,
+      actions: [
+        { label: "Add credits", url: vars.paymentLink },
+        { label: "Enable Auto Recharge", url: vars.billingUrl }
+      ]
     },
     user: { id: user.id, email: user.email }
   };

--- a/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.spec.ts
@@ -11,7 +11,8 @@ describe(emailVerificationCodeNotification.name, () => {
 
     expect(result.notificationId).toMatch(/^emailVerificationCode\.user-123\.[0-9a-f-]{36}$/);
     expect(result.payload.summary).toBe("Your verification code");
-    expect(result.payload.description).toContain("<strong>123456</strong>");
+    expect(result.payload.code).toBe("123456");
+    expect(result.payload.description).not.toContain("123456");
     expect(result.payload.description).toContain("expires in 10 minutes");
     expect(result.user).toEqual({ id: "user-123", email: "test@example.com" });
   });

--- a/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.ts
@@ -7,9 +7,8 @@ export function emailVerificationCodeNotification(user: { id: string; email: str
     notificationId: `emailVerificationCode.${user.id}.${randomUUID()}`,
     payload: {
       summary: "Your verification code",
-      description:
-        `Your email verification code is: <strong>${vars.code}</strong>. ` +
-        `This code expires in 10 minutes. If you did not request this code, please ignore this email.`
+      description: "Enter this code to verify your email address. It expires in 10 minutes. If you did not request it, please ignore this email.",
+      code: vars.code
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/notification-actions.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/notification-actions.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { linkedActions } from "./notification-actions";
+
+describe(linkedActions.name, () => {
+  it("keeps actions that have a url", () => {
+    expect(linkedActions({ label: "Add credits", url: "https://console.akash.network/billing" })).toEqual([
+      { label: "Add credits", url: "https://console.akash.network/billing" }
+    ]);
+  });
+
+  it("returns undefined when every url is missing", () => {
+    expect(linkedActions({ label: "Add credits", url: undefined })).toBeUndefined();
+  });
+
+  it("drops only the actions whose url is missing", () => {
+    expect(linkedActions({ label: "Add credits", url: undefined }, { label: "View billing", url: "https://console.akash.network/billing" })).toEqual([
+      { label: "View billing", url: "https://console.akash.network/billing" }
+    ]);
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/notification-actions.ts
+++ b/apps/api/src/notifications/services/notification-templates/notification-actions.ts
@@ -1,0 +1,9 @@
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+type NotificationAction = NonNullable<CreateNotificationInput["payload"]["actions"]>[number];
+
+/** Jobs enqueued before a link var existed omit it, and the notifications API rejects an action with no url by dropping the whole email. */
+export function linkedActions(...actions: Array<{ label: string; url: string | undefined }>): NotificationAction[] | undefined {
+  const linked = actions.filter((action): action is NotificationAction => !!action.url);
+  return linked.length > 0 ? linked : undefined;
+}

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.spec.ts
@@ -24,7 +24,7 @@ describe(providerUnreachableClosedNotification.name, () => {
     expect(result.payload.description).toContain("<strong>provider.akash.cmolls.de</strong>");
     expect(result.payload.description).toContain("14 days ago");
     expect(result.payload.description).toContain("returned");
-    expect(result.payload.description).toContain(`<a href="${REDEPLOY_URL}">Deploy it again</a>`);
+    expect(result.payload.actions).toEqual([{ label: "Deploy it again", url: REDEPLOY_URL }]);
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-closed.ts
@@ -20,7 +20,8 @@ export function providerUnreachableClosedNotification(
         `Deployment <strong>${vars.dseq}</strong> has been closed. Its provider, ` +
         `<strong>${escapeHtml(toProviderHostName(vars.hostUri))}</strong>, stopped responding ${vars.downForDays} days ago and never came back, ` +
         `so the deployment was costing you money without running anything. What was left of its funds has been returned ` +
-        `to your account. <a href="${vars.redeployUrl}">Deploy it again</a> whenever you are ready.`
+        `to your account.`,
+      actions: [{ label: "Deploy it again", url: vars.redeployUrl }]
     },
     user: { id: user.id, email: user.email }
   };

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.spec.ts
@@ -27,7 +27,7 @@ describe(providerUnreachableNotification.name, () => {
     expect(result.payload.description).toContain("<strong>654321</strong>");
     expect(result.payload.description).toContain("<strong>provider.akash.cmolls.de</strong>");
     expect(result.payload.description).toContain("5 days");
-    expect(result.payload.description).toContain(`<a href="${DEPLOYMENT_URL}">Close the deployment</a>`);
+    expect(result.payload.actions).toEqual([{ label: "Close the deployment", url: DEPLOYMENT_URL }]);
     expect(result.payload.description).toContain("we will close the deployment for you");
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });

--- a/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/provider-unreachable-notification.ts
@@ -22,9 +22,10 @@ export function providerUnreachableNotification(
       description:
         `The provider hosting deployment <strong>${vars.dseq}</strong>, <strong>${escapeHtml(toProviderHostName(vars.hostUri))}</strong>, ` +
         `has not responded for ${formatDistanceToNow(downSince)} and your workload is most likely down. ` +
-        `You are still paying for it. <a href="${vars.deploymentUrl}">Close the deployment</a> to get the remaining ` +
+        `You are still paying for it. Close the deployment to get the remaining ` +
         `funds back, then redeploy somewhere else. If every provider hosting this deployment is still unreachable ` +
-        `${vars.closeAfterDays} days after it went down, we will close the deployment for you and return what is left.`
+        `${vars.closeAfterDays} days after it went down, we will close the deployment for you and return what is left.`,
+      actions: [{ label: "Close the deployment", url: vars.deploymentUrl }]
     },
     user: { id: user.id, email: user.email }
   };

--- a/apps/api/src/notifications/services/notification-templates/runtime-limit-ending-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/runtime-limit-ending-notification.spec.ts
@@ -21,9 +21,8 @@ describe(runtimeLimitEndingNotification.name, () => {
     expect(result.payload.summary).toBe("Your Akash deployment stops soon");
     expect(result.payload.description).toContain("<strong>654321</strong>");
     expect(result.payload.description).toContain("in about 6 hours");
-    expect(result.payload.description).toContain(
-      '<a href="https://console.akash.network/deployments/654321?tab=SETTINGS">extend the limit or switch it to always-on funding</a>'
-    );
+    expect(result.payload.description).toContain("extend the limit or switch it to always-on funding");
+    expect(result.payload.actions).toEqual([{ label: "Extend the limit", url: "https://console.akash.network/deployments/654321?tab=SETTINGS" }]);
     expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
   });
 

--- a/apps/api/src/notifications/services/notification-templates/runtime-limit-ending-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/runtime-limit-ending-notification.ts
@@ -16,7 +16,8 @@ export function runtimeLimitEndingNotification(
       summary: "Your Akash deployment stops soon",
       description:
         `Deployment <strong>${vars.dseq}</strong> reaches its runtime limit ${timeLeft} and will be closed. ` +
-        `To keep it running, <a href="${vars.deploymentSettingsUrl}">extend the limit or switch it to always-on funding</a>.`
+        `To keep it running, extend the limit or switch it to always-on funding.`,
+      actions: [{ label: "Extend the limit", url: vars.deploymentSettingsUrl }]
     },
     user: { id: user.id, email: user.email }
   };

--- a/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.spec.ts
@@ -12,11 +12,13 @@ describe(trialDeploymentClosedNotification.name, () => {
       dseq: "123456",
       owner: "akash1test",
       deploymentLifetimeInHours: 24,
+      paymentLink: "https://console.akash.network/billing?payment=true",
       firstPurchaseBonus: { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 }
     });
 
     expect(result.payload.summary).toBe("Your Trial Deployment Has Been Closed");
     expect(result.payload.description).toContain("has been closed by the system");
     expect(result.payload.description).toContain("10% in bonus credits");
+    expect(result.payload.actions).toEqual([{ label: "Add credits", url: "https://console.akash.network/billing?payment=true" }]);
   });
 });

--- a/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.spec.ts
@@ -21,4 +21,18 @@ describe(trialDeploymentClosedNotification.name, () => {
     expect(result.payload.description).toContain("10% in bonus credits");
     expect(result.payload.actions).toEqual([{ label: "Add credits", url: "https://console.akash.network/billing?payment=true" }]);
   });
+
+  it("omits the action when a job enqueued before paymentLink existed carries no link", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = trialDeploymentClosedNotification(user, {
+      dseq: "123456",
+      owner: "akash1test",
+      deploymentLifetimeInHours: 24,
+      firstPurchaseBonus: { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 }
+    } as Parameters<typeof trialDeploymentClosedNotification>[1]);
+
+    expect(result.payload.actions).toBeUndefined();
+    expect(result.payload.summary).toBe("Your Trial Deployment Has Been Closed");
+  });
 });

--- a/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.ts
@@ -3,6 +3,7 @@ import type { ResolvedValue } from "@src/notifications/services/notification-dat
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
 import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
+import { linkedActions } from "./notification-actions";
 
 export function trialDeploymentClosedNotification(
   user: UserOutput,
@@ -21,7 +22,7 @@ export function trialDeploymentClosedNotification(
       description:
         `Your trial deployment (dseq: ${vars.dseq}) has been closed by the system after reaching the ${vars.deploymentLifetimeInHours}-hour limit. To keep your deployment running, please add a payment method and top up your account.` +
         firstPurchaseBonusSentence(vars.firstPurchaseBonus),
-      actions: [{ label: "Add credits", url: vars.paymentLink }]
+      actions: linkedActions({ label: "Add credits", url: vars.paymentLink })
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.ts
@@ -6,7 +6,13 @@ import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
 
 export function trialDeploymentClosedNotification(
   user: UserOutput,
-  vars: { dseq: string; owner: string; deploymentLifetimeInHours: number; firstPurchaseBonus: ResolvedValue<FirstPurchaseBonusOffer | null> }
+  vars: {
+    dseq: string;
+    owner: string;
+    deploymentLifetimeInHours: number;
+    paymentLink: string;
+    firstPurchaseBonus: ResolvedValue<FirstPurchaseBonusOffer | null>;
+  }
 ): CreateNotificationInput {
   return {
     notificationId: `trialDeploymentClosed.${vars.dseq}.${vars.owner}`,
@@ -14,7 +20,8 @@ export function trialDeploymentClosedNotification(
       summary: "Your Trial Deployment Has Been Closed",
       description:
         `Your trial deployment (dseq: ${vars.dseq}) has been closed by the system after reaching the ${vars.deploymentLifetimeInHours}-hour limit. To keep your deployment running, please add a payment method and top up your account.` +
-        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus),
+      actions: [{ label: "Add credits", url: vars.paymentLink }]
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/trial-ended-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-ended-notification.ts
@@ -13,8 +13,9 @@ export function trialEndedNotification(
     payload: {
       summary: "Your Free Trial Has Ended",
       description:
-        `Your free trial with Akash Network has ended. To continue using the platform and accessing all features, please add a payment method and purchase some credits by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>.` +
-        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
+        `Your free trial with Akash Network has ended. To continue using the platform and accessing all features, please add a payment method and purchase some credits.` +
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus),
+      actions: [{ label: "Add credits", url: vars.paymentLink }]
     },
     user: {
       id: user.id,

--- a/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.ts
@@ -17,6 +17,7 @@ class NotificationJobDto extends createZodDto(
     payload: z.object({
       summary: z.string(),
       description: z.string(),
+      code: z.string().optional(),
       actions: z
         .array(
           z.object({

--- a/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.ts
@@ -16,7 +16,15 @@ class NotificationJobDto extends createZodDto(
     startAfter: z.string().datetime().optional(),
     payload: z.object({
       summary: z.string(),
-      description: z.string()
+      description: z.string(),
+      actions: z
+        .array(
+          z.object({
+            label: z.string(),
+            url: z.string().url()
+          })
+        )
+        .optional()
     })
   })
 ) {}

--- a/apps/notifications/src/modules/notifications/dto/NotificationCommand.dto.spec.ts
+++ b/apps/notifications/src/modules/notifications/dto/NotificationCommand.dto.spec.ts
@@ -14,6 +14,12 @@ describe(NotificationCommandDto.name, () => {
     expect(result.payload.actions).toEqual(actions);
   });
 
+  it("keeps the verification code the email layout renders as a block", () => {
+    const result = NotificationCommandDto.schema.parse(command({ code: "418902" }));
+
+    expect(result.payload.code).toBe("418902");
+  });
+
   it("accepts a command without actions", () => {
     const result = NotificationCommandDto.schema.parse(command({}));
 
@@ -26,7 +32,7 @@ describe(NotificationCommandDto.name, () => {
     expect(result.success).toBe(false);
   });
 
-  function command(payload: { actions?: { label: string; url: string }[] }) {
+  function command(payload: { actions?: { label: string; url: string }[]; code?: string }) {
     return {
       notificationChannelId: "channel-1",
       notificationId: "creditsRunningLow.user-1",

--- a/apps/notifications/src/modules/notifications/dto/NotificationCommand.dto.spec.ts
+++ b/apps/notifications/src/modules/notifications/dto/NotificationCommand.dto.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { NotificationCommandDto } from "./NotificationCommand.dto";
+
+describe(NotificationCommandDto.name, () => {
+  it("keeps the actions the email layout renders as buttons", () => {
+    const actions = [
+      { label: "Add credits", url: "https://console.akash.network/billing?openPayment=true" },
+      { label: "Enable Auto Recharge", url: "https://console.akash.network/billing" }
+    ];
+
+    const result = NotificationCommandDto.schema.parse(command({ actions }));
+
+    expect(result.payload.actions).toEqual(actions);
+  });
+
+  it("accepts a command without actions", () => {
+    const result = NotificationCommandDto.schema.parse(command({}));
+
+    expect(result.payload.actions).toBeUndefined();
+  });
+
+  it("rejects an action url that is not a url", () => {
+    const result = NotificationCommandDto.schema.safeParse(command({ actions: [{ label: "Add credits", url: "not-a-url" }] }));
+
+    expect(result.success).toBe(false);
+  });
+
+  function command(payload: { actions?: { label: string; url: string }[] }) {
+    return {
+      notificationChannelId: "channel-1",
+      notificationId: "creditsRunningLow.user-1",
+      payload: {
+        summary: "Your Akash credits are running low",
+        description: "Your remaining credits are <strong>$4.20</strong>.",
+        ...payload
+      }
+    };
+  }
+});

--- a/apps/notifications/src/modules/notifications/dto/NotificationCommand.dto.ts
+++ b/apps/notifications/src/modules/notifications/dto/NotificationCommand.dto.ts
@@ -6,7 +6,15 @@ const NotificationCommandSchema = z.object({
   notificationId: z.string().optional(),
   payload: z.object({
     summary: z.string(),
-    description: z.string()
+    description: z.string(),
+    actions: z
+      .array(
+        z.object({
+          label: z.string(),
+          url: z.string().url()
+        })
+      )
+      .optional()
   })
 });
 

--- a/apps/notifications/src/modules/notifications/dto/NotificationCommand.dto.ts
+++ b/apps/notifications/src/modules/notifications/dto/NotificationCommand.dto.ts
@@ -7,6 +7,7 @@ const NotificationCommandSchema = z.object({
   payload: z.object({
     summary: z.string(),
     description: z.string(),
+    code: z.string().optional(),
     actions: z
       .array(
         z.object({

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
@@ -91,6 +91,13 @@ describe(renderEmailLayout.name, () => {
     expect(html).toContain('class="btn-cell"');
   });
 
+  it("repeats the button padding on the cell so Outlook keeps the button shape", () => {
+    const { html } = setup({ actions: [{ label: "Add credits", url: "https://console.akash.network/billing" }] });
+
+    expect(html).toContain("mso-padding-alt:12px 24px;");
+    expect(html).toContain("padding:12px 24px;");
+  });
+
   it("renders the footer", () => {
     const { html } = setup({});
     expect(html).toContain("Sent by Akash Console. You're receiving this because you have an Akash Console account.");

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
@@ -71,16 +71,37 @@ describe(renderEmailLayout.name, () => {
     expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
   });
 
+  it("renders the verification code as one selectable token", () => {
+    const { html } = setup({ code: "418902" });
+
+    expect(html).toContain(">418902</span>");
+    expect(html).not.toContain("418 902");
+    expect(html).toContain('class="code-box"');
+  });
+
+  it("renders no code block when there is no code", () => {
+    const { html } = setup({});
+    expect(html).not.toContain('class="code-box"');
+  });
+
+  it("stacks the buttons full width on a narrow screen", () => {
+    const { html } = setup({ actions: [{ label: "Add credits", url: "https://console.akash.network/billing" }] });
+
+    expect(html).toContain("@media (max-width: 480px)");
+    expect(html).toContain('class="btn-cell"');
+  });
+
   it("renders the footer", () => {
     const { html } = setup({});
     expect(html).toContain("Sent by Akash Console. You're receiving this because you have an Akash Console account.");
   });
 
-  function setup(input: { subject?: string; content?: string; actions?: EmailAction[] }) {
+  function setup(input: { subject?: string; content?: string; actions?: EmailAction[]; code?: string }) {
     const html = renderEmailLayout({
       subject: input.subject ?? faker.lorem.sentence(),
       content: input.content ?? faker.lorem.paragraph(),
-      actions: input.actions
+      actions: input.actions,
+      code: input.code
     });
     return { html };
   }

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import { describe, expect, it } from "vitest";
 
-import { renderEmailLayout } from "./email-layout";
+import { type EmailAction, renderEmailLayout } from "./email-layout";
 
 describe(renderEmailLayout.name, () => {
   it("renders a complete html document", () => {
@@ -37,15 +37,50 @@ describe(renderEmailLayout.name, () => {
     expect(html).toContain(content);
   });
 
+  it("renders a primary button for the first action and a secondary one for the rest", () => {
+    const { html } = setup({
+      actions: [
+        { label: "Add credits", url: "https://console.akash.network/billing?openPayment=true" },
+        { label: "Enable Auto Recharge", url: "https://console.akash.network/billing" }
+      ]
+    });
+
+    expect(html).toContain('href="https://console.akash.network/billing?openPayment=true"');
+    expect(html).toContain(">Add credits</a>");
+    expect(html).toContain('class="btn-primary"');
+    expect(html).toContain('href="https://console.akash.network/billing"');
+    expect(html).toContain(">Enable Auto Recharge</a>");
+    expect(html).toContain('class="btn-secondary"');
+  });
+
+  it("renders no button markup when there are no actions", () => {
+    const { html } = setup({});
+    expect(html).not.toContain('class="btn-primary"');
+    expect(html).not.toContain('class="btn-secondary"');
+  });
+
+  it("drops an action whose url is not http", () => {
+    const { html } = setup({ actions: [{ label: "Add credits", url: "javascript:alert(1)" }] });
+    expect(html).not.toContain("javascript:");
+    expect(html).not.toContain('class="btn-primary"');
+  });
+
+  it("escapes html in an action label", () => {
+    const { html } = setup({ actions: [{ label: "<script>alert(1)</script>", url: "https://console.akash.network/billing" }] });
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
   it("renders the footer", () => {
     const { html } = setup({});
     expect(html).toContain("Sent by Akash Console. You're receiving this because you have an Akash Console account.");
   });
 
-  function setup(input: { subject?: string; content?: string }) {
+  function setup(input: { subject?: string; content?: string; actions?: EmailAction[] }) {
     const html = renderEmailLayout({
       subject: input.subject ?? faker.lorem.sentence(),
-      content: input.content ?? faker.lorem.paragraph()
+      content: input.content ?? faker.lorem.paragraph(),
+      actions: input.actions
     });
     return { html };
   }

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
@@ -3,8 +3,44 @@ import escape from "lodash/escape";
 const LOGO_LIGHT_URL = "https://console-cdn.akash.network/akashconsole-logo.png";
 const LOGO_DARK_URL = "https://console-cdn.akash.network/akashconsole-logo-dark.png";
 
+export interface EmailAction {
+  label: string;
+  url: string;
+}
+
+function isHttpUrl(url: string): boolean {
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function renderAction({ label, url }: EmailAction, isPrimary: boolean): string {
+  const buttonClass = isPrimary ? "btn-primary" : "btn-secondary";
+  const fill = isPrimary ? "background-color:#171717;" : "background-color:#ffffff;border:1px solid #171717;";
+  const textColor = isPrimary ? "#ffffff" : "#171717";
+
+  return `<table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 12px 0;">
+            <tr><td class="${buttonClass}" style="${fill}border-radius:8px;">
+              <a href="${escape(url)}" class="${buttonClass}-text" style="display:inline-block;padding:12px 24px;font-size:14px;font-weight:500;line-height:1.2;color:${textColor};text-decoration:none;">${escape(label)}</a>
+            </td></tr>
+          </table>`;
+}
+
+function renderActions(actions: EmailAction[] = []): string {
+  const renderable = actions.filter(action => isHttpUrl(action.url));
+
+  if (!renderable.length) {
+    return "";
+  }
+
+  return `<div style="padding-top:28px;">${renderable.map((action, index) => renderAction(action, index === 0)).join("\n          ")}</div>`;
+}
+
 /** The subject is user-controlled for alert emails, so it is escaped; content must already be sanitized by the caller. */
-export function renderEmailLayout({ subject, content }: { subject: string; content: string }): string {
+export function renderEmailLayout({ subject, content, actions }: { subject: string; content: string; actions?: EmailAction[] }): string {
   const escapedSubject = escape(subject);
 
   return `<!DOCTYPE html>
@@ -30,6 +66,10 @@ export function renderEmailLayout({ subject, content }: { subject: string; conte
       .muted, .footer-text { color: #a1a1aa !important; }
       .logo-light { display: none !important; }
       .logo-dark { display: inline-block !important; }
+      .btn-primary { background-color: #e5e5e5 !important; }
+      .btn-primary-text { color: #171717 !important; }
+      .btn-secondary { background-color: transparent !important; border-color: #e5e5e5 !important; }
+      .btn-secondary-text { color: #e5e5e5 !important; }
     }
   </style>
 </head>
@@ -44,6 +84,7 @@ export function renderEmailLayout({ subject, content }: { subject: string; conte
         <tr><td style="padding:36px 40px;">
           <h1 class="heading" style="margin:0 0 24px 0;font-size:24px;line-height:1.3;font-weight:700;color:#18181b;">${escapedSubject}</h1>
           <div class="body-text" style="font-size:16px;line-height:1.65;color:#3f3f46;">${content}</div>
+          ${renderActions(actions)}
         </td></tr>
         <tr><td class="card-footer" style="padding:24px 40px;background-color:#fafafa;border-top:1px solid #f0f0f1;">
           <p class="muted" style="margin:0 0 12px 0;font-size:11px;letter-spacing:2px;text-transform:uppercase;color:#a1a1aa;font-family:'SF Mono',Menlo,Consolas,monospace;">Akash &middot; The Open Compute Marketplace</p>

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
@@ -2,6 +2,7 @@ import escape from "lodash/escape";
 
 const LOGO_LIGHT_URL = "https://console-cdn.akash.network/akashconsole-logo.png";
 const LOGO_DARK_URL = "https://console-cdn.akash.network/akashconsole-logo-dark.png";
+const BUTTON_PADDING = "12px 24px";
 
 export interface EmailAction {
   label: string;
@@ -17,6 +18,7 @@ function isHttpUrl(url: string): boolean {
   }
 }
 
+/** Outlook renders through Word, which drops padding on an inline <a>, so the cell repeats it as mso-padding-alt. */
 function renderAction({ label, url }: EmailAction, isPrimary: boolean, isLast: boolean): string {
   const buttonClass = isPrimary ? "btn-primary" : "btn-secondary";
   const fill = isPrimary ? "background-color:#171717;" : "background-color:#ffffff;border:1px solid #171717;";
@@ -25,8 +27,8 @@ function renderAction({ label, url }: EmailAction, isPrimary: boolean, isLast: b
 
   return `<td class="btn-cell" style="${gutter}">
                 <table role="presentation" cellpadding="0" cellspacing="0" class="btn-wrap">
-                  <tr><td class="${buttonClass}" style="${fill}border-radius:8px;">
-                    <a href="${escape(url)}" class="btn-link ${buttonClass}-text" style="display:inline-block;padding:12px 24px;font-size:14px;font-weight:500;line-height:1.2;color:${textColor};text-decoration:none;">${escape(label)}</a>
+                  <tr><td class="${buttonClass}" style="${fill}border-radius:8px;mso-padding-alt:${BUTTON_PADDING};">
+                    <a href="${escape(url)}" class="btn-link ${buttonClass}-text" style="display:inline-block;padding:${BUTTON_PADDING};font-size:14px;font-weight:500;line-height:1.2;color:${textColor};text-decoration:none;">${escape(label)}</a>
                   </td></tr>
                 </table>
               </td>`;

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-layout.ts
@@ -17,16 +17,19 @@ function isHttpUrl(url: string): boolean {
   }
 }
 
-function renderAction({ label, url }: EmailAction, isPrimary: boolean): string {
+function renderAction({ label, url }: EmailAction, isPrimary: boolean, isLast: boolean): string {
   const buttonClass = isPrimary ? "btn-primary" : "btn-secondary";
   const fill = isPrimary ? "background-color:#171717;" : "background-color:#ffffff;border:1px solid #171717;";
   const textColor = isPrimary ? "#ffffff" : "#171717";
+  const gutter = isLast ? "" : "padding-right:12px;";
 
-  return `<table role="presentation" cellpadding="0" cellspacing="0" style="margin:0 0 12px 0;">
-            <tr><td class="${buttonClass}" style="${fill}border-radius:8px;">
-              <a href="${escape(url)}" class="${buttonClass}-text" style="display:inline-block;padding:12px 24px;font-size:14px;font-weight:500;line-height:1.2;color:${textColor};text-decoration:none;">${escape(label)}</a>
-            </td></tr>
-          </table>`;
+  return `<td class="btn-cell" style="${gutter}">
+                <table role="presentation" cellpadding="0" cellspacing="0" class="btn-wrap">
+                  <tr><td class="${buttonClass}" style="${fill}border-radius:8px;">
+                    <a href="${escape(url)}" class="btn-link ${buttonClass}-text" style="display:inline-block;padding:12px 24px;font-size:14px;font-weight:500;line-height:1.2;color:${textColor};text-decoration:none;">${escape(label)}</a>
+                  </td></tr>
+                </table>
+              </td>`;
 }
 
 function renderActions(actions: EmailAction[] = []): string {
@@ -36,11 +39,32 @@ function renderActions(actions: EmailAction[] = []): string {
     return "";
   }
 
-  return `<div style="padding-top:28px;">${renderable.map((action, index) => renderAction(action, index === 0)).join("\n          ")}</div>`;
+  const cells = renderable.map((action, index) => renderAction(action, index === 0, index === renderable.length - 1)).join("\n              ");
+
+  return `<div style="padding-top:28px;">
+            <table role="presentation" cellpadding="0" cellspacing="0" class="btn-row"><tr>
+              ${cells}
+            </tr></table>
+          </div>`;
+}
+
+/** Kept as one unbroken token with no letter-spacing so a double-click selects the whole code and autofill can read it. */
+function renderCode(code?: string): string {
+  if (!code) {
+    return "";
+  }
+
+  return `<div style="padding-top:28px;">
+            <table role="presentation" cellpadding="0" cellspacing="0" width="100%"><tr>
+              <td class="code-box" align="center" style="background-color:#fafafa;border:1px solid #e4e4e7;border-radius:8px;padding:20px 24px;">
+                <span class="code-text" style="font-family:'SF Mono',Menlo,Consolas,monospace;font-size:32px;font-weight:700;line-height:1.2;color:#18181b;">${escape(code)}</span>
+              </td>
+            </tr></table>
+          </div>`;
 }
 
 /** The subject is user-controlled for alert emails, so it is escaped; content must already be sanitized by the caller. */
-export function renderEmailLayout({ subject, content, actions }: { subject: string; content: string; actions?: EmailAction[] }): string {
+export function renderEmailLayout({ subject, content, actions, code }: { subject: string; content: string; actions?: EmailAction[]; code?: string }): string {
   const escapedSubject = escape(subject);
 
   return `<!DOCTYPE html>
@@ -55,6 +79,12 @@ export function renderEmailLayout({ subject, content, actions }: { subject: stri
     body { margin: 0; padding: 0; background-color: #f0f0f1; }
     a { color: #52525b; }
     .logo-dark { display: none; }
+    @media (max-width: 480px) {
+      .btn-row { width: 100% !important; }
+      .btn-cell { display: block !important; width: 100% !important; padding: 0 0 12px 0 !important; }
+      .btn-wrap { width: 100% !important; }
+      .btn-link { display: block !important; text-align: center !important; }
+    }
     @media (prefers-color-scheme: dark) {
       body, .outer { background-color: #0a0a0a !important; }
       .card { background-color: #141414 !important; border-color: #27272a !important; }
@@ -70,6 +100,8 @@ export function renderEmailLayout({ subject, content, actions }: { subject: stri
       .btn-primary-text { color: #171717 !important; }
       .btn-secondary { background-color: transparent !important; border-color: #e5e5e5 !important; }
       .btn-secondary-text { color: #e5e5e5 !important; }
+      .code-box { background-color: #101010 !important; border-color: #27272a !important; }
+      .code-text { color: #fafafa !important; }
     }
   </style>
 </head>
@@ -84,6 +116,7 @@ export function renderEmailLayout({ subject, content, actions }: { subject: stri
         <tr><td style="padding:36px 40px;">
           <h1 class="heading" style="margin:0 0 24px 0;font-size:24px;line-height:1.3;font-weight:700;color:#18181b;">${escapedSubject}</h1>
           <div class="body-text" style="font-size:16px;line-height:1.65;color:#3f3f46;">${content}</div>
+          ${renderCode(code)}
           ${renderActions(actions)}
         </td></tr>
         <tr><td class="card-footer" style="padding:24px 40px;background-color:#fafafa;border-top:1px solid #f0f0f1;">

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.spec.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.spec.ts
@@ -64,6 +64,23 @@ describe(EmailSenderService.name, () => {
       expect(sentContent).toContain(content);
     });
 
+    it("renders the actions as buttons in the sent document", async () => {
+      const { service, novu } = await setup();
+
+      await service.send({
+        addresses: [faker.internet.email()],
+        subject: faker.lorem.sentence(),
+        content: faker.lorem.paragraph(),
+        userId: faker.string.uuid(),
+        actions: [{ label: "Add credits", url: "https://console.akash.network/billing" }]
+      });
+
+      const sentContent = novu.trigger.mock.calls[0][0].payload?.content as string;
+      expect(sentContent).toContain('href="https://console.akash.network/billing"');
+      expect(sentContent).toContain(">Add credits</a>");
+      expect(sentContent).toContain('class="btn-primary"');
+    });
+
     it("sends to every address while addressing the first one as the subscriber", async () => {
       const { service, novu } = await setup();
       const addresses = [faker.internet.email(), faker.internet.email(), faker.internet.email()];

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.ts
@@ -6,7 +6,7 @@ import sanitizeHtml from "sanitize-html";
 import { LoggerService } from "@src/common/services/logger/logger.service";
 import { Namespaced } from "@src/lib/types/namespaced-config.type";
 import { NotificationEnvConfig } from "@src/modules/notifications/config/env.config";
-import { renderEmailLayout } from "./email-layout";
+import { type EmailAction, renderEmailLayout } from "./email-layout";
 
 type EmailSendOptions = {
   addresses: string[];
@@ -14,6 +14,7 @@ type EmailSendOptions = {
   content: string;
   userId: string;
   notificationId?: string;
+  actions?: EmailAction[];
 };
 
 @Injectable()
@@ -26,7 +27,7 @@ export class EmailSenderService {
     this.loggerService.setContext(EmailSenderService.name);
   }
 
-  async send({ addresses, userId, subject, content, notificationId }: EmailSendOptions): Promise<void> {
+  async send({ addresses, userId, subject, content, notificationId, actions }: EmailSendOptions): Promise<void> {
     await this.novu.trigger({
       workflowId: this.configService.getOrThrow("notifications.NOVU_MAILER_WORKFLOW_ID"),
       to: {
@@ -37,6 +38,7 @@ export class EmailSenderService {
         subject,
         content: renderEmailLayout({
           subject,
+          actions,
           content: sanitizeHtml(content, {
             allowedTags: ["a", "strong", "p", "br"],
             allowedAttributes: {

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.ts
@@ -15,6 +15,7 @@ type EmailSendOptions = {
   userId: string;
   notificationId?: string;
   actions?: EmailAction[];
+  code?: string;
 };
 
 @Injectable()
@@ -27,7 +28,7 @@ export class EmailSenderService {
     this.loggerService.setContext(EmailSenderService.name);
   }
 
-  async send({ addresses, userId, subject, content, notificationId, actions }: EmailSendOptions): Promise<void> {
+  async send({ addresses, userId, subject, content, notificationId, actions, code }: EmailSendOptions): Promise<void> {
     await this.novu.trigger({
       workflowId: this.configService.getOrThrow("notifications.NOVU_MAILER_WORKFLOW_ID"),
       to: {
@@ -39,6 +40,7 @@ export class EmailSenderService {
         content: renderEmailLayout({
           subject,
           actions,
+          code,
           content: sanitizeHtml(content, {
             allowedTags: ["a", "strong", "p", "br"],
             allowedAttributes: {

--- a/apps/notifications/src/modules/notifications/services/notification-router/notification-router.service.spec.ts
+++ b/apps/notifications/src/modules/notifications/services/notification-router/notification-router.service.spec.ts
@@ -30,6 +30,7 @@ describe(NotificationRouterService.name, () => {
         subject: notificationCommand.payload.summary,
         content: notificationCommand.payload.description,
         actions: notificationCommand.payload.actions,
+        code: notificationCommand.payload.code,
         notificationId: notificationCommand.notificationId
       });
     });

--- a/apps/notifications/src/modules/notifications/services/notification-router/notification-router.service.spec.ts
+++ b/apps/notifications/src/modules/notifications/services/notification-router/notification-router.service.spec.ts
@@ -29,6 +29,7 @@ describe(NotificationRouterService.name, () => {
         addresses: notificationChannel.config.addresses,
         subject: notificationCommand.payload.summary,
         content: notificationCommand.payload.description,
+        actions: notificationCommand.payload.actions,
         notificationId: notificationCommand.notificationId
       });
     });

--- a/apps/notifications/src/modules/notifications/services/notification-router/notification-router.service.ts
+++ b/apps/notifications/src/modules/notifications/services/notification-router/notification-router.service.ts
@@ -31,6 +31,7 @@ export class NotificationRouterService {
         subject: notificationCommand.payload.summary,
         content: notificationCommand.payload.description,
         actions: notificationCommand.payload.actions,
+        code: notificationCommand.payload.code,
         notificationId: notificationCommand.notificationId
       });
     } else {

--- a/apps/notifications/src/modules/notifications/services/notification-router/notification-router.service.ts
+++ b/apps/notifications/src/modules/notifications/services/notification-router/notification-router.service.ts
@@ -30,6 +30,7 @@ export class NotificationRouterService {
         addresses: notificationChannel.config.addresses,
         subject: notificationCommand.payload.summary,
         content: notificationCommand.payload.description,
+        actions: notificationCommand.payload.actions,
         notificationId: notificationCommand.notificationId
       });
     } else {

--- a/apps/notifications/swagger/swagger.internal.json
+++ b/apps/notifications/swagger/swagger.internal.json
@@ -1,29 +1,6 @@
 {
   "openapi": "3.0.0",
   "paths": {
-    "/internal/v1/users/{userId}/purge": {
-      "post": {
-        "operationId": "purge",
-        "parameters": [
-          {
-            "name": "userId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": ""
-          }
-        },
-        "tags": [
-          "Internal/Account"
-        ]
-      }
-    },
     "/internal/v1/jobs/notification": {
       "post": {
         "operationId": "createNotification",
@@ -45,6 +22,29 @@
         },
         "tags": [
           "Jobs"
+        ]
+      }
+    },
+    "/internal/v1/users/{userId}/purge": {
+      "post": {
+        "operationId": "purge",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Internal/Account"
         ]
       }
     }
@@ -80,6 +80,25 @@
               },
               "description": {
                 "type": "string"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "label": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  },
+                  "required": [
+                    "label",
+                    "url"
+                  ]
+                }
               }
             },
             "required": [

--- a/apps/notifications/swagger/swagger.internal.json
+++ b/apps/notifications/swagger/swagger.internal.json
@@ -81,6 +81,9 @@
               "description": {
                 "type": "string"
               },
+              "code": {
+                "type": "string"
+              },
               "actions": {
                 "type": "array",
                 "items": {

--- a/apps/notifications/swagger/swagger.json
+++ b/apps/notifications/swagger/swagger.json
@@ -1134,6 +1134,9 @@
                       },
                       "suppressedBySystem": {
                         "type": "boolean"
+                      },
+                      "reclaimNotifiedAt": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -1414,6 +1417,9 @@
                       },
                       "suppressedBySystem": {
                         "type": "boolean"
+                      },
+                      "reclaimNotifiedAt": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -2240,6 +2246,9 @@
                       },
                       "suppressedBySystem": {
                         "type": "boolean"
+                      },
+                      "reclaimNotifiedAt": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -2541,6 +2550,9 @@
                       },
                       "suppressedBySystem": {
                         "type": "boolean"
+                      },
+                      "reclaimNotifiedAt": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -3501,6 +3513,9 @@
                         },
                         "suppressedBySystem": {
                           "type": "boolean"
+                        },
+                        "reclaimNotifiedAt": {
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -3802,6 +3817,9 @@
                         },
                         "suppressedBySystem": {
                           "type": "boolean"
+                        },
+                        "reclaimNotifiedAt": {
+                          "type": "string"
                         }
                       },
                       "required": [

--- a/packages/console-api-types/src/notifications/internal/operations.gen.ts
+++ b/packages/console-api-types/src/notifications/internal/operations.gen.ts
@@ -3,7 +3,6 @@
 
 export const operations = {
   v1: {
-    purge: { path: "/internal/v1/users/{userId}/purge", method: "post", operationId: "purge", pathParams: ["userId"], queryParams: [], hasBody: false },
     createNotification: {
       path: "/internal/v1/jobs/notification",
       method: "post",
@@ -11,7 +10,8 @@ export const operations = {
       pathParams: [],
       queryParams: [],
       hasBody: true
-    }
+    },
+    purge: { path: "/internal/v1/users/{userId}/purge", method: "post", operationId: "purge", pathParams: ["userId"], queryParams: [], hasBody: false }
   }
 } as const;
 

--- a/packages/console-api-types/src/notifications/internal/schema.d.ts
+++ b/packages/console-api-types/src/notifications/internal/schema.d.ts
@@ -4,22 +4,6 @@
  */
 
 export interface paths {
-  "/internal/v1/users/{userId}/purge": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post: operations["purge"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   "/internal/v1/jobs/notification": {
     parameters: {
       query?: never;
@@ -30,6 +14,22 @@ export interface paths {
     get?: never;
     put?: never;
     post: operations["createNotification"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/internal/v1/users/{userId}/purge": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["purge"];
     delete?: never;
     options?: never;
     head?: never;
@@ -48,6 +48,11 @@ export interface components {
       payload: {
         summary: string;
         description: string;
+        actions?: {
+          label: string;
+          /** Format: uri */
+          url: string;
+        }[];
       };
     };
   };
@@ -59,25 +64,6 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  purge: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        userId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
   createNotification: {
     parameters: {
       query?: never;
@@ -92,6 +78,25 @@ export interface operations {
     };
     responses: {
       /** @description Creates a notification job */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  purge: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        userId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
       204: {
         headers: {
           [name: string]: unknown;

--- a/packages/console-api-types/src/notifications/internal/schema.d.ts
+++ b/packages/console-api-types/src/notifications/internal/schema.d.ts
@@ -48,6 +48,7 @@ export interface components {
       payload: {
         summary: string;
         description: string;
+        code?: string;
         actions?: {
           label: string;
           /** Format: uri */


### PR DESCRIPTION
## Why

Stacked on #3792, which handles the logo half of the same review. Merge that one first.

Denis asked for more prominent buttons for adding credits and auto top-up, in black, rather than the inline links buried in a sentence that every transactional email ends with today.

That turned out not to be a template edit. `EmailSenderService` sanitizes the body down to `a`, `strong`, `p` and `br` with `href` as the only allowed attribute, so any `style` written in a template gets stripped and `table` is dropped entirely. A padded `a` isn't a real button anyway, since Outlook's Word engine ignores padding on inline elements. The only place a button can be built is the layout.

## What

Emails now carry their calls to action as a structured `actions` array that `renderEmailLayout` turns into table-based buttons. The sanitizer stays as locked down as it was.

Colours come from the console's own `--primary` token, so the button matches what the same action looks like in the app:

|            | Light                    | Dark                       |
| ---------- | ------------------------ | -------------------------- |
| First      | `#171717`, white text    | `#E5E5E5`, dark text       |
| Subsequent | outlined `#171717`       | outlined `#E5E5E5`         |

`credits-running-low` is the email Denis was looking at, and it carries both buttons he named: Add credits, then Enable Auto Recharge. That's also why `actions` is an array rather than a single object. Going from object to array later would be a breaking wire change.

The field is optional, so chain alerts, which have no CTA, are unaffected.

**Templates.** Ten moved their inline link into a button. `before-close-trial-deployment` and `trial-deployment-closed` gained a real CTA, since both told the reader to add a payment method without giving them anything to click; their enqueue sites already had `CONSOLE_WEB_PAYMENT_LINK` in scope. The Discord invite in `trial-first-deployment-lease-created` stayed inline on purpose, because it's a community pointer rather than a primary action. `email-verification-code` and `first-purchase-bonus-granted` have no destination and got nothing.

**Escaping.** The layout renders outside the sanitizer, so `renderActions` escapes every label and drops any URL that isn't http or https. This matches the convention already noted at the top of the file.

## Worth a careful look

`actions` had to be declared in **both** zod schemas. The HTTP boundary runs no validation at all, but the queue boundary parses against `NotificationCommandSchema`, a plain `z.object`, which strips unknown keys silently. Declaring it only on the controller DTO would have dropped every button between the controller and the sender with no error and no log. `NotificationCommand.dto.spec.ts` covers this; I confirmed it fails when the field is removed from the schema rather than just passing by construction.

`swagger.json` also picks up a `reclaimNotifiedAt` field in this diff. That's pre-existing drift in the checked-in artifact from an earlier change, not something this PR introduces. Regenerating caught it up.

## Verified

- apps/api: 2544 unit tests pass, lint clean, `tsc` back to the same 42-error baseline as `main`
- apps/notifications: 248 unit and 19 functional tests pass, lint clean, `tsc` at its existing 6-error baseline
- Rendered the layout and checked both colour schemes in a browser

Not verified, and worth doing before merge: one real send through Novu. The dark-mode media query and the table-based button are exactly the things Gmail and Outlook rewrite in ways a local browser render won't show.

One judgement call for Denis: he asked for both buttons in black, and I made the second one outlined black rather than a second filled one, so the pair has some hierarchy. Easy to change if he'd rather have two solid buttons.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added actionable links to notifications for billing, credits, payment methods, deployment management, and runtime limits.
  * Added dedicated verification-code support in notifications and emails.
  * Added responsive, accessible email buttons with primary and secondary styling.

* **Improvements**
  * Notification descriptions now use clearer plain text, with links presented as structured actions.
  * Trial deployment notifications include “Add credits” actions when payment links are available.
  * Notification payload validation now supports optional codes and labeled URL actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->