### PR TITLE
fix(deployment): reconcile deployment records against chain state

### DIFF
--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { ClosedDeploymentsReconcilerService } from "@src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service";
 import type { DeploymentCloseJobService } from "@src/deployment/services/deployment-close-job/deployment-close-job.service";
 import type { ExpiringDeploymentsNotifierService } from "@src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service";
 import type { StaleManagedDeploymentsCleanerService } from "@src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
@@ -27,6 +28,27 @@ describe(TopUpDeploymentsController.name, () => {
       await controller.topUpDeployments(options);
 
       expect(deploymentCloseJobService.reconcileExpired).toHaveBeenCalledWith(options);
+    });
+
+    it("reconciles deployment records against chain state, which the funding sweep's own selection cannot reach", async () => {
+      const { controller, closedDeploymentsReconcilerService } = setup();
+      const options = { concurrency: 5, dryRun: false };
+
+      await controller.topUpDeployments(options);
+
+      expect(closedDeploymentsReconcilerService.reconcileClosedDeployments).toHaveBeenCalledWith(options);
+    });
+
+    it("reconciles deployment records before the funding sweep so a sweep failure cannot skip them", async () => {
+      const { controller, topUpManagedDeploymentsService, closedDeploymentsReconcilerService } = setup();
+      topUpManagedDeploymentsService.topUpDeployments.mockRejectedValue(new Error("chain rpc unavailable"));
+      const options = { concurrency: 5, dryRun: false };
+
+      await expect(controller.topUpDeployments(options)).rejects.toThrow("chain rpc unavailable");
+
+      expect(closedDeploymentsReconcilerService.reconcileClosedDeployments.mock.invocationCallOrder[0]).toBeLessThan(
+        topUpManagedDeploymentsService.topUpDeployments.mock.invocationCallOrder[0]
+      );
     });
 
     it("reconciles close jobs before the funding sweep so a sweep failure cannot skip them", async () => {
@@ -95,13 +117,15 @@ describe(TopUpDeploymentsController.name, () => {
     const expiringDeploymentsNotifierService = mock<ExpiringDeploymentsNotifierService>();
     const unreachableProviderDeploymentsNotifierService = mock<UnreachableProviderDeploymentsNotifierService>();
     const unreachableProviderDeploymentsCloserService = mock<UnreachableProviderDeploymentsCloserService>();
+    const closedDeploymentsReconcilerService = mock<ClosedDeploymentsReconcilerService>();
     const controller = new TopUpDeploymentsController(
       topUpManagedDeploymentsService,
       staleDeploymentsCleanerService,
       deploymentCloseJobService,
       expiringDeploymentsNotifierService,
       unreachableProviderDeploymentsNotifierService,
-      unreachableProviderDeploymentsCloserService
+      unreachableProviderDeploymentsCloserService,
+      closedDeploymentsReconcilerService
     );
 
     return {
@@ -111,7 +135,8 @@ describe(TopUpDeploymentsController.name, () => {
       deploymentCloseJobService,
       expiringDeploymentsNotifierService,
       unreachableProviderDeploymentsNotifierService,
-      unreachableProviderDeploymentsCloserService
+      unreachableProviderDeploymentsCloserService,
+      closedDeploymentsReconcilerService
     };
   }
 });

--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
@@ -1,6 +1,7 @@
 import { singleton } from "tsyringe";
 
 import type { DryRunOptions } from "@src/core/types/console";
+import { ClosedDeploymentsReconcilerService } from "@src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service";
 import { DeploymentCloseJobService } from "@src/deployment/services/deployment-close-job/deployment-close-job.service";
 import { ExpiringDeploymentsNotifierService } from "@src/deployment/services/expiring-deployments-notifier/expiring-deployments-notifier.service";
 import { StaleManagedDeploymentsCleanerService } from "@src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
@@ -17,12 +18,14 @@ export class TopUpDeploymentsController {
     private readonly deploymentCloseJobService: DeploymentCloseJobService,
     private readonly expiringDeploymentsNotifierService: ExpiringDeploymentsNotifierService,
     private readonly unreachableProviderDeploymentsNotifierService: UnreachableProviderDeploymentsNotifierService,
-    private readonly unreachableProviderDeploymentsCloserService: UnreachableProviderDeploymentsCloserService
+    private readonly unreachableProviderDeploymentsCloserService: UnreachableProviderDeploymentsCloserService,
+    private readonly closedDeploymentsReconcilerService: ClosedDeploymentsReconcilerService
   ) {}
 
-  /** The reconcile goes first because it only needs the database, so a chain-RPC failure in the sweep cannot skip it for the hour. */
+  /** The reconciles go first because they only need the databases, so a chain-RPC failure in the sweep cannot skip them for the hour. */
   async topUpDeployments(options: DryRunOptions) {
     await this.deploymentCloseJobService.reconcileExpired(options);
+    await this.closedDeploymentsReconcilerService.reconcileClosedDeployments(options);
     await this.topUpManagedDeploymentsService.topUpDeployments(options);
   }
 

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -692,6 +692,73 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("findOpenDeploymentsIteratively", () => {
+    it("yields an open deployment whose owner turned funding off, which the funding sweep never reaches", async () => {
+      const { deploymentSettingRepository, user, wallet, findOpenDeployments } = await setup();
+      const fundingOff = await deploymentSettingRepository.create({ userId: user.id, dseq: newDseq(), autoTopUpEnabled: false });
+
+      const open = await findOpenDeployments([wallet.address]);
+
+      expect(open.map(deployment => deployment.id)).toContain(fundingOff.id);
+    });
+
+    it("reports the owner address and dseq a chain lookup needs", async () => {
+      const { deploymentSettingRepository, settingId, wallet, findOpenDeployments } = await setup();
+      const setting = await deploymentSettingRepository.findById(settingId);
+
+      const open = await findOpenDeployments([wallet.address]);
+
+      expect(open).toContainEqual({ id: settingId, dseq: setting!.dseq, address: wallet.address });
+    });
+
+    it("passes over a deployment already marked closed", async () => {
+      const { deploymentSettingRepository, settingId, wallet, findOpenDeployments } = await setup();
+      await deploymentSettingRepository.markAsClosed([settingId]);
+
+      const open = await findOpenDeployments([wallet.address]);
+
+      expect(open.map(deployment => deployment.id)).not.toContain(settingId);
+    });
+
+    it("passes over a deployment whose wallet has no address yet, since there is nothing to look up", async () => {
+      const { deploymentSettingRepository, userRepository, db, userWalletsTable, findOpenDeployments } = await setup();
+      const walletlessUser = await userRepository.create({ userId: faker.string.uuid() });
+      await db.insert(userWalletsTable).values({ userId: walletlessUser.id, deploymentAllowance: "0", feeAllowance: "0", isTrialing: false });
+      const setting = await deploymentSettingRepository.create({ userId: walletlessUser.id, dseq: newDseq(), autoTopUpEnabled: true });
+
+      const open = await findOpenDeployments();
+
+      expect(open.map(deployment => deployment.id)).not.toContain(setting.id);
+    });
+
+    it("pages every open deployment exactly once when the batch is smaller than the set", async () => {
+      const { createSetting, wallet, findOpenDeployments } = await setup();
+      await createSetting();
+      await createSetting();
+      await createSetting();
+
+      const oneAtATime = await findOpenDeployments([wallet.address], 1);
+      const allAtOnce = await findOpenDeployments([wallet.address], 1000);
+
+      expect(allAtOnce).toHaveLength(4);
+      expect(oneAtATime.map(deployment => deployment.id).sort()).toEqual(allAtOnce.map(deployment => deployment.id).sort());
+    });
+
+    it("yields batches no larger than the size asked for", async () => {
+      const { deploymentSettingRepository, createSetting } = await setup();
+      await createSetting();
+      await createSetting();
+      await createSetting();
+      const sizes: number[] = [];
+
+      for await (const batch of deploymentSettingRepository.findOpenDeploymentsIteratively({ batchSize: 2 })) {
+        sizes.push(batch.length);
+      }
+
+      expect(Math.max(...sizes)).toBeLessThanOrEqual(2);
+    });
+  });
+
   describe("createDefaultIfMissing", () => {
     it("records a deployment nothing had recorded yet, with funding on", async () => {
       const { deploymentSettingRepository, user } = await setup();
@@ -766,6 +833,16 @@ describe(DeploymentSettingRepository.name, () => {
       return setting.id;
     }
 
+    async function findOpenDeployments(addresses?: string[], batchSize = 1000) {
+      const open = [];
+
+      for await (const batch of deploymentSettingRepository.findOpenDeploymentsIteratively({ batchSize })) {
+        open.push(...batch.filter(deployment => !addresses || addresses.includes(deployment.address)));
+      }
+
+      return open;
+    }
+
     async function findAutoTopUpOwners(addresses: string[]) {
       const owners = [];
 
@@ -829,6 +906,7 @@ describe(DeploymentSettingRepository.name, () => {
       deploymentSettingRepository,
       db,
       deploymentSettingsTable,
+      userWalletsTable,
       user,
       trialUser,
       wallet,
@@ -841,6 +919,7 @@ describe(DeploymentSettingRepository.name, () => {
       createLimitedSetting,
       createAnchoredSetting,
       findAutoTopUpOwners,
+      findOpenDeployments,
       backdateLastFundedAt,
       readClosed
     };

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, or, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { UserWallets, WalletSetting } from "@src/billing/model-schemas";
@@ -38,6 +38,12 @@ export type ExpiringRuntimeDeployment = {
   runtimeEndsAt: Date;
   /** The deadline as stored, in text, so a claim can match it without losing the sub-millisecond digits a `Date` drops. */
   runtimeEndsAtMarker: string;
+};
+
+export type OpenDeployment = {
+  id: string;
+  dseq: string;
+  address: string;
 };
 
 export type AutoTopUpDeployment = {
@@ -105,6 +111,42 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
   findAutoTopUpDeploymentsByOwner(address: string): Promise<AutoTopUpDeployment[]> {
     return this.#findAutoTopUpDeployments(address);
+  }
+
+  /**
+   * Every row still marked open, whatever its owner chose about funding, because a deployment closes on chain
+   * for reasons that have nothing to do with whether Console was funding it. Keyset-paged on `id`, the leading
+   * column of `id_auto_top_up_enabled_closed_idx`, so each batch is an index scan rather than a growing offset.
+   */
+  async *findOpenDeploymentsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<OpenDeployment[]> {
+    let cursor: string | undefined;
+
+    while (true) {
+      const batch = await this.pg
+        .select({
+          id: this.table.id,
+          dseq: this.table.dseq,
+          address: UserWallets.address
+        })
+        .from(this.table)
+        .innerJoin(Users, eq(this.table.userId, Users.id))
+        .innerJoin(UserWallets, eq(Users.id, UserWallets.userId))
+        .where(and(eq(this.table.closed, false), isNotNull(UserWallets.address), ...(cursor ? [gt(this.table.id, cursor)] : [])))
+        .orderBy(asc(this.table.id))
+        .limit(batchSize);
+
+      if (!batch.length) {
+        return;
+      }
+
+      yield batch as OpenDeployment[];
+
+      if (batch.length < batchSize) {
+        return;
+      }
+
+      cursor = batch[batch.length - 1].id;
+    }
   }
 
   async #findAutoTopUpDeployments(address?: string): Promise<AutoTopUpDeployment[]> {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -113,11 +113,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return this.#findAutoTopUpDeployments(address);
   }
 
-  /**
-   * Every row still marked open, whatever its owner chose about funding, because a deployment closes on chain
-   * for reasons that have nothing to do with whether Console was funding it. Keyset-paged on `id`, the leading
-   * column of `id_auto_top_up_enabled_closed_idx`, so each batch is an index scan rather than a growing offset.
-   */
+  /** Keyset-paged on `id`, the leading column of `id_auto_top_up_enabled_closed_idx`, so each batch stays an index scan. */
   async *findOpenDeploymentsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<OpenDeployment[]> {
     let cursor: string | undefined;
 

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.integration.ts
@@ -5,7 +5,15 @@ import { describe, expect, it } from "vitest";
 import { CHAIN_DB } from "@src/chain";
 import { DeploymentRepository } from "./deployment.repository";
 
-import { createAkashBlock, createAkashMessage, createDeployment, createDeploymentGroup, createDeploymentGroupResource, createTransaction } from "@test/seeders";
+import {
+  createAkashAddress,
+  createAkashBlock,
+  createAkashMessage,
+  createDeployment,
+  createDeploymentGroup,
+  createDeploymentGroupResource,
+  createTransaction
+} from "@test/seeders";
 
 const BID_TYPE = "/akash.market.v1beta5.MsgCreateBid";
 
@@ -102,9 +110,74 @@ describe(DeploymentRepository.name, () => {
 
   let testBand = 0;
 
+  describe("findClosureStates", () => {
+    it("reports a deployment the chain has closed as closed", async () => {
+      const { repository } = setup();
+      const owner = createAkashAddress();
+      const deployment = await createDeployment({ owner, closedHeight: 5_000_000 });
+
+      const states = await repository.findClosureStates([{ owner, dseq: deployment.dseq }]);
+
+      expect(states).toEqual([{ owner, dseq: deployment.dseq, isClosed: true }]);
+    });
+
+    it("reports a deployment the chain still holds open as open", async () => {
+      const { repository } = setup();
+      const owner = createAkashAddress();
+      const deployment = await createDeployment({ owner, closedHeight: undefined });
+
+      const states = await repository.findClosureStates([{ owner, dseq: deployment.dseq }]);
+
+      expect(states).toEqual([{ owner, dseq: deployment.dseq, isClosed: false }]);
+    });
+
+    it("leaves out a deployment the indexer holds no row for, so absence is not read as either state", async () => {
+      const { repository } = setup();
+
+      const states = await repository.findClosureStates([{ owner: createAkashAddress(), dseq: "999999999999" }]);
+
+      expect(states).toEqual([]);
+    });
+
+    it("matches on the owner as well as the dseq, so one owner's close cannot answer for another's", async () => {
+      const { repository } = setup();
+      const owner = createAkashAddress();
+      const otherOwner = createAkashAddress();
+      const deployment = await createDeployment({ owner, closedHeight: 5_000_000 });
+
+      const states = await repository.findClosureStates([{ owner: otherOwner, dseq: deployment.dseq }]);
+
+      expect(states).toEqual([]);
+    });
+
+    it("answers for each pair of a mixed batch", async () => {
+      const { repository } = setup();
+      const owner = createAkashAddress();
+      const closed = await createDeployment({ owner, closedHeight: 5_000_000 });
+      const open = await createDeployment({ owner, closedHeight: undefined });
+      const unknownDseq = "888888888888";
+
+      const states = await repository.findClosureStates([
+        { owner, dseq: closed.dseq },
+        { owner, dseq: open.dseq },
+        { owner, dseq: unknownDseq }
+      ]);
+
+      expect(states).toHaveLength(2);
+      expect(states).toContainEqual({ owner, dseq: closed.dseq, isClosed: true });
+      expect(states).toContainEqual({ owner, dseq: open.dseq, isClosed: false });
+    });
+
+    it("returns nothing for an empty batch without querying", async () => {
+      const { repository } = setup();
+
+      await expect(repository.findClosureStates([])).resolves.toEqual([]);
+    });
+  });
+
   function setup() {
-    // Resolve CHAIN_DB so the chain Sequelize instance (and its models) is initialized — the
-    // repository uses the static models directly and does not inject the connection itself.
+    // Resolve CHAIN_DB so the chain Sequelize instance (and its models) is initialized before the
+    // static models this repository still reads through are used.
     container.resolve(CHAIN_DB);
     const repository = container.resolve(DeploymentRepository);
     testBand += 1;

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
@@ -52,10 +52,7 @@ export class DeploymentRepository {
     this.#chainDb = chainDb;
   }
 
-  /**
-   * Whether the chain has closed each of the given deployments. A deployment the indexer holds no row for is
-   * left out of the result rather than reported open, so a caller can tell "still running" from "not indexed".
-   */
+  /** A deployment the indexer holds no row for is left out rather than reported open, so a caller can tell "still running" from "not indexed". */
   async findClosureStates(deployments: DeploymentKey[]): Promise<DeploymentClosureState[]> {
     if (deployments.length === 0) return [];
 

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
@@ -1,8 +1,10 @@
 import { Block } from "@akashnetwork/database/dbSchemas";
 import { AkashMessage, Deployment, DeploymentGroup, DeploymentGroupResource, Lease } from "@akashnetwork/database/dbSchemas/akash";
 import { Transaction } from "@akashnetwork/database/dbSchemas/base";
-import { FindAndCountOptions, FindOptions, literal, Op, WhereOptions } from "sequelize";
-import { singleton } from "tsyringe";
+import { FindAndCountOptions, FindOptions, literal, Op, QueryTypes, type Sequelize, WhereOptions } from "sequelize";
+import { inject, singleton } from "tsyringe";
+
+import { CHAIN_DB } from "@src/chain";
 
 export interface StaleDeploymentsOptions {
   createdHeight: number;
@@ -33,8 +35,43 @@ export interface StaleDeploymentsOutput {
   dseq: number;
 }
 
+export interface DeploymentKey {
+  owner: string;
+  dseq: string;
+}
+
+export interface DeploymentClosureState extends DeploymentKey {
+  isClosed: boolean;
+}
+
 @singleton()
 export class DeploymentRepository {
+  readonly #chainDb: Sequelize;
+
+  constructor(@inject(CHAIN_DB) chainDb: Sequelize) {
+    this.#chainDb = chainDb;
+  }
+
+  /**
+   * Whether the chain has closed each of the given deployments. A deployment the indexer holds no row for is
+   * left out of the result rather than reported open, so a caller can tell "still running" from "not indexed".
+   */
+  async findClosureStates(deployments: DeploymentKey[]): Promise<DeploymentClosureState[]> {
+    if (deployments.length === 0) return [];
+
+    return await this.#chainDb.query<DeploymentClosureState>(
+      `/* deployment:closureStatesByOwnerAndDseq */
+      SELECT d."owner", d."dseq", d."closedHeight" IS NOT NULL AS "isClosed"
+      FROM deployment d
+      JOIN unnest($1::text[], $2::text[]) AS t(owner, dseq)
+        ON d."owner" = t.owner AND d."dseq" = t.dseq`,
+      {
+        bind: [deployments.map(deployment => deployment.owner), deployments.map(deployment => deployment.dseq)],
+        type: QueryTypes.SELECT
+      }
+    );
+  }
+
   async findByOwnerAndDseq(owner: string, dseq: string): Promise<Deployment | null> {
     return await Deployment.findOne({
       where: { owner, dseq }

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.integration.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.integration.ts
@@ -1,0 +1,113 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import { CHAIN_DB } from "@src/chain";
+import type { ApiPgDatabase } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { UserRepository } from "@src/user/repositories";
+import { ClosedDeploymentsReconcilerService } from "./closed-deployments-reconciler.service";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { createDeployment } from "@test/seeders/deployment.seeder";
+
+describe(ClosedDeploymentsReconcilerService.name, () => {
+  it("marks a record closed once the chain has closed its deployment", async () => {
+    const { service, recordDeployment, readClosed } = await setup();
+    const settled = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: true });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(await readClosed(settled.id)).toBe(true);
+  });
+
+  it("marks a record closed even when its owner turned funding off, which the funding sweep never selects", async () => {
+    const { service, recordDeployment, readClosed } = await setup();
+    const fundingOff = await recordDeployment({ autoTopUpEnabled: false, closedOnChain: true });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(await readClosed(fundingOff.id)).toBe(true);
+  });
+
+  it("leaves a record open while its deployment is still running on chain", async () => {
+    const { service, recordDeployment, readClosed } = await setup();
+    const running = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: false });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(await readClosed(running.id)).toBe(false);
+  });
+
+  it("leaves a record alone when the indexer holds no deployment for it", async () => {
+    const { service, recordDeployment, readClosed } = await setup();
+    const unindexed = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: null });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(await readClosed(unindexed.id)).toBe(false);
+  });
+
+  it("matches a record whose dseq carries leading zeros the indexer does not", async () => {
+    const { service, recordDeployment, readClosed } = await setup();
+    const padded = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: true, padDseq: true });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(await readClosed(padded.id)).toBe(true);
+  });
+
+  it("changes nothing during a dry run", async () => {
+    const { service, recordDeployment, readClosed } = await setup();
+    const settled = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: true });
+
+    await service.reconcileClosedDeployments({ dryRun: true });
+
+    expect(await readClosed(settled.id)).toBe(false);
+  });
+
+  it("converges a set larger than one batch", async () => {
+    const { service, recordDeployment, readClosed } = await setup();
+    const settled = await Promise.all(Array.from({ length: 5 }, () => recordDeployment({ autoTopUpEnabled: faker.datatype.boolean(), closedOnChain: true })));
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(await Promise.all(settled.map(({ id }) => readClosed(id)))).toEqual([true, true, true, true, true]);
+  });
+
+  async function setup() {
+    container.resolve(CHAIN_DB);
+
+    const service = container.resolve(ClosedDeploymentsReconcilerService);
+    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+    const userRepository = container.resolve(UserRepository);
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const deploymentSettingsTable = resolveTable("DeploymentSettings");
+    const userWalletsTable = resolveTable("UserWallets");
+
+    const user = await userRepository.create({ userId: faker.string.uuid() });
+    const address = createAkashAddress();
+    await db.insert(userWalletsTable).values({ userId: user.id, address, deploymentAllowance: "0", feeAllowance: "0", isTrialing: false });
+
+    async function recordDeployment(input: { autoTopUpEnabled: boolean; closedOnChain: boolean | null; padDseq?: boolean }) {
+      const dseq = faker.number.int({ min: 100_000, max: 9_999_999 }).toString();
+
+      if (input.closedOnChain !== null) {
+        await createDeployment({ owner: address, dseq, closedHeight: input.closedOnChain ? 5_000_000 : undefined });
+      }
+
+      return await deploymentSettingRepository.create({
+        userId: user.id,
+        dseq: input.padDseq ? `000${dseq}` : dseq,
+        autoTopUpEnabled: input.autoTopUpEnabled
+      });
+    }
+
+    async function readClosed(id: string) {
+      return (await deploymentSettingRepository.findById(id))!.closed;
+    }
+
+    return { service, deploymentSettingRepository, db, deploymentSettingsTable, user, address, recordDeployment, readClosed };
+  }
+});

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.spec.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.spec.ts
@@ -154,6 +154,38 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     expect(countersByName["closed_deployments_reconcile_rows_closed_total"].add).not.toHaveBeenCalled();
   });
 
+  it("stops scanning once enough batches fail in a row to mean the chain database is down rather than flaky", async () => {
+    const batches = Array.from({ length: 6 }, () => [openDeployment()]);
+    const { service, deploymentRepository, logger } = setup({
+      batches,
+      findClosureStates: vi.fn().mockRejectedValue(new Error("chain database unavailable"))
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentRepository.findClosureStates).toHaveBeenCalledTimes(3);
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_ABANDONED", failedBatches: 3 }));
+  });
+
+  it("keeps scanning when failing batches are spaced out by batches that succeed", async () => {
+    const batches = Array.from({ length: 5 }, () => [openDeployment()]);
+    const { service, deploymentRepository, logger } = setup({
+      batches,
+      findClosureStates: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("connection reset"))
+        .mockResolvedValueOnce([])
+        .mockRejectedValueOnce(new Error("connection reset"))
+        .mockResolvedValueOnce([])
+        .mockRejectedValueOnce(new Error("connection reset"))
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentRepository.findClosureStates).toHaveBeenCalledTimes(5);
+    expect(logger.error).not.toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_ABANDONED" }));
+  });
+
   it("reports a failure to read the records rather than raising it, so the funding sweep keeps its run", async () => {
     const { service, logger } = setup({ readError: new Error("database unavailable") });
 
@@ -195,6 +227,7 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     openDeployments?: OpenDeployment[];
     batches?: OpenDeployment[][];
     closureStates?: DeploymentClosureState[];
+    findClosureStates?: DeploymentRepository["findClosureStates"];
     markAsClosed?: DeploymentSettingRepository["markAsClosed"];
     readError?: Error;
   }) {
@@ -212,7 +245,7 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     });
 
     const deploymentRepository = mock<DeploymentRepository>({
-      findClosureStates: vi.fn().mockResolvedValue(input?.closureStates ?? [])
+      findClosureStates: input?.findClosureStates ?? vi.fn().mockResolvedValue(input?.closureStates ?? [])
     });
 
     const countersByName: Record<string, Counter> = {};

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.spec.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.spec.ts
@@ -1,0 +1,234 @@
+import { faker } from "@faker-js/faker";
+import type { Counter } from "@opentelemetry/api";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core";
+import type { MetricsService } from "@src/core/services/metrics/metrics.service";
+import type { DeploymentClosureState, DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
+import type { DeploymentSettingRepository, OpenDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { ClosedDeploymentsReconcilerService } from "./closed-deployments-reconciler.service";
+
+import { createAkashAddress } from "@test/seeders";
+
+describe(ClosedDeploymentsReconcilerService.name, () => {
+  it("marks a record closed when the chain has already closed its deployment", async () => {
+    const closed = openDeployment();
+    const { service, deploymentSettingRepository } = setup({ openDeployments: [closed], closureStates: [closureState(closed, true)] });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closed.id]);
+  });
+
+  it("marks a record closed whatever its owner chose about funding, since the query never reads that flag", async () => {
+    const closed = openDeployment();
+    const { service, deploymentSettingRepository } = setup({ openDeployments: [closed], closureStates: [closureState(closed, true)] });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.findOpenDeploymentsIteratively).toHaveBeenCalledWith({ batchSize: expect.any(Number) });
+    expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closed.id]);
+  });
+
+  it("leaves a record open while the chain still holds its deployment open", async () => {
+    const running = openDeployment();
+    const { service, deploymentSettingRepository, countersByName } = setup({
+      openDeployments: [running],
+      closureStates: [closureState(running, false)]
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+    expect(countersByName["closed_deployments_reconcile_rows_confirmed_open_total"].add).toHaveBeenCalledWith(1);
+  });
+
+  it("leaves a record alone when the indexer holds no deployment for it, rather than guessing it closed", async () => {
+    const unknown = openDeployment();
+    const { service, deploymentSettingRepository, countersByName } = setup({ openDeployments: [unknown], closureStates: [] });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+    expect(countersByName["closed_deployments_reconcile_rows_without_chain_state_total"].add).toHaveBeenCalledWith(1);
+  });
+
+  it("asks the chain about a dseq without the leading zeros only a stored record can carry", async () => {
+    const padded = openDeployment({ dseq: "0000123" });
+    const { service, deploymentRepository } = setup({ openDeployments: [padded] });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentRepository.findClosureStates).toHaveBeenCalledWith([{ owner: padded.address, dseq: "123" }]);
+  });
+
+  it("matches a dseq the two sources spell differently, so leading zeros do not read as an unknown deployment", async () => {
+    const padded = openDeployment({ dseq: "0000123" });
+    const { service, deploymentSettingRepository } = setup({
+      openDeployments: [padded],
+      closureStates: [{ owner: padded.address, dseq: "123", isClosed: true }]
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([padded.id]);
+  });
+
+  it("tells two dseqs apart beyond the precision of a float, so neither answers for the other", async () => {
+    const owner = createAkashAddress();
+    const running = openDeployment({ dseq: "62509094548213308557", address: owner });
+    const closed = openDeployment({ dseq: "62509094548213308558", address: owner });
+    const { service, deploymentSettingRepository } = setup({
+      openDeployments: [running, closed],
+      closureStates: [closureState(running, false), closureState(closed, true)]
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closed.id]);
+  });
+
+  it("closes only the records the chain closed out of a mixed batch", async () => {
+    const closed = openDeployment();
+    const running = openDeployment();
+    const unknown = openDeployment();
+    const { service, deploymentSettingRepository } = setup({
+      openDeployments: [closed, running, unknown],
+      closureStates: [closureState(closed, true), closureState(running, false)]
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closed.id]);
+  });
+
+  it("writes nothing and records no metrics during a dry run", async () => {
+    const closed = openDeployment();
+    const { service, deploymentSettingRepository, countersByName } = setup({
+      openDeployments: [closed],
+      closureStates: [closureState(closed, true)]
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: true });
+
+    expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+    expect(countersByName["closed_deployments_reconcile_rows_closed_total"].add).not.toHaveBeenCalled();
+  });
+
+  it("reports what a dry run would have closed", async () => {
+    const closed = openDeployment();
+    const { service, logger } = setup({ openDeployments: [closed], closureStates: [closureState(closed, true)] });
+
+    await service.reconcileClosedDeployments({ dryRun: true });
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", scanned: 1, closed: 1, dryRun: true }));
+  });
+
+  it("keeps reconciling the remaining batches when one of them fails", async () => {
+    const first = openDeployment();
+    const second = openDeployment();
+    const { service, deploymentSettingRepository, logger } = setup({
+      batches: [[first], [second]],
+      closureStates: [closureState(first, true), closureState(second, true)],
+      markAsClosed: vi.fn().mockRejectedValueOnce(new Error("write conflict")).mockResolvedValue(undefined)
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_BATCH_FAILED" }));
+    expect(deploymentSettingRepository.markAsClosed).toHaveBeenLastCalledWith([second.id]);
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", failedBatches: 1, closed: 1 }));
+  });
+
+  it("credits a failed batch with nothing it did not write", async () => {
+    const failing = openDeployment();
+    const { service, countersByName } = setup({
+      openDeployments: [failing],
+      closureStates: [closureState(failing, true)],
+      markAsClosed: vi.fn().mockRejectedValue(new Error("write conflict"))
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(countersByName["closed_deployments_reconcile_rows_closed_total"].add).not.toHaveBeenCalled();
+  });
+
+  it("reports a failure to read the records rather than raising it, so the funding sweep keeps its run", async () => {
+    const { service, logger } = setup({ readError: new Error("database unavailable") });
+
+    await expect(service.reconcileClosedDeployments({ dryRun: false })).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_FAILED" }));
+    expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END" }));
+  });
+
+  it("reads nothing from the chain when no record is open", async () => {
+    const { service, deploymentRepository, logger } = setup({ openDeployments: [] });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentRepository.findClosureStates).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", scanned: 0 }));
+  });
+
+  it("creates the logger with the service context", () => {
+    const { createLogger } = setup();
+
+    expect(createLogger).toHaveBeenCalledWith({ context: ClosedDeploymentsReconcilerService.name });
+  });
+
+  function openDeployment(overrides: Partial<OpenDeployment> = {}): OpenDeployment {
+    return {
+      id: faker.string.uuid(),
+      dseq: faker.number.int({ min: 1000, max: 9_999_999 }).toString(),
+      address: createAkashAddress(),
+      ...overrides
+    };
+  }
+
+  function closureState(deployment: OpenDeployment, isClosed: boolean): DeploymentClosureState {
+    return { owner: deployment.address, dseq: deployment.dseq, isClosed };
+  }
+
+  function setup(input?: {
+    openDeployments?: OpenDeployment[];
+    batches?: OpenDeployment[][];
+    closureStates?: DeploymentClosureState[];
+    markAsClosed?: DeploymentSettingRepository["markAsClosed"];
+    readError?: Error;
+  }) {
+    const batches = input?.batches ?? [input?.openDeployments ?? []];
+
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>({
+      findOpenDeploymentsIteratively: vi.fn(async function* () {
+        if (input?.readError) throw input.readError;
+
+        for (const batch of batches) {
+          if (batch.length) yield batch;
+        }
+      }),
+      markAsClosed: input?.markAsClosed ?? vi.fn()
+    });
+
+    const deploymentRepository = mock<DeploymentRepository>({
+      findClosureStates: vi.fn().mockResolvedValue(input?.closureStates ?? [])
+    });
+
+    const countersByName: Record<string, Counter> = {};
+    const metricsService = mock<MetricsService>();
+    metricsService.getMeter.mockReturnValue(mock());
+    metricsService.createCounter.mockImplementation((_meter, name) => {
+      const counter = mock<Counter>();
+      countersByName[name] = counter;
+      return counter;
+    });
+
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const service = new ClosedDeploymentsReconcilerService(deploymentSettingRepository, deploymentRepository, metricsService, createLogger);
+
+    return { service, deploymentSettingRepository, deploymentRepository, metricsService, countersByName, logger, createLogger };
+  }
+});

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
@@ -8,6 +8,8 @@ import { DeploymentRepository } from "@src/deployment/repositories/deployment/de
 import { DeploymentSettingRepository, type OpenDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 
 const BATCH_SIZE = 1000;
+/** Bounds what an unreachable chain database can cost the funding sweep that shares this command's hour. */
+const MAX_CONSECUTIVE_BATCH_FAILURES = 3;
 
 type BatchOutcome = {
   closed: number;
@@ -20,11 +22,7 @@ type ReconcileTally = BatchOutcome & {
   failedBatches: number;
 };
 
-/**
- * A dseq's digits without leading zeros, which only a stored record can carry, so it has to be normalized both
- * on the way into the chain lookup and on the way back out of it. Stripped as text rather than through `Number`,
- * which a dseq above 2^53 would not survive intact.
- */
+/** Stripped as text rather than through `Number`, which a dseq above 2^53 would not survive intact. */
 function normalizeDseq(dseq: string): string {
   return dseq.replace(/^0+(?=\d)/, "");
 }
@@ -60,23 +58,13 @@ export class ClosedDeploymentsReconcilerService {
     });
   }
 
-  /**
-   * Brings every open deployment record back in step with the chain, whatever its owner chose about funding and
-   * whether or not it ever held a lease, because those are the two things that decide which rows the funding
-   * sweep can reach and neither has any bearing on whether a deployment is still running.
-   *
-   * Closure is read from the indexer rather than from the chain directly: the record and the indexed deployment
-   * are one indexed lookup apart, where a chain read would mean paginating every owner's whole history. Reading a
-   * source that lags is safe in one direction only, which is the direction this needs. A close it has not caught
-   * up to leaves the row open for the next run, and it can never invent a close that did not happen.
-   *
-   * Reports failure rather than raising it, because this shares the hourly command with the funding sweep and a
-   * database that would not answer here must not cost the sweep its run.
-   */
+  /** Only safe because the indexer lags in one direction: it can miss a close it has not caught up to, never invent one. */
   async reconcileClosedDeployments({ dryRun }: DryRunOptions): Promise<void> {
     const tally: ReconcileTally = { scanned: 0, closed: 0, confirmedOpen: 0, withoutChainState: 0, failedBatches: 0 };
 
     this.#logger.info({ event: "CLOSED_DEPLOYMENTS_RECONCILE_START", batchSize: BATCH_SIZE, dryRun });
+
+    let consecutiveFailures = 0;
 
     try {
       for await (const batch of this.deploymentSettingRepository.findOpenDeploymentsIteratively({ batchSize: BATCH_SIZE })) {
@@ -92,9 +80,17 @@ export class ClosedDeploymentsReconcilerService {
           if (!dryRun) {
             this.#recordOutcome(outcome);
           }
+
+          consecutiveFailures = 0;
         } catch (error) {
           tally.failedBatches++;
+          consecutiveFailures++;
           this.#logger.error({ event: "CLOSED_DEPLOYMENTS_RECONCILE_BATCH_FAILED", batchSize: batch.length, error });
+
+          if (consecutiveFailures >= MAX_CONSECUTIVE_BATCH_FAILURES) {
+            this.#logger.error({ event: "CLOSED_DEPLOYMENTS_RECONCILE_ABANDONED", ...tally, consecutiveFailures });
+            break;
+          }
         }
       }
     } catch (error) {

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
@@ -1,0 +1,141 @@
+import type { Counter } from "@opentelemetry/api";
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { MetricsService } from "@src/core/services/metrics/metrics.service";
+import type { DryRunOptions } from "@src/core/types/console";
+import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
+import { DeploymentSettingRepository, type OpenDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+
+const BATCH_SIZE = 1000;
+
+type BatchOutcome = {
+  closed: number;
+  confirmedOpen: number;
+  withoutChainState: number;
+};
+
+type ReconcileTally = BatchOutcome & {
+  scanned: number;
+  failedBatches: number;
+};
+
+/**
+ * A dseq's digits without leading zeros, which only a stored record can carry, so it has to be normalized both
+ * on the way into the chain lookup and on the way back out of it. Stripped as text rather than through `Number`,
+ * which a dseq above 2^53 would not survive intact.
+ */
+function normalizeDseq(dseq: string): string {
+  return dseq.replace(/^0+(?=\d)/, "");
+}
+
+function closureKey({ owner, dseq }: { owner: string; dseq: string }): string {
+  return `${owner}/${normalizeDseq(dseq)}`;
+}
+
+@singleton()
+export class ClosedDeploymentsReconcilerService {
+  readonly #logger: ReturnType<CreateLogger>;
+  readonly #rowsClosed: Counter;
+  readonly #rowsConfirmedOpen: Counter;
+  readonly #rowsWithoutChainState: Counter;
+
+  constructor(
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly deploymentRepository: DeploymentRepository,
+    metricsService: MetricsService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.#logger = createLogger({ context: ClosedDeploymentsReconcilerService.name });
+
+    const meter = metricsService.getMeter("closed-deployments-reconcile");
+    this.#rowsClosed = metricsService.createCounter(meter, "closed_deployments_reconcile_rows_closed_total", {
+      description: "Deployment records marked closed because the chain had already closed their deployment"
+    });
+    this.#rowsConfirmedOpen = metricsService.createCounter(meter, "closed_deployments_reconcile_rows_confirmed_open_total", {
+      description: "Deployment records left open because the chain still holds their deployment open"
+    });
+    this.#rowsWithoutChainState = metricsService.createCounter(meter, "closed_deployments_reconcile_rows_without_chain_state_total", {
+      description: "Deployment records left alone because the indexer holds no deployment for them"
+    });
+  }
+
+  /**
+   * Brings every open deployment record back in step with the chain, whatever its owner chose about funding and
+   * whether or not it ever held a lease, because those are the two things that decide which rows the funding
+   * sweep can reach and neither has any bearing on whether a deployment is still running.
+   *
+   * Closure is read from the indexer rather than from the chain directly: the record and the indexed deployment
+   * are one indexed lookup apart, where a chain read would mean paginating every owner's whole history. Reading a
+   * source that lags is safe in one direction only, which is the direction this needs. A close it has not caught
+   * up to leaves the row open for the next run, and it can never invent a close that did not happen.
+   *
+   * Reports failure rather than raising it, because this shares the hourly command with the funding sweep and a
+   * database that would not answer here must not cost the sweep its run.
+   */
+  async reconcileClosedDeployments({ dryRun }: DryRunOptions): Promise<void> {
+    const tally: ReconcileTally = { scanned: 0, closed: 0, confirmedOpen: 0, withoutChainState: 0, failedBatches: 0 };
+
+    this.#logger.info({ event: "CLOSED_DEPLOYMENTS_RECONCILE_START", batchSize: BATCH_SIZE, dryRun });
+
+    try {
+      for await (const batch of this.deploymentSettingRepository.findOpenDeploymentsIteratively({ batchSize: BATCH_SIZE })) {
+        tally.scanned += batch.length;
+
+        try {
+          const outcome = await this.#reconcileBatch(batch, dryRun);
+
+          tally.closed += outcome.closed;
+          tally.confirmedOpen += outcome.confirmedOpen;
+          tally.withoutChainState += outcome.withoutChainState;
+
+          if (!dryRun) {
+            this.#recordOutcome(outcome);
+          }
+        } catch (error) {
+          tally.failedBatches++;
+          this.#logger.error({ event: "CLOSED_DEPLOYMENTS_RECONCILE_BATCH_FAILED", batchSize: batch.length, error });
+        }
+      }
+    } catch (error) {
+      this.#logger.error({ event: "CLOSED_DEPLOYMENTS_RECONCILE_FAILED", ...tally, error });
+      return;
+    }
+
+    this.#logger.info({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", ...tally, dryRun });
+  }
+
+  async #reconcileBatch(batch: OpenDeployment[], dryRun: boolean): Promise<BatchOutcome> {
+    const closureStates = await this.deploymentRepository.findClosureStates(batch.map(({ address, dseq }) => ({ owner: address, dseq: normalizeDseq(dseq) })));
+    const closedByKey = new Map(closureStates.map(state => [closureKey(state), state.isClosed]));
+
+    const idsToClose: string[] = [];
+    let confirmedOpen = 0;
+    let withoutChainState = 0;
+
+    for (const deployment of batch) {
+      const isClosedOnChain = closedByKey.get(closureKey({ owner: deployment.address, dseq: deployment.dseq }));
+
+      if (isClosedOnChain === true) {
+        idsToClose.push(deployment.id);
+      } else if (isClosedOnChain === false) {
+        confirmedOpen++;
+      } else {
+        withoutChainState++;
+      }
+    }
+
+    if (!dryRun && idsToClose.length) {
+      await this.deploymentSettingRepository.markAsClosed(idsToClose);
+    }
+
+    return { closed: idsToClose.length, confirmedOpen, withoutChainState };
+  }
+
+  /** Credited per batch and only after its write landed, so a run that dies part way still reports what it converged. */
+  #recordOutcome({ closed, confirmedOpen, withoutChainState }: BatchOutcome): void {
+    this.#rowsClosed.add(closed);
+    this.#rowsConfirmedOpen.add(confirmedOpen);
+    this.#rowsWithoutChainState.add(withoutChainState);
+  }
+}


### PR DESCRIPTION
## Why

#3806 has merged and stopped new drift. This one drains the backlog that already exists, and keeps it drained.

Nothing brought `deployment_settings.closed` back in step with the chain unless the hourly funding sweep happened to reach the row, and the sweep reaches very little:

- `#findAutoTopUpDeployments` filters `auto_top_up_enabled = true`, so the 27,965 rows whose owner turned funding off are visited by nothing at all. They are frozen, not lagging.
- Even for the rows it does select, closing is conditional on `findLeases` returning a lease. A deployment that closed without ever holding one, which is the steady state of an account whose creates keep losing bids, falls through an unlogged `!deployment` skip and can never be closed however often the sweep visits it.

Whether a deployment is still running has nothing to do with either of those things, so this pass keys off neither.

Part of CON-923

## What

`ClosedDeploymentsReconcilerService` walks every open record in keyset batches and closes the ones whose deployment the indexer has already seen close. It runs ahead of the funding sweep in the existing hourly `top-up-deployments` command, beside the runtime-deadline reconcile that is there for the same stated reason: it needs only the two databases, so a chain-RPC failure in the sweep cannot skip it for the hour. No new CronJob, no helm change.

Closure comes from the indexer's `deployment.closedHeight` rather than from the chain. The record and the indexed deployment are one indexed lookup apart on a unique `(owner, dseq)`, where a chain read would mean paginating every owner's whole history for 16k wallets an hour. `closedHeight` is written both by `MsgCloseDeployment` and by the last-lease-closed side effect, which are the two ways a managed deployment ends.

Reading a source that lags is safe in one direction only, and this is that direction. A close the indexer has not caught up to leaves the row open for the next run, and it cannot invent a close that never happened. A record the indexer holds no deployment for is left alone and counted rather than guessed at, so the residual is measured: `DeleteUnbackedDeploymentSetting` already owns a create that never landed, and `cleanup-stale-deployments` owns lease-less-but-open.

A batch that fails is logged and skipped rather than raised, so one bad batch does not cost the sweep its run. Three failures in a row end the scan instead, because the two reads hit different databases: an indexer Postgres that is simply down would otherwise burn a `SEQUELIZE_POOL_ACQUIRE` timeout per batch across every open row before the sweep got its turn.

Three counters under the `closed-deployments-reconcile` meter, plus a per-run summary log. `rows_confirmed_open_total` is the drift measure the issue asks for and should settle near the open-lease count; `rows_without_chain_state_total` sizes what the indexer cannot decide. Both are credited per batch and only after the write landed, so a run that dies part way reports what it actually converged.

New repository methods: `DeploymentSettingRepository.findOpenDeploymentsIteratively` (no funding filter, keyset-paged on `id`, the leading column of the existing `id_auto_top_up_enabled_closed_idx`) and `DeploymentRepository.findClosureStates`. The latter needed a `CHAIN_DB` injection on `DeploymentRepository`, which previously reached the indexer only through the static Sequelize models.

## Verification

The two databases are separate Postgres instances, so the join happens in application code and only a real run proves it. Query plan against the live mainnet indexer copy is a nested loop over `deployment_owner_dseq`, 1000 probes in 226ms cold, so the 48k backlog converges in roughly one batch-second per thousand rows.

End to end on scratch databases, seeding one record per case and running the real command:

| record | on chain | after run |
| --- | --- | --- |
| funding on | closed | closed |
| funding **off** | closed | closed |
| funding on | still running | left open |
| funding on | no indexer row | left open |
| dseq `0001000005` | closed as `1000005` | closed |

`--dry-run` reported the same counts (`scanned: 5, closed: 3, confirmedOpen: 1, withoutChainState: 1`) and changed no rows. A second real run reported `scanned: 2, closed: 0`, so convergence is stable.

The leading-zero row is there because the integration test caught a real bug in review of my own first cut: I normalized the dseq when matching results back but not when building the query, so a padded dseq never matched in SQL. The unit test had missed it because the mock bypassed the query. Both now cover it.

Suites in `apps/api` after the rebase onto main: unit green (197 files, 2689 tests), lint clean, and `tsc --noEmit` still at its baseline of 42 errors, none of them in the changed files. Functional and integration were green before the rebase, which touched none of their code, so CI re-runs both; the integration suite carries 4 pre-existing failures in the user and api-key repositories that also fail on a clean tree.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reconciliation for deployments confirmed closed on-chain before top-up processing.
  * Added batch processing for open deployments with wallet addresses.
  * Added safeguards for dry runs, transient failures, unresolved states, and deployment ID normalization.
* **Bug Fixes**
  * Closed deployments are now identified and marked consistently using on-chain closure status.
* **Tests**
  * Added comprehensive unit and integration coverage for reconciliation, pagination, filtering, failures, and multi-batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
