### PR TITLE
feat(bid): screen providers by CPU architecture

### DIFF
--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -50,12 +50,31 @@ const StorageResourceSchema = z
     }
   });
 
-const ResourceSchema = z.object({
-  id: z.number().int().openapi({ description: "Resource unit ID", example: 1 }),
-  cpu: z.object({
+// Mirrors CPU_ARCHITECTURES in apps/provider-inventory, which owns the screening this route proxies to.
+const CPU_ARCHITECTURES = ["amd64", "arm64"] as const;
+
+const CpuResourceSchema = z
+  .object({
     units: ResourceValueSchema,
     attributes: z.array(AttributeSchema).optional()
-  }),
+  })
+  .superRefine((cpu, ctx) => {
+    for (const attr of cpu.attributes ?? []) {
+      if (attr.key !== "arch") {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Unsupported CPU attribute "${attr.key}": "arch" is the only one`, path: ["attributes"] });
+      } else if (!CPU_ARCHITECTURES.some(architecture => architecture === attr.value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Unsupported CPU architecture "${attr.value}": expected ${CPU_ARCHITECTURES.join(" or ")}`,
+          path: ["attributes"]
+        });
+      }
+    }
+  });
+
+const ResourceSchema = z.object({
+  id: z.number().int().openapi({ description: "Resource unit ID", example: 1 }),
+  cpu: CpuResourceSchema,
   memory: z.object({
     quantity: ResourceValueSchema,
     attributes: z.array(AttributeSchema).optional()

--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -59,15 +59,21 @@ const CpuResourceSchema = z
     attributes: z.array(AttributeSchema).optional()
   })
   .superRefine((cpu, ctx) => {
+    let archSeen = false;
+
     for (const attr of cpu.attributes ?? []) {
       if (attr.key !== "arch") {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Unsupported CPU attribute "${attr.key}": "arch" is the only one`, path: ["attributes"] });
+      } else if (archSeen) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Duplicate CPU attribute "arch": a resource asks for one architecture`, path: ["attributes"] });
       } else if (!CPU_ARCHITECTURES.some(architecture => architecture === attr.value)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: `Unsupported CPU architecture "${attr.value}": expected ${CPU_ARCHITECTURES.join(" or ")}`,
           path: ["attributes"]
         });
+      } else {
+        archSeen = true;
       }
     }
   });

--- a/apps/provider-inventory/CONTEXT.md
+++ b/apps/provider-inventory/CONTEXT.md
@@ -63,11 +63,11 @@ The CPU architecture a **GroupSpec** asks for, carried as the `arch` attribute o
 _Avoid_: cpu arch attribute, platform
 
 **reported architecture**:
-The architecture a **node** says it runs, from `cpu.info[].arch` in the provider's inventory stream. Empty on nodes whose inventory operator predates architecture reporting. Beats the **declared architecture** whenever both exist.
+The architecture a **node** says it runs, from `cpu.info[].arch` in the provider's inventory stream. Empty on nodes whose inventory operator predates architecture reporting. Beats the **declared architecture** whenever both exist, and a value that is neither `amd64` nor `arm64` makes the node ineligible for every request rather than falling back.
 _Avoid_: observed arch, node arch
 
 **declared architecture**:
-The `hardware-cpu-arch` **self-attribute** (or **signed-attribute**) a provider writes about itself. Unverified, so it only stands in for nodes with no **reported architecture**, and is normalized on read because providers spell it by hand (`x86_64`, `aarch64`).
+The `hardware-cpu-arch` **self-attribute** (or **signed-attribute**) a provider writes about itself. Unverified, so it only stands in for nodes with no **reported architecture**, and is normalized on read because providers spell it by hand (`x86_64`, `aarch64`). Often not an architecture at all — mainnet declares `x86`, `x64-86`, `Zen 4`, `AMD EPYC-Rome` — so an unrecognized one counts as no declaration.
 _Avoid_: hardware-cpu-arch, advertised arch
 
 **glob attribute**:
@@ -160,6 +160,6 @@ _Avoid_: matcher, scheduler
 - **"snapshot"** was used for both the legacy historical row and the bid-screening current state. Resolved: legacy = **provider snapshot**, bid-screening = **provider inventory**.
 - **"online"** in `provider.isOnline` (legacy) means "passed the last 15-min HTTP probe". In `provider_inventory.is_online` it means "streamer has an open `streamStatus` channel and has received at least one message since reconnect". These will diverge intentionally.
 - **"attribute"** without qualifier is ambiguous. Always say **self-attribute** or **signed-attribute** — they are independent on-chain facts and the **prefilter** treats them differently.
-- **"architecture"** without qualifier is ambiguous, and the three senses disagree on purpose. **requested** comes from the deployment, **reported** from the node's inventory, **declared** from the provider's own attribute. Precedence is reported, then declared, then `amd64`.
+- **"architecture"** without qualifier is ambiguous, and the three senses disagree on purpose. **requested** comes from the deployment, **reported** from the node's inventory, **declared** from the provider's own attribute. Precedence is reported, then declared, then `amd64` — and only a **reported** value can take a node out of the running entirely.
 - **"available CPU"** vs **"max node free CPU"** — `total_available_cpu` is the cluster sum, used to filter on the GroupSpec total; `max_node_free_cpu` is the largest single-node free slice, used to filter on the largest replica. The first does not imply the second.
 - **"storage"** is overloaded. **Ephemeral storage** is per-node and disappears with the workload. **Persistent storage** is cluster-wide and survives. **RAM storage** is allocated against node memory. The three are tracked separately and flow through different rollup columns.

--- a/apps/provider-inventory/CONTEXT.md
+++ b/apps/provider-inventory/CONTEXT.md
@@ -58,6 +58,18 @@ A single instance of a service in a deployment. The **GroupSpec** lists resource
 **resource unit** / **group**:
 One entry in **GroupSpec.resources**. A set of resources (CPU, memory, GPU, storage) requested for `count` replicas. All replicas in the same unit share the same resource shape; replicas in different units may have different shapes.
 
+**requested architecture**:
+The CPU architecture a **GroupSpec** asks for, carried as the `arch` attribute on a resource's CPU. Exactly `amd64` or `arm64` — the SDL writes no implicit default, so a spec that names none is screened as `amd64` by the **bin-packer**, matching the provider bid engine. Anything else is a bad request, not an empty result.
+_Avoid_: cpu arch attribute, platform
+
+**reported architecture**:
+The architecture a **node** says it runs, from `cpu.info[].arch` in the provider's inventory stream. Empty on nodes whose inventory operator predates architecture reporting. Beats the **declared architecture** whenever both exist.
+_Avoid_: observed arch, node arch
+
+**declared architecture**:
+The `hardware-cpu-arch` **self-attribute** (or **signed-attribute**) a provider writes about itself. Unverified, so it only stands in for nodes with no **reported architecture**, and is normalized on read because providers spell it by hand (`x86_64`, `aarch64`).
+_Avoid_: hardware-cpu-arch, advertised arch
+
 **glob attribute**:
 A **GroupSpec.requirements.attributes** entry whose `key` contains `*` or `?`. Matched against provider attribute keys via PG regex (`~`). Works under SeqScan; not GIN-accelerated.
 
@@ -121,6 +133,7 @@ _Avoid_: matcher, scheduler
 - A **provider inventory** row carries `self_attributes` and `signed_attributes` (denormalised from chain queries; see `discovery loop`) plus `audited_by`.
 - Two **providers** with the same `hostUri` collapse into one stream connection (latest by `createdHeight` wins).
 - The **prefilter** reads only `provider_inventory`; the legacy `provider*` tables are not joined.
+- Architecture is checked by the **bin-packer** alone, never the **prefilter**: it needs per-node data, and an architecture-free request must screen exactly as it did before.
 - `apps/api` calls the **bid-screening proxy** for every `/v1/bid-screening` request; the proxy makes a single internal HTTP call to `apps/provider-inventory` and returns the response unchanged.
 - The legacy **provider snapshot** tables coexist; readers other than bid screening still use them.
 
