### PR TITLE
feat(deployment): derive a deployment's manifest from the definition it stored

### DIFF
--- a/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.spec.ts
+++ b/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.spec.ts
@@ -22,13 +22,23 @@ import { mockConfigService } from "@test/mocks/config-service.mock";
 const USER_ID = "3f1b6d4e-0000-4000-8000-000000000001";
 const DSEQ = "1420000000001";
 
-function sdlWith(env: string[], credentials?: Record<string, string>) {
-  const credentialsBlock = credentials
-    ? `    credentials:\n${Object.entries(credentials)
+function sdlWith(env: string[], options: { credentials?: Record<string, string>; denom?: string; gpuModel?: string } = {}) {
+  const credentialsBlock = options.credentials
+    ? `    credentials:\n${Object.entries(options.credentials)
         .map(([field, value]) => `      ${field}: ${JSON.stringify(value)}\n`)
         .join("")}`
     : "";
   const envBlock = env.map(entry => `      - ${JSON.stringify(entry)}\n`).join("");
+  const gpuBlock = options.gpuModel
+    ? [
+        `        gpu:`,
+        `          units: 1`,
+        `          attributes:`,
+        `            vendor:`,
+        `              nvidia:`,
+        `                - model: ${options.gpuModel}`
+      ].join("\n")
+    : "";
 
   return [
     `version: "2.0"`,
@@ -48,11 +58,12 @@ function sdlWith(env: string[], credentials?: Record<string, string>) {
     `          size: 128Mi`,
     `        storage:`,
     `          - size: 128Mi`,
+    gpuBlock,
     `  placement:`,
     `    dcloud:`,
     `      pricing:`,
     `        web:`,
-    `          denom: uakt`,
+    `          denom: ${options.denom ?? "uakt"}`,
     `          amount: 1000`,
     `deployment:`,
     `  web:`,
@@ -98,7 +109,9 @@ describe(LeaseManifestService.name, () => {
       const [username, password] = [randomUUID(), randomUUID()];
       const { service } = setup({
         definition: {
-          sdl: sdlWith(["LOG_LEVEL=debug"], { host: "registry.example.test", username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" }),
+          sdl: sdlWith(["LOG_LEVEL=debug"], {
+            credentials: { host: "registry.example.test", username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" }
+          }),
           sealedSecrets: "sealed"
         },
         stored: { REG_USER: username, REG_PASS: password }
@@ -106,7 +119,7 @@ describe(LeaseManifestService.name, () => {
 
       const manifest = await service.deriveFor({ dseq: DSEQ });
 
-      expect(manifest).toBe(manifestOf(sdlWith(["LOG_LEVEL=debug"], { host: "registry.example.test", username, password })));
+      expect(manifest).toBe(manifestOf(sdlWith(["LOG_LEVEL=debug"], { credentials: { host: "registry.example.test", username, password } })));
     });
 
     it("derives identical bytes from one stored definition twice over", async () => {
@@ -168,6 +181,30 @@ describe(LeaseManifestService.name, () => {
       expect(sdlSecretsService.openStored).toHaveBeenCalledWith({ userId: USER_ID, dseq: DSEQ, sealedSecrets: "sealed" });
     });
 
+    it("logs what it derived and no part of what it resolved", async () => {
+      const token = randomUUID();
+      const { service, logger } = setup({
+        definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN", "LOG_LEVEL=debug"]), sealedSecrets: "sealed" },
+        stored: { API_TOKEN: token }
+      });
+
+      await service.deriveFor({ dseq: DSEQ });
+
+      expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_DERIVED", userId: USER_ID, dseq: DSEQ, resolvedSecretCount: 1 });
+    });
+
+    it("logs nothing carrying a resolved value, whichever level it logs at", async () => {
+      const token = randomUUID();
+      const { service, logger } = setup({
+        definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "sealed" },
+        stored: { API_TOKEN: token }
+      });
+
+      await service.deriveFor({ dseq: DSEQ });
+
+      expect(JSON.stringify([logger.info.mock.calls, logger.warn.mock.calls, logger.error.mock.calls])).not.toContain(token);
+    });
+
     it("falls back when the console recorded nothing for the deployment", async () => {
       const { service, logger } = setup({ definition: null });
 
@@ -184,6 +221,13 @@ describe(LeaseManifestService.name, () => {
 
       expect(manifest).toBeNull();
       expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_FALLBACK", userId: USER_ID, dseq: DSEQ, reason: "nothing-recorded" });
+    });
+
+    it("refuses a row holding a token beside no sdl rather than accepting a client manifest for it", async () => {
+      const { service, logger } = setup({ definition: { sdl: null, sealedSecrets: "sealed" } });
+
+      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+      expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "LEASE_MANIFEST_FALLBACK" }));
     });
 
     it("falls back when a definition carrying no reference will not re-derive", async () => {
@@ -254,13 +298,30 @@ describe(LeaseManifestService.name, () => {
       expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
     });
 
-    it("refuses a trial-blocked gpu no more than the create that already cleared it", async () => {
-      const stored = sdlWith(["LOG_LEVEL=debug"]);
-      const { service } = setup({ definition: { sdl: stored, sealedSecrets: null }, blockedGpuModels: ["a100"] });
+    it("derives a gpu the trial rules block, because the create it belongs to already cleared it", async () => {
+      const stored = sdlWith(["LOG_LEVEL=debug"], { gpuModel: "a100" });
+      const { service } = setup({ definition: { sdl: stored, sealedSecrets: null }, blockedGpuModels: ["nvidia/a100"] });
 
       const manifest = await service.deriveFor({ dseq: DSEQ });
 
       expect(manifest).toBe(manifestOf(stored));
+    });
+
+    it("derives resources above the trial ceilings, because the create it belongs to already cleared them", async () => {
+      const stored = sdlWith(["LOG_LEVEL=debug"]);
+      const { service } = setup({ definition: { sdl: stored, sealedSecrets: null }, trialMaxCpu: 0.05, trialMaxMemoryGi: 0.01 });
+
+      const manifest = await service.deriveFor({ dseq: DSEQ });
+
+      expect(manifest).toBe(manifestOf(stored));
+    });
+
+    it("derives an sdl priced in a denom the manifest generator would reject unpriced in the grant denom", async () => {
+      const { service } = setup({ definition: { sdl: sdlWith(["LOG_LEVEL=debug"], { denom: "uatom" }), sealedSecrets: null } });
+
+      const manifest = await service.deriveFor({ dseq: DSEQ });
+
+      expect(manifest).toBe(manifestOf(sdlWith(["LOG_LEVEL=debug"])));
     });
   });
 
@@ -268,6 +329,8 @@ describe(LeaseManifestService.name, () => {
     definition?: { sdl: string | null; sealedSecrets: string | null } | null;
     stored?: Record<string, string>;
     blockedGpuModels?: string[];
+    trialMaxCpu?: number;
+    trialMaxMemoryGi?: number;
   }) {
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     const scopedRepository = mock<DeploymentSettingRepository>();
@@ -285,8 +348,8 @@ describe(LeaseManifestService.name, () => {
       mock<BillingConfig>({
         DEPLOYMENT_GRANT_DENOM: "uakt",
         MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: [],
-        MANAGED_WALLET_TRIAL_MAX_CPU: 0,
-        MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: 0
+        MANAGED_WALLET_TRIAL_MAX_CPU: input.trialMaxCpu ?? 0,
+        MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: input.trialMaxMemoryGi ?? 0
       }),
       new BlockedGpuService(mockConfigService<BillingConfigService>({ MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: input.blockedGpuModels ?? [] })),
       sdlReferenceService

--- a/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.spec.ts
+++ b/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.spec.ts
@@ -1,0 +1,299 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { generateManifest, manifestToSortedJSON, yaml } from "@akashnetwork/chain-sdk";
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthService } from "@src/auth/services/auth.service";
+import type { BillingConfig } from "@src/billing/providers";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { CreateLogger } from "@src/core";
+import type { DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
+import { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import type { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import type { UserOutput } from "@src/user/repositories";
+import { LeaseManifestService } from "./lease-manifest.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const USER_ID = "3f1b6d4e-0000-4000-8000-000000000001";
+const DSEQ = "1420000000001";
+
+function sdlWith(env: string[], credentials?: Record<string, string>) {
+  const credentialsBlock = credentials
+    ? `    credentials:\n${Object.entries(credentials)
+        .map(([field, value]) => `      ${field}: ${JSON.stringify(value)}\n`)
+        .join("")}`
+    : "";
+  const envBlock = env.map(entry => `      - ${JSON.stringify(entry)}\n`).join("");
+
+  return [
+    `version: "2.0"`,
+    `services:`,
+    `  web:`,
+    `    image: nginx`,
+    credentialsBlock.replace(/\n$/, ""),
+    `    env:`,
+    envBlock.replace(/\n$/, ""),
+    `profiles:`,
+    `  compute:`,
+    `    web:`,
+    `      resources:`,
+    `        cpu:`,
+    `          units: 0.1`,
+    `        memory:`,
+    `          size: 128Mi`,
+    `        storage:`,
+    `          - size: 128Mi`,
+    `  placement:`,
+    `    dcloud:`,
+    `      pricing:`,
+    `        web:`,
+    `          denom: uakt`,
+    `          amount: 1000`,
+    `deployment:`,
+    `  web:`,
+    `    dcloud:`,
+    `      profile: web`,
+    `      count: 1`
+  ]
+    .filter(line => line !== "")
+    .join("\n");
+}
+
+function manifestOf(sdl: string) {
+  const result = generateManifest(yaml.raw<SDLInput>(sdl));
+
+  return manifestToSortedJSON((result as Extract<typeof result, { ok: true }>).value.groups);
+}
+
+describe(LeaseManifestService.name, () => {
+  describe("deriveFor", () => {
+    it("derives the manifest of the sdl the console stored", async () => {
+      const stored = sdlWith(["LOG_LEVEL=debug"]);
+      const { service } = setup({ definition: { sdl: stored, sealedSecrets: null } });
+
+      const manifest = await service.deriveFor({ dseq: DSEQ });
+
+      expect(manifest).toBe(manifestOf(stored));
+    });
+
+    it("resolves the values of the stored token into the manifest", async () => {
+      const token = randomUUID();
+      const { service } = setup({
+        definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "sealed" },
+        stored: { API_TOKEN: token }
+      });
+
+      const manifest = await service.deriveFor({ dseq: DSEQ });
+
+      expect(manifest).toBe(manifestOf(sdlWith([`API_TOKEN=${token}`])));
+      expect(manifest).not.toContain("ac-secret://");
+    });
+
+    it("resolves a stored registry credential into the manifest", async () => {
+      const [username, password] = [randomUUID(), randomUUID()];
+      const { service } = setup({
+        definition: {
+          sdl: sdlWith(["LOG_LEVEL=debug"], { host: "registry.example.test", username: "ac-secret://REG_USER", password: "ac-secret://REG_PASS" }),
+          sealedSecrets: "sealed"
+        },
+        stored: { REG_USER: username, REG_PASS: password }
+      });
+
+      const manifest = await service.deriveFor({ dseq: DSEQ });
+
+      expect(manifest).toBe(manifestOf(sdlWith(["LOG_LEVEL=debug"], { host: "registry.example.test", username, password })));
+    });
+
+    it("derives identical bytes from one stored definition twice over", async () => {
+      const { service } = setup({
+        definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN", "LOG_LEVEL=debug"]), sealedSecrets: "sealed" },
+        stored: { API_TOKEN: randomUUID() }
+      });
+
+      const first = await service.deriveFor({ dseq: DSEQ });
+      const second = await service.deriveFor({ dseq: DSEQ });
+
+      expect(first).toBe(second);
+      expect(first).toEqual(expect.any(String));
+    });
+
+    it("reads the definition of the authenticated user, which no caller can name for it", async () => {
+      const { service, scopedRepository } = setup({ definition: { sdl: sdlWith([]), sealedSecrets: null } });
+
+      await service.deriveFor({ dseq: DSEQ });
+
+      expect(scopedRepository.findOneBy).toHaveBeenCalledWith({ userId: USER_ID, dseq: DSEQ });
+    });
+
+    it("opens a stored token for the authenticated user rather than for whoever the row names", async () => {
+      const { service, sdlSecretsService } = setup({
+        definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "sealed" },
+        stored: { API_TOKEN: "value" }
+      });
+
+      await service.deriveFor({ dseq: DSEQ });
+
+      expect(sdlSecretsService.openStored).toHaveBeenCalledWith(expect.objectContaining({ userId: USER_ID }));
+    });
+
+    it("reads the definition scoped to the caller's own ability", async () => {
+      const { service, deploymentSettingRepository, authService } = setup({ definition: { sdl: sdlWith([]), sealedSecrets: null } });
+
+      await service.deriveFor({ dseq: DSEQ });
+
+      expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(authService.ability, "read");
+    });
+
+    it("opens no stored token for a definition that has none", async () => {
+      const { service, sdlSecretsService } = setup({ definition: { sdl: sdlWith(["LOG_LEVEL=debug"]), sealedSecrets: null } });
+
+      await service.deriveFor({ dseq: DSEQ });
+
+      expect(sdlSecretsService.openStored).not.toHaveBeenCalled();
+    });
+
+    it("opens the stored token under the deployment it was sealed for", async () => {
+      const { service, sdlSecretsService } = setup({
+        definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "sealed" },
+        stored: { API_TOKEN: "value" }
+      });
+
+      await service.deriveFor({ dseq: DSEQ });
+
+      expect(sdlSecretsService.openStored).toHaveBeenCalledWith({ userId: USER_ID, dseq: DSEQ, sealedSecrets: "sealed" });
+    });
+
+    it("falls back when the console recorded nothing for the deployment", async () => {
+      const { service, logger } = setup({ definition: null });
+
+      const manifest = await service.deriveFor({ dseq: DSEQ });
+
+      expect(manifest).toBeNull();
+      expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_FALLBACK", userId: USER_ID, dseq: DSEQ, reason: "nothing-recorded" });
+    });
+
+    it("falls back when the row it found carries no sdl", async () => {
+      const { service, logger } = setup({ definition: { sdl: null, sealedSecrets: null } });
+
+      const manifest = await service.deriveFor({ dseq: DSEQ });
+
+      expect(manifest).toBeNull();
+      expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_FALLBACK", userId: USER_ID, dseq: DSEQ, reason: "nothing-recorded" });
+    });
+
+    it("falls back when a definition carrying no reference will not re-derive", async () => {
+      const { service, logger } = setup({ definition: { sdl: "version: '2.0'\nservices: {}", sealedSecrets: null } });
+
+      const manifest = await service.deriveFor({ dseq: DSEQ });
+
+      expect(manifest).toBeNull();
+      expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_FALLBACK", userId: USER_ID, dseq: DSEQ, reason: "unresolvable" });
+    });
+
+    it("refuses a definition whose reference has no stored value rather than falling back", async () => {
+      const { service } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: null } });
+
+      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+    });
+
+    it("refuses a definition whose token is missing the name its sdl references", async () => {
+      const { service } = setup({
+        definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "sealed" },
+        stored: { SOMETHING_ELSE: "value" }
+      });
+
+      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+    });
+
+    it("refuses a stored sdl that will not parse rather than assuming it carries no reference", async () => {
+      const { service } = setup({ definition: { sdl: "services:\n  - web\n :::", sealedSecrets: null } });
+
+      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+    });
+
+    it("refuses a sealed definition that will not re-derive even with no reference left in its sdl", async () => {
+      const { service } = setup({ definition: { sdl: "version: '2.0'\nservices: {}", sealedSecrets: "sealed" }, stored: {} });
+
+      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+    });
+
+    it("says nothing of the definition in the refusal it reports", async () => {
+      const token = randomUUID();
+      const { service } = setup({ definition: { sdl: sdlWith([`API_TOKEN=ac-secret://${token.replace(/-/g, "_")}`]), sealedSecrets: null } });
+
+      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ message: "Unable to derive the deployment manifest" });
+    });
+
+    it("logs the refusal so a definition nothing can re-derive is measurable", async () => {
+      const { service, logger } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: null } });
+
+      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toThrow();
+      expect(logger.error).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_UNRESOLVABLE", userId: USER_ID, dseq: DSEQ });
+    });
+
+    it("lets a token it cannot open fail the derivation untouched", async () => {
+      const unreadable = Object.assign(new Error("Unable to read the stored value"), { status: 500 });
+      const { service, sdlSecretsService } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "tampered" } });
+      sdlSecretsService.openStored.mockRejectedValue(unreadable);
+
+      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toBe(unreadable);
+    });
+
+    it("writes nothing to the row it read, whatever the derivation makes of it", async () => {
+      const { service, deploymentSettingRepository } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: null } });
+
+      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toThrow();
+
+      expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.updateById).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
+    });
+
+    it("refuses a trial-blocked gpu no more than the create that already cleared it", async () => {
+      const stored = sdlWith(["LOG_LEVEL=debug"]);
+      const { service } = setup({ definition: { sdl: stored, sealedSecrets: null }, blockedGpuModels: ["a100"] });
+
+      const manifest = await service.deriveFor({ dseq: DSEQ });
+
+      expect(manifest).toBe(manifestOf(stored));
+    });
+  });
+
+  function setup(input: {
+    definition?: { sdl: string | null; sealedSecrets: string | null } | null;
+    stored?: Record<string, string>;
+    blockedGpuModels?: string[];
+  }) {
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    const scopedRepository = mock<DeploymentSettingRepository>();
+    const authService = mock<AuthService>({ currentUser: mock<UserOutput>({ id: USER_ID }) });
+    const sdlSecretsService = mock<SdlSecretsService>({ openStored: vi.fn().mockResolvedValue(input.stored ?? {}) });
+    const logger = mock<ReturnType<CreateLogger>>();
+
+    deploymentSettingRepository.accessibleBy.mockReturnValue(scopedRepository);
+    scopedRepository.findOneBy.mockResolvedValue(
+      input.definition ? mock<DeploymentSettingsOutput>({ sdl: input.definition.sdl, sealedSecrets: input.definition.sealedSecrets }) : undefined
+    );
+
+    const sdlReferenceService = new SdlReferenceService();
+    const sdlService = new SdlService(
+      mock<BillingConfig>({
+        DEPLOYMENT_GRANT_DENOM: "uakt",
+        MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: [],
+        MANAGED_WALLET_TRIAL_MAX_CPU: 0,
+        MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: 0
+      }),
+      new BlockedGpuService(mockConfigService<BillingConfigService>({ MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: input.blockedGpuModels ?? [] })),
+      sdlReferenceService
+    );
+
+    const service = new LeaseManifestService(deploymentSettingRepository, authService, sdlSecretsService, sdlReferenceService, sdlService, () => logger);
+
+    return { service, deploymentSettingRepository, scopedRepository, authService, sdlSecretsService, sdlService, logger };
+  }
+});

