### PR TITLE
fix(observability): bound the block and transaction list caches

### DIFF
--- a/apps/api/src/block/services/akash-block/akash-block.service.ts
+++ b/apps/api/src/block/services/akash-block/akash-block.service.ts
@@ -9,7 +9,7 @@ import { averageBlockTime } from "@src/utils/constants";
 export class AkashBlockService {
   constructor(private readonly akashBlockRepository: AkashBlockRepository) {}
 
-  @Memoize({ ttlInSeconds: averageBlockTime })
+  @Memoize({ ttlInSeconds: averageBlockTime, maxEntries: 500 })
   async getBlocks(limit: number): Promise<ListBlocksResponse> {
     return await this.akashBlockRepository.getBlocks(limit);
   }

--- a/apps/api/src/transaction/services/transaction/transaction.service.ts
+++ b/apps/api/src/transaction/services/transaction/transaction.service.ts
@@ -10,7 +10,7 @@ import { averageBlockTime } from "@src/utils/constants";
 export class TransactionService {
   constructor(private readonly transactionRepository: TransactionRepository) {}
 
-  @Memoize({ ttlInSeconds: averageBlockTime })
+  @Memoize({ ttlInSeconds: averageBlockTime, maxEntries: 500 })
   async getTransactions(limit: number): Promise<ListTransactionsResponse> {
     return await this.transactionRepository.getTransactions(limit);
   }


### PR DESCRIPTION
## Why

Follow-up to #3787. CodeRabbit posted one finding outside the diff that never got picked up before the merge: `getBlocks` and `getTransactions` still memoize per caller-supplied `limit` into the shared unbounded cache. Both routes are anonymous, and their query schemas validate `limit` with `z.coerce.number().min(1).max(100)` without `.int()`, so any distinct float in that range creates a new cache entry. That is the same unbounded key space #3787 capped everywhere else.

## What

Adds `maxEntries: 500` to `AkashBlockService#getBlocks` and `TransactionService#getTransactions`, matching the other list caches bounded in #3787.
