### PR TITLE
fix(deployment): hand a create back the manifest of the document it submitted

### DIFF
--- a/apps/api/src/deployment/controllers/lease/lease.controller.ts
+++ b/apps/api/src/deployment/controllers/lease/lease.controller.ts
@@ -1,6 +1,6 @@
 import { singleton } from "tsyringe";
 
-import { Protected } from "@src/auth/services/auth.service";
+import { AuthService, Protected } from "@src/auth/services/auth.service";
 import { type CreateLeaseResponse } from "@src/deployment/http-schemas/deployment.schema";
 import { type CreateLeaseRequest } from "@src/deployment/http-schemas/lease.schema";
 import { type FallbackLeaseListResponse } from "@src/deployment/http-schemas/lease-rpc.schema";
@@ -12,12 +12,17 @@ import { LeaseService } from "@src/deployment/services/lease/lease.service";
 export class LeaseController {
   constructor(
     private readonly fallbackLeaseReaderService: FallbackLeaseReaderService,
-    private readonly leaseService: LeaseService
+    private readonly leaseService: LeaseService,
+    private readonly authService: AuthService
   ) {}
 
   @Protected([{ action: "sign", subject: "UserWallet" }])
   async createLeasesAndSendManifest(input: CreateLeaseRequest): Promise<CreateLeaseResponse> {
-    return { data: await this.leaseService.createLeasesAndSendManifest(input) };
+    const data = await this.leaseService.createLeasesAndSendManifest({
+      ...input,
+      userId: this.authService.currentUser.id
+    });
+    return { data };
   }
 
   async listLeasesFallback(params: DatabaseLeaseListParams): Promise<FallbackLeaseListResponse> {

--- a/apps/api/src/deployment/http-schemas/lease.schema.ts
+++ b/apps/api/src/deployment/http-schemas/lease.schema.ts
@@ -3,7 +3,10 @@ import { z } from "zod";
 import { AkashAddressSchema, DseqSchema } from "@src/utils/schema";
 
 export const CreateLeaseRequestSchema = z.object({
-  manifest: z.string(),
+  manifest: z.string().optional().openapi({
+    description: "The manifest to send to the provider, in YAML format (deprecated)",
+    deprecated: true
+  }),
   leases: z.array(
     z.object({
       dseq: DseqSchema,

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -254,7 +254,7 @@ describe(DeploymentWriterService.name, () => {
 
     it("builds the returned manifest before broadcasting, so a document it cannot rebuild costs no deployment on chain", async () => {
       const { service, sdlService, signerService } = setup();
-      sdlService.generateManifest.mockReturnValue({ ok: false, value: [mock<ValidationError>({ message: "unbuildable" })] });
+      sdlService.generateManifest.mockResolvedValue({ ok: false, value: [mock<ValidationError>({ message: "unbuildable" })] });
 
       await expect(service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 })).rejects.toMatchObject({ status: 400 });
 
@@ -1240,7 +1240,7 @@ describe(DeploymentWriterService.name, () => {
 
     walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
     sdlService.parse.mockReturnValue({ ok: true, value: parsedSdlValue } as any);
-    sdlService.generateManifest.mockReturnValue({ ok: true, value: manifestValue } as any);
+    sdlService.generateManifest.mockResolvedValue({ ok: true, value: manifestValue } as any);
     sdlService.generateManifestVersion.mockResolvedValue(new Uint8Array([4, 5, 6]));
     sdlService.generateResolvedManifest.mockResolvedValue({
       ok: true,

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -232,13 +232,32 @@ describe(DeploymentWriterService.name, () => {
       expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
     });
 
-    it("returns the manifest built from the resolved sdl", async () => {
+    it("returns the manifest built from the submitted sdl, not the resolved one it hashed", async () => {
       const { service } = setup();
 
       const result = await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
 
-      expect(result.manifest).toContain("resolved-group");
-      expect(result.manifest).not.toContain("test-group");
+      expect(result.manifest).toContain("test-group");
+      expect(result.manifest).not.toContain("resolved-group");
+    });
+
+    it("applies the trial limits to the manifest it hashes and not to the one it returns", async () => {
+      const { service, sdlService, walletReaderService } = setup();
+      walletReaderService.getWalletByUserId.mockResolvedValue({ ...wallet, isTrialing: true });
+
+      await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
+
+      expect(sdlService.generateResolvedManifest).toHaveBeenCalledWith(expect.objectContaining({ isTrialing: true }));
+      expect(sdlService.generateManifest).toHaveBeenCalledWith("valid-sdl");
+    });
+
+    it("builds the returned manifest before broadcasting, so a document it cannot rebuild costs no deployment on chain", async () => {
+      const { service, sdlService, signerService } = setup();
+      sdlService.generateManifest.mockReturnValue({ ok: false, value: [{ message: "unbuildable" }] } as never);
+
+      await expect(service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 })).rejects.toMatchObject({ status: 400 });
+
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
     });
 
     it("forwards the reclamation block to getCreateDeploymentMsg when the SDL declares it", async () => {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,3 +1,4 @@
+import type { ValidationError } from "@akashnetwork/chain-sdk";
 import { DeploymentReclamation, MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { faker } from "@faker-js/faker";
@@ -253,7 +254,7 @@ describe(DeploymentWriterService.name, () => {
 
     it("builds the returned manifest before broadcasting, so a document it cannot rebuild costs no deployment on chain", async () => {
       const { service, sdlService, signerService } = setup();
-      sdlService.generateManifest.mockReturnValue({ ok: false, value: [{ message: "unbuildable" }] } as never);
+      sdlService.generateManifest.mockReturnValue({ ok: false, value: [mock<ValidationError>({ message: "unbuildable" })] });
 
       await expect(service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 })).rejects.toMatchObject({ status: 400 });
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -74,6 +74,7 @@ export class DeploymentWriterService {
 
     const dseq = Date.now().toString();
     const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: supplied, isTrialing: !!wallet.isTrialing });
+    const unresolvedManifest = this.#unresolvedManifestOf(input.sdl);
     const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: stored });
 
     if (wallet.isTrialing) {
@@ -106,7 +107,7 @@ export class DeploymentWriterService {
 
     return {
       dseq: dseq.toString(),
-      manifest: manifestToSortedJSON(manifest.groups),
+      manifest: unresolvedManifest,
       signTx: result
     };
   }
@@ -316,6 +317,17 @@ export class DeploymentWriterService {
     await this.sendManifestToProviders({ auth, dseq, manifest: manifestToSortedJSON(manifest.groups), leases: deployment.leases });
 
     return await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
+  }
+
+  /** Carries no trial limits, because the resolved build above has already applied them and cleared this document, so nothing here can refuse what that allowed. */
+  #unresolvedManifestOf(sdl: string): string {
+    const result = this.sdlService.generateManifest(sdl);
+
+    if (!result.ok) {
+      throw this.#rejectInvalidSdl(result.value);
+    }
+
+    return manifestToSortedJSON(result.value.groups);
   }
 
   /** Only the manifest version is taken from the resolved SDL: the resolved manifest itself must not leave this call. Runs before any lookup so a bad reference always answers 400 rather than racing a 404. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -319,7 +319,7 @@ export class DeploymentWriterService {
     return await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
   }
 
-  /** Carries no trial limits, because the resolved build above has already applied them and cleared this document, so nothing here can refuse what that allowed. */
+  /** Must reach only the response field: the hash, the group specs and the recorded definition all still come from the resolved build above. */
   #unresolvedManifestOf(sdl: string): string {
     const result = this.sdlService.generateManifest(sdl);
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -74,7 +74,7 @@ export class DeploymentWriterService {
 
     const dseq = Date.now().toString();
     const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: supplied, isTrialing: !!wallet.isTrialing });
-    const unresolvedManifest = this.#unresolvedManifestOf(input.sdl);
+    const unresolvedManifest = await this.#unresolvedManifestOf(input.sdl);
     const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: stored });
 
     if (wallet.isTrialing) {
@@ -320,8 +320,8 @@ export class DeploymentWriterService {
   }
 
   /** Must reach only the response field: the hash, the group specs and the recorded definition all still come from the resolved build above. */
-  #unresolvedManifestOf(sdl: string): string {
-    const result = this.sdlService.generateManifest(sdl);
+  async #unresolvedManifestOf(sdl: string): Promise<string> {
+    const result = await this.sdlService.generateManifest(sdl);
 
     if (!result.ok) {
       throw this.#rejectInvalidSdl(result.value);

--- a/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.spec.ts
+++ b/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.spec.ts
@@ -93,7 +93,7 @@ describe(LeaseManifestService.name, () => {
       const stored = sdlWith(["LOG_LEVEL=debug"]);
       const { service } = setup({ definition: { sdl: stored, sealedSecrets: null } });
 
-      const manifest = await service.deriveFor({ dseq: DSEQ });
+      const manifest = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(manifest).toBe(manifestOf(stored));
     });
@@ -105,7 +105,7 @@ describe(LeaseManifestService.name, () => {
         stored: { API_TOKEN: token }
       });
 
-      const manifest = await service.deriveFor({ dseq: DSEQ });
+      const manifest = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(manifest).toBe(manifestOf(sdlWith([`API_TOKEN=${token}`])));
       expect(manifest).not.toContain("ac-secret://");
@@ -123,7 +123,7 @@ describe(LeaseManifestService.name, () => {
         stored: { REG_USER: username, REG_PASS: password }
       });
 
-      const manifest = await service.deriveFor({ dseq: DSEQ });
+      const manifest = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(manifest).toBe(manifestOf(sdlWith(["LOG_LEVEL=debug"], { credentials: { host: "registry.example.test", username, password } })));
     });
@@ -134,8 +134,8 @@ describe(LeaseManifestService.name, () => {
         stored: { API_TOKEN: randomUUID() }
       });
 
-      const first = await service.deriveFor({ dseq: DSEQ });
-      const second = await service.deriveFor({ dseq: DSEQ });
+      const first = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
+      const second = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(first).toBe(second);
       expect(first).toEqual(expect.any(String));
@@ -144,7 +144,7 @@ describe(LeaseManifestService.name, () => {
     it("reads the definition of the authenticated user, which no caller can name for it", async () => {
       const { service, scopedRepository } = setup({ definition: { sdl: sdlWith([]), sealedSecrets: null } });
 
-      await service.deriveFor({ dseq: DSEQ });
+      await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(scopedRepository.findOneBy).toHaveBeenCalledWith({ userId: USER_ID, dseq: DSEQ });
     });
@@ -155,7 +155,7 @@ describe(LeaseManifestService.name, () => {
         stored: { API_TOKEN: "value" }
       });
 
-      await service.deriveFor({ dseq: DSEQ });
+      await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(sdlSecretsService.openStored).toHaveBeenCalledWith(expect.objectContaining({ userId: USER_ID }));
     });
@@ -163,7 +163,7 @@ describe(LeaseManifestService.name, () => {
     it("reads the definition scoped to the caller's own ability", async () => {
       const { service, deploymentSettingRepository, authService } = setup({ definition: { sdl: sdlWith([]), sealedSecrets: null } });
 
-      await service.deriveFor({ dseq: DSEQ });
+      await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(authService.ability, "read");
     });
@@ -171,7 +171,7 @@ describe(LeaseManifestService.name, () => {
     it("opens no stored token for a definition that has none", async () => {
       const { service, sdlSecretsService } = setup({ definition: { sdl: sdlWith(["LOG_LEVEL=debug"]), sealedSecrets: null } });
 
-      await service.deriveFor({ dseq: DSEQ });
+      await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(sdlSecretsService.openStored).not.toHaveBeenCalled();
     });
@@ -182,7 +182,7 @@ describe(LeaseManifestService.name, () => {
         stored: { API_TOKEN: "value" }
       });
 
-      await service.deriveFor({ dseq: DSEQ });
+      await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(sdlSecretsService.openStored).toHaveBeenCalledWith({ userId: USER_ID, dseq: DSEQ, sealedSecrets: "sealed" });
     });
@@ -194,7 +194,7 @@ describe(LeaseManifestService.name, () => {
         stored: { API_TOKEN: token }
       });
 
-      await service.deriveFor({ dseq: DSEQ });
+      await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_DERIVED", userId: USER_ID, dseq: DSEQ, resolvedSecretCount: 1 });
     });
@@ -206,7 +206,7 @@ describe(LeaseManifestService.name, () => {
         stored: { API_TOKEN: token }
       });
 
-      await service.deriveFor({ dseq: DSEQ });
+      await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(JSON.stringify([logger.info.mock.calls, logger.warn.mock.calls, logger.error.mock.calls])).not.toContain(token);
     });
@@ -214,7 +214,7 @@ describe(LeaseManifestService.name, () => {
     it("falls back when the console recorded nothing for the deployment", async () => {
       const { service, logger } = setup({ definition: null });
 
-      const manifest = await service.deriveFor({ dseq: DSEQ });
+      const manifest = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(manifest).toBeNull();
       expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_FALLBACK", userId: USER_ID, dseq: DSEQ, reason: "nothing-recorded" });
@@ -223,7 +223,7 @@ describe(LeaseManifestService.name, () => {
     it("falls back when the row it found carries no sdl", async () => {
       const { service, logger } = setup({ definition: { sdl: null, sealedSecrets: null } });
 
-      const manifest = await service.deriveFor({ dseq: DSEQ });
+      const manifest = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(manifest).toBeNull();
       expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_FALLBACK", userId: USER_ID, dseq: DSEQ, reason: "nothing-recorded" });
@@ -232,14 +232,14 @@ describe(LeaseManifestService.name, () => {
     it("refuses a row holding a token beside no sdl rather than accepting a client manifest for it", async () => {
       const { service, logger } = setup({ definition: { sdl: null, sealedSecrets: "sealed" } });
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toMatchObject({ status: 500 });
       expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "LEASE_MANIFEST_FALLBACK" }));
     });
 
     it("falls back when a definition carrying no reference will not re-derive", async () => {
       const { service, logger } = setup({ definition: { sdl: "version: '2.0'\nservices: {}", sealedSecrets: null } });
 
-      const manifest = await service.deriveFor({ dseq: DSEQ });
+      const manifest = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(manifest).toBeNull();
       expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_FALLBACK", userId: USER_ID, dseq: DSEQ, reason: "unresolvable" });
@@ -248,7 +248,7 @@ describe(LeaseManifestService.name, () => {
     it("refuses a definition whose reference has no stored value rather than falling back", async () => {
       const { service } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: null } });
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toMatchObject({ status: 500 });
     });
 
     it("refuses a definition whose token is missing the name its sdl references", async () => {
@@ -257,32 +257,32 @@ describe(LeaseManifestService.name, () => {
         stored: { SOMETHING_ELSE: "value" }
       });
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toMatchObject({ status: 500 });
     });
 
     it("refuses a stored sdl that will not parse rather than assuming it carries no reference", async () => {
       const { service } = setup({ definition: { sdl: "services:\n  - web\n :::", sealedSecrets: null } });
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toMatchObject({ status: 500 });
     });
 
     it("refuses a sealed definition that will not re-derive even with no reference left in its sdl", async () => {
       const { service } = setup({ definition: { sdl: "version: '2.0'\nservices: {}", sealedSecrets: "sealed" }, stored: {} });
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 500 });
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toMatchObject({ status: 500 });
     });
 
     it("says nothing of the definition in the refusal it reports", async () => {
       const token = randomUUID();
       const { service } = setup({ definition: { sdl: sdlWith([`API_TOKEN=ac-secret://${token.replace(/-/g, "_")}`]), sealedSecrets: null } });
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ message: "Unable to derive the deployment manifest" });
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toMatchObject({ message: "Unable to derive the deployment manifest" });
     });
 
     it("logs the refusal so a definition nothing can re-derive is measurable", async () => {
       const { service, logger } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: null } });
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toThrow();
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toThrow();
       expect(logger.error).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_UNRESOLVABLE", userId: USER_ID, dseq: DSEQ });
     });
 
@@ -291,14 +291,14 @@ describe(LeaseManifestService.name, () => {
       const { service, sdlSecretsService } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "tampered" } });
       sdlSecretsService.openStored.mockRejectedValue(unreadable);
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toBe(unreadable);
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toBe(unreadable);
     });
 
     it("logs a token it cannot open as the lease failure it is, not only as the cipher's", async () => {
       const { service, sdlSecretsService, logger } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "tampered" } });
       sdlSecretsService.openStored.mockRejectedValue(createError(500, "Unable to read stored secrets"));
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toThrow();
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toThrow();
       expect(logger.error).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_UNRESOLVABLE", userId: USER_ID, dseq: DSEQ });
     });
 
@@ -306,14 +306,17 @@ describe(LeaseManifestService.name, () => {
       const { service, sdlSecretsService } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "sealed" } });
       sdlSecretsService.openStored.mockRejectedValue(createError(503, "SDL secrets are temporarily unavailable"));
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toMatchObject({ status: 503, message: "SDL secrets are temporarily unavailable" });
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toMatchObject({
+        status: 503,
+        message: "SDL secrets are temporarily unavailable"
+      });
     });
 
     it("counts an unreachable key service apart from the definitions that can never be re-derived", async () => {
       const { service, sdlSecretsService, logger } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: "sealed" } });
       sdlSecretsService.openStored.mockRejectedValue(createError(503, "SDL secrets are temporarily unavailable"));
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toThrow();
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toThrow();
       expect(logger.warn).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_UNREACHABLE", userId: USER_ID, dseq: DSEQ });
       expect(logger.error).not.toHaveBeenCalledWith(expect.objectContaining({ event: "LEASE_MANIFEST_UNRESOLVABLE" }));
     });
