### PR TITLE
feat(sdl): choose a CPU architecture when configuring a deployment

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ComputeResourcesCard/ComputeResourcesCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ComputeResourcesCard/ComputeResourcesCard.spec.tsx
@@ -156,6 +156,51 @@ describe(ComputeResourcesCard.name, () => {
     expect(analyticsService.track).not.toHaveBeenCalledWith("configure_cpu_count_changed", expect.anything());
   });
 
+  it("writes the chosen CPU architecture to the service profile", async () => {
+    const { getValues } = setup({});
+
+    await userEvent.click(screen.getByLabelText("CPU Architecture"));
+    await userEvent.click(screen.getByRole("option", { name: "arm64" }));
+
+    expect(getValues().services[0].profile.arch).toBe("arm64");
+  });
+
+  it("clears the architecture when the default is chosen, so the SDL keeps writing none", async () => {
+    const { getValues } = setup({ arch: "arm64" });
+
+    await userEvent.click(screen.getByLabelText("CPU Architecture"));
+    await userEvent.click(screen.getByRole("option", { name: "Default (amd64)" }));
+
+    expect(getValues().services[0].profile.arch).toBeUndefined();
+  });
+
+  it("tracks the chosen CPU architecture", async () => {
+    const { analyticsService } = setup({});
+
+    await userEvent.click(screen.getByLabelText("CPU Architecture"));
+    await userEvent.click(screen.getByRole("option", { name: "arm64" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("configure_cpu_arch_changed", { category: "deployments", arch: "arm64" });
+  });
+
+  it("hides the architecture selector while the flag is off", () => {
+    setup({ isCpuArchEnabled: false });
+
+    expect(screen.queryByLabelText("CPU Architecture")).not.toBeInTheDocument();
+  });
+
+  it("shows an imported architecture even while the flag is off", () => {
+    setup({ isCpuArchEnabled: false, arch: "arm64" });
+
+    expect(screen.getByLabelText("CPU Architecture")).toBeInTheDocument();
+  });
+
+  it("disables the architecture selector while locked", () => {
+    setup({ locked: true });
+
+    expect(screen.getByLabelText("CPU Architecture")).toBeDisabled();
+  });
+
   function setup(input: {
     ram?: number;
     ramUnit?: string;
@@ -163,12 +208,15 @@ describe(ComputeResourcesCard.name, () => {
     storageUnit?: string;
     cpuError?: string;
     locked?: boolean;
+    arch?: "amd64" | "arm64";
+    isCpuArchEnabled?: boolean;
     resolver?: Resolver<SdlBuilderFormValuesType>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const values = defaultServiceWithPlacement({
       profile: {
         cpu: 0.5,
+        arch: input.arch,
         gpu: 1,
         gpuModels: [{ vendor: "nvidia" }],
         hasGpu: false,
@@ -193,10 +241,11 @@ describe(ComputeResourcesCard.name, () => {
 
     const analyticsService = mock<AnalyticsService>();
     const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
+    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isCpuArchEnabled ?? true;
 
     render(
       <Wrapper>
-        <ComputeResourcesCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, useServices, ...input.dependencies }} />
+        <ComputeResourcesCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, useServices, useFlag, ...input.dependencies }} />
       </Wrapper>
     );
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ComputeResourcesCard/ComputeResourcesCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ComputeResourcesCard/ComputeResourcesCard.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 import {
   Field,
@@ -11,14 +11,30 @@ import {
   FormMessage,
   Input,
   NumberUnitInput,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   useFieldError
 } from "@akashnetwork/ui/components";
 
 import { useServices } from "@src/context/ServicesProvider";
+import { useFlag } from "@src/hooks/useFlag";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { memoryUnits, storageUnits, validationConfig } from "@src/utils/akash/units";
+import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
 
-export const DEPENDENCIES = { NumberUnitInput, useFieldError, useServices };
+export const DEPENDENCIES = { NumberUnitInput, useFieldError, useServices, useFlag };
+
+/** Value standing in for "write no architecture at all", which a Select cannot express as an empty string. */
+const DEFAULT_ARCH_OPTION = "default";
+
+const ARCH_OPTIONS = [
+  { value: DEFAULT_ARCH_OPTION, label: "Default (amd64)" },
+  { value: "amd64", label: "amd64" },
+  { value: "arm64", label: "arm64" }
+] as const;
 
 type Props = {
   serviceIndex: number;
@@ -37,6 +53,19 @@ export const ComputeResourcesCard: FC<Props> = ({ serviceIndex, locked = false, 
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const { analyticsService } = d.useServices();
   const cpuFocusValueRef = useRef<number | null>(null);
+  const isCpuArchEnabled = d.useFlag("ui_sdl_cpu_arch");
+
+  const arch = useController({ control, name: `services.${serviceIndex}.profile.arch` });
+  /**
+   * An architecture imported from an SDL stays visible with the flag off, so the value is never
+   * silently carried into a deployment through a control the user cannot see.
+   */
+  const [hasCarriedArch] = useState(() => !!arch.field.value);
+
+  const selectCpuArch = (value: string) => {
+    arch.field.onChange(value === DEFAULT_ARCH_OPTION ? undefined : value);
+    analyticsService.track("configure_cpu_arch_changed", { category: "deployments", arch: value });
+  };
 
   const ram = useController({ control, name: `services.${serviceIndex}.profile.ram` });
   const ramUnit = useController({ control, name: `services.${serviceIndex}.profile.ramUnit` });
@@ -126,6 +155,26 @@ export const ComputeResourcesCard: FC<Props> = ({ serviceIndex, locked = false, 
           </FieldContent>
         </Field>
       </div>
+
+      {(isCpuArchEnabled || hasCarriedArch) && (
+        <Field className="gap-2">
+          <FieldLabel>CPU Architecture</FieldLabel>
+          <FieldContent>
+            <Select value={arch.field.value ?? DEFAULT_ARCH_OPTION} onValueChange={selectCpuArch} disabled={locked}>
+              <SelectTrigger aria-label="CPU Architecture" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {ARCH_OPTIONS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FieldContent>
+        </Field>
+      )}
     </>
   );
 };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/hardwarePresets.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/hardwarePresets.spec.ts
@@ -107,6 +107,14 @@ describe(applyPresetToProfile.name, () => {
     expect(result.storage[1]).toMatchObject({ name: "data", isPersistent: true });
   });
 
+  it("leaves a chosen CPU architecture alone, since a preset sizes hardware rather than picking it", () => {
+    const base = { ...defaultService("p").profile, arch: "arm64" as const };
+
+    const result = applyPresetToProfile(base, compute);
+
+    expect(result.arch).toBe("arm64");
+  });
+
   it("round-trips through detectPreset", () => {
     const result = applyPresetToProfile(defaultService("p").profile, DEFAULT_HARDWARE_PRESET);
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.spec.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
-import { useDeploymentGpuCount, useDeploymentHasGpu } from "./useDeploymentResourceSummary";
+import { useDeploymentCpuArch, useDeploymentGpuCount, useDeploymentHasGpu } from "./useDeploymentResourceSummary";
 
 import { renderHook } from "@testing-library/react";
 
@@ -81,5 +81,42 @@ describe(useDeploymentHasGpu.name, () => {
     };
 
     return renderHook(() => useDeploymentHasGpu(), { wrapper: Wrapper });
+  }
+});
+
+describe(useDeploymentCpuArch.name, () => {
+  it("returns the architecture a service requests", () => {
+    const { result } = setup({ arch: "arm64" });
+
+    expect(result.current).toBe("arm64");
+  });
+
+  it("returns undefined when no service requests an architecture", () => {
+    const { result } = setup({});
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it("ignores a service in another placement", () => {
+    const { result } = setup({ arch: "arm64", placementId: "other-placement", scopeTo: "placement-1" });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  function setup(input: { arch?: "amd64" | "arm64"; placementId?: string; scopeTo?: string }) {
+    const base = defaultServiceWithPlacement({ image: "nginx:latest" });
+    const values = {
+      ...base,
+      services: base.services.map((service, index) =>
+        index === 0 ? { ...service, placementId: input.placementId ?? service.placementId, profile: { ...service.profile, arch: input.arch } } : service
+      )
+    };
+
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    return renderHook(() => useDeploymentCpuArch(input.scopeTo), { wrapper: Wrapper });
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.spec.tsx
@@ -2,8 +2,8 @@ import type { PropsWithChildren } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { describe, expect, it } from "vitest";
 
-import type { SdlBuilderFormValuesType } from "@src/types";
-import { defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import type { CpuArchType, SdlBuilderFormValuesType } from "@src/types";
+import { defaultPlacement, defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import { useDeploymentCpuArch, useDeploymentGpuCount, useDeploymentHasGpu } from "./useDeploymentResourceSummary";
 
 import { renderHook } from "@testing-library/react";
@@ -86,30 +86,44 @@ describe(useDeploymentHasGpu.name, () => {
 
 describe(useDeploymentCpuArch.name, () => {
   it("returns the architecture a service requests", () => {
-    const { result } = setup({ arch: "arm64" });
+    const { result } = setup({ services: [{ arch: "arm64" }] });
 
     expect(result.current).toBe("arm64");
   });
 
   it("returns undefined when no service requests an architecture", () => {
-    const { result } = setup({});
+    const { result } = setup({ services: [{}] });
 
     expect(result.current).toBeUndefined();
   });
 
   it("ignores a service in another placement", () => {
-    const { result } = setup({ arch: "arm64", placementId: "other-placement", scopeTo: "placement-1" });
+    const { result } = setup({ services: [{ arch: "arm64", placementId: "other-placement" }], scopeTo: "placement-1" });
 
     expect(result.current).toBeUndefined();
   });
 
-  function setup(input: { arch?: "amd64" | "arm64"; placementId?: string; scopeTo?: string }) {
-    const base = defaultServiceWithPlacement({ image: "nginx:latest" });
-    const values = {
-      ...base,
-      services: base.services.map((service, index) =>
-        index === 0 ? { ...service, placementId: input.placementId ?? service.placementId, profile: { ...service.profile, arch: input.arch } } : service
-      )
+  it("returns the architecture shared by every service that requests one", () => {
+    const { result } = setup({ services: [{ arch: "arm64" }, {}, { arch: "arm64" }] });
+
+    expect(result.current).toBe("arm64");
+  });
+
+  it("returns undefined when scoped services request different architectures", () => {
+    const { result } = setup({ services: [{ arch: "arm64" }, { arch: "amd64" }] });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  function setup(input: { services: Array<{ arch?: CpuArchType; placementId?: string }>; scopeTo?: string }) {
+    const placement = defaultPlacement();
+    const values: SdlBuilderFormValuesType = {
+      placements: [placement],
+      endpoints: [],
+      services: input.services.map(service => {
+        const built = defaultService(service.placementId ?? placement.id, { image: "nginx:latest" });
+        return { ...built, profile: { ...built.profile, arch: service.arch } };
+      })
     };
 
     const Wrapper = ({ children }: PropsWithChildren) => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
@@ -36,15 +36,17 @@ export function useDeploymentHasGpu(): boolean {
 }
 
 /**
- * The CPU architecture the viewed placement asks for, or undefined when it asks for none. Only an explicitly
- * requested architecture is reported: a spec that writes no `arch` attribute is served by every provider, so
- * naming an architecture in the marketplace's empty state would be inventing a constraint the user never set.
+ * The one CPU architecture the viewed placement asks for, or undefined when it asks for none or for several.
+ * Only an explicitly requested architecture is reported: a spec that writes no `arch` attribute is served by
+ * every provider, so naming an architecture in the marketplace's empty state would be inventing a constraint
+ * the user never set, and a placement whose services disagree has no single architecture to name.
  */
 export function useDeploymentCpuArch(placementId?: string): CpuArchType | undefined {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const services = useWatch({ control, name: "services" });
   return useMemo(() => {
     const scoped = placementId ? (services ?? []).filter(service => service.placementId === placementId) : services ?? [];
-    return scoped.find(service => service.profile?.arch)?.profile?.arch;
+    const requested = new Set(scoped.flatMap(service => service.profile?.arch ?? []));
+    return requested.size === 1 ? [...requested][0] : undefined;
   }, [services, placementId]);
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 
-import type { SdlBuilderFormValuesType } from "@src/types";
+import type { CpuArchType, SdlBuilderFormValuesType } from "@src/types";
 import { aggregateDeploymentResources, formatDeploymentResources } from "./deploymentResources";
 
 /** Returns the live "Your deployment" resource summary string derived from the current form spec. */
@@ -33,4 +33,18 @@ export function useDeploymentGpuCount(placementId?: string): number {
  */
 export function useDeploymentHasGpu(): boolean {
   return useDeploymentGpuCount() > 0;
+}
+
+/**
+ * The CPU architecture the viewed placement asks for, or undefined when it asks for none. Only an explicitly
+ * requested architecture is reported: a spec that writes no `arch` attribute is served by every provider, so
+ * naming an architecture in the marketplace's empty state would be inventing a constraint the user never set.
+ */
+export function useDeploymentCpuArch(placementId?: string): CpuArchType | undefined {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const services = useWatch({ control, name: "services" });
+  return useMemo(() => {
+    const scoped = placementId ? (services ?? []).filter(service => service.placementId === placementId) : services ?? [];
+    return scoped.find(service => service.profile?.arch)?.profile?.arch;
+  }, [services, placementId]);
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -120,7 +120,7 @@ describe(MarketplacePane.name, () => {
     const { MarketplaceProvidersTable } = setup({ requestedCpuArch: "arm64" });
 
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(
-      expect.objectContaining({ emptyMessage: "No providers currently offer arm64 hardware for this configuration." }),
+      expect.objectContaining({ emptyMessage: "No arm64 providers matched this configuration." }),
       expect.anything()
     );
   });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -116,6 +116,27 @@ describe(MarketplacePane.name, () => {
     return { ...buildScreenedProvider(), offerState: "searching", ...overrides };
   }
 
+  it("explains an empty provider list by architecture when the spec asks for one", () => {
+    const { MarketplaceProvidersTable } = setup({ requestedCpuArch: "arm64" });
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(
+      expect.objectContaining({ emptyMessage: "No providers currently offer arm64 hardware for this configuration." }),
+      expect.anything()
+    );
+  });
+
+  it("leaves the empty message generic when the spec asks for no architecture", () => {
+    const { MarketplaceProvidersTable } = setup({});
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ emptyMessage: undefined }), expect.anything());
+  });
+
+  it("scopes the requested architecture to the placement it renders bids for", () => {
+    const { useDeploymentCpuArch } = setup({ selectedPlacementId: "placement-2" });
+
+    expect(useDeploymentCpuArch).toHaveBeenCalledWith("placement-2");
+  });
+
   function setup(
     input: {
       sdl?: string;
@@ -130,6 +151,7 @@ describe(MarketplacePane.name, () => {
       isInvalid?: boolean;
       isSearchActive?: boolean;
       gpuCount?: number;
+      requestedCpuArch?: "amd64" | "arm64";
       isOnboarded?: boolean;
       selectedPlacementId?: string;
       selectedBidId?: string;
@@ -155,12 +177,14 @@ describe(MarketplacePane.name, () => {
       </button>
     ));
     const useDeploymentGpuCount = vi.fn(() => input.gpuCount ?? 0);
+    const useDeploymentCpuArch = vi.fn(() => input.requestedCpuArch);
     const dependencies: typeof DEPENDENCIES = {
       usePlacementOffers: usePlacementOffers as never,
       useProviderSearch: useProviderSearch as never,
       MarketplaceProvidersTable: MarketplaceProvidersTable as never,
       ProviderSearchInput,
       useDeploymentGpuCount,
+      useDeploymentCpuArch,
       useIsOnboarded: () => input.isOnboarded ?? true
     };
     const user = userEvent.setup();
@@ -178,6 +202,6 @@ describe(MarketplacePane.name, () => {
         dependencies={dependencies}
       />
     );
-    return { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, useDeploymentGpuCount, user };
+    return { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, useDeploymentGpuCount, useDeploymentCpuArch, user };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -83,7 +83,7 @@ export const MarketplacePane: FC<Props> = ({
             isSelectable={phase === "quoting"}
             gpuCount={gpuCount}
             showProviderLink={showProviderLink}
-            emptyMessage={requestedCpuArch ? `No providers currently offer ${requestedCpuArch} hardware for this configuration.` : undefined}
+            emptyMessage={requestedCpuArch ? `No ${requestedCpuArch} providers matched this configuration.` : undefined}
           />
         )}
       </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -2,13 +2,21 @@ import type { FC } from "react";
 
 import { useIsOnboarded } from "@src/hooks/useIsOnboarded";
 import { usePlacementOffers } from "@src/queries/usePlacementOffers";
-import { useDeploymentGpuCount } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
+import { useDeploymentCpuArch, useDeploymentGpuCount } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable/MarketplaceProvidersTable";
 import { useProviderSearch } from "./MarketplaceProvidersTable/useProviderSearch/useProviderSearch";
 import { ProviderSearchInput } from "./ProviderSearchInput/ProviderSearchInput";
 
-export const DEPENDENCIES = { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, ProviderSearchInput, useDeploymentGpuCount, useIsOnboarded };
+export const DEPENDENCIES = {
+  usePlacementOffers,
+  useProviderSearch,
+  MarketplaceProvidersTable,
+  ProviderSearchInput,
+  useDeploymentGpuCount,
+  useDeploymentCpuArch,
+  useIsOnboarded
+};
 
 interface Props {
   sdl: string;
@@ -37,6 +45,7 @@ export const MarketplacePane: FC<Props> = ({
   const { query, setQuery, clear, filteredProviders, isSearchActive } = d.useProviderSearch(offers);
   const hasFailedWithoutData = isError && offers.length === 0;
   const gpuCount = d.useDeploymentGpuCount(selectedPlacementId);
+  const requestedCpuArch = d.useDeploymentCpuArch(selectedPlacementId);
   /** Provider names link out only once the user is onboarded: the route gate bounces a not-yet-onboarded user back into the funnel, so the link would dead-end. */
   const showProviderLink = d.useIsOnboarded();
 
@@ -74,6 +83,7 @@ export const MarketplacePane: FC<Props> = ({
             isSelectable={phase === "quoting"}
             gpuCount={gpuCount}
             showProviderLink={showProviderLink}
+            emptyMessage={requestedCpuArch ? `No providers currently offer ${requestedCpuArch} hardware for this configuration.` : undefined}
           />
         )}
       </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -124,6 +124,19 @@ describe(MarketplaceProvidersTable.name, () => {
     expect(screen.queryByRole("button", { name: /clear search/i })).not.toBeInTheDocument();
   });
 
+  it("shows a caller-supplied empty message in place of the plain one", () => {
+    setup({ providers: [], isSearchActive: false, emptyMessage: "No providers currently offer arm64 hardware for this configuration." });
+
+    expect(screen.getByText("No providers currently offer arm64 hardware for this configuration.")).toBeInTheDocument();
+    expect(screen.queryByText("No providers found.")).not.toBeInTheDocument();
+  });
+
+  it("keeps the search empty state when a search is active, even with an empty message supplied", () => {
+    setup({ providers: [], isSearchActive: true, emptyMessage: "No providers currently offer arm64 hardware for this configuration." });
+
+    expect(screen.getByText("No providers match your search.")).toBeInTheDocument();
+  });
+
   it("omits the clear action in the search empty state when no clear handler is provided", () => {
     setup({ providers: [], isSearchActive: true });
 
@@ -338,6 +351,7 @@ describe(MarketplaceProvidersTable.name, () => {
     isSelectable?: boolean;
     gpuCount?: number;
     showProviderLink?: boolean;
+    emptyMessage?: string;
   }) {
     const onSelect = vi.fn();
     const user = userEvent.setup();
@@ -355,6 +369,7 @@ describe(MarketplaceProvidersTable.name, () => {
               isSelectable={input.isSelectable}
               gpuCount={input.gpuCount}
               showProviderLink={input.showProviderLink ?? true}
+              emptyMessage={input.emptyMessage}
             />
           </TooltipProvider>
         </IntlProvider>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -125,14 +125,14 @@ describe(MarketplaceProvidersTable.name, () => {
   });
 
   it("shows a caller-supplied empty message in place of the plain one", () => {
-    setup({ providers: [], isSearchActive: false, emptyMessage: "No providers currently offer arm64 hardware for this configuration." });
+    setup({ providers: [], isSearchActive: false, emptyMessage: "No arm64 providers matched this configuration." });
 
-    expect(screen.getByText("No providers currently offer arm64 hardware for this configuration.")).toBeInTheDocument();
+    expect(screen.getByText("No arm64 providers matched this configuration.")).toBeInTheDocument();
     expect(screen.queryByText("No providers found.")).not.toBeInTheDocument();
   });
 
   it("keeps the search empty state when a search is active, even with an empty message supplied", () => {
-    setup({ providers: [], isSearchActive: true, emptyMessage: "No providers currently offer arm64 hardware for this configuration." });
+    setup({ providers: [], isSearchActive: true, emptyMessage: "No arm64 providers matched this configuration." });
 
     expect(screen.getByText("No providers match your search.")).toBeInTheDocument();
   });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -47,6 +47,8 @@ interface Props {
   gpuCount?: number;
   /** Whether provider names link to their detail pages. */
   showProviderLink: boolean;
+  /** Replaces the generic no-provider text when the spec asks for something specific enough to name, e.g. a CPU architecture. */
+  emptyMessage?: string;
 }
 
 export const MarketplaceProvidersTable: FC<Props> = ({
@@ -58,7 +60,8 @@ export const MarketplaceProvidersTable: FC<Props> = ({
   onSelect,
   isSelectable = true,
   gpuCount = 0,
-  showProviderLink
+  showProviderLink,
+  emptyMessage
 }) => {
   const [sorting, setSorting] = useState<SortingState>([]);
 
@@ -98,7 +101,7 @@ export const MarketplaceProvidersTable: FC<Props> = ({
         </div>
       );
     }
-    return <p className="p-4 text-sm text-muted-foreground">No providers found.</p>;
+    return <p className="p-4 text-sm text-muted-foreground">{emptyMessage ?? "No providers found."}</p>;
   }
 
   const sortedRows = table.getRowModel().rows;

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -116,6 +116,7 @@ export type AnalyticsEvent =
   | "configure_gpu_type_selected"
   | "configure_gpu_count_changed"
   | "configure_cpu_count_changed"
+  | "configure_cpu_arch_changed"
   | "configure_sdl_imported"
   | "configure_sdl_downloaded"
   | "configure_sdl_copied"

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -9,4 +9,5 @@ export type FeatureFlag =
   | "ui_agent_mode_deploy"
   | "hackathons"
   | "deployment_runtime_limit"
-  | "ui_sdl_proxy_http_options";
+  | "ui_sdl_proxy_http_options"
+  | "ui_sdl_cpu_arch";

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -4,6 +4,7 @@ import {
   CredentialsSchema,
   EndpointSchema,
   EnvironmentVariableSchema,
+  ProfileSchema,
   SdlBuilderFormValuesSchema,
   ServiceExposeHTTPProxySchema,
   ServiceSchema,
@@ -602,4 +603,31 @@ describe("EndpointSchema", () => {
     const result = EndpointSchema.safeParse({ id: "e-1", name: "endpoint-1" });
     expect(result.success).toBe(true);
   });
+});
+
+describe("ProfileSchema cpu architecture", () => {
+  it.each(["amd64", "arm64"])("accepts %s", arch => {
+    expect(ProfileSchema.safeParse(buildProfile(arch)).success).toBe(true);
+  });
+
+  it("accepts a profile that names no architecture", () => {
+    expect(ProfileSchema.safeParse(buildProfile(undefined)).success).toBe(true);
+  });
+
+  it("rejects an architecture outside the SDL enum", () => {
+    const result = ProfileSchema.safeParse(buildProfile("sparc64"));
+
+    expect(result.success).toBe(false);
+    expect((result as { error: { issues: { path: (string | number)[] }[] } }).error.issues).toContainEqual(expect.objectContaining({ path: ["arch"] }));
+  });
+
+  function buildProfile(arch: string | undefined) {
+    return {
+      cpu: 0.5,
+      ...(arch === undefined ? {} : { arch }),
+      ram: 512,
+      ramUnit: "Mi",
+      storage: [{ size: 512, unit: "Mi", isPersistent: false }]
+    };
+  }
 });

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -234,9 +234,14 @@ export const CredentialsSchema = z
   })
   .optional();
 
+/** The architectures an SDL may ask for. Omitting the attribute is a third state, and the only one that writes nothing. */
+export const CPU_ARCHITECTURES = ["amd64", "arm64"] as const;
+
 export const ProfileSchema = z
   .object({
     cpu: z.number({ invalid_type_error: "CPU count is required." }).min(0.1, { message: "Minimum amount of CPU for a single service instance is 0.1." }),
+    /** Requested CPU architecture. Undefined writes no `arch` attribute at all, which is what every pre-arm64 deployment has. */
+    arch: z.enum(CPU_ARCHITECTURES).optional(),
     hasGpu: z.boolean().optional(),
     gpu: z.number({ invalid_type_error: "GPU amount is required." }).optional(),
     gpuModels: z.array(ProfileGpuModelSchema).optional(),
@@ -691,6 +696,7 @@ export const SdlBuilderFormValuesSchema = z
 export type ServiceType = z.infer<typeof ServiceSchema>;
 export type SdlBuilderFormValuesType = z.infer<typeof SdlBuilderFormValuesSchema>;
 export type ProfileGpuModelType = z.infer<typeof ProfileGpuModelSchema>;
+export type CpuArchType = (typeof CPU_ARCHITECTURES)[number];
 export type EnvironmentVariableType = z.infer<typeof EnvironmentVariableSchema>;
 export type AcceptType = z.infer<typeof AcceptSchema>;
 export type PlacementAttributeType = z.infer<typeof PlacementAttributeSchema>;

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -382,3 +382,58 @@ describe("proxy manifest round-trip", () => {
     expect(groups[0].services[0].expose[0].httpOptions?.proxy).toEqual(fullProxy);
   });
 });
+
+describe("CPU architecture", () => {
+  it("writes no cpu attributes when the service names no architecture", () => {
+    const parsed = yaml.load(generateSdl(buildArchFormValues(undefined))) as ComputeYaml;
+
+    expect(parsed.profiles.compute.web.resources.cpu).toEqual({ units: 0.5 });
+  });
+
+  it.each(["amd64", "arm64"] as const)("writes %s as a cpu arch attribute", arch => {
+    const parsed = yaml.load(generateSdl(buildArchFormValues(arch))) as ComputeYaml;
+
+    expect(parsed.profiles.compute.web.resources.cpu).toEqual({ units: 0.5, attributes: { arch } });
+  });
+
+  it("produces byte-identical SDL to a service with no architecture field at all", () => {
+    const withUndefined = generateSdl(buildArchFormValues(undefined));
+    const withoutTheField = generateSdl(buildArchFormValues());
+
+    expect(withUndefined).toBe(withoutTheField);
+  });
+
+  it("carries the architecture onto the manifest group spec a provider matches on", () => {
+    const parsedYaml = yaml.load(generateSdl(buildArchFormValues("arm64")));
+
+    const groups = getManifest(parsedYaml);
+
+    expect(groups[0].services[0].resources.cpu.attributes).toEqual([{ key: "arch", value: "arm64" }]);
+  });
+
+  type ComputeYaml = { profiles: { compute: Record<string, { resources: { cpu: { units: number; attributes?: { arch: string } } } }> } };
+
+  function buildArchFormValues(...arch: ["amd64" | "arm64" | undefined] | []): SdlBuilderFormValuesType {
+    const placement: PlacementType = { id: "p-1", name: "dcloud" };
+    const service = {
+      id: "web-id",
+      title: "web",
+      image: "nginx:latest",
+      profile: {
+        cpu: 0.5,
+        ...(arch.length ? { arch: arch[0] } : {}),
+        ram: 512,
+        ramUnit: "Mi",
+        storage: [{ size: 512, unit: "Mi", isPersistent: false }],
+        hasGpu: false,
+        gpu: 0
+      },
+      expose: [{ port: 80, as: 80, global: true, to: [] }],
+      placementId: "p-1",
+      pricing: { amount: 1000, denom: "uakt" },
+      count: 1
+    } as ServiceType;
+
+    return { placements: [placement], services: [service] } as SdlBuilderFormValuesType;
+  }
+});

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -141,7 +141,8 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
     sdl.profiles.compute[service.title] = {
       resources: {
         cpu: {
-          units: service.profile.cpu
+          units: service.profile.cpu,
+          ...(service.profile.arch ? { attributes: { arch: service.profile.arch } } : {})
         },
         memory: {
           size: `${service.profile.ram}${service.profile.ramUnit}`

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -634,3 +634,73 @@ describe("importSimpleSdl reclamation", () => {
     expect(parsed.reclamation).toEqual({ min_window: minWindow });
   });
 });
+
+describe("importSimpleSdl cpu architecture", () => {
+  it("imports the architecture an SDL requests", () => {
+    const services = importSimpleSdl(archSdl("arm64"));
+
+    expect(services.services[0].profile.arch).toBe("arm64");
+  });
+
+  it("leaves the architecture unset when the SDL declares no cpu attributes", () => {
+    const services = importSimpleSdl(archSdl(undefined));
+
+    expect(services.services[0].profile.arch).toBeUndefined();
+  });
+
+  it.each(["amd64", "arm64"] as const)("round-trips an explicit %s without changing it", arch => {
+    const regenerated = generateSdl(importSimpleSdl(archSdl(arch)));
+    const parsed = yaml.load(regenerated) as { profiles: { compute: Record<string, { resources: { cpu: { attributes?: { arch: string } } } }> } };
+
+    expect(parsed.profiles.compute.web.resources.cpu.attributes).toEqual({ arch });
+  });
+
+  it("writes no cpu attributes when round-tripping an SDL that declared none", () => {
+    const regenerated = generateSdl(importSimpleSdl(archSdl(undefined)));
+    const parsed = yaml.load(regenerated) as { profiles: { compute: Record<string, { resources: { cpu: { attributes?: { arch: string } } } }> } };
+
+    expect(parsed.profiles.compute.web.resources.cpu).not.toHaveProperty("attributes");
+  });
+
+  it("rejects an architecture no provider could serve", () => {
+    expect(() => importSimpleSdl(archSdl("sparc64"))).toThrow('Unsupported CPU architecture "sparc64"');
+  });
+
+  function archSdl(arch: string | undefined): string {
+    const cpuAttributes = arch ? ["          attributes:", `            arch: ${arch}`] : [];
+    return [
+      "---",
+      'version: "2.0"',
+      "services:",
+      "  web:",
+      "    image: nginx",
+      "    expose:",
+      "      - port: 80",
+      "        to:",
+      "          - global: true",
+      "profiles:",
+      "  compute:",
+      "    web:",
+      "      resources:",
+      "        cpu:",
+      "          units: 0.5",
+      ...cpuAttributes,
+      "        memory:",
+      "          size: 512Mi",
+      "        storage:",
+      "          - size: 512Mi",
+      "  placement:",
+      "    dcloud:",
+      "      pricing:",
+      "        web:",
+      "          denom: uakt",
+      "          amount: 1000",
+      "deployment:",
+      "  web:",
+      "    dcloud:",
+      "      profile: web",
+      "      count: 1",
+      ""
+    ].join("\n");
+  }
+});

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -2,6 +2,7 @@ import yaml from "js-yaml";
 import { nanoid } from "nanoid";
 
 import type {
+  CpuArchType,
   EndpointType,
   ExposeType,
   PlacementAttributeType,
@@ -11,7 +12,7 @@ import type {
   ServiceExposeHTTPProxyType,
   ServiceType
 } from "@src/types";
-import { ReclamationMinWindowSchema, RESERVED_ENV_KEYS } from "@src/types/sdlBuilder/sdlBuilder";
+import { CPU_ARCHITECTURES, ReclamationMinWindowSchema, RESERVED_ENV_KEYS } from "@src/types/sdlBuilder/sdlBuilder";
 import { CustomValidationError } from "../deploymentData";
 import { capitalizeFirstLetter } from "../stringUtils";
 import { defaultHttpOptions } from "./data";
@@ -79,6 +80,7 @@ export const importSimpleSdl = (yamlStr: string, { placementPerService = false }
 
       service.profile = {
         cpu: compute.resources.cpu.units,
+        arch: getCpuArch(compute.resources.cpu.attributes),
         gpu: compute.resources.gpu ? compute.resources.gpu.units : 0,
         gpuModels: compute.resources.gpu ? getGpuModels(compute.resources.gpu.attributes.vendor) : [],
         interconnect: compute.resources.gpu ? getGpuInterconnect(compute.resources.gpu.attributes) : undefined,
@@ -215,6 +217,22 @@ const getResourceDigit = (size: string): number => {
 const getResourceUnit = (size: string): string => {
   const match = size.match(/[a-zA-Z]+/g);
   return match ? capitalizeFirstLetter(match[0]) : "";
+};
+
+/**
+ * Reads the requested CPU architecture from `cpu.attributes.arch`, leaving it off when the SDL sets none
+ * so a round trip through the builder keeps writing no CPU attributes at all.
+ */
+const getCpuArch = (attributes: { arch?: unknown } | undefined): CpuArchType | undefined => {
+  const arch = attributes?.arch;
+  if (arch === undefined || arch === null) return undefined;
+
+  const supported = CPU_ARCHITECTURES.find(candidate => candidate === arch);
+  if (!supported) {
+    throw new CustomValidationError(`Unsupported CPU architecture "${arch}". Expected ${CPU_ARCHITECTURES.join(" or ")}.`);
+  }
+
+  return supported;
 };
 
 /**


### PR DESCRIPTION
## Why

Closes CON-932

Tenants cannot ask for arm64 hardware from Console at all. The configure flow has no notion of CPU architecture, so the SDL it writes never carries one and arm64 capacity is unreachable through the product. This is the tenant-facing half of ARM support.

> Stacked on #3801 (the chain-sdk alpha.45 bump), which is what validates an architecture-bearing SDL. Base is set to that branch, so this PR shows only its own delta.

## What

The Compute Resources card gains a **CPU Architecture** select, next to vCPU, memory and storage.

**Three states, not two.** "Default (amd64)" writes no `arch` attribute at all, and amd64 and arm64 each write one. The explicit amd64 option is the interesting one: an imported SDL that sets `arch: amd64` has to survive a round trip, and a two-state control would quietly drop it and change that deployment's group spec. With the default selected the generated SDL is byte-identical to what it is today, which a test asserts directly rather than by inspection.

**The flag has an escape hatch.** The control sits behind `ui_sdl_cpu_arch`, but an architecture carried in from an imported SDL renders even with the flag off. Otherwise a value would ride into a deployment through a control the user cannot see. Same shape as the `hasCarriedProxyValues` guard added for proxy http_options in e41a8bf.

**The marketplace explains itself.** When a spec asks for an architecture and no provider matches, the list says so by name instead of the bare "No providers found." that leaves the user guessing which part of their spec emptied it. Only an explicitly requested architecture is named, since a spec that writes none is served by everyone.

Presets are untouched: they size hardware rather than pick it, so applying one leaves a chosen architecture alone. That is now pinned by a test instead of being true by accident.

Scope: the redesigned configure flow only, as the issue asks. The legacy SDL Builder page shares the importer and generator, so an arm64 SDL still round-trips there, just without a control.

**Manual step before this can be turned on:** create `ui_sdl_cpu_arch` in Unleash, default off. It should stay off until providers filter on architecture (AKT-490) and an arm64 provider is reachable (AKT-584).

### Verification

Full deploy-web unit suite: 3760 passing, up 30. `eslint --quiet` clean, and `tsc --noEmit` reports no errors in any non-test file.

Two mutation checks, because "the tests pass" is worth less than "the tests would notice":

- Deleting the line that writes `cpu.attributes` turns 5 generator and importer tests red, including the manifest round-trip that proves the attribute reaches the group spec a provider matches on.
- Replacing the flag gate with `true` turns the flag-off test red.

Not covered here: no arm64 provider exists to deploy against yet, so the end-to-end proof is CON-935, gated on AKT-584.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CPU architecture selection for deployments, supporting `amd64` and `arm64`.
  - Preserved selected architectures when importing and regenerating deployment configurations.
  - Added architecture-specific messaging when no compatible marketplace providers are available.
  - Added architecture details to generated deployment resources.

- **Bug Fixes**
  - Hardware presets now preserve an existing `arm64` selection.
  - Unsupported CPU architectures are rejected during import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->