### PR TITLE
fix(deployment): record a deployment close from the landed transaction

### DIFF
--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -528,6 +528,20 @@ describe(ManagedSignerService.name, () => {
       expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENT_RECORD_FAILED", userId: "user-123", dseq: "123" }));
     });
 
+    it("records a close even when a create in the same transaction fails to publish", async () => {
+      const { service, deploymentSettingRepository } = setupForClose({
+        publish: vi.fn().mockRejectedValue(new Error("queue unavailable"))
+      });
+      const createMessage: EncodeObject = {
+        typeUrl: MsgCreateDeployment.$type,
+        value: MsgCreateDeployment.fromPartial({ id: { owner: "akash1test", dseq: 123 } })
+      };
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createMessage, closeMessageFor(456)])).rejects.toThrow("queue unavailable");
+
+      expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: "user-123", dseq: "456" });
+    });
+
     function closeMessageFor(dseq: number): EncodeObject {
       return {
         typeUrl: MsgCloseDeployment.$type,

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -542,24 +542,6 @@ describe(ManagedSignerService.name, () => {
       expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: "user-123", dseq: "456" });
     });
 
-    function closeMessageFor(dseq: number): EncodeObject {
-      return {
-        typeUrl: MsgCloseDeployment.$type,
-        value: MsgCloseDeployment.fromPartial({ id: { owner: "akash1test", dseq } })
-      };
-    }
-
-    function setupForClose(input?: Parameters<typeof setup>[0]) {
-      return setup({
-        findOneByUserId: vi.fn().mockResolvedValue(createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100, isTrialing: false })),
-        findById: vi.fn().mockResolvedValue(createUser({ userId: "user-123" })),
-        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
-        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
-        publish: vi.fn().mockResolvedValue(undefined),
-        ...input
-      });
-    }
-
     it("does not publish FundDeploymentCommand when a trialing wallet creates a lease", async () => {
       const wallet = createUserWallet({
         userId: "user-123",
@@ -1135,6 +1117,24 @@ describe(ManagedSignerService.name, () => {
 
     expect(createLogger).toHaveBeenCalledWith({ context: ManagedSignerService.name });
   });
+
+  function closeMessageFor(dseq: number): EncodeObject {
+    return {
+      typeUrl: MsgCloseDeployment.$type,
+      value: MsgCloseDeployment.fromPartial({ id: { owner: "akash1test", dseq } })
+    };
+  }
+
+  function setupForClose(input?: Parameters<typeof setup>[0]) {
+    return setup({
+      findOneByUserId: vi.fn().mockResolvedValue(createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100, isTrialing: false })),
+      findById: vi.fn().mockResolvedValue(createUser({ userId: "user-123" })),
+      signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
+      refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+      publish: vi.fn().mockResolvedValue(undefined),
+      ...input
+    });
+  }
 
   function setupForCreate(input: { deploymentLimit: number } & Omit<NonNullable<Parameters<typeof setup>[0]>, "retrieveDeploymentLimit">) {
     const { deploymentLimit, ...rest } = input;

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -24,6 +24,7 @@ import type { WalletReloadJobService } from "@src/billing/services/wallet-reload
 import type { CreateLogger } from "@src/core";
 import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import type { FeatureFlagValue } from "@src/core/services/feature-flags/feature-flags";
+import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { RecordDeploymentSetting } from "@src/deployment/services/record-deployment-setting/record-deployment-setting.handler";
 import type { UserOutput, UserRepository } from "@src/user/repositories";
 import { createAkashAddress } from "../../../../test/seeders";
@@ -475,6 +476,75 @@ describe(ManagedSignerService.name, () => {
 
       expect(domainEvents.publish).not.toHaveBeenCalledWith(expect.any(RecordDeploymentSetting), expect.anything());
     });
+
+    it("records a deployment closed by broadcasting its message, so no later sweep has to discover the close", async () => {
+      const { service, deploymentSettingRepository } = setupForClose();
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [closeMessageFor(123)]);
+
+      expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: "user-123", dseq: "123" });
+    });
+
+    it("records every deployment one transaction closes", async () => {
+      const { service, deploymentSettingRepository } = setupForClose();
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [closeMessageFor(123), closeMessageFor(456)]);
+
+      expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: "user-123", dseq: "123" });
+      expect(deploymentSettingRepository.markClosed).toHaveBeenCalledWith({ userId: "user-123", dseq: "456" });
+    });
+
+    it("records nothing closed when the close reverted on chain", async () => {
+      const { service, deploymentSettingRepository } = setupForClose({
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 11, hash: "tx-hash", rawLog: "out of gas" })
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [closeMessageFor(123)])).rejects.toThrow("out of gas");
+
+      expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
+    });
+
+    it("records nothing closed for a transaction that closes no deployment", async () => {
+      const { service, deploymentSettingRepository } = setupForClose();
+      const createMessage: EncodeObject = {
+        typeUrl: MsgCreateDeployment.$type,
+        value: MsgCreateDeployment.fromPartial({ id: { owner: "akash1test", dseq: 123 } })
+      };
+
+      await service.executeDerivedDecodedTxByUserId("user-123", [createMessage]);
+
+      expect(deploymentSettingRepository.markClosed).not.toHaveBeenCalled();
+    });
+
+    it("logs a failed record rather than reporting a close the chain accepted as failed", async () => {
+      const { service, logger } = setupForClose({
+        markClosed: vi.fn().mockRejectedValue(new Error("database unavailable"))
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [closeMessageFor(123)])).resolves.toEqual(
+        expect.objectContaining({ code: 0, transactionHash: "tx-hash" })
+      );
+
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENT_RECORD_FAILED", userId: "user-123", dseq: "123" }));
+    });
+
+    function closeMessageFor(dseq: number): EncodeObject {
+      return {
+        typeUrl: MsgCloseDeployment.$type,
+        value: MsgCloseDeployment.fromPartial({ id: { owner: "akash1test", dseq } })
+      };
+    }
+
+    function setupForClose(input?: Parameters<typeof setup>[0]) {
+      return setup({
+        findOneByUserId: vi.fn().mockResolvedValue(createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100, isTrialing: false })),
+        findById: vi.fn().mockResolvedValue(createUser({ userId: "user-123" })),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "tx-hash", rawLog: "success" }),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(undefined),
+        ...input
+      });
+    }
 
     it("does not publish FundDeploymentCommand when a trialing wallet creates a lease", async () => {
       const wallet = createUserWallet({
@@ -1081,6 +1151,7 @@ describe(ManagedSignerService.name, () => {
     transformChainError?: ChainErrorService["toAppError"];
     hasLeases?: LeaseHttpService["hasLeases"];
     scheduleImmediate?: WalletReloadJobService["scheduleImmediate"];
+    markClosed?: DeploymentSettingRepository["markClosed"];
     decode?: Registry["decode"];
   }) {
     const mocks = {
@@ -1130,6 +1201,9 @@ describe(ManagedSignerService.name, () => {
         refillWalletFees: vi.fn()
       }),
       trialActivationJobService: mock<TrialActivationJobService>(),
+      deploymentSettingRepository: mock<DeploymentSettingRepository>({
+        markClosed: input?.markClosed ?? vi.fn()
+      }),
       logger: mock<ReturnType<CreateLogger>>({
         error: vi.fn(),
         warn: vi.fn()
@@ -1157,6 +1231,7 @@ describe(ManagedSignerService.name, () => {
       mocks.walletReloadJobService,
       mocks.managedUserWalletService,
       mocks.trialActivationJobService,
+      mocks.deploymentSettingRepository,
       createLogger
     );
 

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -1,5 +1,5 @@
 import { MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
-import { MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
 import { LeaseHttpService } from "@akashnetwork/http-sdk";
 import { Trace, withSpan } from "@akashnetwork/instrumentation";
@@ -23,6 +23,7 @@ import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.se
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { RecordDeploymentSetting, recordDeploymentSettingKeyFor } from "@src/deployment/services/record-deployment-setting/record-deployment-setting.handler";
 import { UserRepository } from "@src/user/repositories";
 import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
@@ -58,6 +59,7 @@ export class ManagedSignerService {
     private readonly walletReloadJobService: WalletReloadJobService,
     private readonly managedUserWalletService: ManagedUserWalletService,
     private readonly trialActivationJobService: TrialActivationJobService,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: ManagedSignerService.name });
@@ -179,6 +181,7 @@ export class ManagedSignerService {
     }
 
     await this.#recordCreatedDeployments(userWallet, messages);
+    await this.#recordClosedDeployments(userWallet, messages);
 
     await this.balancesService.refreshUserWalletLimits(userWallet);
     await this.#ensureAutoReloadSchedule(userWallet.userId, messages);
@@ -198,15 +201,33 @@ export class ManagedSignerService {
 
   /** A create broadcast here never passes through the deployment API that would record it, so the record is written from the landed transaction. */
   async #recordCreatedDeployments(userWallet: UserWalletOutput, messages: EncodeObject[]) {
-    const createdDseqs = messages
-      .filter((message): message is { typeUrl: string; value: MsgCreateDeployment } => message.typeUrl.endsWith(".MsgCreateDeployment"))
-      .map(message => message.value.id?.dseq)
-      .filter(dseq => dseq !== undefined);
-
-    for (const dseq of createdDseqs) {
+    for (const dseq of this.#findDeploymentDseqs(messages, ".MsgCreateDeployment")) {
       const key = { userId: userWallet.userId, dseq: dseq.toString() };
       await this.domainEvents.publish(new RecordDeploymentSetting(key), { singletonKey: recordDeploymentSettingKeyFor(key) });
     }
+  }
+
+  /**
+   * A close is recorded from the landed transaction for the same reason a create is, since neither the deployment
+   * API's close nor the raw transaction endpoint writes the record; failing to write it must not report a close the
+   * chain already accepted as failed, so the hourly reconcile is what covers a row this misses.
+   */
+  async #recordClosedDeployments(userWallet: UserWalletOutput, messages: EncodeObject[]) {
+    for (const dseq of this.#findDeploymentDseqs(messages, ".MsgCloseDeployment")) {
+      try {
+        await this.deploymentSettingRepository.markClosed({ userId: userWallet.userId, dseq: dseq.toString() });
+      } catch (error) {
+        this.logger.error({ event: "CLOSED_DEPLOYMENT_RECORD_FAILED", userId: userWallet.userId, dseq: dseq.toString(), error });
+      }
+    }
+  }
+
+  /** Both deployment messages carry the id in the same shape, so one of the two types describes either. */
+  #findDeploymentDseqs(messages: EncodeObject[], typeUrlSuffix: string): bigint[] {
+    return messages
+      .filter((message): message is { typeUrl: string; value: MsgCreateDeployment | MsgCloseDeployment } => message.typeUrl.endsWith(typeUrlSuffix))
+      .map(message => message.value.id?.dseq)
+      .filter((dseq): dseq is bigint => dseq !== undefined);
   }
 
   async #ensureAutoReloadSchedule(userId: UserWalletOutput["userId"], messages: EncodeObject[]) {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -147,6 +147,8 @@ export class ManagedSignerService {
       throw error;
     }
 
+    await this.#recordClosedDeployments(userWallet, messages);
+
     if (hasCreateTrialLeaseMessage) {
       await this.domainEvents.publish(
         new TrialDeploymentLeaseCreated({
@@ -181,7 +183,6 @@ export class ManagedSignerService {
     }
 
     await this.#recordCreatedDeployments(userWallet, messages);
-    await this.#recordClosedDeployments(userWallet, messages);
 
     await this.balancesService.refreshUserWalletLimits(userWallet);
     await this.#ensureAutoReloadSchedule(userWallet.userId, messages);
@@ -208,9 +209,9 @@ export class ManagedSignerService {
   }
 
   /**
-   * A close is recorded from the landed transaction for the same reason a create is, since neither the deployment
-   * API's close nor the raw transaction endpoint writes the record; failing to write it must not report a close the
-   * chain already accepted as failed, so the hourly reconcile is what covers a row this misses.
+   * Recorded from the landed transaction because neither the deployment API's close nor the raw transaction endpoint
+   * writes the record, and ahead of the rest of the post-broadcast work so a batch that also creates cannot lose the
+   * close to an unrelated publish failure. A record that fails to write must never fail a close the chain accepted.
    */
   async #recordClosedDeployments(userWallet: UserWalletOutput, messages: EncodeObject[]) {
     for (const dseq of this.#findDeploymentDseqs(messages, ".MsgCloseDeployment")) {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -208,11 +208,7 @@ export class ManagedSignerService {
     }
   }
 
-  /**
-   * Recorded from the landed transaction because neither the deployment API's close nor the raw transaction endpoint
-   * writes the record, and ahead of the rest of the post-broadcast work so a batch that also creates cannot lose the
-   * close to an unrelated publish failure. A record that fails to write must never fail a close the chain accepted.
-   */
+  /** No close path writes this record, and it runs before the other post-broadcast work so a rejected publish cannot drop an accepted close. */
   async #recordClosedDeployments(userWallet: UserWalletOutput, messages: EncodeObject[]) {
     for (const dseq of this.#findDeploymentDseqs(messages, ".MsgCloseDeployment")) {
       try {


### PR DESCRIPTION
## Why

`deployment_settings.closed` is Console's record of whether a managed deployment is still running, and on prod it had drifted badly: 48,345 rows claiming open against roughly 391 open leases across 16,098 managed wallets.

A large part of that turns out to be simpler than the issue's own diagnosis suggested. `ManagedSignerService` already writes a settings row when it broadcasts a create, precisely because "a create broadcast here never passes through the deployment API that would record it". Nothing does the same for a close, even though the method four lines below already inspects the message list for `MsgCloseDeployment` in order to schedule a credits-low check. So every close through `DELETE /v1/deployments/{dseq}`, the raw `/v1/tx` endpoint, and the trial-cleanup job leaves the row saying the deployment is still running. Creates get recorded, closes do not, and that alone would produce a gap of roughly this size.

First of three PRs. This one stops new drift at the source. A follow-up reconciles the backlog that already exists, and a third fixes the funding sweep's own lease-keyed skip.

Part of CON-923

## What

- `#recordClosedDeployments` on `ManagedSignerService`, called from `executeDecodedTxByUserWallet` once the tx has landed with code 0, so a reverted close never marks a row closed. It runs ahead of the other post-broadcast work: a batch submitted through the raw `/v1/tx` endpoint can carry a create alongside a close, and a rejected domain-event publish would otherwise drop the close record.
- It calls the existing `markClosed({ userId, dseq })`, which upserts on the natural key, so a deployment that never had a row is still remembered as closed instead of being re-closed by every later sweep.
- The write is best-effort. The chain has already accepted the close by the time it runs, so a failure is logged as `CLOSED_DEPLOYMENT_RECORD_FAILED` rather than thrown, and PR 2's reconcile is what covers a row this misses.
- The dseq extraction that both the create and close paths need is now one helper, `#findDeploymentDseqs`.

Not covered here: `StaleManagedDeploymentsCleanerService` broadcasts through the lower-level `executeDerivedTx`, so it stays as CON-918 left it and gets picked up by the reconcile in PR 2.

## Verification

6 new unit tests. In `apps/api`: unit suite green (191 files, 2617 tests), functional green (36 files, 385 passed and 1 skipped), integration green apart from 4 failures in the user and api-key repositories that fail identically on a clean tree. `tsc --noEmit` baseline unchanged at 42 errors, none in the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Successfully broadcast deployment-close transactions now record the affected deployments as closed.
  - Multiple deployment closures in a single transaction are supported.
  - Transactions containing both deployment creation and closure messages are handled correctly.

- **Bug Fixes**
  - Deployment closure records are not created for failed transactions or transactions without close messages.
  - Closure-recording failures no longer interrupt successful transaction results or subsequent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