@@ -321,7 +324,7 @@ describe(LeaseManifestService.name, () => {
     it("writes nothing to the row it read, whatever the derivation makes of it", async () => {
       const { service, deploymentSettingRepository } = setup({ definition: { sdl: sdlWith(["API_TOKEN=ac-secret://API_TOKEN"]), sealedSecrets: null } });
 
-      await expect(service.deriveFor({ dseq: DSEQ })).rejects.toThrow();
+      await expect(service.deriveFor({ dseq: DSEQ, userId: USER_ID })).rejects.toThrow();
 
       expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
       expect(deploymentSettingRepository.updateById).not.toHaveBeenCalled();
@@ -332,7 +335,7 @@ describe(LeaseManifestService.name, () => {
       const stored = sdlWith(["LOG_LEVEL=debug"], { gpuModel: "a100" });
       const { service } = setup({ definition: { sdl: stored, sealedSecrets: null }, blockedGpuModels: ["nvidia/a100"] });
 
-      const manifest = await service.deriveFor({ dseq: DSEQ });
+      const manifest = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(manifest).toBe(manifestOf(stored));
     });
@@ -341,7 +344,7 @@ describe(LeaseManifestService.name, () => {
       const stored = sdlWith(["LOG_LEVEL=debug"]);
       const { service } = setup({ definition: { sdl: stored, sealedSecrets: null }, trialMaxCpu: 0.05, trialMaxMemoryGi: 0.01 });
 
-      const manifest = await service.deriveFor({ dseq: DSEQ });
+      const manifest = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(manifest).toBe(manifestOf(stored));
     });
@@ -351,8 +354,8 @@ describe(LeaseManifestService.name, () => {
       const { service, denomExchangeService } = setup({ definition: { sdl: stored, sealedSecrets: null }, grantDenom: "uact" });
       denomExchangeService.getExchangeRateToUSD.mockResolvedValueOnce(aktToUsdRateOf(0.325)).mockResolvedValueOnce(aktToUsdRateOf(9));
 
-      const first = await service.deriveFor({ dseq: DSEQ });
-      const second = await service.deriveFor({ dseq: DSEQ });
+      const first = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
+      const second = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(first).toBe(second);
       expect(first).toBe(manifestOf(stored));
@@ -365,7 +368,7 @@ describe(LeaseManifestService.name, () => {
         aktToUsdRate: 0
       });
 
-      const manifest = await service.deriveFor({ dseq: DSEQ });
+      const manifest = await service.deriveFor({ dseq: DSEQ, userId: USER_ID });
 
       expect(manifest).toBeNull();
       expect(logger.info).toHaveBeenCalledWith({ event: "LEASE_MANIFEST_FALLBACK", userId: USER_ID, dseq: DSEQ, reason: "unresolvable" });

--- a/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.ts
+++ b/apps/api/src/deployment/services/lease-manifest/lease-manifest.service.ts
@@ -41,8 +41,7 @@ export class LeaseManifestService {
 
   /** Re-derives without trial limits, which gate a create rather than shape a manifest, so no lease is refused by a rule the create it belongs to already cleared. */
   @Trace()
-  async deriveFor({ dseq }: { dseq: string }): Promise<string | null> {
-    const userId = this.authService.currentUser.id;
+  async deriveFor({ dseq, userId }: { dseq: string; userId: string }): Promise<string | null> {
     const definition = await this.#findDefinition({ userId, dseq });
 
     if (!definition) {

--- a/apps/api/src/deployment/services/lease/lease.service.spec.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.spec.ts
@@ -1,4 +1,5 @@
 import type { LeaseHttpService } from "@akashnetwork/http-sdk";
+import type { LoggerService } from "@akashnetwork/logging";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -239,7 +240,8 @@ describe(LeaseService.name, () => {
       deploymentReaderService,
       walletReaderService,
       leaseHttpService,
-      leaseManifestService
+      leaseManifestService,
+      () => mock<LoggerService>()
     );
 
     return {

--- a/apps/api/src/deployment/services/lease/lease.service.spec.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.spec.ts
@@ -117,6 +117,38 @@ describe(LeaseService.name, () => {
       expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ manifest: MANIFEST }));
     });
 
+    it("sends the derived manifest for a request that carried none", async () => {
+      const { service, providerService, wallet } = setup({ derived: DERIVED_MANIFEST });
+      const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
+
+      await service.createLeasesAndSendManifest({ leases: [lease], userId: wallet.userId });
+
+      expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ manifest: DERIVED_MANIFEST }));
+    });
+
+    it("costs no lease on chain when the request carries no manifest and the console recorded nothing to derive one from", async () => {
+      const { service, signerService, providerService, wallet } = setup({ derived: null });
+      const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
+
+      await expect(service.createLeasesAndSendManifest({ leases: [lease], userId: wallet.userId })).rejects.toMatchObject({ status: 422 });
+
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      expect(providerService.sendManifest).not.toHaveBeenCalled();
+    });
+
+    it("sends nothing to any provider once one placement of the deployment has no manifest to send", async () => {
+      const { service, providerService, leaseManifestService, wallet } = setup();
+      leaseManifestService.deriveFor.mockImplementation(async ({ dseq }) => (dseq === "100" ? DERIVED_MANIFEST : null));
+      const leases = [
+        { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() },
+        { dseq: "200", gseq: 1, oseq: 1, provider: createAkashAddress() }
+      ];
+
+      await expect(service.createLeasesAndSendManifest({ leases, userId: wallet.userId })).rejects.toMatchObject({ status: 422 });
+
+      expect(providerService.sendManifest).not.toHaveBeenCalled();
+    });
+
     it("derives once for a deployment however many placements it leases", async () => {
       const { service, leaseManifestService, wallet } = setup({ derived: DERIVED_MANIFEST });
       const leases = [

--- a/apps/api/src/deployment/services/lease/lease.service.spec.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.spec.ts
@@ -2,7 +2,6 @@ import type { LeaseHttpService } from "@akashnetwork/http-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { AuthService } from "@src/auth/services/auth.service";
 import type { WalletInitialized } from "@src/billing/repositories";
 import type { ManagedSignerService, RpcMessageService } from "@src/billing/services";
 import type { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
@@ -10,7 +9,6 @@ import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deploym
 import type { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
 import type { LeaseManifestService } from "@src/deployment/services/lease-manifest/lease-manifest.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
-import type { UserOutput } from "@src/user/repositories";
 import { LeaseService } from "./lease.service";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
@@ -26,7 +24,7 @@ describe(LeaseService.name, () => {
       const { service, leaseHttpService, signerService, rpcMessageService, providerService, wallet, deployment } = setup();
       const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
 
-      const result = await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST });
+      const result = await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
 
       expect(leaseHttpService.list).toHaveBeenCalledWith({ owner: wallet.address, dseq: lease.dseq });
       expect(rpcMessageService.getCreateLeaseMsg).toHaveBeenCalledWith({
@@ -49,7 +47,7 @@ describe(LeaseService.name, () => {
         pagination: { next_key: null, total: "1" }
       });
 
-      const result = await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST });
+      const result = await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
 
       expect(rpcMessageService.getCreateLeaseMsg).not.toHaveBeenCalled();
       expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
@@ -65,19 +63,19 @@ describe(LeaseService.name, () => {
         pagination: { next_key: null, total: "1" }
       });
 
-      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST });
+      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
 
       expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
     });
 
     it("creates every placement lease in a single transaction when none exist", async () => {
-      const { service, signerService, rpcMessageService, providerService } = setup();
+      const { service, signerService, rpcMessageService, providerService, wallet } = setup();
       const leases = [
         { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() },
         { dseq: "100", gseq: 2, oseq: 1, provider: createAkashAddress() }
       ];
 
-      await service.createLeasesAndSendManifest({ leases, manifest: MANIFEST });
+      await service.createLeasesAndSendManifest({ leases, manifest: MANIFEST, userId: wallet.userId });
 
       expect(rpcMessageService.getCreateLeaseMsg).toHaveBeenCalledTimes(2);
       expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
@@ -90,7 +88,7 @@ describe(LeaseService.name, () => {
       const { service, providerService, wallet } = setup();
       const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
 
-      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST });
+      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
 
       expect(providerService.toProviderAuth).toHaveBeenCalledWith({ walletId: wallet.id, provider: lease.provider });
       expect(providerService.sendManifest).toHaveBeenCalledWith({
@@ -102,45 +100,45 @@ describe(LeaseService.name, () => {
     });
 
     it("sends the manifest it derived from the stored definition, not the one the request carried", async () => {
-      const { service, providerService } = setup({ derived: DERIVED_MANIFEST });
+      const { service, providerService, wallet } = setup({ derived: DERIVED_MANIFEST });
       const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
 
-      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST });
+      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
 
       expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ manifest: DERIVED_MANIFEST }));
     });
 
     it("sends the manifest the request carried for a deployment the console recorded nothing for", async () => {
-      const { service, providerService } = setup({ derived: null });
+      const { service, providerService, wallet } = setup({ derived: null });
       const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
 
-      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST });
+      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
 
       expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ manifest: MANIFEST }));
     });
 
     it("derives once for a deployment however many placements it leases", async () => {
-      const { service, leaseManifestService } = setup({ derived: DERIVED_MANIFEST });
+      const { service, leaseManifestService, wallet } = setup({ derived: DERIVED_MANIFEST });
       const leases = [
         { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() },
         { dseq: "100", gseq: 2, oseq: 1, provider: createAkashAddress() }
       ];
 
-      await service.createLeasesAndSendManifest({ leases, manifest: MANIFEST });
+      await service.createLeasesAndSendManifest({ leases, manifest: MANIFEST, userId: wallet.userId });
 
       expect(leaseManifestService.deriveFor).toHaveBeenCalledOnce();
-      expect(leaseManifestService.deriveFor).toHaveBeenCalledWith({ dseq: "100" });
+      expect(leaseManifestService.deriveFor).toHaveBeenCalledWith({ dseq: "100", userId: wallet.userId });
     });
 
     it("looks each lease's manifest up under that lease's own dseq, not the first lease's", async () => {
-      const { service, providerService, leaseManifestService } = setup();
+      const { service, providerService, leaseManifestService, wallet } = setup();
       leaseManifestService.deriveFor.mockImplementation(async ({ dseq }) => `manifest-of-${dseq}`);
       const leases = [
         { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() },
         { dseq: "200", gseq: 1, oseq: 1, provider: createAkashAddress() }
       ];
 
-      await service.createLeasesAndSendManifest({ leases, manifest: MANIFEST });
+      await service.createLeasesAndSendManifest({ leases, manifest: MANIFEST, userId: wallet.userId });
 
       expect(vi.mocked(providerService.sendManifest).mock.calls.map(([options]) => [options.dseq, options.manifest])).toEqual([
         ["100", "manifest-of-100"],
@@ -149,12 +147,12 @@ describe(LeaseService.name, () => {
     });
 
     it("reads the identity it funds the lease from off the authenticated user", async () => {
-      const { service, walletReaderService, authService } = setup();
+      const { service, walletReaderService, wallet } = setup();
       const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
 
-      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST });
+      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
 
-      expect(walletReaderService.getWalletByUserId).toHaveBeenCalledWith(authService.currentUser.id);
+      expect(walletReaderService.getWalletByUserId).toHaveBeenCalledWith(wallet.userId);
     });
 
     it("still sends the derived manifest when the lease already exists on chain", async () => {
@@ -165,18 +163,18 @@ describe(LeaseService.name, () => {
         pagination: { next_key: null, total: "1" }
       });
 
-      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST });
+      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
 
       expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ manifest: DERIVED_MANIFEST }));
     });
 
     it("broadcasts nothing and sends nothing when the stored definition cannot be derived", async () => {
       const refusal = new Error("underivable");
-      const { service, signerService, providerService, leaseManifestService } = setup();
+      const { service, signerService, providerService, leaseManifestService, wallet } = setup();
       leaseManifestService.deriveFor.mockRejectedValue(refusal);
       const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
 
-      await expect(service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST })).rejects.toBe(refusal);
+      await expect(service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId })).rejects.toBe(refusal);
 
       expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
       expect(providerService.sendManifest).not.toHaveBeenCalled();
