### PR TITLE
feat(deployment): open the token a deployment's definition was stored with

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -18,8 +18,9 @@ import type { DeploymentSettingRepository } from "@src/deployment/repositories/d
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-import type { ReceivedSdlSecrets, SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import type { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
@@ -301,17 +302,16 @@ describe(DeploymentWriterService.name, () => {
     });
 
     it("resolves the manifest from the values the intake handed back", async () => {
-      const byService = { web: { TOKEN: "resolved" } };
-      const { service, sdlService } = setup({ received: { supplied: { TOKEN: "resolved" }, byService } });
+      const received = { TOKEN: "resolved" };
+      const { service, sdlService } = setup({ received });
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
 
-      expect(sdlService.generateResolvedManifest).toHaveBeenCalledWith(expect.objectContaining({ secrets: byService }));
+      expect(sdlService.generateResolvedManifest).toHaveBeenCalledWith(expect.objectContaining({ secrets: received }));
     });
 
     it("seals what the client supplied together with the credentials it took out itself, against the dseq it just minted", async () => {
-      const supplied = { TOKEN: "resolved" };
-      const { service, sdlSecretsService } = setup({ received: { supplied, byService: { web: supplied } } });
+      const { service, sdlSecretsService } = setup({ received: { TOKEN: "resolved" } });
       vi.spyOn(Date, "now").mockReturnValue(1748400000000);
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
@@ -334,8 +334,7 @@ describe(DeploymentWriterService.name, () => {
     });
 
     it("refuses a supplied name the console derives for the same deployment, before minting a dseq", async () => {
-      const supplied = { s0_c_password: "resolved" };
-      const { service, deploymentSettingRepository, signerService } = setup({ received: { supplied, byService: { web: supplied } } });
+      const { service, deploymentSettingRepository, signerService } = setup({ received: { s0_c_password: "resolved" } });
       const dateNow = vi.spyOn(Date, "now");
 
       await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 })).rejects.toMatchObject({
@@ -367,8 +366,8 @@ describe(DeploymentWriterService.name, () => {
     });
 
     it("seals once for the whole create", async () => {
-      const supplied = Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`SECRET_${index}`, "value"]));
-      const { service, sdlSecretsService } = setup({ received: { supplied, byService: { web: supplied, worker: supplied } } });
+      const received = Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`SECRET_${index}`, "value"]));
+      const { service, sdlSecretsService } = setup({ received });
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
 
@@ -492,7 +491,7 @@ describe(DeploymentWriterService.name, () => {
     });
 
     it("says nothing about a supplied value in what it logs", async () => {
-      const { service, logger } = setup({ received: { supplied: { TOKEN: ENV_VALUE }, byService: { web: { TOKEN: ENV_VALUE } } } });
+      const { service, logger } = setup({ received: { TOKEN: ENV_VALUE } });
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
 
@@ -1184,7 +1183,7 @@ describe(DeploymentWriterService.name, () => {
     transactionRuns?: boolean;
     compensationEnqueued?: boolean;
     manifestVersion?: Uint8Array;
-    received?: ReceivedSdlSecrets;
+    received?: SdlSecrets;
     sealedSecrets?: string | null;
   }) {
     const signerService = mock<ManagedSignerService>();
@@ -1216,7 +1215,7 @@ describe(DeploymentWriterService.name, () => {
     const sdlSecretsService = mock<SdlSecretsService>();
     /** Real rather than doubled, because what every stored-sdl assertion below measures is the document this produces. */
     const sdlSecretsDerivationService = new SdlSecretsDerivationService(new SdlReferenceService());
-    sdlSecretsService.receive.mockResolvedValue({ ok: true, value: input?.received ?? { supplied: {}, byService: {} } });
+    sdlSecretsService.receive.mockResolvedValue({ ok: true, value: input?.received ?? {} });
     sdlSecretsService.sealForStorage.mockResolvedValue(input?.sealedSecrets ?? null);
 
     walletReaderService.getWalletByUserId.mockResolvedValue(wallet);

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -19,8 +19,7 @@ import {
   unbackedDeploymentSettingKeyFor
 } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
-import { MAX_ECHOED_REFERENCE_LENGTH, type NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
-import type { ReceivedSdlSecrets } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import { MAX_ECHOED_REFERENCE_LENGTH } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
 import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
@@ -70,11 +69,11 @@ export class DeploymentWriterService {
 
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const depositInDollars = this.deploymentConfig.get("DEPLOYMENT_DEFAULT_DEPOSIT");
-    const secrets = await this.#receiveSecrets(input);
-    const stored = this.#storedSecretsOf(secrets.supplied, derived);
+    const supplied = await this.#receiveSecrets(input);
+    const stored = this.#storedSecretsOf(supplied, derived);
 
     const dseq = Date.now().toString();
-    const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: secrets.byService, isTrialing: !!wallet.isTrialing });
+    const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: supplied, isTrialing: !!wallet.isTrialing });
     const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: stored });
 
     if (wallet.isTrialing) {
@@ -320,7 +319,7 @@ export class DeploymentWriterService {
   }
 
   /** Only the manifest version is taken from the resolved SDL: the resolved manifest itself must not leave this call. Runs before any lookup so a bad reference always answers 400 rather than racing a 404. */
-  async #resolveSdl(sdl: string, options: { secrets?: NamespacedSdlSecrets; isTrialing?: boolean }) {
+  async #resolveSdl(sdl: string, options: { secrets?: SdlSecrets; isTrialing?: boolean }) {
     const result = await this.sdlService.generateResolvedManifest({ sdl, ...options, secrets: options.secrets ?? {} });
 
     if (!result.ok) {
@@ -331,7 +330,7 @@ export class DeploymentWriterService {
   }
 
   /** Reports through the same channel every other reference mistake uses, so a missing value reads identically whether the intake or substitution found it. */
-  async #receiveSecrets(input: CreateDeploymentRequest["data"]): Promise<ReceivedSdlSecrets> {
+  async #receiveSecrets(input: CreateDeploymentRequest["data"]): Promise<SdlSecrets> {
     const parsed = this.sdlService.parse(input.sdl);
 
     if (!parsed.ok) {

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
@@ -3,7 +3,7 @@ import { yaml } from "@akashnetwork/chain-sdk";
 import { faker } from "@faker-js/faker";
 import { describe, expect, it } from "vitest";
 
-import type { NamespacedSdlSecrets, SdlReferenceResolver } from "./sdl-reference.service";
+import type { SdlReferenceResolver } from "./sdl-reference.service";
 import { MAX_SDL_REFERENCE_NAME_LENGTH, SdlReferenceService } from "./sdl-reference.service";
 
 const VALID_NAMES = ["A", "a", "_", "_A", "A9", `A${"b".repeat(62)}`, `A${"b".repeat(63)}`];
@@ -113,7 +113,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["DATABASE_URL=ac-secret://DATABASE_URL"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { DATABASE_URL: "postgres://u:p@host/db" } } });
+      const errors = service.substitute(sdl, { secrets: { DATABASE_URL: "postgres://u:p@host/db" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["DATABASE_URL=postgres://u:p@host/db"]);
@@ -124,7 +124,7 @@ describe(SdlReferenceService.name, () => {
       const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"]);
       const env = sdl.services.web.env;
 
-      service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
+      service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(env).toBe(sdl.services.web.env);
       expect(env).toEqual(["TOKEN=resolved"]);
@@ -135,7 +135,7 @@ describe(SdlReferenceService.name, () => {
       const value = "a: b #c |x >y {z} [w] &anchor *alias \"q\" 's'\nsecond: line\n\t- dash";
       const sdl = sdlWithEnv(["WEIRD=ac-secret://WEIRD"]);
 
-      service.substitute(sdl, { secrets: { web: { WEIRD: value } } });
+      service.substitute(sdl, { secrets: { WEIRD: value } });
 
       expect(sdl.services.web.env).toEqual([`WEIRD=${value}`]);
     });
@@ -144,7 +144,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["PAIR=ac-secret://PAIR"]);
 
-      service.substitute(sdl, { secrets: { web: { PAIR: "a=b=c" } } });
+      service.substitute(sdl, { secrets: { PAIR: "a=b=c" } });
 
       expect(sdl.services.web.env).toEqual(["PAIR=a=b=c"]);
     });
@@ -153,7 +153,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["MIXED=prefix ac-secret://TOKEN", 'QUOTED="ac-secret://TOKEN"', "LISTED=ac,ac-secret://TOKEN"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["MIXED=prefix ac-secret://TOKEN", 'QUOTED="ac-secret://TOKEN"', "LISTED=ac,ac-secret://TOKEN"]);
@@ -162,7 +162,7 @@ describe(SdlReferenceService.name, () => {
     it("reports a value opening with a reference and trailing something else", () => {
       const { service } = setup();
 
-      const [error] = service.substitute(sdlWithEnv(["SUFFIX=ac-secret://TOKEN suffix"]), { secrets: { web: { TOKEN: "resolved" } } });
+      const [error] = service.substitute(sdlWithEnv(["SUFFIX=ac-secret://TOKEN suffix"]), { secrets: { TOKEN: "resolved" } });
 
       expect(error.message).toContain("reserved");
     });
@@ -171,7 +171,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["ac-secret://TOKEN"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["ac-secret://TOKEN"]);
@@ -181,7 +181,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["A=ac-secret://A"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { A: "ac-secret://B", B: "leaked" } } });
+      const errors = service.substitute(sdl, { secrets: { A: "ac-secret://B", B: "leaked" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["A=ac-secret://B"]);
@@ -203,46 +203,46 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["TOKEN=ac-var://TOKEN"]);
 
-      const [error] = service.substitute(sdl, { secrets: { web: { TOKEN: "resolved" } } });
+      const [error] = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(error.message).toContain("unknown SDL Reference kind");
       expect(sdl.services.web.env).toEqual(["TOKEN=ac-var://TOKEN"]);
     });
 
-    it("gives each service its own value for the same name", () => {
+    it("gives every service that references one name the same value", () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["TOKEN=ac-secret://TOKEN"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "web-value" }, worker: { TOKEN: "worker-value" } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: "shared" } });
 
       expect(errors).toEqual([]);
-      expect(sdl.services.web.env).toEqual(["TOKEN=web-value"]);
-      expect(sdl.services.worker.env).toEqual(["TOKEN=worker-value"]);
+      expect(sdl.services.web.env).toEqual(["TOKEN=shared"]);
+      expect(sdl.services.worker.env).toEqual(["TOKEN=shared"]);
     });
 
-    it("reports a name one service supplies and another does not, naming the service that lacks it", () => {
+    it("names the service a missing value was referenced from", () => {
       const { service } = setup();
-      const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["TOKEN=ac-secret://TOKEN"]);
+      const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["OTHER=ac-secret://OTHER"]);
 
-      const [error] = service.substitute(sdl, { secrets: { web: { TOKEN: "web-value" } } });
+      const [error] = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
-      expect(error.message).toContain("ac-secret://TOKEN");
+      expect(error.message).toContain("ac-secret://OTHER");
       expect(error.message).toContain("worker");
       expect(error.instancePath).toBe("/services/worker/env/0");
-      expect(sdl.services.worker.env).toEqual(["TOKEN=ac-secret://TOKEN"]);
+      expect(sdl.services.worker.env).toEqual(["OTHER=ac-secret://OTHER"]);
     });
 
-    it("resolves one service while another service supplies no namespace at all", () => {
+    it("resolves one service while another references nothing", () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["TOKEN=ac-secret://TOKEN"], ["PORT=8080"]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: "web-value" } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: "resolved" } });
 
       expect(errors).toEqual([]);