--- a/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.spec.ts
+++ b/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.spec.ts
@@ -7,6 +7,7 @@ import { mock } from "vitest-mock-extended";
 import type { AuthService } from "@src/auth/services/auth.service";
 import type { BillingConfig } from "@src/billing/providers";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { DenomExchangeService } from "@src/chain/services/denom-exchange/denom-exchange.service";
 import type { CreateLogger } from "@src/core";
 import type { DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
@@ -22,7 +23,7 @@ import { mockConfigService } from "@test/mocks/config-service.mock";
 const USER_ID = "3f1b6d4e-0000-4000-8000-000000000001";
 const DSEQ = "1420000000001";
 
-function sdlWith(env: string[], options: { credentials?: Record<string, string>; denom?: string; gpuModel?: string } = {}) {
+function sdlWith(env: string[], options: { credentials?: Record<string, string>; gpuModel?: string } = {}) {
   const credentialsBlock = options.credentials
     ? `    credentials:\n${Object.entries(options.credentials)
         .map(([field, value]) => `      ${field}: ${JSON.stringify(value)}\n`)
@@ -63,7 +64,7 @@ function sdlWith(env: string[], options: { credentials?: Record<string, string>;
     `    dcloud:`,
     `      pricing:`,
     `        web:`,
-    `          denom: ${options.denom ?? "uakt"}`,
+    `          denom: uakt`,
     `          amount: 1000`,
     `deployment:`,
     `  web:`,
@@ -79,6 +80,10 @@ function manifestOf(sdl: string) {
   const result = generateManifest(yaml.raw<SDLInput>(sdl));
 
   return manifestToSortedJSON((result as Extract<typeof result, { ok: true }>).value.groups);
+}
+
+function aktToUsdRateOf(price: number) {
+  return mock<Awaited<ReturnType<DenomExchangeService["getExchangeRateToUSD"]>>>({ price });
 }
 
 describe(LeaseManifestService.name, () => {
@@ -316,12 +321,29 @@ describe(LeaseManifestService.name, () => {
       expect(manifest).toBe(manifestOf(stored));
     });
 
-    it("derives an sdl priced in a denom the manifest generator would reject unpriced in the grant denom", async () => {
-      const { service } = setup({ definition: { sdl: sdlWith(["LOG_LEVEL=debug"], { denom: "uatom" }), sealedSecrets: null } });
+    it("derives the same bytes twice over however the akt price the grant denom restates through moves between them", async () => {
+      const stored = sdlWith(["LOG_LEVEL=debug"]);
+      const { service, denomExchangeService } = setup({ definition: { sdl: stored, sealedSecrets: null }, grantDenom: "uact" });
+      denomExchangeService.getExchangeRateToUSD.mockResolvedValueOnce(aktToUsdRateOf(0.325)).mockResolvedValueOnce(aktToUsdRateOf(9));
+
+      const first = await service.deriveFor({ dseq: DSEQ });
+      const second = await service.deriveFor({ dseq: DSEQ });
+
+      expect(first).toBe(second);
+      expect(first).toBe(manifestOf(stored));
+    });
+
+    it("falls back when the akt price the grant denom restatement needs is unavailable", async () => {
+      const { service, logger } = setup({
+        definition: { sdl: sdlWith(["LOG_LEVEL=debug"]), sealedSecrets: null },
+        grantDenom: "uact",
+        aktToUsdRate: 0
+      });
 
       const manifest = await service.deriveFor({ dseq: DSEQ });
 
-      expect(manifest).toBe(manifestOf(sdlWith(["LOG_LEVEL=debug"])));
+      expect(manifest).toBeNull();
+      expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_FALLBACK", userId: USER_ID, dseq: DSEQ, reason: "unresolvable" });
     });
   });
 
@@ -331,6 +353,8 @@ describe(LeaseManifestService.name, () => {
     blockedGpuModels?: string[];
     trialMaxCpu?: number;
     trialMaxMemoryGi?: number;
+    grantDenom?: BillingConfig["DEPLOYMENT_GRANT_DENOM"];
+    aktToUsdRate?: number;
   }) {
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     const scopedRepository = mock<DeploymentSettingRepository>();
@@ -343,20 +367,27 @@ describe(LeaseManifestService.name, () => {
       input.definition ? mock<DeploymentSettingsOutput>({ sdl: input.definition.sdl, sealedSecrets: input.definition.sealedSecrets }) : undefined
     );
 
+    const createLogger: CreateLogger = () => logger;
+    const denomExchangeService = mock<DenomExchangeService>({
+      getExchangeRateToUSD: vi.fn().mockResolvedValue(aktToUsdRateOf(input.aktToUsdRate ?? 1))
+    });
+
     const sdlReferenceService = new SdlReferenceService();
     const sdlService = new SdlService(
       mock<BillingConfig>({
-        DEPLOYMENT_GRANT_DENOM: "uakt",
+        DEPLOYMENT_GRANT_DENOM: input.grantDenom ?? "uakt",
         MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: [],
         MANAGED_WALLET_TRIAL_MAX_CPU: input.trialMaxCpu ?? 0,
         MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: input.trialMaxMemoryGi ?? 0
       }),
       new BlockedGpuService(mockConfigService<BillingConfigService>({ MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: input.blockedGpuModels ?? [] })),
-      sdlReferenceService
+      sdlReferenceService,
+      denomExchangeService,
+      createLogger
     );
 
-    const service = new LeaseManifestService(deploymentSettingRepository, authService, sdlSecretsService, sdlReferenceService, sdlService, () => logger);
+    const service = new LeaseManifestService(deploymentSettingRepository, authService, sdlSecretsService, sdlReferenceService, sdlService, createLogger);
 
-    return { service, deploymentSettingRepository, scopedRepository, authService, sdlSecretsService, sdlService, logger };
+    return { service, deploymentSettingRepository, scopedRepository, authService, sdlSecretsService, sdlService, denomExchangeService, logger };
   }
 });

--- a/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.ts
+++ b/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.ts
@@ -1,0 +1,95 @@
+import { manifestToSortedJSON } from "@akashnetwork/chain-sdk";
+import { Trace } from "@akashnetwork/instrumentation";
+import createError from "http-errors";
+import { inject, singleton } from "tsyringe";
+
+import { AuthService } from "@src/auth/services/auth.service";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+
+/** Everything a stored definition has to say for the manifest it stands for to be derived again. */
+type StoredDefinition = { sdl: string; sealedSecrets: string | null };
+
+/** Why a deployment has no manifest of its own, which is what the residual volume of client-supplied ones is measured by. */
+type StoredDefinitionMiss = "nothing-recorded" | "unresolvable";
+
+/** Deliberately names no part of the definition, because the error handler echoes `message` for every `http-errors` instance regardless of `expose`. */
+const UNDERIVABLE_ERROR_MESSAGE = "Unable to derive the deployment manifest";
+
+/** The manifest a lease sends its provider: what the console stored for the deployment, resolved and re-derived, rather than what the client asked for. */
+@singleton()
+export class LeaseManifestService {
+  readonly #loggerService: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly authService: AuthService,
+    private readonly sdlSecretsService: SdlSecretsService,
+    private readonly sdlReferenceService: SdlReferenceService,
+    private readonly sdlService: SdlService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.#loggerService = createLogger({ context: LeaseManifestService.name });
+  }
+
+  /** Re-derives without trial limits, which gate a create rather than shape a manifest, so no lease is refused by a rule the create it belongs to already cleared. */
+  @Trace()
+  async deriveFor({ dseq }: { dseq: string }): Promise<string | null> {
+    const userId = this.authService.currentUser.id;
+    const definition = await this.#findDefinition({ userId, dseq });
+
+    if (!definition) {
+      return this.#fallBack({ userId, dseq, reason: "nothing-recorded" });
+    }
+
+    const secrets = definition.sealedSecrets ? await this.sdlSecretsService.openStored({ userId, dseq, sealedSecrets: definition.sealedSecrets }) : {};
+
+    const resolved = await this.sdlService.generateResolvedManifest({ sdl: definition.sdl, secrets });
+
+    if (!resolved.ok) {
+      return this.#refuseOrFallBack(definition, { userId, dseq });
+    }
+
+    this.#loggerService.info({ event: "LEASE_MANIFEST_DERIVED", userId, dseq, resolvedSecretCount: Object.keys(secrets).length });
+
+    return manifestToSortedJSON(resolved.value.manifest.groups);
+  }
+
+  /** Scoped twice over, by the query and by the caller's own ability, so a later refactor has to defeat both to derive one user's manifest for another. */
+  async #findDefinition(key: { userId: string; dseq: string }): Promise<StoredDefinition | null> {
+    const setting = await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "read").findOneBy(key);
+
+    return setting?.sdl ? { sdl: setting.sdl, sealedSecrets: setting.sealedSecrets } : null;
+  }
+
+  /** A definition carrying a reference is never eligible for the fallback, because accepting a client's manifest for it would mean accepting a client-supplied secret value. */
+  #refuseOrFallBack(definition: StoredDefinition, key: { userId: string; dseq: string }): null {
+    if (definition.sealedSecrets !== null || this.#carriesReference(definition.sdl)) {
+      throw this.#refuse(key);
+    }
+
+    return this.#fallBack({ ...key, reason: "unresolvable" });
+  }
+
+  /** An SDL that will not parse cannot be shown to carry no reference, and only a definition shown to carry none may fall back. */
+  #carriesReference(sdl: string): boolean {
+    const document = this.sdlService.parse(sdl);
+
+    return !document.ok || this.sdlReferenceService.hasAnyReference(document.value);
+  }
+
+  #fallBack({ reason, ...key }: { userId: string; dseq: string; reason: StoredDefinitionMiss }): null {
+    this.#loggerService.info({ event: "LEASE_MANIFEST_FALLBACK", ...key, reason });
+
+    return null;
+  }
+
+  #refuse(key: { userId: string; dseq: string }) {
+    this.#loggerService.error({ event: "LEASE_MANIFEST_UNRESOLVABLE", ...key });
+
+    return createError(500, UNDERIVABLE_ERROR_MESSAGE);
+  }
+}

--- a/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.ts
+++ b/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.ts
@@ -10,7 +10,6 @@ import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 
-/** Everything a stored definition has to say for the manifest it stands for to be derived again. */
 type StoredDefinition = { sdl: string; sealedSecrets: string | null };
 
 /** Why a deployment has no manifest of its own, which is what the residual volume of client-supplied ones is measured by. */
@@ -58,11 +57,15 @@ export class LeaseManifestService {
     return manifestToSortedJSON(resolved.value.manifest.groups);
   }
 
-  /** Scoped twice over, by the query and by the caller's own ability, so a later refactor has to defeat both to derive one user's manifest for another. */
+  /** A token beside no sdl is refused rather than fallen back on, so that safety property lives here instead of resting on the one writer that happens to fill both columns in a single statement. */
   async #findDefinition(key: { userId: string; dseq: string }): Promise<StoredDefinition | null> {
     const setting = await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "read").findOneBy(key);
 
-    return setting?.sdl ? { sdl: setting.sdl, sealedSecrets: setting.sealedSecrets } : null;
+    if (setting?.sdl) return { sdl: setting.sdl, sealedSecrets: setting.sealedSecrets };
+
+    if (setting?.sealedSecrets) throw this.#refuse(key);
+
+    return null;
   }
 
   /** A definition carrying a reference is never eligible for the fallback, because accepting a client's manifest for it would mean accepting a client-supplied secret value. */

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.spec.ts
@@ -560,6 +560,44 @@ describe(SdlReferenceService.name, () => {
     });
   });
 
+  describe("hasAnyReference", () => {
+    it("reports none for an sdl whose values are all plain", () => {
+      const { service } = setup();
+
+      expect(service.hasAnyReference(sdlWithEnv(["PORT=8080", "MODE=production"]))).toBe(false);
+    });
+
+    it("reports one for an env value that is a reference", () => {
+      const { service } = setup();
+
+      expect(service.hasAnyReference(sdlWithEnv(["TOKEN=ac-secret://TOKEN"]))).toBe(true);
+    });
+
+    it("reports one for a registry credential that is a reference", () => {
+      const { service } = setup();
+
+      expect(service.hasAnyReference(sdlWithCredentials({ password: "ac-secret://REG_PASS" }))).toBe(true);
+    });
+
+    it("reports one for a reference of a kind nothing resolves", () => {
+      const { service } = setup();
+
+      expect(service.hasAnyReference(sdlWithEnv(["TOKEN=ac-var://TOKEN"]))).toBe(true);
+    });
+
+    it.each(RESERVED_VALUES)("reports one for the reserved value %j, which stands where a reference stands", value => {
+      const { service } = setup();
+
+      expect(service.hasAnyReference(sdlWithEnv([`MODE=${value}`]))).toBe(true);
+    });
+
+    it("reports none for an sdl with no services at all", () => {
+      const { service } = setup();
+
+      expect(service.hasAnyReference(yaml.raw<SDLInput>(`version: "2.0"`))).toBe(false);
+    });
+  });
+
   function setup(input: { resolvers?: SdlReferenceResolver[] } = {}) {
     const service = new SdlReferenceService();
     input.resolvers?.forEach(resolver => service.register(resolver));

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -236,6 +236,19 @@ export class SdlReferenceService {
     return declarations;
   }
 
+  /** A reserved value counts as one, because it stands exactly where a reference stands and nothing may accept a client's manifest for the position it holds. */
+  hasAnyReference(sdl: SDLInput): boolean {
+    let found = false;
+
+    const reserved = this.#eachReference(sdl, () => {
+      found = true;
+
+      return undefined;
+    });
+
+    return found || reserved.length > 0;
+  }
+
   #eachReference(sdl: SDLInput, visit: SdlReferenceVisitor): ValidationError[] {
     const errors: ValidationError[] = [];
 


### PR DESCRIPTION
## Why

Part of CON-867.

CON-867 makes lease creation send the provider the manifest the console derived from what it stored, rather than the one the client asked for. This PR adds the thing that answers "what manifest does this deployment's stored definition mean?", so the next PR in the stack is only a wiring change.

It also settles the two questions that decide whether that answer is safe to act on:

**Why no feature flag.** The spec asks to "keep the read side behind the same flag as resolution". There is no such flag: resolution on the create path is gated by nothing but whether a seal is present (`DeploymentWriterService.create`), and `FeatureFlags` has no SDL-secrets entry. The worry the sentence encodes — that one release is simultaneously the first writer and the first reader — is already answered by the data: a deployment the writer never wrote has `sdl IS NULL`, and this service falls back for it. The read is self-gating, so a flag would add a config surface and a branch with nothing to protect.

**Why no trial limits.** `SdlService.generateManifestFrom` applies its trial rules (blocked GPU, GPU interconnect, `findTrialResourceViolation`) by returning `{ ok: false }` and never by touching the SDL or the manifest — so they gate a create rather than shape a manifest, and re-applying them here could refuse a lease over a rule the create it belongs to already cleared, against inputs (the blocked-model list, the trial CPU/memory ceilings) that move independently of the deployment. Byte-identity is unaffected either way.

## What

`LeaseManifestService.deriveFor({ userId, dseq })` returns the sorted-JSON manifest for a deployment's stored definition, or `null` when the console recorded nothing for it and a caller may fall back on a client-supplied manifest.

The read is scoped twice over — by `(userId, dseq)` and by the caller's own ability — following `DeploymentReaderService.findConsoleSettings`, so another user's dseq resolves to nothing recorded rather than to their manifest.

A definition that exists but will not re-derive is refused rather than fallen back on whenever it carries a Console Reference, because accepting a client's manifest for it would mean accepting a client-supplied secret value. A stored SDL that will not parse is refused too: only a definition that can be *shown* to carry no reference is eligible. Every refusal is a 500 naming no part of the definition (503 when the key service is unreachable, from the cipher), because a definition the console wrote and cannot read back is not something the caller can fix.

`SdlReferenceService.hasAnyReference` is what that decision reads. It reuses the existing walk rather than duplicating it, and counts a reserved `ac-` value as a reference, since it stands exactly where one stands.

`deriveFor` takes no `userId`. It reads `authService.currentUser.id` itself, because `openStored` authorizes nothing — `SecretCipherService.decrypt(userId, …)` unwraps whatever id it is handed, so a `userId` read back off the definition row would turn a row-lookup bug into a cross-tenant secret read. With no parameter there is nothing for a caller to get wrong, and two tests pin it.

Nothing calls `deriveFor` yet, so this PR changes no behaviour. It is covered against a real `SdlService` and a real `SdlReferenceService`, including the byte-identity regression net CON-867 asks for: two derivations from one stored definition must produce the same string.

### Mutation testing found four guards that could not fail — all four fixed

- **`LEASE_MANIFEST_DERIVED` was asserted nowhere**, on the one path where plaintext secrets exist. Logging every resolved value plus the whole manifest left all 21 tests green. Now pinned by exact object like the other two events, plus a case that fails if any resolved value reaches any log level.
- **Every trial branch was inert** (no GPU in the SDL; ceilings of zero, which `findTrialResourceViolation` early-returns on), so nothing defended the decision above. Both branches bite now: a blocked GPU model keyed `vendor/model` as `findBlockedGpus` expects, and ceilings the SDL exceeds. Hard-coding `isTrialing: true` fails 2 tests.
- **The denom rewrite is not pinnable by bytes** — the denom never reaches the manifest, and the expected value bypasses `SdlService`. Covered instead by a stored SDL priced in a denom the generator rejects: without the rewrite there is no manifest at all. Deleting `price.denom = deploymentGrantDenom` fails 1 test.
- **A row holding a token beside no `sdl`** fell back as `nothing-recorded`, accepting a client manifest for a deployment that has stored secrets. Unreachable while `upsertDefinition` is the sole writer of both columns, but the property now holds in `#findDefinition` rather than resting on that.

### Carried over from the PR1 review, non-blocking

- **No seal→open round trip through the real `SecretCipherService` yet.** Both sides are still tested against a mock asserting its own `{ sub, dseq }` literal. The next PR wires the lease path and can replace `test/functional/*`'s `openStoredToken` helpers — which duplicate that literal a third time — with `openStored`, buying the round trip and deleting the duplication together.
- **`parseSdlSecrets` stays in the unsealer's module** rather than moving beside `jsonEncodedBytes` in `sdl-secrets.config.ts`: it is a payload rule, not a size budget, and both callers already import `SdlSecrets` from that module. `decodeSecretsJson` stays split out for the same reason `positionOf` is in `sdl-for-storage.ts` — it isolates a `try/catch` whose only job is to turn a throw into a null.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deriving deployment lease manifests from stored deployment definitions and secrets.
  - Generated manifests are returned in a consistent, sorted format.
  - Added handling for environment values, registry credentials, reserved references, and authenticated access.
  - Unsafe or incomplete definitions now receive appropriate fallback responses or clear server errors.

- **Bug Fixes**
  - Improved secret handling, logging redaction, fallback behavior, and exchange-rate processing for manifest generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->