@@ -195,8 +193,6 @@ describe(LeaseService.name, () => {
     const leaseManifestService = mock<LeaseManifestService>({
       deriveFor: vi.fn().mockResolvedValue(input.derived === undefined ? DERIVED_MANIFEST : input.derived)
     });
-    const authService = mock<AuthService>({ currentUser: mock<UserOutput>({ id: wallet.userId }) });
-
     const deployment = mock<GetDeploymentResponse["data"]>();
 
     walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
@@ -211,8 +207,7 @@ describe(LeaseService.name, () => {
       deploymentReaderService,
       walletReaderService,
       leaseHttpService,
-      leaseManifestService,
-      authService
+      leaseManifestService
     );
 
     return {
@@ -224,7 +219,6 @@ describe(LeaseService.name, () => {
       walletReaderService,
       leaseHttpService,
       leaseManifestService,
-      authService,
       wallet,
       deployment
     };

--- a/apps/api/src/deployment/services/lease/lease.service.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.ts
@@ -5,7 +5,7 @@ import { inject, singleton } from "tsyringe";
 
 import { ManagedSignerService, RpcMessageService } from "@src/billing/services";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
-import { CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { type DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import { type CreateLeaseRequest } from "@src/deployment/http-schemas/lease.schema";
 import { LeaseManifestService } from "@src/deployment/services/lease-manifest/lease-manifest.service";

--- a/apps/api/src/deployment/services/lease/lease.service.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.ts
@@ -2,7 +2,6 @@ import { LeaseHttpService } from "@akashnetwork/http-sdk";
 import { Trace } from "@akashnetwork/instrumentation";
 import { singleton } from "tsyringe";
 
-import { AuthService } from "@src/auth/services/auth.service";
 import { ManagedSignerService, RpcMessageService } from "@src/billing/services";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
 import { type DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
@@ -20,16 +19,15 @@ export class LeaseService {
     private readonly deploymentReaderService: DeploymentReaderService,
     private readonly walletReaderService: WalletReaderService,
     private readonly leaseHttpService: LeaseHttpService,
-    private readonly leaseManifestService: LeaseManifestService,
-    private readonly authService: AuthService
+    private readonly leaseManifestService: LeaseManifestService
   ) {}
 
   /** The `manifest` a request carries is only the fallback for a deployment the console recorded nothing for, no longer the document a provider is sent. */
   @Trace()
-  public async createLeasesAndSendManifest({ leases, manifest }: CreateLeaseRequest): Promise<DeploymentResponse> {
-    const wallet = await this.walletReaderService.getWalletByUserId(this.authService.currentUser.id);
+  public async createLeasesAndSendManifest({ leases, manifest, userId }: CreateLeaseRequest & { userId: string }): Promise<DeploymentResponse> {
+    const wallet = await this.walletReaderService.getWalletByUserId(userId);
     const dseq = leases[0].dseq;
-    const derived = await this.#derivedByDseq(leases);
+    const derived = await this.#derivedByDseq(leases, userId);
 
     // Leases for all groups are created in one tx, so one existing lease means all exist:
     // skip creation when already on-chain to keep retries idempotent.
@@ -62,11 +60,12 @@ export class LeaseService {
   }
 
   /** Called before anything is broadcast, so a definition the console cannot re-derive costs no lease on chain. */
-  async #derivedByDseq(leases: CreateLeaseRequest["leases"]): Promise<Map<string, string | null>> {
+  async #derivedByDseq(leases: CreateLeaseRequest["leases"], userId: string): Promise<Map<string, string | null>> {
     const derived = new Map<string, string | null>();
 
     for (const { dseq } of leases) {
-      if (!derived.has(dseq)) derived.set(dseq, await this.leaseManifestService.deriveFor({ dseq }));
+      if (derived.has(dseq)) continue;
+      derived.set(dseq, await this.leaseManifestService.deriveFor({ dseq, userId }));
     }
 
     return derived;

--- a/apps/api/src/deployment/services/lease/lease.service.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.ts
@@ -1,5 +1,6 @@
 import { LeaseHttpService } from "@akashnetwork/http-sdk";
 import { Trace } from "@akashnetwork/instrumentation";
+import { HTTPException } from "hono/http-exception";
 import { singleton } from "tsyringe";
 
 import { ManagedSignerService, RpcMessageService } from "@src/billing/services";
@@ -27,7 +28,7 @@ export class LeaseService {
   public async createLeasesAndSendManifest({ leases, manifest, userId }: CreateLeaseRequest & { userId: string }): Promise<DeploymentResponse> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
     const dseq = leases[0].dseq;
-    const derived = await this.#derivedByDseq(leases, userId);
+    const manifests = await this.#manifestsByDseq(leases, userId, manifest);
 
     // Leases for all groups are created in one tx, so one existing lease means all exist:
     // skip creation when already on-chain to keep retries idempotent.
@@ -51,7 +52,7 @@ export class LeaseService {
       await this.providerService.sendManifest({
         provider: lease.provider,
         dseq: lease.dseq,
-        manifest: derived.get(lease.dseq) ?? manifest,
+        manifest: manifests.get(lease.dseq)!,
         auth: await this.providerService.toProviderAuth({ walletId: wallet.id, provider: lease.provider })
       });
     }
@@ -59,16 +60,24 @@ export class LeaseService {
     return deployment;
   }
 
-  /** Called before anything is broadcast, so a definition the console cannot re-derive costs no lease on chain. */
-  async #derivedByDseq(leases: CreateLeaseRequest["leases"], userId: string): Promise<Map<string, string | null>> {
-    const derived = new Map<string, string | null>();
+  /** Called before anything is broadcast, so a definition the console cannot re-derive costs no lease on chain and no provider a partial send. */
+  async #manifestsByDseq(leases: CreateLeaseRequest["leases"], userId: string, requested: string | undefined): Promise<Map<string, string>> {
+    const manifests = new Map<string, string>();
 
     for (const { dseq } of leases) {
-      if (derived.has(dseq)) continue;
-      derived.set(dseq, await this.leaseManifestService.deriveFor({ dseq, userId }));
+      if (manifests.has(dseq)) continue;
+
+      const manifest = (await this.leaseManifestService.deriveFor({ dseq, userId })) ?? requested;
+      if (!manifest) {
+        throw new HTTPException(422, {
+          message: `No manifest to send for lease ${dseq}. Please provide a manifest in the request body or re-create deployment from scratch`
+        });
+      }
+
+      manifests.set(dseq, manifest);
     }
 
-    return derived;
+    return manifests;
   }
 
   async #hasActiveLease(owner: string, dseq: string): Promise<boolean> {

--- a/apps/api/src/deployment/services/lease/lease.service.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.ts
@@ -1,10 +1,11 @@
 import { LeaseHttpService } from "@akashnetwork/http-sdk";
 import { Trace } from "@akashnetwork/instrumentation";
 import { HTTPException } from "hono/http-exception";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { ManagedSignerService, RpcMessageService } from "@src/billing/services";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
+import { CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { type DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import { type CreateLeaseRequest } from "@src/deployment/http-schemas/lease.schema";
 import { LeaseManifestService } from "@src/deployment/services/lease-manifest/lease-manifest.service";
@@ -13,6 +14,8 @@ import { DeploymentReaderService } from "../deployment-reader/deployment-reader.
 
 @singleton()
 export class LeaseService {
+  readonly #logger: ReturnType<CreateLogger>;
+
   constructor(
     private readonly signerService: ManagedSignerService,
     private readonly rpcMessageService: RpcMessageService,
@@ -20,8 +23,11 @@ export class LeaseService {
     private readonly deploymentReaderService: DeploymentReaderService,
     private readonly walletReaderService: WalletReaderService,
     private readonly leaseHttpService: LeaseHttpService,
-    private readonly leaseManifestService: LeaseManifestService
-  ) {}
+    private readonly leaseManifestService: LeaseManifestService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.#logger = createLogger({ context: "lease-service" });
+  }
 
   /** The `manifest` a request carries is only the fallback for a deployment the console recorded nothing for, no longer the document a provider is sent. */
   @Trace()
@@ -67,7 +73,12 @@ export class LeaseService {
     for (const { dseq } of leases) {
       if (manifests.has(dseq)) continue;
 
-      const manifest = (await this.leaseManifestService.deriveFor({ dseq, userId })) ?? requested;
+      const derivedManifest = await this.leaseManifestService.deriveFor({ dseq, userId });
+      const manifest = derivedManifest ?? requested;
+      if (!derivedManifest && requested) {
+        this.#logger.warn({ event: "LEASE_MANIFEST_FALLBACK_USED", dseq });
+      }
+
       if (!manifest) {
         throw new HTTPException(422, {
           message: `No manifest to send for lease ${dseq}. Please provide a manifest in the request body or re-create deployment from scratch`

--- a/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
+++ b/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
@@ -212,9 +212,10 @@ describe("Managed Wallet API Deployment Flow", () => {
 
     expect(deploymentResponse.data).toMatchObject({
       dseq: expect.any(String),
-      // until manifest is not ignored by lease create API, it returns secrets as is
-      manifest: expect.stringMatching(/(secret-value|another secret value)/)
+      manifest: expect.stringContaining("ac-secret://TEST_SECRET")
     });
+    expect(deploymentResponse.data.manifest).not.toContain("secret-value");
+    expect(deploymentResponse.data.manifest).not.toContain("another secret value");
 
     try {
       const bid = await waitForBids(api, deploymentResponse.data.dseq);

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -8937,11 +8937,12 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "type": "array",
                   },
                   "manifest": {
+                    "deprecated": true,
+                    "description": "The manifest to send to the provider, in YAML format (deprecated)",
                     "type": "string",
                   },
                 },
                 "required": [
-                  "manifest",
                   "leases",
                 ],
                 "type": "object",

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -292,8 +292,7 @@ describe("Deployment sealed secrets", () => {
     expect(Buffer.from(setting!.manifestVersion!, "base64")).toEqual(Buffer.from(broadcastHash()));
   });
 
-  // skip it temporary until manifest field is ignored during lease creation
-  it.skip("returns no secret value, in the manifest it hands back or anywhere else in the body", async () => {
+  it("returns no secret value, in the manifest it hands back or anywhere else in the body", async () => {
     const { apiKey } = await persistedUser();
     const token = randomUUID();
 


### PR DESCRIPTION
## Why

Closes CON-867.

A create still hands the client a manifest built from the **resolved** document — the one with every `ac-secret://NAME` replaced by the real value. So a client that seals a value and posts it gets that value back decrypted, in cleartext, in its own 201 response. This is the last place in the create/lease round trip where a stored secret leaves the server, and the test that says so has been skipped since the reference work began:

```
// skip it temporary until manifest field is ignored during lease creation
it.skip("returns no secret value, in the manifest it hands back or anywhere else in the body", ...)
```

This un-skips it.

Stacked on #3799 → #3797 → #3796. Review the top commit only.

## What

`create` keeps returning `manifest`, and keeps returning a real manifest — it is now built from the **submitted** document with its references left standing, via `SdlService.generateManifest` (whose own contract is "SDL References are validated here and never substituted, so no caller of this can hand a resolved value back to a client"). The resolved manifest still does everything it did before: it is what gets hashed, what `groupSpecs` and `reclamation` come from, and what the chain commits to. Nothing about the hash path moves.

This also makes the code match an invariant `#resolveSdl` already claimed in writing and did not have: *"Only the manifest version is taken from the resolved SDL: the resolved manifest itself must not leave this call."*

### This is the only shape that works, not a preference

Three shapes were on the table. Two of them fail against things already in the repository, so this is not a judgement call — please don't spend review time re-deriving it:

| Shape | Verdict |
|---|---|
| Drop the `manifest` field | **Fails the very test being un-skipped.** Its second assertion is `expect(body).toContain("ac-secret://API_TOKEN")` — the test does not merely tolerate a manifest in the response, it *requires* one carrying the reference literal. It also breaks deploy-web: `useDeploymentFlow.ts:280` stores the field and `:439` compares it against a client-built manifest to detect a quoting-window SDL edit, so a missing field would leave that state `null` and fire an on-chain deployment-update tx on **every** deploy. |
| Keep the resolved manifest, rewrite deploy-web's detector | Unnecessary work in another app, and it would still hand back the client's own sealed value decrypted — i.e. it doesn't fix the leak at all. |
| **Keep the field, return the unresolved manifest** | Satisfies both assertions of the un-skipped test, needs no deploy-web change, no type change, and removes the leak. |

So the un-skipped test is not just consistent with this change — it *specifies* it.

### Why this is safe, measured rather than assumed

Every claim below was probed against the real `SdlService` and chain-sdk before the change was written.

| Question | Answer |
|---|---|
| Does a client with no seal see any change? | **No.** For an SDL with plain values the unresolved and resolved manifests are byte-identical. And `git grep sealedSecrets -- apps/deploy-web` is empty, so no deploy-web user seals today. |
| Does the detector still match for a sealing client? | **Yes.** `manifestFromSdl(sdl)` is fed the submitted SDL text and runs client-side, so it produces the same reference literals the server now returns. |
| Can this refuse a request the old path allowed? | **No.** `generateManifest` is called with no trial options, and the trial flag only ever decides *whether* to refuse — it never changes the bytes. So the resolved build above remains the sole source of refusals. |
| Can it refuse twice, or differently? | **No.** `SdlReferenceService.validate`'s error set is a strict subset of `substitute`'s (`unknownKindError` vs `unknownKindError ∪ missingSdlReferenceValueError`), so a document the resolved build cleared cannot fail validation. Refusals only ever run the safe direction: a missing value and a too-short sealed password are refused by the resolved path while the unresolved one succeeds. |
| Does anything on chain change? | **No, structurally.** `#unresolvedManifestOf`'s result reaches exactly one field of the HTTP response and nothing else — the chain message's `groups`/`hash`/`reclamation` and the recorded definition all still read the *resolved* build. The second build's own `groupSpecs` are never read at all. (They also happen to be byte-identical between the two builds, but that is a corroborating observation, not the guarantee: the isolation holds even if a future chain-sdk change breaks the equality.) |
| Does any consumer tie the response manifest to a chain hash? | **No.** The only `.hash` comparison in deploy-web (`ManifestUpdate.tsx:141`) compares a client-built `NewDeploymentData(editedManifest, …).hash` to `deployment.hash` from the chain and never reads this response. Zero hits in `packages/http-sdk`, `packages/react-query-sdk`, `apps/provider-console`. |

### A lease create can now find itself with nothing to send

Making the request's `manifest` optional means a lease create has two ways to get a document and can now come up empty on both: no stored definition to derive from, and no fallback in the body. That case is refused with a 422 naming the dseq.

The refusal is decided **before the broadcast**, alongside the derivation, rather than inside the send loop. Deciding it in the loop is not just untidy — a request leasing two deployments where only the first is derivable would have shipped a manifest to the first provider, and created every lease on chain, before refusing the second. Three tests pin this: the derived manifest is sent for a request that carried none, an unsatisfiable single-lease request costs neither a tx nor a send, and a mixed multi-dseq request contacts no provider at all.

Hoisting it also removed a type error the send site had (`derived.get(dseq) ?? manifest` is `string | undefined` where `sendManifest` wants `string`); the map the loop now reads is `Map<string, string>` by construction.

### Cost

One extra `yaml` parse and one extra chain-sdk `generateManifest` per create. Real but small, and the create path already parses the submitted SDL three times (`#storedSdlOf`, `#receiveSecrets`, `#resolveSdl`). Not hidden, and not worth a shared entry point on `SdlService` at this size — the two calls take the raw string independently, which also keeps them from sharing the mutable parsed document that `generateManifestFrom` rewrites in place.

It runs **before** the broadcast, so if it ever did fail it would cost no deployment on chain, and it reports through the same 400 channel every other SDL refusal uses rather than inventing a second one.

## No schema or type change

`CreateDeploymentResponseSchema.data.manifest` is still `z.string()`, still required. `packages/console-api-types/src/schema.d.ts:8281` is unchanged and **needs no regeneration** — only the value assigned to the field changed, not its type. No migration, no OpenAPI diff.

## Checks

`apps/api`:

```
npm test                → 267 files, 3594 passed, exit 0   (unit + integration + functional, docker up)
npm run lint -- --quiet → exit 0, no output
npx tsc --noEmit        → 43 errors
```

The `e2e` project is not part of `npm test` and was not run — see the release note below.

43 is one **fewer** than the 44 measured on the same tree with the two lease files reverted, and the diff of the two error lists is exactly the `string | undefined` error described above. No other error moved, and neither touched file appears in the remaining 43.

`apps/deploy-web`, run because this changes a contract it consumes even though no file in it is edited:

```
npx tsc --noEmit                        → 92 errors, byte-identical to the same command on the base
useDeploymentFlow unit tests            → 2 files, 70 passed, exit 0
```

The 92 are pre-existing spec-mock typing errors; none is in `ConfigureDeployment` or `useDeploymentFlow`. They cannot move, since this PR edits no file outside `apps/api`.

## It also fixes a latent bug in deploy-web's detector

Beyond removing the leak, this makes the quoting-window detector work for sealed deploys, which it did not before. Pre-PR4 a sealed create returned **resolved** values while deploy-web's `manifestFromSdl` built **reference literals** from the same SDL, so `activeManifest !== manifest` at `useDeploymentFlow.ts:439` was *always* true and an on-chain deployment-update tx would have fired on every sealed deploy even with the SDL untouched. Both sides now build from the submitted document, so the comparison means what it says. No deploy-web change needed to get that.

## ⚠️ One check a human must run before release

`apps/api/test/e2e/managed-api-deployment-flow.spec.ts` forwards the create response's manifest straight into `createLease` (`:41` and `:230`), which makes it **the only assertion in the repo that exercises PR3 and PR4 against each other**. It needs live network and funding, so it did not run in review and has not been run here — please run it before release rather than discovering it after merge.

While reading it I found and fixed a stale assertion in it that this PR falsifies: `:213` asserted the create response's manifest matched `/(secret-value|another secret value)/` — i.e. it pinned the leak — under the comment *"until manifest is not ignored by lease create API, it returns secrets as is"*. That is now done, so the assertion is inverted to require `ac-secret://TEST_SECRET` and forbid both cleartext values, mirroring the un-skipped functional test at e2e level. It typechecks and lints, but **it has not been executed**, which is the main thing the pre-release run needs to confirm.

## Mutation-tested

Reverting the response to `manifestToSortedJSON(manifest.groups)` fails the un-skipped functional test and the unit test that pins it — 1 each, both by assertion rather than by crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployment responses now return manifests based on the submitted SDL, while resolved manifests continue to support deployment processing.
  - Deployment requests can omit the legacy YAML manifest field, which is now marked deprecated.

- **Bug Fixes**
  - Secret references are preserved in deployment responses without exposing decrypted secret values.
  - Manifest generation now completes before transactions are broadcast, preventing broadcasts when validation fails.
  - Deployment and lease processing now consistently uses the authenticated user’s context.
  - Deployments return a validation error when no usable manifest is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