@@ -147,5 +160,6 @@ _Avoid_: matcher, scheduler
 - **"snapshot"** was used for both the legacy historical row and the bid-screening current state. Resolved: legacy = **provider snapshot**, bid-screening = **provider inventory**.
 - **"online"** in `provider.isOnline` (legacy) means "passed the last 15-min HTTP probe". In `provider_inventory.is_online` it means "streamer has an open `streamStatus` channel and has received at least one message since reconnect". These will diverge intentionally.
 - **"attribute"** without qualifier is ambiguous. Always say **self-attribute** or **signed-attribute** — they are independent on-chain facts and the **prefilter** treats them differently.
+- **"architecture"** without qualifier is ambiguous, and the three senses disagree on purpose. **requested** comes from the deployment, **reported** from the node's inventory, **declared** from the provider's own attribute. Precedence is reported, then declared, then `amd64`.
 - **"available CPU"** vs **"max node free CPU"** — `total_available_cpu` is the cluster sum, used to filter on the GroupSpec total; `max_node_free_cpu` is the largest single-node free slice, used to filter on the largest replica. The first does not imply the second.
 - **"storage"** is overloaded. **Ephemeral storage** is per-node and disappears with the workload. **Persistent storage** is cluster-wide and survives. **RAM storage** is allocated against node memory. The three are tracked separately and flow through different rollup columns.

--- a/apps/provider-inventory/docs/resource-matching-acceptance-criteria.md
+++ b/apps/provider-inventory/docs/resource-matching-acceptance-criteria.md
@@ -326,6 +326,12 @@ served by whatever its provider declares in the `hardware-cpu-arch` attribute, a
 declares nothing either is treated as `amd64`, which is what every node predating architecture
 reporting runs.
 
+The two sources fail differently on a value neither `amd64` nor `arm64`. A *reported* one comes from
+the node's own inventory, so a node reporting `ppc64le` serves no request at all rather than being
+claimed as `amd64`. A *declared* one is hand-written and routinely is not an architecture — mainnet
+providers declare `x86`, `x64-86`, `Zen 4`, `AMD EPYC-Rome` — so an unrecognized declaration is
+treated as no declaration and the node falls back to `amd64`.
+
 Because the comparison happens per node, replicas of one resource unit never split across
 architectures, and a provider running both serves requests for either.
 
