### PR TITLE
chore(repo): bump @akashnetwork/chain-sdk to 1.0.0-alpha.45 for cpu arch support

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -148,9 +148,9 @@
       }
     },
     "apps/api/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
-      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "version": "1.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.45.tgz",
+      "integrity": "sha512-SRS+raOpTMjEnvXolPED2dFpD3/arRl5VdnD78agxx1W5gef/KzSBM18TEKvwDDMgKmfEmJ49Xs0Cms0KYF8GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -564,7 +564,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -691,9 +691,9 @@
       }
     },
     "apps/deploy-web/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
-      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "version": "1.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.45.tgz",
+      "integrity": "sha512-SRS+raOpTMjEnvXolPED2dFpD3/arRl5VdnD78agxx1W5gef/KzSBM18TEKvwDDMgKmfEmJ49Xs0Cms0KYF8GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -2273,7 +2273,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2326,9 +2326,9 @@
       }
     },
     "apps/indexer/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
-      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "version": "1.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.45.tgz",
+      "integrity": "sha512-SRS+raOpTMjEnvXolPED2dFpD3/arRl5VdnD78agxx1W5gef/KzSBM18TEKvwDDMgKmfEmJ49Xs0Cms0KYF8GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -2697,7 +2697,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2765,9 +2765,9 @@
       }
     },
     "apps/notifications/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
-      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "version": "1.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.45.tgz",
+      "integrity": "sha512-SRS+raOpTMjEnvXolPED2dFpD3/arRl5VdnD78agxx1W5gef/KzSBM18TEKvwDDMgKmfEmJ49Xs0Cms0KYF8GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -3874,7 +3874,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -3917,9 +3917,9 @@
       }
     },
     "apps/provider-inventory/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
-      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "version": "1.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.45.tgz",
+      "integrity": "sha512-SRS+raOpTMjEnvXolPED2dFpD3/arRl5VdnD78agxx1W5gef/KzSBM18TEKvwDDMgKmfEmJ49Xs0Cms0KYF8GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -4323,7 +4323,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4355,9 +4355,9 @@
       }
     },
     "apps/provider-proxy/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
-      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "version": "1.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.45.tgz",
+      "integrity": "sha512-SRS+raOpTMjEnvXolPED2dFpD3/arRl5VdnD78agxx1W5gef/KzSBM18TEKvwDDMgKmfEmJ49Xs0Cms0KYF8GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -4516,7 +4516,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4574,9 +4574,9 @@
       }
     },
     "apps/stats-web/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
-      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "version": "1.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.45.tgz",
+      "integrity": "sha512-SRS+raOpTMjEnvXolPED2dFpD3/arRl5VdnD78agxx1W5gef/KzSBM18TEKvwDDMgKmfEmJ49Xs0Cms0KYF8GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -5369,7 +5369,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5415,9 +5415,9 @@
       }
     },
     "apps/tx-signer/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
-      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "version": "1.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.45.tgz",
+      "integrity": "sha512-SRS+raOpTMjEnvXolPED2dFpD3/arRl5VdnD78agxx1W5gef/KzSBM18TEKvwDDMgKmfEmJ49Xs0Cms0KYF8GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -46235,7 +46235,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       },
@@ -46244,9 +46244,9 @@
       }
     },
     "packages/network-store/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.44",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.44.tgz",
-      "integrity": "sha512-tVctkmCpxdDVLsE0dpbBlRLe6aM3AQELHCW7YZF0VBGB1wzgFgrRir7RecrJ0nVuET2JZkoDQ/beL1FMx+hC2Q==",
+      "version": "1.0.0-alpha.45",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.45.tgz",
+      "integrity": "sha512-SRS+raOpTMjEnvXolPED2dFpD3/arRl5VdnD78agxx1W5gef/KzSBM18TEKvwDDMgKmfEmJ49Xs0Cms0KYF8GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.44",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.45",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   },


### PR DESCRIPTION
## Why

Closes CON-930

Nothing in Console can read a node's CPU architecture or validate an architecture-bearing SDL until the monorepo runs the SDK release that has them. Nine workspaces pin the version, so this is the repo-wide step the rest of the ARM work sits on.

## What

All nine pins move from `1.0.0-alpha.44` to `1.0.0-alpha.45`.

**What the release brings.** `cpu.attributes` is now constrained to `arch`, with amd64 and arm64 the only accepted values, so the same SDL is accepted or rejected identically by both SDKs. Omitting it still produces zero CPU attributes — no implicit amd64 anywhere, which is what keeps every existing deployment's group spec byte-identical. It also carries two ordering fixes worth knowing about, since both changed signed group spec bytes rather than just appearance: manifest endpoints for an SDL with several global exposes were ordered by kind instead of sequence number, and nine string comparisons used `localeCompare` where Go uses a plain byte comparison.

Behaviourally this is a tightening. An SDL that put some other key under `cpu.attributes` now fails validation in deploy-web. Go rejected those already, so no live deployment can carry one.

**On the lockfile.** Hand-patched, not re-resolved. A full `npm install` also deduplicated the nine nested copies into one hoisted copy and pulled `@scure/base` from 2.3.0 to 2.4.0, and neither belongs in a version bump. `npm view` confirms chain-sdk's own dependency set is byte-identical across the two versions, so patching version, resolved and integrity in place is exact rather than approximate. The result is a 36-line diff touching nothing but chain-sdk, validated with `npm ci --ignore-scripts --dry-run` and then installed with a real `npm ci`.

**One thing worth fixing separately.** The root `.npmrc` sets `min-release-age=7` and tries to exempt our own packages with `min-release-age-exclude[]=@akashnetwork/*`. npm 11.11.0 does not support that key — it prints `Unknown project config "min-release-age-exclude"` and quarantines alpha.45 anyway. So the exemption is not doing anything today and this install needed `npm_config_min_release_age=0` to resolve. `npm ci` is lockfile-driven and ignores the guard entirely, so CI is unaffected.

### Verification

Type-checking is not enough for an SDK bump — the codegen changes runtime behaviour the compiler cannot see — so the full suites ran, not just the diff:

| App | Result |
| -- | -- |
| deploy-web | 3730 unit |
| api | 190 unit files, 386 functional, 390 integration |
| notifications | 47 unit files, 19 functional |
| provider-inventory | 464 unit + integration + functional |
| provider-proxy | 142 |
| indexer / stats-web / tx-signer | all green |
| packages | net, openapi-sdk, react-query-proxy, ui all green |

Production type-checking is clean: `tsc -p tsconfig.build.json` reports zero errors for indexer, notifications and provider-proxy, and provider-inventory, stats-web and tx-signer are zero under bare `tsc` too. The bare-`tsc` noise in api (42) and deploy-web (92) is pre-existing and lives entirely in spec and test-helper files; api's count is unchanged from before the bump.

Four api integration tests do fail locally (`UserRepository.markAsActive`, `ApiKeyRepository.markAsUsed`). They are **not** caused by this bump — I reinstalled alpha.44 and reproduced all four identically, so they are a pre-existing local-environment issue with the native Postgres this machine runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Akash Chain SDK across application and shared packages to version `1.0.0-alpha.45`.
  * Keeps network-related services and interfaces aligned with the latest SDK release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->