-      expect(sdl.services.web.env).toEqual(["TOKEN=web-value"]);
+      expect(sdl.services.web.env).toEqual(["TOKEN=resolved"]);
     });
 
-    it.each(["constructor", "__proto__", "toString", "hasOwnProperty"])("reports a missing namespace for the service name %j", serviceName => {
+    it.each(["constructor", "__proto__", "toString", "hasOwnProperty"])("reports a missing value for a service named %j", serviceName => {
       const { service } = setup();
       const sdl = yaml.raw<SDLInput>(sdlYaml(serviceYaml(serviceName, ["TOKEN=ac-secret://TOKEN"])));
 
@@ -260,16 +260,6 @@ describe(SdlReferenceService.name, () => {
 
       expect(error.message.length).toBeLessThan(300);
       expect(error.message).toContain(String(error.params.serviceName));
-    });
-
-    it.each([{ web: "supersecret" }, { web: ["item"] }])("reports a missing value for the non-object namespace %j", secrets => {
-      const { service } = setup();
-      const sdl = sdlWithEnv(["A=ac-secret://length"]);
-
-      const [error] = service.substitute(sdl, { secrets: secrets as unknown as NamespacedSdlSecrets });
-
-      expect(error.message).toContain("no value supplied");
-      expect(sdl.services.web.env).toEqual(["A=ac-secret://length"]);
     });
 
     it.each([42, null, { nested: true }, ["array"], true])("refuses a resolver's non-string value %j", resolved => {
@@ -313,7 +303,7 @@ describe(SdlReferenceService.name, () => {
       const [username, password] = [faker.string.alphanumeric(10), faker.internet.password()];
       const sdl = sdlWithCredentials({ username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" });
 
-      const errors = service.substitute(sdl, { secrets: { web: { REG_USER: username, REG_PASS: password } } });
+      const errors = service.substitute(sdl, { secrets: { REG_USER: username, REG_PASS: password } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.credentials).toMatchObject({ username, password });
@@ -323,22 +313,21 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithCredentials({ password: "ac-secret://REG_PASS" });
 
-      service.substitute(sdl, { secrets: { web: { REG_PASS: faker.internet.password() } } });
+      service.substitute(sdl, { secrets: { REG_PASS: faker.internet.password() } });
 
       expect(sdl.services.web.credentials).toMatchObject({ host: "registry.example.test", email: "ops@example.test" });
     });
 
-    it("resolves a credential from its own service's namespace", () => {
+    it("resolves a credential in every service that references it", () => {
       const { service } = setup();
       const sdl = sdlWithCredentials({ password: "ac-secret://REG_PASS" }, { password: "ac-secret://REG_PASS" });
+      const password = faker.internet.password();
 
-      const [webPassword, workerPassword] = [faker.internet.password(), faker.internet.password()];
-
-      const errors = service.substitute(sdl, { secrets: { web: { REG_PASS: webPassword }, worker: { REG_PASS: workerPassword } } });
+      const errors = service.substitute(sdl, { secrets: { REG_PASS: password } });
 
       expect(errors).toEqual([]);
-      expect(sdl.services.web.credentials!.password).toBe(webPassword);
-      expect(sdl.services.worker.credentials!.password).toBe(workerPassword);
+      expect(sdl.services.web.credentials!.password).toBe(password);
+      expect(sdl.services.worker.credentials!.password).toBe(password);
     });
 
     it("quotes the reference of a credential it holds no value for, a reserved-prefix string being one no registry could accept anyway", () => {
@@ -366,7 +355,7 @@ describe(SdlReferenceService.name, () => {
       const password = `ac-dc-${faker.internet.password()}`;
       const sdl = sdlSharingOneCredentialsBlock("ac-secret://REG_PASS");
 
-      const errors = service.substitute(sdl, { secrets: { web: { REG_PASS: password }, worker: { REG_PASS: password } } });
+      const errors = service.substitute(sdl, { secrets: { REG_PASS: password } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.credentials!.password).toBe(password);
@@ -378,7 +367,7 @@ describe(SdlReferenceService.name, () => {
       const value = `ac-dc-${faker.string.alphanumeric(16)}`;
       const sdl = sdlSharingOneEnvList("TOKEN=ac-secret://TOKEN");
 
-      const errors = service.substitute(sdl, { secrets: { web: { TOKEN: value }, worker: { TOKEN: value } } });
+      const errors = service.substitute(sdl, { secrets: { TOKEN: value } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual([`TOKEN=${value}`]);
@@ -417,7 +406,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv([`A=ac-secret://${name}`]);
 
-      const errors = service.substitute(sdl, { secrets: { web: { [name]: "resolved" } } });
+      const errors = service.substitute(sdl, { secrets: { [name]: "resolved" } });
 
       expect(errors).toEqual([]);
       expect(sdl.services.web.env).toEqual(["A=resolved"]);
@@ -427,7 +416,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const reference = `ac-secret://${name}`;
 
-      const [error] = service.substitute(sdlWithEnv([`A=${reference}`]), { secrets: { web: { [name]: "resolved" } } });
+      const [error] = service.substitute(sdlWithEnv([`A=${reference}`]), { secrets: { [name]: "resolved" } });
 
       expect(error.message).toContain("reserved");
     });
@@ -435,7 +424,7 @@ describe(SdlReferenceService.name, () => {
     it.each(RESERVED_VALUES)("rejects the reserved value %j", value => {
       const { service } = setup();
 
-      const [error] = service.substitute(sdlWithEnv([`A=${value}`]), { secrets: { web: { X: "resolved", TOKEN: "resolved" } } });
+      const [error] = service.substitute(sdlWithEnv([`A=${value}`]), { secrets: { X: "resolved", TOKEN: "resolved" } });
 
       expect(error.message).toContain("reserved");
       expect(error.message).toContain(value);
@@ -454,7 +443,7 @@ describe(SdlReferenceService.name, () => {
       const { service } = setup();
       const sdl = sdlWithEnv(["UPPER=ac-secret://TOKEN", "LOWER=ac-secret://token"]);
 
-      service.substitute(sdl, { secrets: { web: { TOKEN: "upper", token: "lower" } } });
+      service.substitute(sdl, { secrets: { TOKEN: "upper", token: "lower" } });
 
       expect(sdl.services.web.env).toEqual(["UPPER=upper", "LOWER=lower"]);
     });
@@ -462,7 +451,7 @@ describe(SdlReferenceService.name, () => {
     it("reports a name whose case does not match the supplied one", () => {
       const { service } = setup();
 
-      const [error] = service.substitute(sdlWithEnv(["A=ac-secret://token"]), { secrets: { web: { TOKEN: "resolved" } } });
+      const [error] = service.substitute(sdlWithEnv(["A=ac-secret://token"]), { secrets: { TOKEN: "resolved" } });
 
       expect(error.message).toContain("ac-secret://token");
     });

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -43,11 +43,8 @@ function readEnvDeclaration(entry: string): { key: string; value: string } | nul
   return valueStart === -1 ? null : { key: entry.slice(0, valueStart), value: entry.slice(valueStart + 1) };
 }
 
-/** One namespace per service, so two services can reference the same name and receive their own value. */
-export type NamespacedSdlSecrets = Record<string, SdlSecrets>;
-
 export interface SdlReferenceContext {
-  secrets: NamespacedSdlSecrets;
+  secrets: SdlSecrets;
 }
 
 export interface SdlReferenceTarget {
@@ -85,18 +82,14 @@ export interface SdlReferenceDeclaration extends SdlReferenceTarget {
 
 type SdlReferenceVisitor = (reference: SdlReferenceDeclaration, slot: SdlReferenceSlot) => ValidationError | undefined;
 
-/** A service or reference name may spell an `Object.prototype` member, and a bare lookup would answer such a name with an inherited function. */
+/** A reference name may spell an `Object.prototype` member, and a bare lookup would answer such a name with an inherited function. */
 export function ownValue<T>(record: Record<string, T>, key: string): T | undefined {
   return Object.hasOwn(record, key) ? record[key] : undefined;
 }
 
 const secretReferenceResolver: SdlReferenceResolver = {
   kind: "secret",
-  resolve: ({ serviceName, name }, { secrets }) => {
-    const namespace = ownValue(secrets, serviceName);
-
-    return typeof namespace === "object" && namespace !== null ? ownValue(namespace, name) : undefined;
-  }
+  resolve: ({ name }, { secrets }) => ownValue(secrets, name)
 };
 
 function referenceError(instancePath: string, message: string, params: Record<string, unknown>): ValidationError {

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -300,9 +300,8 @@ describe(SdlSecretsDerivationService.name, () => {
 
     const secrets = service.derive(rewritten, { includeEnvValues: true });
     const reparsed = yaml.raw<SDLInput>(dump(rewritten, { lineWidth: -1 }));
-    const byService = Object.fromEntries(Object.keys(reparsed.services).map(serviceName => [serviceName, secrets]));
 
-    expect(sdlReferenceService.substitute(reparsed, { secrets: byService })).toEqual([]);
+    expect(sdlReferenceService.substitute(reparsed, { secrets })).toEqual([]);
     expect(reparsed.services.web.env).toEqual(values.map((value, index) => `V${index}=${value}`));
   });
 
@@ -319,9 +318,8 @@ describe(SdlSecretsDerivationService.name, () => {
     const rewritten = documentWith(services);
 
     const secrets = service.derive(rewritten, { includeEnvValues: true });
-    const byService = Object.fromEntries(Object.keys(rewritten.services).map(serviceName => [serviceName, secrets]));
 
-    expect(sdlReferenceService.substitute(rewritten, { secrets: byService })).toEqual([]);
+    expect(sdlReferenceService.substitute(rewritten, { secrets })).toEqual([]);
     expect(rewritten).toEqual(submitted);
   });
 

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
@@ -57,6 +57,25 @@ function isSdlBound(header: SealHeader) {
   return header.sdlHash !== undefined;
 }
 
+function decodeSecretsJson(plaintext: string): unknown {
+  try {
+    return JSON.parse(plaintext);
+  } catch {
+    return null;
+  }
+}
+
+/** Shared with the read of a token the console sealed itself, so one place decides whether a payload is a flat set of secrets. */
+export function parseSdlSecrets(plaintext: string): SdlSecrets | null {
+  const decoded = decodeSecretsJson(plaintext);
+
+  if (!decoded || typeof decoded !== "object" || Array.isArray(decoded) || Object.values(decoded).some(value => typeof value !== "string")) {
+    return null;
+  }
+
+  return decoded as SdlSecrets;
+}
+
 /** Holds only what makes a seal a seal — the claims a client must prove and the flat string payload — because the wire format lives in `KmsWrappedJweService`. */
 @singleton()
 export class SdlSecretsUnsealerService {
@@ -173,21 +192,13 @@ export class SdlSecretsUnsealerService {
   }
 
   #parseSecrets(plaintext: Buffer): SdlSecrets {
-    const secrets = this.#decodeSecretsJson(plaintext);
+    const secrets = parseSdlSecrets(plaintext.toString("utf8"));
 
-    if (!secrets || typeof secrets !== "object" || Array.isArray(secrets) || Object.values(secrets).some(value => typeof value !== "string")) {
+    if (!secrets) {
       throw this.#reject(400, "SDL_SECRETS_SEAL_PAYLOAD_INVALID", "Sealed secrets must be a flat object of string values", {});
     }
 
-    return secrets as SdlSecrets;
-  }
-
-  #decodeSecretsJson(plaintext: Buffer): unknown {
-    try {
-      return JSON.parse(plaintext.toString("utf8"));
-    } catch {
-      return null;
-    }
+    return secrets;
   }
 
   #reject(status: number, event: string, message: string, details: Record<string, unknown>) {

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
@@ -378,6 +378,62 @@ describe(SdlSecretsService.name, () => {
     });
   });
 
+  describe("openStored", () => {
+    it("opens the token under the binding the seal was written with", async () => {
+      const { service, secretCipherService } = setup({ stored: { TOKEN: "one" } });
+
+      await service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: SEAL });
+
+      expect(secretCipherService.decrypt).toHaveBeenCalledWith("user-1", SEAL, { sub: "user-1", dseq: "1420000" });
+    });
+
+    it("returns every value the token carries", async () => {
+      const secrets = { TOKEN: faker.string.alphanumeric(32), DATABASE_URL: `postgres://app:${faker.string.alphanumeric(16)}@db/app` };
+      const { service } = setup({ stored: secrets });
+
+      await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: SEAL })).resolves.toEqual(secrets);
+    });
+
+    it("says nothing about a value in what it logs", async () => {
+      const value = faker.string.alphanumeric(32);
+      const { service, logger } = setup({ stored: { TOKEN: value } });
+
+      await service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: SEAL });
+
+      expect(logger.info).toHaveBeenCalledWith({ event: "SDL_SECRETS_STORED_OPENED", userId: "user-1", dseq: "1420000", secretCount: 1 });
+    });
+
+    it("refuses a payload that is not a flat set of string values", async () => {
+      const { service, secretCipherService } = setup();
+      secretCipherService.decrypt.mockResolvedValue(JSON.stringify({ TOKEN: { nested: "one" } }));
+
+      await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: SEAL })).rejects.toMatchObject({ status: 500 });
+    });
+
+    it("refuses a payload that is not json at all", async () => {
+      const { service, secretCipherService } = setup();
+      secretCipherService.decrypt.mockResolvedValue("not-json");
+
+      await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: SEAL })).rejects.toMatchObject({ status: 500 });
+    });
+
+    it("logs a payload it cannot read as the fault of the console that wrote it", async () => {
+      const { service, secretCipherService, logger } = setup();
+      secretCipherService.decrypt.mockResolvedValue("[]");
+
+      await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: SEAL })).rejects.toThrow();
+      expect(logger.error).toHaveBeenCalledWith({ event: "SDL_SECRETS_STORED_PAYLOAD_INVALID", userId: "user-1", dseq: "1420000" });
+    });
+
+    it("lets a token the cipher refuses fail untouched", async () => {
+      const refusal = Object.assign(new Error("Unable to read the stored value"), { status: 500 });
+      const { service, secretCipherService } = setup();
+      secretCipherService.decrypt.mockRejectedValue(refusal);
+
+      await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: SEAL })).rejects.toBe(refusal);
+    });
+  });
+
   function receivedOf(result: Awaited<ReturnType<SdlSecretsService["receive"]>>) {
     return (result as Extract<typeof result, { ok: true }>).value;
   }
@@ -386,9 +442,12 @@ describe(SdlSecretsService.name, () => {
     return (result as Extract<typeof result, { ok: false }>).value;
   }
 
-  function setup(input?: { supplied?: SdlSecrets; maxCount?: number; maxValueBytes?: number }) {
+  function setup(input?: { supplied?: SdlSecrets; stored?: SdlSecrets; maxCount?: number; maxValueBytes?: number }) {
     const unsealerService = mock<SdlSecretsUnsealerService>({ open: vi.fn().mockResolvedValue(input?.supplied ?? {}) });
-    const secretCipherService = mock<SecretCipherService>({ encrypt: vi.fn().mockResolvedValue("encrypted") });
+    const secretCipherService = mock<SecretCipherService>({
+      encrypt: vi.fn().mockResolvedValue("encrypted"),
+      decrypt: vi.fn().mockResolvedValue(JSON.stringify(input?.stored ?? {}))
+    });
     const config = mockConfigService<DeploymentConfigService>({
       SDL_SECRETS_MAX_COUNT: input?.maxCount ?? MAX_COUNT,
       SDL_SECRETS_MAX_VALUE_BYTES: input?.maxValueBytes ?? MAX_VALUE_BYTES

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
@@ -25,16 +25,16 @@ function sdlWith(services: Record<string, string[]>): SDLInput {
 
 describe(SdlSecretsService.name, () => {
   describe("receive", () => {
-    it("hands a referenced value to the service that referenced it", async () => {
+    it("returns the value a reference names", async () => {
       const { service } = setup({ supplied: { TOKEN: "resolved" } });
 
       const result = await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
 
       expect(result.ok).toBe(true);
-      expect(receivedOf(result).byService).toEqual({ web: { TOKEN: "resolved" } });
+      expect(receivedOf(result)).toEqual({ TOKEN: "resolved" });
     });
 
-    it("hands one supplied value to every service that references it", async () => {
+    it("accepts one value several services reference", async () => {
       const { service } = setup({ supplied: { TOKEN: "shared" } });
 
       const result = await service.receive({
@@ -43,10 +43,10 @@ describe(SdlSecretsService.name, () => {
         sealedSecrets: SEAL
       });
 
-      expect(receivedOf(result).byService).toEqual({ web: { TOKEN: "shared" }, worker: { TOKEN: "shared" }, cron: { TOKEN: "shared" } });
+      expect(receivedOf(result)).toEqual({ TOKEN: "shared" });
     });
 
-    it("hands a service only the names it references", async () => {
+    it("accepts names referenced from different services", async () => {
       const { service } = setup({ supplied: { TOKEN: "one", DATABASE_URL: "two" } });
 
       const result = await service.receive({
@@ -55,10 +55,10 @@ describe(SdlSecretsService.name, () => {
         sealedSecrets: SEAL
       });
 
-      expect(receivedOf(result).byService).toEqual({ web: { TOKEN: "one" }, db: { DATABASE_URL: "two" } });
+      expect(receivedOf(result)).toEqual({ TOKEN: "one", DATABASE_URL: "two" });
     });
 
-    it("hands nothing to a service that references nothing", async () => {
+    it("accepts a document whose other service references nothing", async () => {
       const { service } = setup({ supplied: { TOKEN: "resolved" } });
 
       const result = await service.receive({
@@ -67,20 +67,7 @@ describe(SdlSecretsService.name, () => {
         sealedSecrets: SEAL
       });
 
-      expect(Object.keys(receivedOf(result).byService)).toEqual(["web"]);
-    });
-
-    it("keeps what the client sealed unchanged, for storage", async () => {
-      const supplied = { TOKEN: "one", DATABASE_URL: "two" };
-      const { service } = setup({ supplied });
-
-      const result = await service.receive({
-        sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN", "DATABASE_URL=ac-secret://DATABASE_URL"] }),
-        rawSdl: RAW_SDL,
-        sealedSecrets: SEAL
-      });
-
-      expect(receivedOf(result).supplied).toEqual(supplied);
+      expect(receivedOf(result)).toEqual({ TOKEN: "resolved" });
     });
 
     it("names a reference it holds no value for", async () => {
@@ -147,12 +134,12 @@ describe(SdlSecretsService.name, () => {
       expect(JSON.stringify(errorsOf(result))).not.toContain(value);
     });
 
-    it("resolves a name spelling an Object.prototype member from what was supplied for it", async () => {
+    it("accepts a name spelling an Object.prototype member supplied for it", async () => {
       const { service } = setup({ supplied: JSON.parse('{"constructor":"resolved"}') as SdlSecrets });
 
       const result = await service.receive({ sdl: sdlWith({ web: ["C=ac-secret://constructor"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
 
-      expect(receivedOf(result).byService).toEqual({ web: { constructor: "resolved" } });
+      expect(result.ok).toBe(true);
     });
 
     it("refuses a reference whose name spells an Object.prototype member nothing was supplied for", async () => {
@@ -168,7 +155,7 @@ describe(SdlSecretsService.name, () => {
 
       const result = await service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL });
 
-      expect(receivedOf(result)).toEqual({ supplied: {}, byService: {} });
+      expect(receivedOf(result)).toEqual({});
       expect(unsealerService.open).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
@@ -4,7 +4,7 @@ import { inject, singleton } from "tsyringe";
 
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { jsonEncodedBytes } from "@src/deployment/config/sdl-secrets.config";
-import type { NamespacedSdlSecrets, SdlReferenceDeclaration } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { SdlReferenceDeclaration } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import {
   MAX_ECHOED_REFERENCE_LENGTH,
   MAX_SDL_REFERENCE_NAME_LENGTH,
@@ -20,16 +20,10 @@ import { DeploymentConfigService } from "../deployment-config/deployment-config.
 /** The kind of SDL Reference a sealed payload answers. Other kinds resolve from elsewhere and are none of this service's business. */
 const SECRET_REFERENCE_KIND = "secret";
 
-export interface ReceivedSdlSecrets {
-  /** What the client sealed, unchanged, because this is what gets re-sealed for storage: one flat name-to-value map per deployment. */
-  supplied: SdlSecrets;
-  /** The same values indexed by the service that referenced them, which is the shape resolution reads. */
-  byService: NamespacedSdlSecrets;
-}
+/** What the client sealed, unchanged: the one flat name-to-value map a deployment has, which is both what resolution reads and what gets re-sealed for storage. */
+export type ReceiveSdlSecretsResult = { ok: true; value: SdlSecrets } | { ok: false; value: ValidationError[] };
 
-export type ReceiveSdlSecretsResult = { ok: true; value: ReceivedSdlSecrets } | { ok: false; value: ValidationError[] };
-
-const NOTHING_SUPPLIED: ReceivedSdlSecrets = { supplied: {}, byService: {} };
+const NOTHING_SUPPLIED: SdlSecrets = {};
 
 function unreferencedNameError(name: string): ValidationError {
   const echoed = name.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
@@ -69,7 +63,7 @@ export class SdlSecretsService {
     const supplied = await this.unsealerService.open({ seal: input.sealedSecrets, sdl: input.rawSdl });
     this.#assertWithinLimits(supplied);
 
-    const { byService, errors } = this.#assignToServices(declarations, supplied);
+    const errors = this.#mismatchesBetween(declarations, supplied);
 
     if (errors.length > 0) return { ok: false, value: errors };
 
@@ -77,10 +71,10 @@ export class SdlSecretsService {
       event: "SDL_SECRETS_RECEIVED",
       suppliedCount: Object.keys(supplied).length,
       referencedNames: [...new Set(declarations.map(declaration => declaration.name))],
-      serviceCount: Object.keys(byService).length
+      serviceCount: new Set(declarations.map(declaration => declaration.serviceName)).size
     });
 
-    return { ok: true, value: { supplied, byService } };
+    return { ok: true, value: supplied };
   }
 
   /** Returns null when nothing was supplied, so a create always has a value to write and a retry cannot inherit an abandoned attempt's token. */
@@ -96,30 +90,25 @@ export class SdlSecretsService {
     return sealed;
   }
 
-  /** Namespaces are built from the walk rather than by copying everything to every service, so a service that references nothing is handed nothing. */
-  #assignToServices(declarations: SdlReferenceDeclaration[], supplied: SdlSecrets) {
-    const byService: NamespacedSdlSecrets = Object.create(null);
+  /** Both directions are reported from one pass, so a request that gets each side wrong hears about both at once. */
+  #mismatchesBetween(declarations: SdlReferenceDeclaration[], supplied: SdlSecrets): ValidationError[] {
     const errors: ValidationError[] = [];
     const referenced = new Set<string>();
 
     for (const declaration of declarations) {
-      const value = ownValue(supplied, declaration.name);
-
-      if (typeof value !== "string") {
-        errors.push(missingSdlReferenceValueError(declaration));
+      if (typeof ownValue(supplied, declaration.name) === "string") {
+        referenced.add(declaration.name);
         continue;
       }
 
-      const namespace = (byService[declaration.serviceName] ??= Object.create(null) as SdlSecrets);
-      namespace[declaration.name] = value;
-      referenced.add(declaration.name);
+      errors.push(missingSdlReferenceValueError(declaration));
     }
 
     for (const name of Object.keys(supplied)) {
       if (!referenced.has(name)) errors.push(unreferencedNameError(name));
     }
 
-    return { byService, errors };
+    return errors;
   }
 
   /** Every bound is measured as `jsonEncodedBytes`, matching the seal budget, because a raw-length check would let a payload pass here and die on the body limit. */

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
@@ -13,7 +13,8 @@ import {
   SdlReferenceService
 } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
-import { SdlSecretsUnsealerService } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import { parseSdlSecrets, SdlSecretsUnsealerService } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import { SECRET_UNREADABLE_ERROR_MESSAGE } from "@src/secret/config/secret-at-rest.config";
 import { SecretCipherService } from "@src/secret/services/secret-cipher/secret-cipher.service";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 
@@ -88,6 +89,22 @@ export class SdlSecretsService {
     this.#loggerService.info({ event: "SDL_SECRETS_SEALED", userId: input.userId, dseq: input.dseq, secretCount: names.length });
 
     return sealed;
+  }
+
+  /** Opens what `sealForStorage` wrote under the same binding, so a token moved to another deployment's row or another user's fails to open rather than resolving into it. */
+  async openStored(input: { userId: string; dseq: string; sealedSecrets: string }): Promise<SdlSecrets> {
+    const opened = await this.secretCipherService.decrypt(input.userId, input.sealedSecrets, { sub: input.userId, dseq: input.dseq });
+    const secrets = parseSdlSecrets(opened);
+
+    if (!secrets) {
+      this.#loggerService.error({ event: "SDL_SECRETS_STORED_PAYLOAD_INVALID", userId: input.userId, dseq: input.dseq });
+
+      throw createError(500, SECRET_UNREADABLE_ERROR_MESSAGE);
+    }
+
+    this.#loggerService.info({ event: "SDL_SECRETS_STORED_OPENED", userId: input.userId, dseq: input.dseq, secretCount: Object.keys(secrets).length });
+
+    return secrets;
   }
 
   /** Both directions are reported from one pass, so a request that gets each side wrong hears about both at once. */

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -782,7 +782,7 @@ describe(SdlService.name, () => {
     it("returns a manifest carrying the resolved value", async () => {
       const { service } = await setup();
 
-      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
+      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { TOKEN: "resolved" } });
 
       expect(result.ok).toBe(true);
       expect(resolvedOf(result).manifest.groups[0].services[0].env).toEqual(["TOKEN=resolved"]);
@@ -794,7 +794,7 @@ describe(SdlService.name, () => {
 
       const result = await service.generateResolvedManifest({
         sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
-        secrets: { web: { REG_USER: username, REG_PASS: password } }
+        secrets: { REG_USER: username, REG_PASS: password }
       });
 
       expect(result.ok).toBe(true);
@@ -807,7 +807,7 @@ describe(SdlService.name, () => {
 
       const substituted = await service.generateResolvedManifest({
         sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
-        secrets: { web: { REG_USER: username, REG_PASS: password } }
+        secrets: { REG_USER: username, REG_PASS: password }
       });
       const inline = await service.generateResolvedManifest({ sdl: SDL_WITH_CREDENTIALS(username, password), secrets: {} });
 
@@ -819,7 +819,7 @@ describe(SdlService.name, () => {
 
       const result = await service.generateResolvedManifest({
         sdl: SDL_WITH_CREDENTIALS("ac-secret://REG_USER", "ac-secret://REG_PASS"),
-        secrets: { web: { REG_USER: faker.string.alphanumeric(10), REG_PASS: "short" } }
+        secrets: { REG_USER: faker.string.alphanumeric(10), REG_PASS: "short" }
       });
 
       expect(result.ok).toBe(false);
@@ -829,7 +829,7 @@ describe(SdlService.name, () => {
     it("hashes an sdl with a substituted value exactly as one carrying that value inline", async () => {
       const { service } = await setup();
 
-      const substituted = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
+      const substituted = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-secret://TOKEN"), secrets: { TOKEN: "resolved" } });
       const inline = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=resolved"), secrets: {} });
 
       expect(versionOf(substituted)).toEqual(versionOf(inline));
@@ -839,8 +839,8 @@ describe(SdlService.name, () => {
       const { service } = await setup();
       const sdl = SDL_WITH_ENV("TOKEN=ac-secret://TOKEN");
 
-      const first = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "one" } } });
-      const second = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "two" } } });
+      const first = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "one" } });
+      const second = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "two" } });
 
       expect(versionOf(first)).not.toEqual(versionOf(second));
     });
@@ -849,8 +849,8 @@ describe(SdlService.name, () => {
       const { service } = await setup();
       const sdl = SDL_WITH_ENV("TOKEN=ac-secret://TOKEN");
 
-      const first = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "resolved" } } });
-      const second = await service.generateResolvedManifest({ sdl, secrets: { web: { TOKEN: "resolved" } } });
+      const first = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "resolved" } });
+      const second = await service.generateResolvedManifest({ sdl, secrets: { TOKEN: "resolved" } });
 
       expect(versionOf(first)).toEqual(versionOf(second));
     });
@@ -867,7 +867,7 @@ describe(SdlService.name, () => {
     it("returns errors for an unrecognized kind", async () => {
       const { service } = await setup();
 
-      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-var://TOKEN"), secrets: { web: { TOKEN: "resolved" } } });
+      const result = await service.generateResolvedManifest({ sdl: SDL_WITH_ENV("TOKEN=ac-var://TOKEN"), secrets: { TOKEN: "resolved" } });
 
       expect(errorsOf(result)[0].message).toContain("ac-var://TOKEN");
     });

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -7,8 +7,8 @@ import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers"
 import { DenomExchangeService } from "@src/chain/services/denom-exchange/denom-exchange.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
-import type { NamespacedSdlSecrets } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import { sdlRequestsGpuInterconnect } from "@src/deployment/utils/gpu-interconnect/gpu-interconnect";
 import { findTrialResourceViolation } from "@src/deployment/utils/group-resources/group-resources";
 import { restatePricesInGrantDenom } from "@src/deployment/utils/price-denom/price-denom";
@@ -56,7 +56,7 @@ export class SdlService {
   }
 
   /** The only path that substitutes SDL References, and the only caller of the substitution walk, so a resolved manifest exists nowhere a caller has not asked for one. */
-  async generateResolvedManifest(input: { sdl: string; secrets: NamespacedSdlSecrets; isTrialing?: boolean }): Promise<GenerateResolvedManifestResult> {
+  async generateResolvedManifest(input: { sdl: string; secrets: SdlSecrets; isTrialing?: boolean }): Promise<GenerateResolvedManifestResult> {
     const parsed = this.parse(input.sdl);
 
     if (!parsed.ok) return parsed;

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -692,9 +692,8 @@ describe("Deployment sealed secrets", () => {
 
   function resolvedDocumentOf(storedSdl: string, secrets: Record<string, string>) {
     const document = yaml.raw<SDLInput>(storedSdl);
-    const byService = Object.fromEntries(Object.keys(document.services).map(serviceName => [serviceName, secrets]));
 
-    expect(container.resolve(SdlReferenceService).substitute(document, { secrets: byService })).toEqual([]);
+    expect(container.resolve(SdlReferenceService).substitute(document, { secrets })).toEqual([]);
 
     return document;
   }


### PR DESCRIPTION
## Why

Part of CON-867.

CON-867 makes lease creation derive the provider manifest from the definition the console stored, instead of taking it from the request. Doing that means reading back the sealed token a create wrote — which nothing in the codebase does today: `SdlSecretsService` can only `sealForStorage`, and the one reader it has (`SdlSecretsUnsealerService.open`) opens a *client's* seal, under different claims and with different failure semantics.

This is the first of four stacked PRs and adds only that read. Nothing calls it yet, so this PR changes no behaviour.

## What

`SdlSecretsService.openStored({ userId, dseq, sealedSecrets })` opens what `sealForStorage` wrote, under the same `{ sub, dseq }` binding — so a token moved to another deployment's row or another user's fails to open rather than resolving into it.

The payload shape rule ("a flat object of string values") moves out of `SdlSecretsUnsealerService`'s private `#parseSecrets` into an exported `parseSdlSecrets`, so one place decides whether a payload is a set of secrets whoever sealed it. The unsealer keeps its own reporting: a *client's* malformed payload is a 400 that blames the caller, while a payload the console sealed itself and cannot read back is a 500 that blames the console, reported exactly as `SecretCipherService` reports one.

Nothing here logs, echoes or returns a secret value — `openStored` logs a count, and the invalid-payload path logs only the row's key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Deployment secrets now use a consistent flat format across intake, storage, and manifest resolution.
  - Shared secret references resolve consistently across services.
  - Stored sealed secrets are decrypted and validated before use.
  - Invalid or malformed secret payloads are rejected with clear deployment errors.
  - Secret validation continues to identify missing references and unrecognized secret names.
  - Manifest generation now restates prices using current denomination exchange rates.
  - Pricing validation reports errors when exchange-rate retrieval or conversion fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->