@@ -339,8 +345,10 @@ architectures, and a provider running both serves requests for either.
   `arm64` → skipped. Reported inventory always beats a self-declaration.
 - ✅ **Match (today's fleet):** No node reports an architecture and no provider declares one;
   request names none → every node is eligible, exactly as before architecture existed.
-- ❌ **Reject request:** `arch: sparc64`, or any CPU attribute other than `arch` → rejected as a
-  bad request rather than screened against nothing.
+- ❌ **Skip node:** Node reports `ppc64le` → skipped by every request, whatever its provider
+  declares.
+- ❌ **Reject request:** `arch: sparc64`, `arch` given twice, or any CPU attribute other than
+  `arch` → rejected as a bad request rather than screened against nothing.
 
 Spelling: a *requested* architecture must be exactly `amd64` or `arm64`, matching the SDL enum.
 *Reported* and *declared* values are normalized first, so `x86_64` reads as `amd64` and `aarch64`

--- a/apps/provider-inventory/docs/resource-matching-acceptance-criteria.md
+++ b/apps/provider-inventory/docs/resource-matching-acceptance-criteria.md
@@ -262,8 +262,9 @@ Kubernetes.
 
 ### AC17 — Check ordering and short-circuit
 **WHAT:** For each node, the engine checks resources in a fixed order and stops at the first
-failure: **CPU → GPU → Memory → Storage volumes (in declaration order)**.
+failure: **CPU architecture → CPU → GPU → Memory → Storage volumes (in declaration order)**.
 
+- A node of the wrong architecture (AC22) is never tested for any other dimension.
 - A node failing CPU is never tested for GPU / memory / storage on this replica.
 - A node failing GPU is never tested for memory / storage.
 - The first storage volume that fails determines the failure kind (node-level for ephemeral /
@@ -314,6 +315,37 @@ confirmed.
 
 ---
 
+### AC22 — CPU architecture matching
+**WHAT:** A replica is placed only on a node running the CPU architecture it asks for. The request
+carries it as the `arch` attribute on the resource's CPU, whose only accepted values are `amd64`
+and `arm64`. A request that names no architecture is treated as `amd64` — the SDL writes no
+implicit default, so this is the engine's default rather than the client's.
+**HOW:** Architecture is resolved per node and compared before any capacity check. A node reports
+its architecture in `cpu.info[].arch`; the first entry is authoritative. A node reporting none is
+served by whatever its provider declares in the `hardware-cpu-arch` attribute, and a provider that
+declares nothing either is treated as `amd64`, which is what every node predating architecture
+reporting runs.
+
+Because the comparison happens per node, replicas of one resource unit never split across
+architectures, and a provider running both serves requests for either.
+
+- ✅ **Match:** Node reports `arm64`; request asks for `arm64` → placed.
+- ❌ **Skip node:** Node reports `amd64`; request asks for `arm64` → skipped; try next node.
+- ❌ **Skip node:** Node reports `arm64`; request names no architecture → skipped, since the
+  request means `amd64`.
+- ✅ **Match (declared stand-in):** Node reports no architecture, provider declares
+  `hardware-cpu-arch: arm64`; request asks for `arm64` → placed.
+- ❌ **Skip node:** Node reports `amd64` while its provider declares `arm64`; request asks for
+  `arm64` → skipped. Reported inventory always beats a self-declaration.
+- ✅ **Match (today's fleet):** No node reports an architecture and no provider declares one;
+  request names none → every node is eligible, exactly as before architecture existed.
+- ❌ **Reject request:** `arch: sparc64`, or any CPU attribute other than `arch` → rejected as a
+  bad request rather than screened against nothing.
+
+Spelling: a *requested* architecture must be exactly `amd64` or `arm64`, matching the SDL enum.
+*Reported* and *declared* values are normalized first, so `x86_64` reads as `amd64` and `aarch64`
+as `arm64`.
+
 ## Worked Example — Mixed GPU Cluster, 3 Replicas
 
 **Cluster:**
@@ -352,6 +384,7 @@ Variations:
 - Main entry point: [Adjust](../cluster/kube/operators/clients/inventory/inventory.go#L214)
 - Per-replica placement: [tryAdjust](../cluster/kube/operators/clients/inventory/inventory.go#L46)
 - GPU matching: [tryAdjustGPU](../cluster/kube/operators/clients/inventory/inventory.go#L125)
+- CPU architecture matching: [tryAdjustCPU](https://github.com/akash-network/provider/pull/433)
 - Attribute parsing: [ParseGPUAttributes / ParseStorageAttributes](../cluster/types/v1beta3/clients/inventory/metrics.go)
 - Interface normalization: [FilterGPUInterface](../cluster/types/v1beta3/types.go#L160)
 - Test fixtures (4-node CPU example): [client_test.go:609-704](../cluster/kube/operators/clients/inventory/client_test.go#L609-L704)

--- a/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.spec.ts
+++ b/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.spec.ts
@@ -77,6 +77,12 @@ describe(isEqualClusterState.name, () => {
       expect(isEqualClusterState(a, b)).toBe(false);
     });
 
+    it("returns false when a node's reported CPU architecture changes", () => {
+      const a = buildCluster({ nodes: [buildNode({ cpus: [{ vendor: "ampere", model: "altra", arch: "" }] })] });
+      const b = buildCluster({ nodes: [buildNode({ cpus: [{ vendor: "ampere", model: "altra", arch: "arm64" }] })] });
+      expect(isEqualClusterState(a, b)).toBe(false);
+    });
+
     it("returns false when a node's storageClasses differ", () => {
       const a = buildCluster({ nodes: [buildNode({ storageClasses: ["beta2"] })] });
       const b = buildCluster({ nodes: [buildNode({ storageClasses: ["beta3"] })] });

--- a/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.ts
+++ b/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.ts
@@ -63,7 +63,7 @@ function cpuInfoEqual(a: readonly CpuInfo[], b: readonly CpuInfo[]): boolean {
   if (a.length !== b.length) return false;
 
   for (let i = 0; i < a.length; i++) {
-    const match = b.some(c => c.vendor === a[i].vendor && c.model === a[i].model);
+    const match = b.some(c => c.vendor === a[i].vendor && c.model === a[i].model && c.arch === a[i].arch);
     if (!match) return false;
   }
   return true;

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.spec.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { BidScreeningRequestSchema } from "./bid-screening.schema";
+
+describe("BidScreeningRequestSchema", () => {
+  it("accepts a request that declares no CPU attributes", () => {
+    const result = BidScreeningRequestSchema.safeParse(buildRequest());
+
+    expect(result.success).toBe(true);
+  });
+
+  it.each(["amd64", "arm64"])("accepts %s as a requested CPU architecture", value => {
+    const result = BidScreeningRequestSchema.safeParse(buildRequest([{ key: "arch", value }]));
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an architecture outside the SDL enum", () => {
+    const result = BidScreeningRequestSchema.safeParse(buildRequest([{ key: "arch", value: "sparc64" }]));
+
+    expect(result.success).toBe(false);
+    expect((result as { error: { issues: unknown[] } }).error.issues).toContainEqual(
+      expect.objectContaining({ message: 'Unsupported CPU architecture "sparc64": expected amd64 or arm64' })
+    );
+  });
+
+  it("rejects a CPU attribute key other than arch", () => {
+    const result = BidScreeningRequestSchema.safeParse(buildRequest([{ key: "vendor", value: "intel" }]));
+
+    expect(result.success).toBe(false);
+    expect((result as { error: { issues: unknown[] } }).error.issues).toContainEqual(
+      expect.objectContaining({ message: 'Unsupported CPU attribute "vendor": "arch" is the only one' })
+    );
+  });
+
+  function buildRequest(cpuAttributes?: { key: string; value: string }[]) {
+    return {
+      timezone: "America/Chicago",
+      requirements: { signedBy: { allOf: [], anyOf: [] }, attributes: [] },
+      resources: [
+        {
+          resource: {
+            id: 1,
+            cpu: { units: { val: "1000" }, attributes: cpuAttributes },
+            memory: { quantity: { val: "1073741824" } },
+            gpu: { units: { val: "0" } },
+            storage: [{ name: "default", quantity: { val: "5368709120" }, attributes: [{ key: "persistent", value: "false" }] }],
+            endpoints: []
+          },
+          count: 1,
+          price: { denom: "uakt", amount: "1000" }
+        }
+      ]
+    };
+  }
+});

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.spec.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.spec.ts
@@ -33,6 +33,20 @@ describe("BidScreeningRequestSchema", () => {
     );
   });
 
+  it("rejects a request asking for two architectures at once", () => {
+    const result = BidScreeningRequestSchema.safeParse(
+      buildRequest([
+        { key: "arch", value: "amd64" },
+        { key: "arch", value: "arm64" }
+      ])
+    );
+
+    expect(result.success).toBe(false);
+    expect((result as { error: { issues: unknown[] } }).error.issues).toContainEqual(
+      expect.objectContaining({ message: 'Duplicate CPU attribute "arch": a resource asks for one architecture' })
+    );
+  });
+
   function buildRequest(cpuAttributes?: { key: string; value: string }[]) {
     return {
       timezone: "America/Chicago",

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -1,5 +1,7 @@
 import { z } from "@hono/zod-openapi";
 
+import { CPU_ARCHITECTURES } from "@src/mappers/cpu-attribute-parser/cpu-attribute-parser";
+
 const UIntStringSchema = z.string().regex(/^\d+$/, "Must be an unsigned integer string");
 
 const ResourceValueSchema = z.object({
@@ -50,12 +52,28 @@ const StorageResourceSchema = z
     }
   });
 
-const ResourceSchema = z.object({
-  id: z.number().int().openapi({ description: "Resource unit ID", example: 1 }),
-  cpu: z.object({
+const CpuResourceSchema = z
+  .object({
     units: ResourceValueSchema,
     attributes: z.array(AttributeSchema).optional()
-  }),
+  })
+  .superRefine((cpu, ctx) => {
+    for (const attr of cpu.attributes ?? []) {
+      if (attr.key !== "arch") {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Unsupported CPU attribute "${attr.key}": "arch" is the only one`, path: ["attributes"] });
+      } else if (!CPU_ARCHITECTURES.some(architecture => architecture === attr.value)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Unsupported CPU architecture "${attr.value}": expected ${CPU_ARCHITECTURES.join(" or ")}`,
+          path: ["attributes"]
+        });
+      }
+    }
+  });
+
+const ResourceSchema = z.object({
+  id: z.number().int().openapi({ description: "Resource unit ID", example: 1 }),
+  cpu: CpuResourceSchema,
   memory: z.object({
     quantity: ResourceValueSchema,
     attributes: z.array(AttributeSchema).optional()

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -58,15 +58,21 @@ const CpuResourceSchema = z
     attributes: z.array(AttributeSchema).optional()
   })
   .superRefine((cpu, ctx) => {
+    let archSeen = false;
+
     for (const attr of cpu.attributes ?? []) {
       if (attr.key !== "arch") {
         ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Unsupported CPU attribute "${attr.key}": "arch" is the only one`, path: ["attributes"] });
+      } else if (archSeen) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `Duplicate CPU attribute "arch": a resource asks for one architecture`, path: ["attributes"] });
       } else if (!CPU_ARCHITECTURES.some(architecture => architecture === attr.value)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: `Unsupported CPU architecture "${attr.value}": expected ${CPU_ARCHITECTURES.join(" or ")}`,
           path: ["attributes"]
         });
+      } else {
+        archSeen = true;
       }
     }
   });

--- a/apps/provider-inventory/src/mappers/cpu-attribute-parser/cpu-attribute-parser.spec.ts
+++ b/apps/provider-inventory/src/mappers/cpu-attribute-parser/cpu-attribute-parser.spec.ts
@@ -23,6 +23,15 @@ describe(parseCPUAttributes.name, () => {
   it("rejects an attribute key other than arch", () => {
     expect(() => parseCPUAttributes([{ key: "vendor", value: "intel" }])).toThrow('Unsupported CPU attribute "vendor"');
   });
+
+  it("rejects a request asking for two architectures at once", () => {
+    expect(() =>
+      parseCPUAttributes([
+        { key: "arch", value: "amd64" },
+        { key: "arch", value: "arm64" }
+      ])
+    ).toThrow('Duplicate CPU attribute "arch"');
+  });
 });
 
 describe(normalizeCpuArch.name, () => {
@@ -65,8 +74,16 @@ describe(resolveNodeCpuArch.name, () => {
     expect(resolveNodeCpuArch([], null)).toBe("amd64");
   });
 
-  it("defaults to amd64 when the declared architecture is unrecognized", () => {
+  it("defaults to amd64 when the declared architecture is unrecognized, since providers spell it by hand", () => {
     expect(resolveNodeCpuArch([], "sparc64")).toBe("amd64");
+  });
+
+  it("resolves to no architecture when the node reports one nothing can request", () => {
+    expect(resolveNodeCpuArch([cpuInfo("ppc64le")], null)).toBeNull();
+  });
+
+  it("resolves to no architecture even when the provider declares a supported one", () => {
+    expect(resolveNodeCpuArch([cpuInfo("ppc64le")], "amd64")).toBeNull();
   });
 
   it("reads the first CPU entry, which is the one the provider bid engine checks", () => {

--- a/apps/provider-inventory/src/mappers/cpu-attribute-parser/cpu-attribute-parser.spec.ts
+++ b/apps/provider-inventory/src/mappers/cpu-attribute-parser/cpu-attribute-parser.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import type { CpuInfo } from "../../types/inventory";
+import { normalizeCpuArch, parseCPUAttributes, resolveNodeCpuArch } from "./cpu-attribute-parser";
+
+describe(parseCPUAttributes.name, () => {
+  it("returns a null architecture when no attributes are declared", () => {
+    expect(parseCPUAttributes([]).arch).toBeNull();
+  });
+
+  it.each(["amd64", "arm64"])("reads %s off the arch attribute", value => {
+    expect(parseCPUAttributes([{ key: "arch", value }]).arch).toBe(value);
+  });
+
+  it("rejects an architecture outside the SDL enum", () => {
+    expect(() => parseCPUAttributes([{ key: "arch", value: "sparc64" }])).toThrow('Unsupported CPU architecture "sparc64"');
+  });
+
+  it("rejects the alias spellings a node may report, since a request must be exact", () => {
+    expect(() => parseCPUAttributes([{ key: "arch", value: "aarch64" }])).toThrow('Unsupported CPU architecture "aarch64"');
+  });
+
+  it("rejects an attribute key other than arch", () => {
+    expect(() => parseCPUAttributes([{ key: "vendor", value: "intel" }])).toThrow('Unsupported CPU attribute "vendor"');
+  });
+});
+
+describe(normalizeCpuArch.name, () => {
+  it.each([
+    ["amd64", "amd64"],
+    ["x86_64", "amd64"],
+    ["x86-64", "amd64"],
+    ["X86_64", "amd64"],
+    ["  amd64 ", "amd64"],
+    ["arm64", "arm64"],
+    ["aarch64", "arm64"],
+    ["AArch64", "arm64"]
+  ])("normalizes %s to %s", (reported, expected) => {
+    expect(normalizeCpuArch(reported)).toBe(expected);
+  });
+
+  it.each([["sparc64"], [""], [null], [undefined]])("returns null for %s", reported => {
+    expect(normalizeCpuArch(reported)).toBeNull();
+  });
+});
+
+describe(resolveNodeCpuArch.name, () => {
+  it("prefers what the node reports over what the provider declares", () => {
+    expect(resolveNodeCpuArch([cpuInfo("arm64")], "amd64")).toBe("arm64");
+  });
+
+  it("falls back to the declared architecture when the node reports none", () => {
+    expect(resolveNodeCpuArch([cpuInfo("")], "arm64")).toBe("arm64");
+  });
+
+  it("falls back to the declared architecture when the node reports no CPUs at all", () => {
+    expect(resolveNodeCpuArch([], "arm64")).toBe("arm64");
+  });
+
+  it("normalizes a declared architecture, which providers write by hand", () => {
+    expect(resolveNodeCpuArch([], "aarch64")).toBe("arm64");
+  });
+
+  it("defaults to amd64 when neither the node nor the provider says anything", () => {
+    expect(resolveNodeCpuArch([], null)).toBe("amd64");
+  });
+
+  it("defaults to amd64 when the declared architecture is unrecognized", () => {
+    expect(resolveNodeCpuArch([], "sparc64")).toBe("amd64");
+  });
+
+  it("reads the first CPU entry, which is the one the provider bid engine checks", () => {
+    expect(resolveNodeCpuArch([cpuInfo("arm64"), cpuInfo("amd64")], null)).toBe("arm64");
+  });
+
+  function cpuInfo(arch: string): CpuInfo {
+    return { vendor: "ampere", model: "altra", arch };
+  }
+});

--- a/apps/provider-inventory/src/mappers/cpu-attribute-parser/cpu-attribute-parser.ts
+++ b/apps/provider-inventory/src/mappers/cpu-attribute-parser/cpu-attribute-parser.ts
@@ -1,0 +1,57 @@
+import type { CpuInfo, ResourceAttribute } from "../../types/inventory";
+
+export const CPU_ARCHITECTURES = ["amd64", "arm64"] as const;
+
+export type CpuArch = (typeof CPU_ARCHITECTURES)[number];
+
+/** The architecture a request that names none is screened as, matching the default the provider bid engine applies. */
+export const DEFAULT_CPU_ARCH: CpuArch = "amd64";
+
+const ARCH_ALIASES: Record<string, CpuArch> = {
+  amd64: "amd64",
+  x86_64: "amd64",
+  "x86-64": "amd64",
+  arm64: "arm64",
+  aarch64: "arm64"
+};
+
+export interface ParsedCPUAttributes {
+  arch: CpuArch | null;
+}
+
+/**
+ * Reads a requested architecture off a group spec's CPU attributes, rejecting anything the SDL schema
+ * would not have produced so a request no provider could serve fails loudly instead of matching nothing.
+ */
+export function parseCPUAttributes(attributes: ResourceAttribute[]): ParsedCPUAttributes {
+  let arch: CpuArch | null = null;
+
+  for (const attr of attributes) {
+    if (attr.key !== "arch") {
+      throw new Error(`Unsupported CPU attribute "${attr.key}"`);
+    }
+
+    const requested = CPU_ARCHITECTURES.find(candidate => candidate === attr.value);
+    if (!requested) {
+      throw new Error(`Unsupported CPU architecture "${attr.value}"`);
+    }
+
+    arch = requested;
+  }
+
+  return { arch };
+}
+
+/** Accepts the spellings inventory and provider attributes use in the wild, unlike a requested architecture which must be exact. */
+export function normalizeCpuArch(arch: string | null | undefined): CpuArch | null {
+  if (!arch) return null;
+  return ARCH_ALIASES[arch.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * The architecture a node runs: what its inventory reports, else what its provider declares on chain,
+ * else amd64 — every node predating architecture reporting runs it.
+ */
+export function resolveNodeCpuArch(cpus: readonly CpuInfo[], declaredArch: string | null): CpuArch {
+  return normalizeCpuArch(cpus[0]?.arch) ?? normalizeCpuArch(declaredArch) ?? DEFAULT_CPU_ARCH;
+}

--- a/apps/provider-inventory/src/mappers/cpu-attribute-parser/cpu-attribute-parser.ts
+++ b/apps/provider-inventory/src/mappers/cpu-attribute-parser/cpu-attribute-parser.ts
@@ -19,16 +19,17 @@ export interface ParsedCPUAttributes {
   arch: CpuArch | null;
 }
 
-/**
- * Reads a requested architecture off a group spec's CPU attributes, rejecting anything the SDL schema
- * would not have produced so a request no provider could serve fails loudly instead of matching nothing.
- */
+/** Rejects anything the SDL schema would not have produced, so a request no provider could serve fails loudly instead of matching nothing. */
 export function parseCPUAttributes(attributes: ResourceAttribute[]): ParsedCPUAttributes {
   let arch: CpuArch | null = null;
 
   for (const attr of attributes) {
     if (attr.key !== "arch") {
       throw new Error(`Unsupported CPU attribute "${attr.key}"`);
+    }
+
+    if (arch) {
+      throw new Error(`Duplicate CPU attribute "arch"`);
     }
 
     const requested = CPU_ARCHITECTURES.find(candidate => candidate === attr.value);
@@ -48,10 +49,10 @@ export function normalizeCpuArch(arch: string | null | undefined): CpuArch | nul
   return ARCH_ALIASES[arch.trim().toLowerCase()] ?? null;
 }
 
-/**
- * The architecture a node runs: what its inventory reports, else what its provider declares on chain,
- * else amd64 — every node predating architecture reporting runs it.
- */
-export function resolveNodeCpuArch(cpus: readonly CpuInfo[], declaredArch: string | null): CpuArch {
-  return normalizeCpuArch(cpus[0]?.arch) ?? normalizeCpuArch(declaredArch) ?? DEFAULT_CPU_ARCH;
+/** Null when a node reports an architecture no request can name, since such a node serves neither amd64 nor arm64. */
+export function resolveNodeCpuArch(cpus: readonly CpuInfo[], declaredArch: string | null): CpuArch | null {
+  const reported = cpus[0]?.arch;
+  if (reported) return normalizeCpuArch(reported);
+
+  return normalizeCpuArch(declaredArch) ?? DEFAULT_CPU_ARCH;
 }

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.spec.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.spec.ts
@@ -30,19 +30,18 @@ describe(mapGroupSpecToResourceUnits.name, () => {
     ]);
   });
 
-  it("returns null CPU fingerprint when no attributes are declared", () => {
+  it("returns a null CPU architecture when no attributes are declared", () => {
     const { units } = setup({});
-    expect(units[0].resources.cpu.fingerprint).toBeNull();
+    expect(units[0].resources.cpu.arch).toBeNull();
   });
 
-  it("computes a stable CPU fingerprint from sorted key=value attributes", () => {
-    const { units } = setup({
-      cpuAttributes: [
-        { key: "arch", value: "amd64" },
-        { key: "family", value: "epyc" }
-      ]
-    });
-    expect(units[0].resources.cpu.fingerprint).toBe("arch=amd64,family=epyc");
+  it("reads the requested CPU architecture off the arch attribute", () => {
+    const { units } = setup({ cpuAttributes: [{ key: "arch", value: "arm64" }] });
+    expect(units[0].resources.cpu.arch).toBe("arm64");
+  });
+
+  it("rejects a CPU attribute the SDL schema would not have produced", () => {
+    expect(() => setup({ cpuAttributes: [{ key: "family", value: "epyc" }] })).toThrow('Unsupported CPU attribute "family"');
   });
 
   it("returns an empty GPU parsedSpecs array when no GPU attributes are declared", () => {

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -1,6 +1,7 @@
 import type { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 
-import type { RequestedResourceUnit, RequestedStorage, ResourceAttribute, ToJSON } from "../../types/inventory";
+import type { RequestedResourceUnit, RequestedStorage, ToJSON } from "../../types/inventory";
+import { parseCPUAttributes } from "../cpu-attribute-parser/cpu-attribute-parser";
 import { parseGPUAttributes } from "../gpu-attribute-parser/gpu-attribute-parser";
 import { parseStorageAttributes } from "../storage-attribute-parser/storage-attribute-parser";
 
@@ -13,7 +14,7 @@ export function mapGroupSpecToResourceUnits(request: Omit<GroupSpecJSON, "name">
       resources: {
         cpu: {
           units: resource.cpu.units.val,
-          fingerprint: getAttributeFingerprint(resource.cpu.attributes)
+          arch: parseCPUAttributes(resource.cpu.attributes ?? []).arch
         },
         gpu: {
           units: resource.gpu.units.val,
@@ -35,14 +36,6 @@ export function mapGroupSpecToResourceUnits(request: Omit<GroupSpecJSON, "name">
       count: unit.count
     };
   });
-}
-
-export function getAttributeFingerprint(attributes: ResourceAttribute[] | undefined): string | null {
-  if (!attributes || attributes.length === 0) return null;
-  return attributes
-    .map(a => `${a.key}=${a.value}`)
-    .sort()
-    .join(",");
 }
 
 export type GroupSpecJSON = ToJSON<GroupSpec>;

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.aggregator.spec.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.aggregator.spec.ts
@@ -462,7 +462,7 @@ function makeUnit(input: {
     id: 1,
     count: input.count ?? 1,
     resources: {
-      cpu: { units: input.cpu ?? 0n, fingerprint: null },
+      cpu: { units: input.cpu ?? 0n, arch: null },
       memory: { quantity: input.memory ?? 0n },
       gpu: { units: input.gpu ?? 0n, attributes: parseGPUAttributes(input.gpuAttributes ?? []) },
       storage: (input.storage ?? []).map(s => ({ name: s.name, quantity: s.quantity, attributes: parseStorageAttributes(s.attributes) })),

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.integration.ts
@@ -258,6 +258,40 @@ describe(BidScreeningRepository.name, () => {
     });
   });
 
+  describe("declared CPU architecture projection", () => {
+    it("prefers hardware-cpu-arch from signed_attributes when both sets define it", async () => {
+      await seed({
+        owner: "akash1signedarch",
+        selfAttributes: [{ key: "hardware-cpu-arch", value: "amd64" }],
+        signedAttributes: [{ key: "hardware-cpu-arch", value: "arm64", auditor: AUDITOR }]
+      });
+
+      const [row] = await repository.findCandidates([unit({})], requirements());
+
+      expect(row.declaredCpuArch).toBe("arm64");
+    });
+
+    it("falls back to self_attributes when signed_attributes has no hardware-cpu-arch", async () => {
+      await seed({
+        owner: "akash1selfarch",
+        selfAttributes: [{ key: "hardware-cpu-arch", value: "arm64" }],
+        signedAttributes: [{ key: "country", value: "us", auditor: AUDITOR }]
+      });
+
+      const [row] = await repository.findCandidates([unit({})], requirements());
+
+      expect(row.declaredCpuArch).toBe("arm64");
+    });
+
+    it("returns null when neither attribute set defines hardware-cpu-arch", async () => {
+      await seed({ owner: "akash1noarch", selfAttributes: [{ key: "country", value: "us" }] });
+
+      const [row] = await repository.findCandidates([unit({})], requirements());
+
+      expect(row.declaredCpuArch).toBeNull();
+    });
+  });
+
   describe("gpu_models filter", () => {
     it("vendor-only request matches mixed-model providers via the vendor token", async () => {
       await seed({ owner: "akash1nvidiaA100", gpuModels: ["nvidia", "nvidia/a100"], totalAvailableGpu: 8n, maxNodeFreeGpu: 8n });
@@ -662,7 +696,7 @@ function unit(input: {
     id: 1,
     count: input.count ?? 1,
     resources: {
-      cpu: { units: input.cpu ?? 0n, fingerprint: null },
+      cpu: { units: input.cpu ?? 0n, arch: null },
       memory: { quantity: input.memory ?? 0n },
       gpu: { units: input.gpu ?? 0n, attributes: parseGPUAttributes(input.gpuAttributes ?? []) },
       storage: (input.storage ?? []).map(s => ({ name: s.name, quantity: s.quantity, attributes: parseStorageAttributes(s.attributes) })),

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
@@ -17,6 +17,8 @@ export interface BidScreeningCandidate {
   updatedAt: string;
   location: string | null;
   organization: string | null;
+  /** Self-declared CPU architecture, used for nodes whose inventory reports none. */
+  declaredCpuArch: string | null;
 }
 
 const TABLE = getTableName(providerInventory);
@@ -76,7 +78,11 @@ export class BidScreeningRepository {
           COALESCE(
             (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.signedAttributes.name)}) AS sa WHERE sa->>'key' = 'organization' LIMIT 1),
             (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.selfAttributes.name)}) AS sa WHERE sa->>'key' = 'organization' LIMIT 1)
-          ) AS organization
+          ) AS organization,
+          COALESCE(
+            (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.signedAttributes.name)}) AS sa WHERE sa->>'key' = 'hardware-cpu-arch' LIMIT 1),
+            (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.selfAttributes.name)}) AS sa WHERE sa->>'key' = 'hardware-cpu-arch' LIMIT 1)
+          ) AS "declaredCpuArch"
         FROM ${sql(TABLE)}
         WHERE ${sql(providerInventory.owner.name)} = ANY(${ownersToFetch}::text[])
       `;

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
@@ -69,7 +69,18 @@ describe(BidScreeningService.name, () => {
 
       await service.findMatchingProviders(makeRequest());
 
-      expect(matcher.match).toHaveBeenCalledWith(candidate.cluster, expect.any(Array));
+      expect(matcher.match).toHaveBeenCalledWith(candidate.cluster, expect.any(Array), { declaredCpuArch: null });
+    });
+
+    it("passes the candidate's declared CPU architecture to the matcher", async () => {
+      const { service, repository, matcher } = setup();
+      const candidate = makeCandidate("akash1abc", { declaredCpuArch: "arm64" });
+      repository.findCandidates.mockResolvedValue([candidate]);
+      matcher.match.mockReturnValue({ matched: true });
+
+      await service.findMatchingProviders(makeRequest());
+
+      expect(matcher.match).toHaveBeenCalledWith(candidate.cluster, expect.any(Array), { declaredCpuArch: "arm64" });
     });
 
     it("returns empty array when no candidates are returned", async () => {
@@ -247,7 +258,7 @@ function makeDowntimeRow(provider: string, overrides?: Partial<DailyDowntimeRow>
 
 function makeCandidate(
   owner: string,
-  overrides?: { isAudited?: boolean; createdAt?: string; location?: string | null; organization?: string | null }
+  overrides?: { isAudited?: boolean; createdAt?: string; location?: string | null; organization?: string | null; declaredCpuArch?: string | null }
 ): BidScreeningCandidate {
   return {
     owner,
@@ -257,6 +268,7 @@ function makeCandidate(
     updatedAt: "2026-01-01T00:00:00.000Z",
     location: overrides?.location ?? null,
     organization: overrides?.organization ?? null,
+    declaredCpuArch: overrides?.declaredCpuArch ?? null,
     cluster: {
       nodes: [
         {

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
@@ -90,7 +90,7 @@ export class BidScreeningService {
     const matched: BidScreeningCandidate[] = [];
 
     for (const candidate of candidates) {
-      const matchResult = this.#matcher.match(candidate.cluster, resourceUnits);
+      const matchResult = this.#matcher.match(candidate.cluster, resourceUnits, { declaredCpuArch: candidate.declaredCpuArch });
 
       if (matchResult.matched) {
         matched.push(candidate);

--- a/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.spec.ts
+++ b/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.spec.ts
@@ -1110,6 +1110,15 @@ describe(ClusterInventoryMatcherService.name, () => {
       expect(service.match(cluster, archUnits("arm64"), { declaredCpuArch: "arm64" }).matched).toBe(false);
     });
 
+    it("excludes a node reporting an architecture no request can name", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([{ ...roomyNode, cpus: [cpuInfo("ppc64le")] }]);
+
+      expect(service.match(cluster, archUnits("amd64")).matched).toBe(false);
+      expect(service.match(cluster, archUnits(null)).matched).toBe(false);
+      expect(service.match(cluster, archUnits("arm64"), { declaredCpuArch: "arm64" }).matched).toBe(false);
+    });
+
     it("treats a provider that says nothing at all as amd64", () => {
       const service = new ClusterInventoryMatcherService();
       const cluster = makeCluster([roomyNode]);

--- a/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.spec.ts
+++ b/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { parseCPUAttributes } from "@src/mappers/cpu-attribute-parser/cpu-attribute-parser";
 import { parseGPUAttributes } from "@src/mappers/gpu-attribute-parser/gpu-attribute-parser";
-import { getAttributeFingerprint } from "@src/mappers/groupspec-mapper/groupspec-mapper";
 import { parseStorageAttributes } from "@src/mappers/storage-attribute-parser/storage-attribute-parser";
 import type { ClusterState, CpuInfo, GpuInfo, NodeState, RequestedResourceUnit, ResourceAttribute } from "../../types/inventory";
 import { ClusterInventoryMatcherService } from "./cluster-inventory-matcher.service";
@@ -749,30 +749,30 @@ describe(ClusterInventoryMatcherService.name, () => {
       expect(service.match(cluster, [wildcardService, h100Service]).matched).toBe(true);
     });
 
-    it("places two services with different non-empty CPU fingerprints independently", () => {
+    it("places two services requesting different architectures independently", () => {
       const service = new ClusterInventoryMatcherService();
       const cluster = makeCluster([
-        { cpu: 8000n, memory: 17179869184n, ephemeral: 107374182400n },
-        { cpu: 8000n, memory: 17179869184n, ephemeral: 107374182400n }
+        { cpu: 8000n, memory: 17179869184n, ephemeral: 107374182400n, cpus: [cpuInfo("amd64")] },
+        { cpu: 8000n, memory: 17179869184n, ephemeral: 107374182400n, cpus: [cpuInfo("arm64")] }
       ]);
-      const intelService = buildResourceUnit({
+      const amdService = buildResourceUnit({
         id: 1,
         cpu: 1000n,
-        cpuAttributes: [{ key: "vendor", value: "intel" }],
+        cpuAttributes: [{ key: "arch", value: "amd64" }],
         memory: 1073741824n,
         storage: [{ name: "default", quantity: 1073741824n, attributes: [{ key: "persistent", value: "false" }] }],
         count: 1
       });
-      const amdService = buildResourceUnit({
+      const armService = buildResourceUnit({
         id: 2,
         cpu: 1000n,
-        cpuAttributes: [{ key: "vendor", value: "amd" }],
+        cpuAttributes: [{ key: "arch", value: "arm64" }],
         memory: 1073741824n,
         storage: [{ name: "default", quantity: 1073741824n, attributes: [{ key: "persistent", value: "false" }] }],
         count: 1
       });
 
-      const result = service.match(cluster, [intelService, amdService]);
+      const result = service.match(cluster, [amdService, armService]);
       expect(result.matched).toBe(true);
       expect(result.error).toBeUndefined();
     });
@@ -1039,6 +1039,86 @@ describe(ClusterInventoryMatcherService.name, () => {
     });
   });
 
+  describe("CPU architecture matching", () => {
+    it("matches a cluster reporting no architecture, as every provider does before the operator upgrade", () => {
+      const { service, cluster, resourceUnits } = setup({});
+      expect(service.match(cluster, resourceUnits).matched).toBe(true);
+    });
+
+    it("excludes an amd64-only provider from an arm64 request", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([{ ...roomyNode, cpus: [cpuInfo("amd64")] }]);
+
+      expect(service.match(cluster, archUnits("arm64")).matched).toBe(false);
+    });
+
+    it("excludes an arm64-only provider from an amd64 request", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([{ ...roomyNode, cpus: [cpuInfo("arm64")] }]);
+
+      expect(service.match(cluster, archUnits("amd64")).matched).toBe(false);
+    });
+
+    it("excludes an arm64-only provider from a request naming no architecture", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([{ ...roomyNode, cpus: [cpuInfo("arm64")] }]);
+
+      expect(service.match(cluster, archUnits(null)).matched).toBe(false);
+    });
+
+    it("serves both architectures from a mixed provider", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([
+        { ...roomyNode, cpus: [cpuInfo("amd64")] },
+        { ...roomyNode, cpus: [cpuInfo("arm64")] }
+      ]);
+
+      expect(service.match(cluster, archUnits("amd64")).matched).toBe(true);
+      expect(service.match(cluster, archUnits("arm64")).matched).toBe(true);
+    });
+
+    it("places replicas of one unit only on nodes of the requested architecture", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([
+        { cpu: 2000n, memory: 17179869184n, ephemeral: 107374182400n, cpus: [cpuInfo("arm64")] },
+        { cpu: 8000n, memory: 17179869184n, ephemeral: 107374182400n, cpus: [cpuInfo("amd64")] }
+      ]);
+
+      expect(service.match(cluster, archUnits("arm64", 2)).matched).toBe(true);
+      expect(service.match(cluster, archUnits("arm64", 3)).matched).toBe(false);
+    });
+
+    it("falls back to the declared architecture when the node reports none", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([roomyNode]);
+
+      expect(service.match(cluster, archUnits("arm64"), { declaredCpuArch: "arm64" }).matched).toBe(true);
+    });
+
+    it("normalizes a declared architecture written the way a provider spells it", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([roomyNode]);
+
+      expect(service.match(cluster, archUnits("amd64"), { declaredCpuArch: "x86_64" }).matched).toBe(true);
+      expect(service.match(cluster, archUnits("arm64"), { declaredCpuArch: "x86_64" }).matched).toBe(false);
+    });
+
+    it("ignores a declared architecture the node's own inventory contradicts", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([{ ...roomyNode, cpus: [cpuInfo("amd64")] }]);
+
+      expect(service.match(cluster, archUnits("arm64"), { declaredCpuArch: "arm64" }).matched).toBe(false);
+    });
+
+    it("treats a provider that says nothing at all as amd64", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([roomyNode]);
+
+      expect(service.match(cluster, archUnits("amd64"), { declaredCpuArch: null }).matched).toBe(true);
+      expect(service.match(cluster, archUnits("arm64"), { declaredCpuArch: null }).matched).toBe(false);
+    });
+  });
+
   describe("input immutability", () => {
     it("does not mutate the cluster argument on a successful match", () => {
       const service = new ClusterInventoryMatcherService();
@@ -1113,6 +1193,25 @@ describe(ClusterInventoryMatcherService.name, () => {
     return { service, cluster, resourceUnits };
   }
 });
+
+const roomyNode = { cpu: 8000n, memory: 17179869184n, ephemeral: 107374182400n };
+
+function cpuInfo(arch: string): CpuInfo {
+  return { vendor: "vendor", model: "model", arch };
+}
+
+function archUnits(arch: string | null, count = 1): RequestedResourceUnit[] {
+  return [
+    buildResourceUnit({
+      id: 1,
+      cpu: 1000n,
+      cpuAttributes: arch ? [{ key: "arch", value: arch }] : [],
+      memory: 1073741824n,
+      storage: [{ name: "default", quantity: 1073741824n, attributes: [{ key: "persistent", value: "false" }] }],
+      count
+    })
+  ];
+}
 
 function makeCluster(
   nodes: {
@@ -1221,7 +1320,7 @@ function buildResourceUnit(input: {
   return {
     id: input.id,
     resources: {
-      cpu: { units: input.cpu, fingerprint: getAttributeFingerprint(input.cpuAttributes) },
+      cpu: { units: input.cpu, arch: parseCPUAttributes(input.cpuAttributes ?? []).arch },
       gpu: { units: input.gpuUnits ?? 0n, attributes: parseGPUAttributes(input.gpuAttributes ?? []) },
       memory: { quantity: input.memory },
       storage: input.storage.map(s => ({ name: s.name, quantity: s.quantity, attributes: parseStorageAttributes(s.attributes) })),

--- a/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.ts
+++ b/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.ts
@@ -1,6 +1,7 @@
 import { singleton } from "tsyringe";
 
 import { canAllocate } from "@src/domain/resource-pair/resource-pair";
+import { type CpuArch, DEFAULT_CPU_ARCH, resolveNodeCpuArch } from "../../mappers/cpu-attribute-parser/cpu-attribute-parser";
 import { matchesGPU, type ParsedGPUAttributes } from "../../mappers/gpu-attribute-parser/gpu-attribute-parser";
 import type { ClusterState, MatchResult, NodeState, RequestedResourceUnit } from "../../types/inventory";
 
@@ -10,28 +11,31 @@ const GPU_CHECK_FAIL = Object.freeze({ ok: false } as const);
 const NO_CAPACITY = Object.freeze({ matched: false, error: "INSUFFICIENT_CAPACITY" } as MatchResult);
 const MATCHED = Object.freeze({ matched: true } as MatchResult);
 const EMPTY_NODES = Object.freeze([] as readonly NodeState[]);
+const NO_PROVIDER_CONTEXT = Object.freeze({ declaredCpuArch: null } as ProviderContext);
 
 @singleton()
 export class ClusterInventoryMatcherService {
-  match(cluster: ClusterState | undefined, resourceUnits: RequestedResourceUnit[]): MatchResult {
+  match(cluster: ClusterState | undefined, resourceUnits: RequestedResourceUnit[], provider: ProviderContext = NO_PROVIDER_CONTEXT): MatchResult {
     if (!cluster) return NO_CAPACITY;
 
     const clusterNodes = cluster.nodes ?? EMPTY_NODES;
     const nodeCount = clusterNodes.length;
     const nodeDeltas: NodeDelta[] = new Array(nodeCount);
+    const nodeArchs: CpuArch[] = new Array(nodeCount);
     for (let i = 0; i < nodeCount; i++) {
       nodeDeltas[i] = { cpu: 0n, mem: 0n, eph: 0n, gpu: 0n };
+      nodeArchs[i] = resolveNodeCpuArch(clusterNodes[i].cpus, provider.declaredCpuArch);
     }
     const storageDeltas: Record<string, bigint> = Object.create(null);
 
     for (let i = resourceUnits.length - 1; i >= 0; i--) {
       const group = resourceUnits[i];
-      let canonical: CanonicalHardware = { gpuSpecs: null, cpuFingerprint: group.resources.cpu.fingerprint };
+      let canonical: CanonicalHardware = { gpuSpecs: null };
 
       let remaining = group.count;
 
       for (let nodeIdx = 0; nodeIdx < nodeCount && remaining > 0; ) {
-        const result = this.#tryAdjust(clusterNodes[nodeIdx], nodeDeltas[nodeIdx], cluster.storage, storageDeltas, group, canonical);
+        const result = this.#tryAdjust(clusterNodes[nodeIdx], nodeArchs[nodeIdx], nodeDeltas[nodeIdx], cluster.storage, storageDeltas, group, canonical);
         if (!result.clusterOk) return NO_CAPACITY;
 
         if (result.nodeOk) {
@@ -63,12 +67,14 @@ export class ClusterInventoryMatcherService {
 
   #tryAdjust(
     node: NodeState,
+    nodeArch: CpuArch,
     baseDelta: NodeDelta,
     clusterStorage: ClusterState["storage"],
     storageDeltas: Record<string, bigint>,
     group: RequestedResourceUnit,
     canonical: CanonicalHardware
   ): AttemptResult {
+    if (nodeArch !== (group.resources.cpu.arch ?? DEFAULT_CPU_ARCH)) return FAIL_NODE;
     if (!canAllocate(node.cpu, group.resources.cpu.units + baseDelta.cpu)) return FAIL_NODE;
     if (!canAllocate(node.memory, group.resources.memory.quantity + baseDelta.mem)) return FAIL_NODE;
     if (!canAllocate(node.gpu.quantity, group.resources.gpu.units + baseDelta.gpu)) return FAIL_NODE;
@@ -178,9 +184,13 @@ export class ClusterInventoryMatcherService {
   }
 }
 
+/** What a provider declares about itself on chain, standing in for inventory a node has not reported. */
+export interface ProviderContext {
+  declaredCpuArch: string | null;
+}
+
 interface CanonicalHardware {
   gpuSpecs: ParsedGPUAttributes | null;
-  cpuFingerprint: string | null;
 }
 
 interface NodeDelta {

--- a/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.ts
+++ b/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.ts
@@ -21,7 +21,7 @@ export class ClusterInventoryMatcherService {
     const clusterNodes = cluster.nodes ?? EMPTY_NODES;
     const nodeCount = clusterNodes.length;
     const nodeDeltas: NodeDelta[] = new Array(nodeCount);
-    const nodeArchs: CpuArch[] = new Array(nodeCount);
+    const nodeArchs: (CpuArch | null)[] = new Array(nodeCount);
     for (let i = 0; i < nodeCount; i++) {
       nodeDeltas[i] = { cpu: 0n, mem: 0n, eph: 0n, gpu: 0n };
       nodeArchs[i] = resolveNodeCpuArch(clusterNodes[i].cpus, provider.declaredCpuArch);
@@ -67,7 +67,7 @@ export class ClusterInventoryMatcherService {
 
   #tryAdjust(
     node: NodeState,
-    nodeArch: CpuArch,
+    nodeArch: CpuArch | null,
     baseDelta: NodeDelta,
     clusterStorage: ClusterState["storage"],
     storageDeltas: Record<string, bigint>,

--- a/apps/provider-inventory/src/services/provider-stream-factory/stream-status-mapper.spec.ts
+++ b/apps/provider-inventory/src/services/provider-stream-factory/stream-status-mapper.spec.ts
@@ -261,13 +261,37 @@ describe(mapProviderStatusToClusterState.name, () => {
     it("maps cpu info entries", () => {
       const inventory = buildStatus({
         cluster: buildCluster({
+          nodes: [buildNode({ cpus: [{ vendor: "amd", model: "epyc", arch: "amd64" } as CPUInfo] })]
+        })
+      });
+
+      const result = mapProviderStatusToClusterState(inventory);
+
+      expect(result.nodes?.[0].cpus).toEqual([{ vendor: "amd", model: "epyc", arch: "amd64" }]);
+    });
+
+    it("maps the architecture an arm64 node reports", () => {
+      const inventory = buildStatus({
+        cluster: buildCluster({
+          nodes: [buildNode({ cpus: [{ vendor: "ampere", model: "altra", arch: "arm64" } as CPUInfo] })]
+        })
+      });
+
+      const result = mapProviderStatusToClusterState(inventory);
+
+      expect(result.nodes?.[0].cpus[0].arch).toBe("arm64");
+    });
+
+    it("maps an empty architecture for inventory that predates architecture reporting", () => {
+      const inventory = buildStatus({
+        cluster: buildCluster({
           nodes: [buildNode({ cpus: [{ vendor: "amd", model: "epyc" } as CPUInfo] })]
         })
       });
 
       const result = mapProviderStatusToClusterState(inventory);
 
-      expect(result.nodes?.[0].cpus).toEqual([{ vendor: "amd", model: "epyc" }]);
+      expect(result.nodes?.[0].cpus[0].arch).toBe("");
     });
 
     it("defaults cpu info to an empty array when absent", () => {

--- a/apps/provider-inventory/src/services/provider-stream-factory/stream-status-mapper.ts
+++ b/apps/provider-inventory/src/services/provider-stream-factory/stream-status-mapper.ts
@@ -83,7 +83,7 @@ function mapGpuInfo(info: GPUInfo): GpuInfo {
 }
 
 function mapCpuInfo(info: CPUInfo): CpuInfo {
-  return { vendor: info.vendor, model: info.model };
+  return { vendor: info.vendor, model: info.model, arch: info.arch ?? "" };
 }
 
 function mapNode(node: SdkNode): NodeState {

--- a/apps/provider-inventory/src/types/inventory.ts
+++ b/apps/provider-inventory/src/types/inventory.ts
@@ -1,4 +1,5 @@
 import type { DailyDowntimeRow } from "@src/repositories/provider-incident/provider-incident.repository";
+import type { CpuArch } from "../mappers/cpu-attribute-parser/cpu-attribute-parser";
 import type { ParsedGPUAttributes } from "../mappers/gpu-attribute-parser/gpu-attribute-parser";
 import type { ParsedStorageAttributes } from "../mappers/storage-attribute-parser/storage-attribute-parser";
 
@@ -15,6 +16,8 @@ export interface GpuInfo {
 export interface CpuInfo {
   vendor: string;
   model: string;
+  /** Empty on nodes running an inventory operator that predates architecture reporting. */
+  arch: string;
 }
 
 export interface NodeState {
@@ -46,7 +49,7 @@ export interface ResourceAttribute {
 }
 
 export interface RequestedResources {
-  cpu: { units: bigint; fingerprint: string | null };
+  cpu: { units: bigint; arch: CpuArch | null };
   gpu: { units: bigint; attributes: ParsedGPUAttributes[] };
   memory: { quantity: bigint };
   storage: RequestedStorage[];


### PR DESCRIPTION
## Why

Closes CON-931

Screening ignores CPU architecture today. Ask for arm64 and the marketplace offers every amd64 provider as a candidate, you pick one, and the workload fails to start. Screening has to be honest about architecture before the option is offered to tenants.

## What

The bin-packer now places a replica only on a node of the architecture the request asks for, mirroring `tryAdjustCPU` in [provider#433](https://github.com/akash-network/provider/pull/433).

**The rule.** A request naming no architecture means amd64: the SDL writes no implicit default, and the provider defaults it the same way, so this keeps the two ends agreeing. A node's architecture is what its own inventory reports (`cpu.info[].arch`, already on the SDK type but dropped by the stream mapper), else what its provider declares in `hardware-cpu-arch`, else amd64. That last step is what makes the feature useful before the fleet upgrades, and it is why nothing changes for today's providers, which report and declare nothing.

The two sources fail differently on a value that is neither amd64 nor arm64. A *reported* one comes from the node's own inventory, so a node reporting `ppc64le` serves nothing rather than being claimed as amd64. A *declared* one is hand-written and routinely is not an architecture at all: mainnet holds `x86`, `x64-86`, `Zen 4` and `AMD EPYC-Rome` across 7 providers, all of which mean amd64, so an unrecognized declaration counts as no declaration.

Because the comparison happens per node, replicas of one resource unit never split across architectures, and a mixed provider serves both.

**Where the check lives.** In the bin-packer, not the SQL prefilter. It needs per-node data, and this way an architecture-free request runs byte-for-byte the same query it ran before, so screening latency for the overwhelmingly common case is unchanged. A `cpu_archs` rollup column can be added later if arm64 volume ever makes the in-memory rejection show up.

**Bad requests fail loudly.** `arch` is the only CPU attribute either SDK accepts, with amd64 and arm64 the only values. The request schema now rejects anything else with a 400 instead of silently screening against nothing, `arch` given twice included, which would otherwise have screened against whichever value came last. Mirrored in the `apps/api` proxy copy of the schema; the OpenAPI output is unchanged, so no snapshot or `console-api-types` regeneration.

**On the CPU fingerprint this replaces.** `RequestedResources.cpu.fingerprint` was computed on every request purely to seed `CanonicalHardware.cpuFingerprint`, which had no reader — the unfinished form of exactly this check. It is gone rather than left running alongside the real one.

Provider-side spelling is normalized (`x86_64`, `aarch64`) since providers write `hardware-cpu-arch` by hand; a *requested* architecture stays exact, matching the SDL enum.

Docs: new AC22 in the resource-matching acceptance criteria, plus the three senses of "architecture" (requested / reported / declared) in `CONTEXT.md`, which were the ambiguity worth pinning down here.

### Verification

Full suite green: 517 tests across unit, integration and functional. `tsc --noEmit` and `eslint --quiet` clean in both `apps/provider-inventory` and `apps/api`.

The architecture tests are load-bearing rather than decorative: deleting the one-line check in `#tryAdjust` turns exactly 7 of them red, and none of the other 58 matcher tests notice.

Not covered here: no arm64 provider exists to point this at yet, so the end-to-end proof is CON-935, gated on AKT-584.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for CPU architecture requests, supporting `amd64` and `arm64` while rejecting unsupported or duplicate architecture attributes.
  * Added CPU architecture matching during provider and node resource selection.
  * Added architecture normalization and resolution for inventory and provider data.
* **Bug Fixes**
  * CPU architecture changes are now detected when comparing cluster state.
  * Nodes with incompatible or unsupported reported architectures are excluded from matching.
* **Documentation**
  * Documented CPU architecture resolution, defaults, and matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
