### PR TITLE
fix(managed-wallet): stop replaying a gas simulation past the tx window it carries

### DIFF
--- a/apps/tx-signer/README.md
+++ b/apps/tx-signer/README.md
@@ -27,6 +27,11 @@ Copy `env/.env.sample` to the env file you use and set:
 request timeout is never what abandons a transaction still in flight. Keep `apps/api`'s
 `TX_SIGNER_REQUEST_TIMEOUT_MS` above it.
 
+`RPC_REQUEST_TIMEOUT_MS` must stay below `UNORDERED_TX_TTL_MS`. Transactions are signed as unordered,
+so every payload sent to the node carries its own validity window, and a call allowed to outlive that
+window comes back rejected as expired instead of naming whatever went wrong on the wire. The config
+refuses to start when either relationship is broken.
+
 ## Local dev
 
 - `npm run dev` watch build

--- a/apps/tx-signer/src/config/env.config.spec.ts
+++ b/apps/tx-signer/src/config/env.config.spec.ts
@@ -1,0 +1,36 @@
+import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
+
+import { envSchema } from "./env.config";
+
+describe("envSchema", () => {
+  it("accepts the shipped defaults", () => {
+    const result = envSchema.safeParse(setup());
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an rpc request timeout that outlives the tx window it carries", () => {
+    const result = envSchema.safeParse(setup({ RPC_REQUEST_TIMEOUT_MS: 30_000, UNORDERED_TX_TTL_MS: 30_000 }));
+
+    expect(result.success).toBe(false);
+    expect(result.error!.issues).toContainEqual(expect.objectContaining({ path: ["RPC_REQUEST_TIMEOUT_MS"] }));
+  });
+
+  it("rejects a signing deadline that cannot fit one whole attempt", () => {
+    const result = envSchema.safeParse(setup({ SIGN_AND_BROADCAST_DEADLINE_MS: 40_000 }));
+
+    expect(result.success).toBe(false);
+    expect(result.error!.issues).toContainEqual(expect.objectContaining({ path: ["SIGN_AND_BROADCAST_DEADLINE_MS"] }));
+  });
+
+  function setup(overrides: Record<string, unknown> = {}) {
+    return {
+      ACCESS_API_KEY: faker.string.alphanumeric(32),
+      FUNDING_WALLET_MNEMONIC_V2: faker.lorem.words(12),
+      DERIVATION_WALLET_MNEMONIC_V2: faker.lorem.words(12),
+      RPC_NODE_ENDPOINT: faker.internet.url(),
+      ...overrides
+    };
+  }
+});

--- a/apps/tx-signer/src/config/env.config.ts
+++ b/apps/tx-signer/src/config/env.config.ts
@@ -36,9 +36,22 @@ export const envSchema = z
     NODE_ENV: z.enum(["development", "production", "test"]).optional().default("development"),
     PORT: z.number({ coerce: true }).optional().default(3091)
   })
-  .refine(env => env.SIGN_AND_BROADCAST_DEADLINE_MS >= minSignAndBroadcastDeadlineMs(env.UNORDERED_TX_TTL_MS), {
-    message: "SIGN_AND_BROADCAST_DEADLINE_MS must leave room for a full tx-recovery poll window derived from UNORDERED_TX_TTL_MS",
-    path: ["SIGN_AND_BROADCAST_DEADLINE_MS"]
+  .superRefine((env, ctx) => {
+    if (env.RPC_REQUEST_TIMEOUT_MS >= env.UNORDERED_TX_TTL_MS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "RPC_REQUEST_TIMEOUT_MS must stay below UNORDERED_TX_TTL_MS so one RPC call can still be answered inside the tx window it carries",
+        path: ["RPC_REQUEST_TIMEOUT_MS"]
+      });
+    }
+
+    if (env.SIGN_AND_BROADCAST_DEADLINE_MS < minSignAndBroadcastDeadlineMs(env.UNORDERED_TX_TTL_MS, env.RPC_REQUEST_TIMEOUT_MS)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "SIGN_AND_BROADCAST_DEADLINE_MS must leave room for a full tx-recovery poll window derived from UNORDERED_TX_TTL_MS",
+        path: ["SIGN_AND_BROADCAST_DEADLINE_MS"]
+      });
+    }
   });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/apps/tx-signer/src/lib/retriable-transport-error/retriable-transport-error.spec.ts
+++ b/apps/tx-signer/src/lib/retriable-transport-error/retriable-transport-error.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { isRetriableTransportError } from "./retriable-transport-error";
+
+describe(isRetriableTransportError.name, () => {
+  it("treats a 5xx-shaped rpc error as retriable", () => {
+    expect(isRetriableTransportError(new Error("Bad status on response: 503"))).toBe(true);
+  });
+
+  it("treats a 4xx-shaped rpc error as not retriable", () => {
+    expect(isRetriableTransportError(new Error("Bad status on response: 404"))).toBe(false);
+  });
+
+  it("treats a top-level network code as retriable", () => {
+    expect(isRetriableTransportError(Object.assign(new Error("socket reset"), { code: "ECONNRESET" }))).toBe(true);
+  });
+
+  it("treats a network code on the cause as retriable", () => {
+    const error = Object.assign(new TypeError("fetch failed"), {
+      cause: Object.assign(new Error("socket reset"), { code: "ECONNRESET" })
+    });
+
+    expect(isRetriableTransportError(error)).toBe(true);
+  });
+
+  it("treats a per-request timeout abort as retriable", () => {
+    expect(isRetriableTransportError(new DOMException("The operation was aborted due to timeout", "TimeoutError"))).toBe(true);
+  });
+
+  it("treats a caller-initiated abort as retriable", () => {
+    expect(isRetriableTransportError(new DOMException("The operation was aborted", "AbortError"))).toBe(true);
+  });
+
+  it("treats a timeout abort on the cause as retriable", () => {
+    const error = Object.assign(new TypeError("fetch failed"), {
+      cause: new DOMException("The operation was aborted due to timeout", "TimeoutError")
+    });
+
+    expect(isRetriableTransportError(error)).toBe(true);
+  });
+
+  it("treats an application error as not retriable", () => {
+    expect(isRetriableTransportError(new Error("totally unrelated failure"))).toBe(false);
+  });
+
+  it("treats a non-error rejection as not retriable", () => {
+    expect(isRetriableTransportError("boom")).toBe(false);
+  });
+});

--- a/apps/tx-signer/src/lib/retriable-transport-error/retriable-transport-error.ts
+++ b/apps/tx-signer/src/lib/retriable-transport-error/retriable-transport-error.ts
@@ -1,0 +1,25 @@
+import { isRetriableError } from "@akashnetwork/http-sdk";
+
+const BAD_STATUS_5XX_RE = /Bad status on response: 5\d{2}/;
+
+/**
+ * `AbortSignal.timeout` rejects with a `DOMException` whose `code` is the legacy numeric 23, so only its `name`
+ * identifies it as a per-request timeout rather than an application failure.
+ */
+const ABORTED_ERROR_NAMES = new Set(["TimeoutError", "AbortError"]);
+
+export function isRetriableTransportError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (BAD_STATUS_5XX_RE.test(error.message)) return true;
+  if (isAborted(error)) return true;
+  if ("code" in error && isRetriableError(error as Error & { code: unknown })) return true;
+  if (error.cause instanceof Error) {
+    if (isAborted(error.cause)) return true;
+    if ("code" in error.cause) return isRetriableError(error.cause as Error & { code: unknown });
+  }
+  return false;
+}
+
+function isAborted(error: Error): boolean {
+  return ABORTED_ERROR_NAMES.has(error.name);
+}

--- a/apps/tx-signer/src/lib/retrying-rpc-client/retrying-rpc-client.spec.ts
+++ b/apps/tx-signer/src/lib/retrying-rpc-client/retrying-rpc-client.spec.ts
@@ -66,6 +66,40 @@ describe(RetryingRpcClient.name, () => {
     expect(inner.execute).toHaveBeenCalledTimes(1);
   });
 
+  it("does not retry a gas simulation query, whose payload carries its own validity window", async () => {
+    const { client, inner } = setup({ responses: [new Error("Bad status on response: 500"), okResponse("would-recover")] });
+
+    await expect(client.execute(buildRequest("abci_query", { path: "/cosmos.tx.v1beta1.Service/Simulate" }))).rejects.toThrow(/Bad status on response: 500/);
+    expect(inner.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries other abci queries", async () => {
+    const { client, inner } = setup({ responses: [new Error("Bad status on response: 500"), okResponse("recovered")] });
+
+    const result = await client.execute(buildRequest("abci_query", { path: "/cosmos.auth.v1beta1.Query/Account" }));
+
+    expect(result.result).toBe("recovered");
+    expect(inner.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a request aborted by the per-request timeout", async () => {
+    const timeout = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    const { client, inner } = setup({ responses: [timeout, okResponse("recovered")] });
+
+    const result = await client.execute(buildRequest("abci_query"));
+
+    expect(result.result).toBe("recovered");
+    expect(inner.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a gas simulation query aborted by the per-request timeout", async () => {
+    const timeout = new DOMException("The operation was aborted due to timeout", "TimeoutError");
+    const { client, inner } = setup({ responses: [timeout, okResponse("would-recover")] });
+
+    await expect(client.execute(buildRequest("abci_query", { path: "/cosmos.tx.v1beta1.Service/Simulate" }))).rejects.toThrow(/aborted due to timeout/);
+    expect(inner.execute).toHaveBeenCalledTimes(1);
+  });
+
   it("does not retry on 4xx-shaped errors", async () => {
     const { client, inner } = setup({ responses: [new Error("Bad status on response: 404"), okResponse("would-recover")] });
 
@@ -88,8 +122,8 @@ describe(RetryingRpcClient.name, () => {
     expect(inner.disconnect).toHaveBeenCalledTimes(1);
   });
 
-  function buildRequest(method: string) {
-    return { jsonrpc: "2.0" as const, id: faker.number.int(), method, params: {} };
+  function buildRequest(method: string, params: Record<string, string> = {}) {
+    return { jsonrpc: "2.0" as const, id: faker.number.int(), method, params };
   }
 
   function okResponse(result: unknown): RpcResponse {

--- a/apps/tx-signer/src/lib/retrying-rpc-client/retrying-rpc-client.ts
+++ b/apps/tx-signer/src/lib/retrying-rpc-client/retrying-rpc-client.ts
@@ -1,15 +1,19 @@
-import { isRetriableError } from "@akashnetwork/http-sdk";
 import { createOtelLogger } from "@akashnetwork/logging/otel";
 import type { RpcClient } from "@cosmjs/tendermint-rpc";
 import type { RetryPolicy } from "cockatiel";
 import { ExponentialBackoff, handleWhen, retry } from "cockatiel";
+
+import { isRetriableTransportError } from "../retriable-transport-error/retriable-transport-error";
 
 type ExecuteRequest = Parameters<RpcClient["execute"]>[0];
 type ExecuteResponse = Awaited<ReturnType<RpcClient["execute"]>>;
 
 const NON_IDEMPOTENT_METHODS = new Set(["broadcast_tx_async", "broadcast_tx_sync", "broadcast_tx_commit"]);
 
-const BAD_STATUS_5XX_RE = /Bad status on response: 5\d{2}/;
+const ABCI_QUERY_METHOD = "abci_query";
+
+/** The simulate query carries a whole tx, `timeoutTimestamp` included, so replaying its bytes can only ever expire. */
+const SIMULATE_ABCI_QUERY_PATH = "/cosmos.tx.v1beta1.Service/Simulate";
 
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_INITIAL_DELAY_MS = 200;
@@ -30,7 +34,7 @@ export class RetryingRpcClient implements RpcClient {
 
   constructor(rpcClient: RpcClient, options: RetryingRpcClientOptions = {}) {
     this.rpcClient = rpcClient;
-    this.#executor = retry(handleWhen(error => this.#isRetriableTransportError(error)), {
+    this.#executor = retry(handleWhen(isRetriableTransportError), {
       maxAttempts: options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
       backoff: new ExponentialBackoff({
         initialDelay: options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS,
@@ -42,8 +46,8 @@ export class RetryingRpcClient implements RpcClient {
   async execute(request: ExecuteRequest): Promise<ExecuteResponse> {
     this.#logger.debug({ event: "RPC_REQUEST", method: request.method });
 
-    if (NON_IDEMPOTENT_METHODS.has(request.method)) {
-      return this.rpcClient.execute(request);
+    if (this.#isReplayUnsafe(request)) {
+      return await this.#executeOnce(request);
     }
 
     try {
@@ -54,12 +58,7 @@ export class RetryingRpcClient implements RpcClient {
         return this.rpcClient.execute(request);
       });
     } catch (error) {
-      this.#logger.error({
-        event: "RPC_REQUEST_FAILED",
-        method: request.method,
-        isRetriable: this.#isRetriableTransportError(error),
-        error
-      });
+      this.#logFailure(request, error);
       throw error;
     }
   }
@@ -68,13 +67,33 @@ export class RetryingRpcClient implements RpcClient {
     this.rpcClient.disconnect();
   }
 
-  #isRetriableTransportError(error: unknown): boolean {
-    if (!(error instanceof Error)) return false;
-    if (BAD_STATUS_5XX_RE.test(error.message)) return true;
-    if ("code" in error && isRetriableError(error as Error & { code: unknown })) return true;
-    if ("cause" in error && error.cause instanceof Error && "code" in error.cause) {
-      return isRetriableError(error.cause as Error & { code: unknown });
+  async #executeOnce(request: ExecuteRequest): Promise<ExecuteResponse> {
+    try {
+      return await this.rpcClient.execute(request);
+    } catch (error) {
+      this.#logFailure(request, error);
+      throw error;
     }
-    return false;
+  }
+
+  #logFailure(request: ExecuteRequest, error: unknown): void {
+    this.#logger.error({
+      event: "RPC_REQUEST_FAILED",
+      method: request.method,
+      isRetriable: isRetriableTransportError(error),
+      error
+    });
+  }
+
+  /**
+   * A request the transport must not replay: either it is not idempotent, or its payload embeds its own validity
+   * window, which only the layer that can rebuild that payload is allowed to retry.
+   */
+  #isReplayUnsafe(request: ExecuteRequest): boolean {
+    if (NON_IDEMPOTENT_METHODS.has(request.method)) return true;
+    if (request.method !== ABCI_QUERY_METHOD) return false;
+
+    const { params } = request;
+    return "path" in params && params.path === SIMULATE_ABCI_QUERY_PATH;
   }
 }

--- a/apps/tx-signer/src/lib/retrying-rpc-client/retrying-rpc-client.ts
+++ b/apps/tx-signer/src/lib/retrying-rpc-client/retrying-rpc-client.ts
@@ -67,11 +67,18 @@ export class RetryingRpcClient implements RpcClient {
     this.rpcClient.disconnect();
   }
 
+  /**
+   * A replay-unsafe request's non-transport rejection is the node's considered answer, which only the caller can
+   * classify: a duplicate broadcast and an expired simulation both arrive here, and both are outcomes it handles.
+   */
   async #executeOnce(request: ExecuteRequest): Promise<ExecuteResponse> {
     try {
       return await this.rpcClient.execute(request);
     } catch (error) {
-      this.#logFailure(request, error);
+      if (isRetriableTransportError(error)) {
+        this.#logFailure(request, error);
+      }
+
       throw error;
     }
   }

--- a/apps/tx-signer/src/lib/signing-client/signing-client.service.spec.ts
+++ b/apps/tx-signer/src/lib/signing-client/signing-client.service.spec.ts
@@ -12,6 +12,7 @@ import { SigningClientService } from "./signing-client.service";
 import { TxNotIncludedError, TxOutcomeUnknownError } from "./tx-outcome.error";
 
 const DEFAULT_TTL_MS = 180_000;
+const DEFAULT_RPC_REQUEST_TIMEOUT_MS = 10_000;
 
 describe(SigningClientService.name, () => {
   it("signs and broadcasts a transaction and returns the recovered transaction", async () => {
@@ -274,14 +275,15 @@ describe(SigningClientService.name, () => {
     return mock<IndexedTx>({ hash: "out-of-gas", code: 11, gasUsed: input.gasUsed, gasWanted: input.gasWanted, height: 100 });
   }
 
-  function setup(input?: { ttlMs?: number; deadlineMs?: number; gasRecoveryMultiplier?: number }) {
+  function setup(input?: { ttlMs?: number; deadlineMs?: number; gasRecoveryMultiplier?: number; rpcRequestTimeoutMs?: number }) {
     const ttlMs = input?.ttlMs ?? DEFAULT_TTL_MS;
     const config = mock<AppConfigService>({
       get: vi.fn().mockImplementation(key => {
         const values = {
           UNORDERED_TX_TTL_MS: ttlMs,
           SIGN_AND_BROADCAST_DEADLINE_MS: input?.deadlineMs ?? 600_000,
-          GAS_RECOVERY_MULTIPLIER: input?.gasRecoveryMultiplier ?? 1.3
+          GAS_RECOVERY_MULTIPLIER: input?.gasRecoveryMultiplier ?? 1.3,
+          RPC_REQUEST_TIMEOUT_MS: input?.rpcRequestTimeoutMs ?? DEFAULT_RPC_REQUEST_TIMEOUT_MS
         };
         return values[key as keyof typeof values];
       })

--- a/apps/tx-signer/src/lib/signing-client/signing-client.service.spec.ts
+++ b/apps/tx-signer/src/lib/signing-client/signing-client.service.spec.ts
@@ -54,9 +54,38 @@ describe(SigningClientService.name, () => {
     const result = await service.signAndBroadcast(createMessages(1));
 
     const [txBytes] = client.broadcastTxSync.mock.calls[0];
-    const expectedHash = toHex(sha256(txBytes));
+    const expectedHash = toHex(sha256(txBytes)).toUpperCase();
     expect(client.getTx).toHaveBeenCalledWith(expectedHash);
     expect(result.hash).toBe(expectedHash);
+  });
+
+  it("polls for a transaction the node never answered for, so a broadcast that timed out can still settle", async () => {
+    const { service, client } = setup();
+    client.broadcastTxSync.mockRejectedValue(Object.assign(new Error("The operation was aborted due to timeout"), { name: "TimeoutError" }));
+
+    const result = await service.signAndBroadcast(createMessages(1));
+
+    const [txBytes] = client.broadcastTxSync.mock.calls[0];
+    const expectedHash = toHex(sha256(txBytes)).toUpperCase();
+    expect(client.getTx).toHaveBeenCalledWith(expectedHash);
+    expect(result.hash).toBe(expectedHash);
+  });
+
+  it("reports a not-included outcome when a broadcast that timed out is followed by a transaction that never lands", async () => {
+    vi.useFakeTimers();
+    try {
+      const { service, client } = setup({ ttlMs: 10_000 });
+      client.broadcastTxSync.mockRejectedValue(Object.assign(new Error("The operation was aborted due to timeout"), { name: "TimeoutError" }));
+      client.getTx.mockResolvedValue(null);
+
+      const promise = service.signAndBroadcast(createMessages(1));
+      promise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      await expect(promise).rejects.toBeInstanceOf(TxNotIncludedError);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not let a failing transaction affect the others", async () => {
@@ -137,6 +166,27 @@ describe(SigningClientService.name, () => {
 
       await expect(promise).rejects.toBeInstanceOf(TxOutcomeUnknownError);
       await expect(promise).rejects.toMatchObject({ status: 504, data: { outcome: "unknown", txHash: "broadcast-hash" } });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops polling at the deadline rather than after a fixed number of attempts when each query is slow", async () => {
+    vi.useFakeTimers();
+    try {
+      const { service, client } = setup({ ttlMs: 60_000, deadlineMs: 20_000 });
+      client.broadcastTxSync.mockResolvedValue("broadcast-hash");
+      client.getTx.mockImplementation(async () => {
+        await new Promise(resolve => setTimeout(resolve, 4_000));
+        return null;
+      });
+
+      const promise = service.signAndBroadcast(createMessages(1));
+      promise.catch(() => {});
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      await expect(promise).rejects.toBeInstanceOf(TxOutcomeUnknownError);
+      expect(client.getTx).toHaveBeenCalledTimes(4);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/tx-signer/src/lib/signing-client/signing-client.service.ts
+++ b/apps/tx-signer/src/lib/signing-client/signing-client.service.ts
@@ -10,6 +10,7 @@ import { ConstantBackoff, handleWhenResult, Policy, retry } from "cockatiel";
 
 import type { AppConfigService } from "@src/services/app-config/app-config.service";
 import type { SigningStargateWithUnorderedSupportClient } from "../signing-stargate-client-factory/signing-stargate-client.factory";
+import { simulateBudgetMs } from "../signing-stargate-client-factory/signing-stargate-client.factory";
 import { TxNotIncludedError, TxOutcomeUnknownError } from "./tx-outcome.error";
 
 export interface SignAndBroadcastOptions {
@@ -36,12 +37,14 @@ const TX_RECOVERY_WINDOW_FACTOR = 1.2;
  */
 const OUT_OF_GAS_RETRY_LIMIT = 3;
 
-/** Budget a retry needs on top of its poll window, for the simulate, sign and broadcast round trips that precede it. */
-const ATTEMPT_OVERHEAD_RESERVE_MS = 15_000;
+/** What an attempt can spend before polling even starts: a gas estimation that exhausts its retries, then one broadcast. */
+function attemptOverheadMs(rpcRequestTimeoutMs: number): number {
+  return simulateBudgetMs(rpcRequestTimeoutMs) + rpcRequestTimeoutMs;
+}
 
 /** The shortest deadline that still lets one attempt outlast a tx's TTL, below which every missing tx reports undecided instead of a definite outcome. */
-export function minSignAndBroadcastDeadlineMs(ttlMs: number): number {
-  return Math.ceil(ttlMs * TX_RECOVERY_WINDOW_FACTOR);
+export function minSignAndBroadcastDeadlineMs(ttlMs: number, rpcRequestTimeoutMs: number): number {
+  return Math.ceil(ttlMs * TX_RECOVERY_WINDOW_FACTOR) + attemptOverheadMs(rpcRequestTimeoutMs);
 }
 
 /** Cosmos SDK `ErrOutOfGas` code (root `sdk` codespace). */
@@ -52,6 +55,7 @@ export class SigningClientService {
 
   readonly #ttlMs: number;
   readonly #deadlineMs: number;
+  readonly #attemptOverheadMs: number;
 
   readonly #gasRecoveryMultiplier: number;
 
@@ -61,6 +65,7 @@ export class SigningClientService {
     this.#client = client;
     this.#ttlMs = config.get("UNORDERED_TX_TTL_MS");
     this.#deadlineMs = config.get("SIGN_AND_BROADCAST_DEADLINE_MS");
+    this.#attemptOverheadMs = attemptOverheadMs(config.get("RPC_REQUEST_TIMEOUT_MS"));
     this.#gasRecoveryMultiplier = config.get("GAS_RECOVERY_MULTIPLIER");
     this.#logger = createOtelLogger({ context: loggerContext });
   }
@@ -182,7 +187,7 @@ export class SigningClientService {
 
     const remainingMs = deadline - Date.now();
 
-    if (remainingMs >= this.#ttlMs * TX_RECOVERY_WINDOW_FACTOR + ATTEMPT_OVERHEAD_RESERVE_MS) {
+    if (remainingMs >= this.#ttlMs * TX_RECOVERY_WINDOW_FACTOR + this.#attemptOverheadMs) {
       return true;
     }
 

--- a/apps/tx-signer/src/lib/signing-client/signing-client.service.ts
+++ b/apps/tx-signer/src/lib/signing-client/signing-client.service.ts
@@ -6,9 +6,10 @@ import { sha256 } from "@cosmjs/crypto";
 import { toHex } from "@cosmjs/encoding";
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import { BroadcastTxError, type IndexedTx } from "@cosmjs/stargate";
-import { ConstantBackoff, handleWhenResult, Policy, retry } from "cockatiel";
+import { ConstantBackoff, Policy, retry } from "cockatiel";
 
 import type { AppConfigService } from "@src/services/app-config/app-config.service";
+import { isRetriableTransportError } from "../retriable-transport-error/retriable-transport-error";
 import type { SigningStargateWithUnorderedSupportClient } from "../signing-stargate-client-factory/signing-stargate-client.factory";
 import { simulateBudgetMs } from "../signing-stargate-client-factory/signing-stargate-client.factory";
 import { TxNotIncludedError, TxOutcomeUnknownError } from "./tx-outcome.error";
@@ -207,51 +208,62 @@ export class SigningClientService {
     try {
       return await this.#client.broadcastTxSync(txBytes);
     } catch (error: unknown) {
-      if (error instanceof Error && error.message.toLowerCase().includes("tx already exists in cache")) {
-        return toHex(sha256(txBytes));
-      }
-
       if (error instanceof BroadcastTxError) {
         throw error;
       }
 
-      throw this.#undecidedOutcomeError(toHex(sha256(txBytes)).toUpperCase(), { error });
+      const txHash = deriveTxHash(txBytes);
+
+      if (error instanceof Error && error.message.toLowerCase().includes("tx already exists in cache")) {
+        return txHash;
+      }
+
+      if (isRetriableTransportError(error)) {
+        this.#logger.warn({ event: "SIGN_AND_BROADCAST_BROADCAST_UNANSWERED", txHash, error });
+        return txHash;
+      }
+
+      throw this.#undecidedOutcomeError(txHash, { error });
     }
   }
 
-  /** A query that never answered leaves the outcome open however long it took, since only an answer can rule the tx out. */
+  /** Stops on a wall clock rather than an attempt count, so a slow `getTx` spends the window instead of running the poll past the deadline. */
   async #pollTx(hash: string, deadline: number): Promise<IndexedTx | null> {
-    const attempts = this.#pollAttempts(deadline);
-
-    if (!attempts) {
+    if (Date.now() >= deadline) {
       throw this.#undecidedOutcomeError(hash, { reason: "no budget left to poll" });
     }
 
-    const poller = retry(
-      handleWhenResult(res => !res),
-      {
-        maxAttempts: attempts - 1,
-        backoff: new ConstantBackoff(TX_RECOVERY_POLL_INTERVAL_MS)
-      }
-    );
+    const pollUntil = Math.min(deadline, Date.now() + this.#ttlMs * TX_RECOVERY_WINDOW_FACTOR);
 
     try {
-      return await poller.execute(context => {
-        this.#logger.debug({ event: "TX_POLL_ATTEMPT", txHash: hash, attempt: context.attempt });
-        return this.#client.getTx(hash);
-      });
+      for (let attempt = 0; ; attempt++) {
+        this.#logger.debug({ event: "TX_POLL_ATTEMPT", txHash: hash, attempt });
+
+        const tx = await this.#client.getTx(hash);
+
+        if (tx) {
+          return tx;
+        }
+
+        if (Date.now() + TX_RECOVERY_POLL_INTERVAL_MS > pollUntil) {
+          return null;
+        }
+
+        await delay(TX_RECOVERY_POLL_INTERVAL_MS);
+      }
     } catch (error: unknown) {
       throw this.#undecidedOutcomeError(hash, { error });
     }
   }
+}
 
-  /** Floors against the budget so no poll is scheduled to start past the deadline, while an unconstrained window keeps the full recovery span. */
-  #pollAttempts(deadline: number): number {
-    const spanAttempts = Math.ceil((this.#ttlMs * TX_RECOVERY_WINDOW_FACTOR) / TX_RECOVERY_POLL_INTERVAL_MS) + 1;
-    const budgetAttempts = Math.floor((deadline - Date.now()) / TX_RECOVERY_POLL_INTERVAL_MS) + 1;
+/** Tendermint indexes a tx under the uppercase hex of its hash, which is also what a `broadcastTxSync` the node answered returns. */
+function deriveTxHash(txBytes: Uint8Array): string {
+  return toHex(sha256(txBytes)).toUpperCase();
+}
 
-    return Math.max(0, Math.min(spanAttempts, budgetAttempts));
-  }
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 /** The expiry the signed body actually carries, read back from the bytes broadcast rather than recomputed from a clock. */

--- a/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.spec.ts
+++ b/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.spec.ts
@@ -11,7 +11,8 @@ import { mock } from "vitest-mock-extended";
 import { createAkashAddress } from "../../../test/seeders";
 import type { Wallet } from "../wallet/wallet";
 import type { UnorderedTxSignConfig } from "./signing-stargate-client.factory";
-import { createSigningStargateClientFactory, SigningStargateWithUnorderedSupportClient } from "./signing-stargate-client.factory";
+import { createSigningStargateClientFactory, SigningStargateWithUnorderedSupportClient, simulateBudgetMs } from "./signing-stargate-client.factory";
+import { SimulationExpiredError } from "./simulation-expired.error";
 
 const SIGN_CONFIG: UnorderedTxSignConfig = { ttlMs: 180_000, gasMultiplier: 1.2, averageGasPrice: 0.025 };
 const RPC_REQUEST_TIMEOUT_MS = 10_000;
@@ -128,6 +129,49 @@ describe(SigningStargateWithUnorderedSupportClient.name, () => {
     expect(AuthInfo.decode(txRaw.authInfoBytes).fee!.granter).toBe("akash1granter");
   });
 
+  it("stamps every gas simulation attempt with a window that opens on that attempt", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      const ttlMs = 30_000;
+      const startTime = 1_700_000_000_000;
+      vi.setSystemTime(startTime);
+      const { client, abciQuery, simulateSentAt } = setup({
+        ttlMs,
+        simulateFailures: [connectionResetError()],
+        onSimulate: () => vi.setSystemTime(Date.now() + ttlMs * 2)
+      });
+
+      await client.signUnordered(createMessages());
+
+      expect(abciQuery).toHaveBeenCalledTimes(2);
+      const stamps = abciQuery.mock.calls.map(call => decodeSimulatedTimeoutTimestamp(call[0].data));
+      expect(stamps).toEqual(simulateSentAt.map(sentAt => sentAt + ttlMs));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("surfaces the transport failure once the gas simulation retries are exhausted", async () => {
+    const { client, abciQuery } = setup({ simulateFailures: Array.from({ length: 4 }, connectionResetError) });
+
+    await expect(client.signUnordered(createMessages())).rejects.toThrow(/socket hang up/);
+    expect(abciQuery).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not retry a gas simulation that failed for a non-transport reason", async () => {
+    const { client, abciQuery } = setup({ simulateFailures: [new Error("Query failed with (18): invalid request")] });
+
+    await expect(client.signUnordered(createMessages())).rejects.toThrow(/invalid request/);
+    expect(abciQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a freshly stamped simulation rejected as expired as a clock problem rather than retrying it", async () => {
+    const { client, abciQuery } = setup({ simulateFailures: [expiredTxError()] });
+
+    await expect(client.signUnordered(createMessages())).rejects.toThrow(SimulationExpiredError);
+    expect(abciQuery).toHaveBeenCalledTimes(1);
+  });
+
   it("fetches chain id and account data only once across concurrent signs", async () => {
     const { client, wallet, getChainId, getAccount } = setup();
 
@@ -142,7 +186,20 @@ describe(SigningStargateWithUnorderedSupportClient.name, () => {
     return [{ typeUrl: "/test.MsgTest", value: {} }];
   }
 
-  function setup(input?: { ttlMs?: number; gasUsed?: number; gasMultiplier?: number; onSimulate?: () => void }) {
+  function connectionResetError() {
+    return Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+  }
+
+  function expiredTxError() {
+    return new Error("Query failed with (6): rpc error: code = Unknown desc = tx timeout with gas used: '0': unknown request");
+  }
+
+  function decodeSimulatedTimeoutTimestamp(data: Uint8Array) {
+    const txBytes = SimulateRequest.decode(data).txBytes;
+    return TxBody.decode(TxRaw.decode(txBytes).bodyBytes).timeoutTimestamp!.getTime();
+  }
+
+  function setup(input?: { ttlMs?: number; gasUsed?: number; gasMultiplier?: number; onSimulate?: () => void; simulateFailures?: Error[] }) {
     const address = createAkashAddress();
     const accountNumber = faker.number.int({ min: 1, max: 1000 });
     const gasUsed = input?.gasUsed ?? 2000;
@@ -172,8 +229,15 @@ describe(SigningStargateWithUnorderedSupportClient.name, () => {
     });
 
     // Gas estimation runs the real #simulateRawTx through the query client, so mock the underlying ABCI query.
+    const simulateFailures = [...(input?.simulateFailures ?? [])];
+    const simulateSentAt: number[] = [];
     const abciQuery = vi.fn().mockImplementation(async () => {
+      simulateSentAt.push(Date.now());
       input?.onSimulate?.();
+
+      const failure = simulateFailures.shift();
+      if (failure) throw failure;
+
       return {
         code: 0,
         value: SimulateResponse.encode(SimulateResponse.fromPartial({ gasInfo: { gasUsed: BigInt(gasUsed), gasWanted: BigInt(gasUsed) } })).finish(),
@@ -187,13 +251,24 @@ describe(SigningStargateWithUnorderedSupportClient.name, () => {
       signConfig: {
         ttlMs: input?.ttlMs ?? 180_000,
         gasMultiplier: input?.gasMultiplier ?? 1.2,
-        averageGasPrice: 0.025
+        averageGasPrice: 0.025,
+        simulateRetry: { maxAttempts: 3, initialDelayMs: 1, maxDelayMs: 1 }
       }
     });
 
     const getChainId = vi.spyOn(client, "getChainId").mockResolvedValue("test-chain");
     const getAccount = vi.spyOn(client, "getAccount").mockResolvedValue(mock<Account>({ address, accountNumber }));
 
-    return { client, wallet, registry, cometClient, abciQuery, getChainId, getAccount, address, accountNumber };
+    return { client, wallet, registry, cometClient, abciQuery, simulateSentAt, getChainId, getAccount, address, accountNumber };
   }
+});
+
+describe(simulateBudgetMs.name, () => {
+  it("covers the first attempt, every retry, and the backoff between them", () => {
+    expect(simulateBudgetMs(10_000, { maxAttempts: 3, maxDelayMs: 2_000 })).toBe(46_000);
+  });
+
+  it("falls back to the shipped retry settings", () => {
+    expect(simulateBudgetMs(10_000)).toBe(46_000);
+  });
 });

--- a/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.ts
+++ b/apps/tx-signer/src/lib/signing-stargate-client-factory/signing-stargate-client.factory.ts
@@ -1,4 +1,5 @@
 import { TxBody, TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { encodeSecp256k1Pubkey } from "@cosmjs/amino";
 import { fromBase64 } from "@cosmjs/encoding";
 import type { EncodeObject, OfflineSigner, Registry } from "@cosmjs/proto-signing";
@@ -8,16 +9,33 @@ import type { SigningStargateClientOptions } from "@cosmjs/stargate";
 import { calculateFee, createProtobufRpcClient, GasPrice, SigningStargateClient } from "@cosmjs/stargate";
 import type { CometClient, RpcClient } from "@cosmjs/tendermint-rpc";
 import { Comet38Client, HttpClient } from "@cosmjs/tendermint-rpc";
+import type { RetryPolicy } from "cockatiel";
+import { ExponentialBackoff, handleWhen, retry } from "cockatiel";
 import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing";
 import { ServiceClientImpl, SimulateRequest } from "cosmjs-types/cosmos/tx/v1beta1/service";
 import { randomUUID } from "node:crypto";
 
 import type { Wallet } from "@src/lib/wallet/wallet";
 import { memoizeAsync } from "../../caching/helpers/helpers";
+import { isRetriableTransportError } from "../retriable-transport-error/retriable-transport-error";
 import { RetryingRpcClient } from "../retrying-rpc-client/retrying-rpc-client";
+import { SimulationExpiredError } from "./simulation-expired.error";
 
 const MEMO = "akash console";
 const FEES_DENOM = "uakt";
+
+const DEFAULT_SIMULATE_MAX_ATTEMPTS = 3;
+const DEFAULT_SIMULATE_INITIAL_DELAY_MS = 200;
+const DEFAULT_SIMULATE_MAX_DELAY_MS = 2_000;
+
+const EXPIRED_TX_LOG_RE = /tx timeout/i;
+
+export interface SimulateRetryConfig {
+  /** Retries allowed after the first attempt, matching cockatiel's own reading of the name. */
+  maxAttempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+}
 
 export interface UnorderedTxSignConfig {
   /** Added to `Date.now()` to derive the tx `timeoutTimestamp` (the unordered-tx TTL). */
@@ -26,6 +44,16 @@ export interface UnorderedTxSignConfig {
   gasMultiplier: number;
   /** Average gas price in {@link FEES_DENOM}, e.g. `0.025`. */
   averageGasPrice: number;
+  /** Overrides the shipped gas-simulation retry settings; {@link simulateBudgetMs} assumes those defaults. */
+  simulateRetry?: SimulateRetryConfig;
+}
+
+/** Longest a gas estimation can run, for callers budgeting a whole signing attempt against a deadline. */
+export function simulateBudgetMs(rpcRequestTimeoutMs: number, config: SimulateRetryConfig = {}): number {
+  const maxRetries = config.maxAttempts ?? DEFAULT_SIMULATE_MAX_ATTEMPTS;
+  const maxDelayMs = config.maxDelayMs ?? DEFAULT_SIMULATE_MAX_DELAY_MS;
+
+  return (maxRetries + 1) * rpcRequestTimeoutMs + maxRetries * maxDelayMs;
 }
 
 type SimulatingSigningStargateClientOptions = SigningStargateClientOptions & { signConfig: UnorderedTxSignConfig };
@@ -36,6 +64,10 @@ export class SigningStargateWithUnorderedSupportClient extends SigningStargateCl
   readonly #signer: OfflineDirectSigner;
 
   readonly #signConfig: UnorderedTxSignConfig;
+
+  readonly #simulateExecutor: RetryPolicy;
+
+  readonly #logger = createOtelLogger({ context: SigningStargateWithUnorderedSupportClient.name });
 
   readonly #getChainId = memoizeAsync(() => this.getChainId());
 
@@ -72,6 +104,13 @@ export class SigningStargateWithUnorderedSupportClient extends SigningStargateCl
 
     this.#signer = signer;
     this.#signConfig = options.signConfig;
+    this.#simulateExecutor = retry(handleWhen(isRetriableTransportError), {
+      maxAttempts: options.signConfig.simulateRetry?.maxAttempts ?? DEFAULT_SIMULATE_MAX_ATTEMPTS,
+      backoff: new ExponentialBackoff({
+        initialDelay: options.signConfig.simulateRetry?.initialDelayMs ?? DEFAULT_SIMULATE_INITIAL_DELAY_MS,
+        maxDelay: options.signConfig.simulateRetry?.maxDelayMs ?? DEFAULT_SIMULATE_MAX_DELAY_MS
+      })
+    });
   }
 
   /**
@@ -84,7 +123,7 @@ export class SigningStargateWithUnorderedSupportClient extends SigningStargateCl
    * rebuilds its own tx body from just the messages and memo — it never sets `unordered`/`timeoutTimestamp` — so it undercounts gas: an
    * unordered tx makes the ante handler write an entry to the unordered-nonce store to dedupe replays, and that extra store write is not
    * exercised when simulating an ordered body. The real tx then consumes more gas than estimated and lands with `code: 11` ("out of gas
-   * in location: WriteFlat"). Simulating the exact body we broadcast makes the estimate account for that write.
+   * in location: WriteFlat"). Simulating a body shaped like the one we broadcast makes the estimate account for that write.
    *
    * When `options.gas` is provided the simulation step is skipped and the value is used verbatim as the gas limit. This is the
    * gas-recovery path: some messages (e.g. an escrow deposit that settles accrued rent) consume gas that grows with the block height
@@ -94,14 +133,11 @@ export class SigningStargateWithUnorderedSupportClient extends SigningStargateCl
   async signUnordered(messages: readonly EncodeObject[], options?: { granter?: string; gas?: number }): Promise<TxRaw> {
     const [address, chainId, accountNumber, pubkey] = await Promise.all([this.#getAddress(), this.#getChainId(), this.#getAccountNumber(), this.#getPubkey()]);
 
-    const txBody = this.#buildTxBody(messages);
-    const fee = await this.#estimateFee(TxBody.encode(txBody).finish(), pubkey, { granter: options?.granter, gas: options?.gas });
+    const fee = await this.#estimateFee(messages, pubkey, { granter: options?.granter, gas: options?.gas });
 
     // sequence MUST be 0 for unordered transactions; the chain rejects a non-zero sequence when unordered is set.
     const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence: 0 }], fee.amount, Number(fee.gas), fee.granter, fee.payer);
-    // update timestampTimeout to compensate time spent in doing stuff above
-    txBody.timeoutTimestamp = new Date(Date.now() + this.#signConfig.ttlMs);
-    const bodyBytes = TxBody.encode(txBody).finish();
+    const bodyBytes = TxBody.encode(this.#buildTxBody(messages)).finish();
     const signDoc = makeSignDoc(bodyBytes, authInfoBytes, chainId, accountNumber);
     const { signature, signed } = await this.#signer.signDirect(address, signDoc);
 
@@ -132,21 +168,43 @@ export class SigningStargateWithUnorderedSupportClient extends SigningStargateCl
     });
   }
 
-  async #estimateFee(bodyBytes: Uint8Array, pubkey: ReturnType<typeof encodePubkey>, options: { granter?: string; gas?: number }) {
-    const gas = options.gas ?? (await this.#estimateGas(bodyBytes, pubkey));
+  async #estimateFee(messages: readonly EncodeObject[], pubkey: ReturnType<typeof encodePubkey>, options: { granter?: string; gas?: number }) {
+    const gas = options.gas ?? (await this.#estimateGas(messages, pubkey));
     const fee = calculateFee(gas, GasPrice.fromString(`${this.#signConfig.averageGasPrice}${FEES_DENOM}`));
 
     return options.granter ? { ...fee, granter: options.granter } : fee;
   }
 
-  async #estimateGas(bodyBytes: Uint8Array, pubkey: ReturnType<typeof encodePubkey>): Promise<number> {
-    // Empty fee with an unset sign mode: this keeps the node treating the tx as a gas simulation rather than one to
-    // execute (it skips signature verification when simulating). Sequence stays 0 to match the unordered tx we sign.
-    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence: 0 }], [], 0, undefined, undefined, SignMode.SIGN_MODE_UNSPECIFIED);
-    const txBytes = TxRaw.encode(TxRaw.fromPartial({ bodyBytes, authInfoBytes, signatures: [new Uint8Array()] })).finish();
+  /**
+   * Every attempt re-encodes the body so it carries a window that opens now: a transport failure is retried with a
+   * transaction the chain can still accept, instead of a replay the ante handler can only reject as expired.
+   */
+  async #estimateGas(messages: readonly EncodeObject[], pubkey: ReturnType<typeof encodePubkey>): Promise<number> {
+    const gasEstimation = await this.#simulateExecutor.execute(async context => {
+      if (context.attempt > 0) {
+        this.#logger.warn({ event: "GAS_SIMULATION_RETRY", attempt: context.attempt });
+      }
 
-    const gasEstimation = await this.#simulateRawTx(txBytes);
+      try {
+        return await this.#simulateRawTx(this.#encodeSimulationTx(messages, pubkey));
+      } catch (error) {
+        throw this.#isExpiryRejection(error) ? new SimulationExpiredError(this.#signConfig.ttlMs, error) : error;
+      }
+    });
+
     return Math.ceil(gasEstimation * this.#signConfig.gasMultiplier);
+  }
+
+  /** The empty fee and unset sign mode keep the node simulating the tx rather than executing it, so it skips signature verification. */
+  #encodeSimulationTx(messages: readonly EncodeObject[], pubkey: ReturnType<typeof encodePubkey>): Uint8Array {
+    const bodyBytes = TxBody.encode(this.#buildTxBody(messages)).finish();
+    const authInfoBytes = makeAuthInfoBytes([{ pubkey, sequence: 0 }], [], 0, undefined, undefined, SignMode.SIGN_MODE_UNSPECIFIED);
+
+    return TxRaw.encode(TxRaw.fromPartial({ bodyBytes, authInfoBytes, signatures: [new Uint8Array()] })).finish();
+  }
+
+  #isExpiryRejection(error: unknown): boolean {
+    return error instanceof Error && EXPIRED_TX_LOG_RE.test(error.message);
   }
 }
 

--- a/apps/tx-signer/src/lib/signing-stargate-client-factory/simulation-expired.error.ts
+++ b/apps/tx-signer/src/lib/signing-stargate-client-factory/simulation-expired.error.ts
@@ -1,0 +1,11 @@
+/**
+ * A simulation body is stamped for the attempt that sends it, so an expiry here cannot mean a stale replay: it means
+ * the node's clock runs ahead of the signer's, or the TTL is shorter than one RPC round trip.
+ */
+export class SimulationExpiredError extends Error {
+  readonly name = "SimulationExpiredError";
+
+  constructor(ttlMs: number, cause: unknown) {
+    super(`Gas simulation was rejected as expired even though its ${ttlMs}ms window opened for this attempt`, { cause });
+  }
+}

--- a/apps/tx-signer/test/functional/sign-and-broadcast-tx.spec.ts
+++ b/apps/tx-signer/test/functional/sign-and-broadcast-tx.spec.ts
@@ -9,8 +9,9 @@ import {
   TxBody,
   TxRaw
 } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
-import { fromBase64, toBase64 } from "@cosmjs/encoding";
+import { fromBase64, fromHex, toBase64 } from "@cosmjs/encoding";
 import type { Registry } from "@cosmjs/proto-signing";
+import { SimulateRequest } from "cosmjs-types/cosmos/tx/v1beta1/service";
 import nock from "nock";
 import { container } from "tsyringe";
 import { afterAll, afterEach, describe, expect, it } from "vitest";
@@ -28,7 +29,7 @@ const DERIVATION_INDEX = 1;
 interface JsonRpcRequest {
   id: number | string;
   method: string;
-  params?: { path?: string; tx?: string };
+  params?: { path?: string; tx?: string; data?: string };
 }
 
 describe(TxController.name, () => {
@@ -68,6 +69,40 @@ describe(TxController.name, () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ data: { code: 0, hash: txHash, rawLog: "" } });
+  });
+
+  it("retries a gas simulation that failed at the transport with a transaction window opened for the retry", async () => {
+    const { txHash, getSimulatedTimeoutTimestamps } = mockRpcNode({ failSimulateTimes: 1 });
+
+    const res = await app.request("/v1/tx/derived", {
+      method: "POST",
+      body: JSON.stringify({ data: { derivationIndex: DERIVATION_INDEX, messages: await buildDerivedMessages() } }),
+      headers: authorizedHeaders()
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: { code: 0, hash: txHash, rawLog: "" } });
+
+    const [firstAttempt, secondAttempt] = getSimulatedTimeoutTimestamps();
+    expect(getSimulatedTimeoutTimestamps()).toHaveLength(2);
+    expect(secondAttempt).toBeGreaterThan(firstAttempt);
+  });
+
+  it("reports the transport failure and stops after four gas simulation attempts when every one fails", async () => {
+    const { getSimulatedTimeoutTimestamps } = mockRpcNode({ failSimulateTimes: 10 });
+
+    const res = await app.request("/v1/tx/derived", {
+      method: "POST",
+      body: JSON.stringify({ data: { derivationIndex: DERIVATION_INDEX, messages: await buildDerivedMessages() } }),
+      headers: authorizedHeaders()
+    });
+
+    const body = await res.text();
+
+    expect(getSimulatedTimeoutTimestamps()).toHaveLength(4);
+    expect(res.status).toBe(503);
+    expect(body).toMatch(/Bad status on response: 503/);
+    expect(body).not.toMatch(/tx timeout/);
   });
 
   it("rejects a tx request that carries no API key", async () => {
@@ -201,7 +236,9 @@ describe(TxController.name, () => {
     return [{ typeUrl: message.typeUrl, value: toBase64(registry.encode(message)) }];
   }
 
-  function mockRpcNode(input: { chainId?: string; accountNumber?: number; sequence?: number; gasUsed?: number; height?: number; txHash?: string } = {}) {
+  function mockRpcNode(
+    input: { chainId?: string; accountNumber?: number; sequence?: number; gasUsed?: number; height?: number; txHash?: string; failSimulateTimes?: number } = {}
+  ) {
     const chainId = input.chainId ?? "sandbox-01";
     const accountNumber = input.accountNumber ?? 42;
     const sequence = input.sequence ?? 7;
@@ -209,6 +246,8 @@ describe(TxController.name, () => {
     const height = input.height ?? 1_000;
     const txHash = input.txHash ?? "AB".repeat(32);
     const broadcastedTxs: string[] = [];
+    const simulatedTxs: string[] = [];
+    let simulateFailuresLeft = input.failSimulateTimes ?? 0;
 
     const accountValue = toBase64(
       QueryAccountResponse.encode(
@@ -226,6 +265,8 @@ describe(TxController.name, () => {
     const simulateValue = toBase64(
       SimulateResponse.encode(SimulateResponse.fromPartial({ gasInfo: { gasUsed: BigInt(gasUsed), gasWanted: BigInt(gasUsed) } })).finish()
     );
+
+    const isSimulate = (request: JsonRpcRequest) => request.method === "abci_query" && request.params?.path?.includes("Simulate") === true;
 
     const reply = (request: JsonRpcRequest) => {
       const base = { jsonrpc: "2.0", id: request.id };
@@ -260,7 +301,7 @@ describe(TxController.name, () => {
             }
           };
         case "abci_query": {
-          const value = request.params?.path?.includes("Simulate") ? simulateValue : accountValue;
+          const value = isSimulate(request) ? simulateValue : accountValue;
           return { ...base, result: { response: { code: 0, log: "", info: "", index: "0", value, height: String(height), codespace: "" } } };
         }
         case "broadcast_tx_sync":
@@ -290,8 +331,31 @@ describe(TxController.name, () => {
     nock(process.env.RPC_NODE_ENDPOINT ?? "http://localhost:26657")
       .persist()
       .post(/.*/)
-      .reply(200, (_uri, requestBody) => reply(requestBody as JsonRpcRequest));
+      .reply((_uri, requestBody) => {
+        const request = requestBody as JsonRpcRequest;
 
-    return { txHash, chainId, accountNumber, sequence, gasUsed, height, getBroadcastedTxs: () => broadcastedTxs };
+        if (isSimulate(request)) {
+          simulatedTxs.push(request.params!.data!);
+
+          if (simulateFailuresLeft > 0) {
+            simulateFailuresLeft -= 1;
+            return [503, ""];
+          }
+        }
+
+        return [200, reply(request)];
+      });
+
+    return {
+      txHash,
+      chainId,
+      accountNumber,
+      sequence,
+      gasUsed,
+      height,
+      getBroadcastedTxs: () => broadcastedTxs,
+      getSimulatedTimeoutTimestamps: () =>
+        simulatedTxs.map(data => TxBody.decode(TxRaw.decode(SimulateRequest.decode(fromHex(data)).txBytes).bodyBytes).timeoutTimestamp!.getTime())
+    };
   }
 });


### PR DESCRIPTION
## Why

Fixes CON-925.

On 2026-08-31 an auto top-up deposit failed with `tx timeout [cosmos/cosmos-sdk@v0.53.6/x/auth/ante/basic.go:221] with gas used: '0'`, which pointed the investigation at a chain problem that did not exist.

The prod stack traces put the expiry in the **gas simulation**, not the broadcast: `QueryClient.queryAbci` → `#simulateRawTx` → `#estimateFee` → `signUnordered`. Managed txs are signed as unordered, so the body sent for simulation carries its own `timeoutTimestamp`. That stamp was applied once, before the `abci_query`, and `RetryingRpcClient` replayed the identical bytes on a transport failure. The first attempt hung ~100s on a broken RPC upstream; the replays landed 58s after the window had closed, against a body the ante handler could only reject. Two costs: retries spent at the moment capacity was scarcest, and the `ECONNRESET` that actually caused the failure never reached the logs.

## What

- **The transport no longer replays a payload that embeds its own validity window.** `RetryingRpcClient` already skipped `broadcast_tx_*` as non-idempotent; the gas-simulation `abci_query` joins it for a different reason, spelled out at the guard. Non-retried failures now log `RPC_REQUEST_FAILED` too, which is where the interesting failures go after this.
- **The gas estimation owns that retry instead**, re-encoding the body on every attempt so each one opens a window it can still be answered inside. This also removes the build/encode/mutate/re-encode dance in `signUnordered` — the signing body is now built once, after gas is known, and the `options.gas` path stops building a body it discards.
- **A per-request timeout counts as a transport failure.** `AbortSignal.timeout` rejects with a `DOMException` whose `code` is the legacy numeric `23`, so `isRetriableError`'s string comparison never matched it and #3804's new `RPC_REQUEST_TIMEOUT_MS` was quietly turning a black-holed node into one attempt with no retry. The predicate moved to `lib/retriable-transport-error` and now matches on `name`.
- **`RPC_REQUEST_TIMEOUT_MS < UNORDERED_TX_TTL_MS` is enforced at startup**, so a single call can never be answered after the window it carries.
- **The out-of-gas budget is derived rather than guessed.** #3804's flat `ATTEMPT_OVERHEAD_RESERVE_MS = 15_000` under-reserves once a simulate leg can retry: an out-of-gas retry would be admitted with 51s left, burn ~56s before polling, and report `TxOutcomeUnknownError` in place of the definite answer that PR exists to produce. It is now `simulateBudgetMs(rpcRequestTimeoutMs) + rpcRequestTimeoutMs`.

### Tradeoff worth a look

That reserve is a worst case, so with the 150s default deadline the out-of-gas recovery admits about one fewer attempt than #3804 does today (roughly 2 instead of 3 on a healthy path). It is the honest number, and #3804's stated preference is to stop rather than return "unknown" — but if it reads as too thin, the knobs are `SIGN_AND_BROADCAST_DEADLINE_MS` up or the simulate retry count down.

### Residuals, both noted in the code

- An attempt aborted at its timeout may still be evaluated by the node afterwards, against a window that has since closed. Harmless — nobody reads that answer.
- Clock skew larger than the TTL makes every body born expired, which no client-side change can prevent. A freshly stamped body rejected as expired now raises `SimulationExpiredError` naming the skew, rather than the opaque node message that cost time in August.

### Two more things #3804 left behind, fixed here

Both were listed as found-but-untouched in an earlier revision of this description. They are in the diff now.

- **`#pollTx` stops on a wall clock instead of an attempt count.** It sized `maxAttempts` from the poll interval alone, as if every `getTx` returned instantly. A `tx_search` that takes seconds makes each cycle cost the interval *plus* the query, so polling ran well past `SIGN_AND_BROADCAST_DEADLINE_MS` and #3804's "always settles within the deadline" claim did not hold: a 20s deadline against 4s queries spent 66s. The loop now checks the clock against the deadline and the recovery window, so a slow query spends the window rather than extending it. The new test pins that at 4 polls where the old formula took 11.
- **A broadcast the node never answered falls through to polling.** `#broadcast` reported an undecided outcome for anything that was not a `BroadcastTxError`, a timeout abort included — but a request that never came back can leave the tx sitting in the node's mempool, so refusing it there throws away an answer polling could still get. It now derives the hash locally (`toHex(sha256(txBytes))`, as the `"tx already exists in cache"` branch already did) and polls, which either finds the tx or, once its `timeoutTimestamp` has passed, reports it as genuinely not included. Safe in both directions, since polling never invents a success and the not-included verdict is still gated on expiry.

The derived hash is uppercase in both paths now, matching what a `broadcastTxSync` the node actually answered returns.

## Testing

`apps/tx-signer`: 141 tests pass, lint and `tsc --noEmit` clean. No `apps/api` files changed.

The functional suite reproduces the August shape end to end against a nock'd node: a simulate that fails at the transport, retried with a fresh window, and — when every attempt fails — exactly four attempts and a response that names `Bad status on response: 503` with no mention of `tx timeout`. That test is also what protects the hardcoded `/cosmos.tx.v1beta1.Service/Simulate` path: if the constant ever stops matching, the retry nests over the transport retry and the attempt count fails loudly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added configurable retries for transient gas simulation and RPC transport failures.
  * Prevented retries for non-repeatable requests and transaction simulations where replay could be unsafe.
  * Improved signing timeout, polling, and retry-budget calculations using RPC and simulation time limits.
  * Added clearer handling for expired simulations and uncertain broadcast outcomes.

* **Bug Fixes**
  * Configuration now rejects incompatible RPC, transaction validity, and signing deadline settings.

* **Documentation**
  * Documented timeout requirements and expired simulation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->