### PR TITLE
fix(deployment): close deployment records the sweep cannot see a lease for

### DIFF
--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -13,6 +13,8 @@ export interface DrainingDeploymentOutput {
   predictedClosedHeight: number;
   closedHeight?: number;
   isClosed?: boolean;
+  /** Set on chain deployments the lease query returned nothing for, whose zero block rate makes them unfundable. */
+  hasNoLease?: boolean;
 }
 
 export interface ActiveLeaseOnProvider {

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -220,6 +220,51 @@ describe(DrainingDeploymentRpcService.name, () => {
       expect(result[0]).not.toHaveProperty("isClosed");
     });
 
+    it("flags a closed deployment that never held a lease, which nothing keyed on leases could see", async () => {
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [{ leases: [], deployment: { escrowState: "closed", funds: 0, transferred: 0 } }]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toEqual([expect.objectContaining({ dseq: Number(dseqs[0]), isClosed: true })]);
+    });
+
+    it("leaves out an open deployment with no lease yet, which is still waiting on a bid rather than closed", async () => {
+      const { service, owner, dseqs, closureHeight, loggerService } = setup({
+        inputs: [{ leases: [], deployment: { escrowState: "open" } }]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toEqual([]);
+      expect(loggerService.warn).not.toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_BLOCK_RATE_INVALID" }));
+    });
+
+    it("flags a lease-less closed deployment alongside an owner's still-running one", async () => {
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [
+          { leases: [], deployment: { dseq: "500001", escrowState: "closed", funds: 0, transferred: 0 } },
+          { leases: [{ blockRate: 100 }], deployment: { dseq: "500002", escrowState: "open" } }
+        ]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toContainEqual(expect.objectContaining({ dseq: 500001, isClosed: true }));
+      expect(result).toContainEqual(expect.objectContaining({ dseq: 500002 }));
+    });
+
+    it("does not flag a closed deployment twice when it also has a closed lease", async () => {
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [{ leases: [{ blockRate: 10, closedHeight: 999999 }], deployment: { escrowState: "closed", funds: 0, transferred: 0 } }]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(1);
+    });
+
     it("keeps a flagged deployment that an open lease would place beyond the closure window", async () => {
       const { service, owner, dseqs } = setup({
         inputs: [{ leases: [{ blockRate: 1 }], deployment: { escrowState: "closed", funds: 10_000_000, transferred: 0 } }]

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -227,17 +227,17 @@ describe(DrainingDeploymentRpcService.name, () => {
 
       const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
 
-      expect(result).toEqual([expect.objectContaining({ dseq: Number(dseqs[0]), isClosed: true })]);
+      expect(result).toEqual([expect.objectContaining({ dseq: Number(dseqs[0]), isClosed: true, hasNoLease: true })]);
     });
 
-    it("leaves out an open deployment with no lease yet, which is still waiting on a bid rather than closed", async () => {
+    it("reports an open deployment with no lease yet as unclosed, since it is still waiting on a bid", async () => {
       const { service, owner, dseqs, closureHeight, loggerService } = setup({
         inputs: [{ leases: [], deployment: { escrowState: "open" } }]
       });
 
       const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
 
-      expect(result).toEqual([]);
+      expect(result).toEqual([expect.objectContaining({ dseq: Number(dseqs[0]), isClosed: false, hasNoLease: true, blockRate: 0 })]);
       expect(loggerService.warn).not.toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_BLOCK_RATE_INVALID" }));
     });
 

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -121,6 +121,8 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
         .filter(deployment => dseqSet.has(deployment.deployment.id.dseq))
         .map(deployment => ({
           dseq: deployment.deployment.id.dseq,
+          owner: deployment.deployment.id.owner,
+          denom: deployment.escrow_account.state.funds[0]?.denom ?? deployment.escrow_account.state.transferred[0]?.denom ?? "",
           createdHeight: Number(deployment.deployment.created_at),
           escrowBalance: this.#sumAmounts(deployment.escrow_account.state.funds) + this.#sumAmounts(deployment.escrow_account.state.transferred),
           isEscrowOpen: deployment.escrow_account.state.state === OPEN_ESCROW_ACCOUNT_STATE
@@ -210,6 +212,7 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
    * which would otherwise drop a drained-and-closed deployment before it can be marked closed.
    * Filters out deployments with missing data, zero balance,
    * or invalid block rates, logging warnings for each case.
+   * Then adds the closed deployments that have no lease at all, which the pass over leases cannot reach.
    *
    * @param leaseMap - Map of draining deployments without predictedClosedHeight
    * @param deploymentMap - Map of deployment info with escrow balances
@@ -219,7 +222,7 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
     leaseMap: Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">>,
     deploymentMap: Map<string, RpcDeploymentInfo>
   ): DrainingDeploymentOutput[] {
-    return Array.from(leaseMap.values()).reduce((acc, drainingDeployment) => {
+    const fromLeases = Array.from(leaseMap.values()).reduce((acc, drainingDeployment) => {
       const deployment = deploymentMap.get(drainingDeployment.dseq.toString());
 
       if (!deployment) {
@@ -259,5 +262,26 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
 
       return [...acc, { ...drainingDeployment, predictedClosedHeight }];
     }, [] as DrainingDeploymentOutput[]);
+
+    return [...fromLeases, ...this.#closedWithoutLease(leaseMap, deploymentMap)];
+  }
+
+  /** Only the closed ones: an open escrow with no lease is a deployment still waiting on a bid, and its zero block rate would fail the checks above. */
+  #closedWithoutLease(
+    leaseMap: Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">>,
+    deploymentMap: Map<string, RpcDeploymentInfo>
+  ): DrainingDeploymentOutput[] {
+    const leasedDseqs = new Set(Array.from(leaseMap.values(), lease => String(lease.dseq)));
+
+    return Array.from(deploymentMap.values())
+      .filter(deployment => !deployment.isEscrowOpen && !leasedDseqs.has(String(Number(deployment.dseq))))
+      .map(deployment => ({
+        dseq: Number(deployment.dseq),
+        owner: deployment.owner,
+        denom: deployment.denom,
+        blockRate: 0,
+        predictedClosedHeight: 0,
+        isClosed: true
+      }));
   }
 }

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -212,7 +212,7 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
    * which would otherwise drop a drained-and-closed deployment before it can be marked closed.
    * Filters out deployments with missing data, zero balance,
    * or invalid block rates, logging warnings for each case.
-   * Then adds the closed deployments that have no lease at all, which the pass over leases cannot reach.
+   * Then adds the deployments that have no lease at all, which the pass over leases cannot reach.
    *
    * @param leaseMap - Map of draining deployments without predictedClosedHeight
    * @param deploymentMap - Map of deployment info with escrow balances
@@ -263,25 +263,26 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
       return [...acc, { ...drainingDeployment, predictedClosedHeight }];
     }, [] as DrainingDeploymentOutput[]);
 
-    return [...fromLeases, ...this.#closedWithoutLease(leaseMap, deploymentMap)];
+    return [...fromLeases, ...this.#withoutLease(leaseMap, deploymentMap)];
   }
 
-  /** Only the closed ones: an open escrow with no lease is a deployment still waiting on a bid, and its zero block rate would fail the checks above. */
-  #closedWithoutLease(
+  /** Carries a zero block rate, so a caller must close these or skip them rather than read them as fundable. */
+  #withoutLease(
     leaseMap: Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">>,
     deploymentMap: Map<string, RpcDeploymentInfo>
   ): DrainingDeploymentOutput[] {
     const leasedDseqs = new Set(Array.from(leaseMap.values(), lease => String(lease.dseq)));
 
     return Array.from(deploymentMap.values())
-      .filter(deployment => !deployment.isEscrowOpen && !leasedDseqs.has(String(Number(deployment.dseq))))
+      .filter(deployment => !leasedDseqs.has(String(Number(deployment.dseq))))
       .map(deployment => ({
         dseq: Number(deployment.dseq),
         owner: deployment.owner,
         denom: deployment.denom,
         blockRate: 0,
         predictedClosedHeight: 0,
-        isClosed: true
+        isClosed: !deployment.isEscrowOpen,
+        hasNoLease: true
       }));
   }
 }

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -176,6 +176,51 @@ describe(DrainingDeploymentService.name, () => {
       expect(callback).toHaveBeenCalledWith(expect.objectContaining({ address, drainingDeployments: [] }));
     });
 
+    it("marks an owner's closed deployments even when the lease source returns nothing else", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const sink = mock<DeploymentTopUpInstrumentation>();
+      const address = createAkashAddress();
+      const closedSetting = createAutoTopUpDeployment({ address, dseq: "4010" });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          yield { address, walletId: closedSetting.walletId, deploymentSettings: [closedSetting] };
+        })()
+      );
+      vi.spyOn(service, "findLeases").mockResolvedValue([
+        createDrainingDeployment({ dseq: Number(closedSetting.dseq), owner: address, predictedClosedHeight: 0, isClosed: true })
+      ]);
+
+      const yielded = vi.fn();
+      for await (const owner of service.findDrainingDeploymentsByOwner(currentHeight, sink)) {
+        yielded(owner);
+      }
+
+      expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closedSetting.id]);
+    });
+
+    it("records a deployment the lease source knows nothing about instead of dropping it silently", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const sink = mock<DeploymentTopUpInstrumentation>();
+      const address = createAkashAddress();
+      const unknownSetting = createAutoTopUpDeployment({ address, dseq: "4011" });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          yield { address, walletId: unknownSetting.walletId, deploymentSettings: [unknownSetting] };
+        })()
+      );
+      vi.spyOn(service, "findLeases").mockResolvedValue([]);
+
+      const yielded = vi.fn();
+      for await (const owner of service.findDrainingDeploymentsByOwner(currentHeight, sink)) {
+        yielded(owner);
+      }
+
+      expect(sink.recordSettingWithoutChainState).toHaveBeenCalledWith({ dseq: unknownSetting.dseq, address });
+      expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+    });
+
     it("marks no deployment closed during a dry run", async () => {
       const { service, deploymentSettingRepository, currentHeight } = setup();
       const sink = mock<DeploymentTopUpInstrumentation>();

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -17,7 +17,7 @@ import type { DeploymentCloseJobService } from "../deployment-close-job/deployme
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
 import type { DeploymentTopUpInstrumentation } from "../top-up-managed-deployments/deployment-top-up-instrumentation";
-import { DrainingDeploymentService } from "./draining-deployment.service";
+import { type AutoTopUpOwnerDeployments, DrainingDeploymentService } from "./draining-deployment.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createAkashAddress } from "@test/seeders";
@@ -219,6 +219,31 @@ describe(DrainingDeploymentService.name, () => {
 
       expect(sink.recordSettingWithoutChainState).toHaveBeenCalledWith({ dseq: unknownSetting.dseq, address });
       expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+    });
+
+    it("leaves a deployment still waiting on a bid out of the missing-chain-state count", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const sink = mock<DeploymentTopUpInstrumentation>();
+      const address = createAkashAddress();
+      const unleasedSetting = createAutoTopUpDeployment({ address, dseq: "4012" });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          yield { address, walletId: unleasedSetting.walletId, deploymentSettings: [unleasedSetting] };
+        })()
+      );
+      vi.spyOn(service, "findLeases").mockResolvedValue([
+        createDrainingDeployment({ dseq: Number(unleasedSetting.dseq), owner: address, predictedClosedHeight: 0, blockRate: 0, hasNoLease: true })
+      ]);
+
+      const yielded: AutoTopUpOwnerDeployments[] = [];
+      for await (const owner of service.findDrainingDeploymentsByOwner(currentHeight, sink)) {
+        yielded.push(owner);
+      }
+
+      expect(sink.recordSettingWithoutChainState).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+      expect(yielded[0].activeDeployments).toEqual([]);
     });
 
     it("marks no deployment closed during a dry run", async () => {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -139,17 +139,13 @@ export class DrainingDeploymentService {
 
     const dseqs = deploymentSettings.map(deployment => deployment.dseq);
     const leases = await this.findLeases(Number.MAX_SAFE_INTEGER, address, dseqs);
-
-    if (!leases.length) {
-      return [];
-    }
-
     const byDseqOwner = keyBy(leases, "dseq");
-    const [active, missingIds] = deploymentSettings.reduce<[DrainingDeployment[], string[]]>(
+    const [active, closedIds] = deploymentSettings.reduce<[DrainingDeployment[], string[]]>(
       (acc, deploymentSetting) => {
         const deployment = byDseqOwner[Number(deploymentSetting.dseq)];
 
         if (!deployment) {
+          instrumentation.recordSettingWithoutChainState({ dseq: deploymentSetting.dseq, address });
           return acc;
         }
 
@@ -167,9 +163,9 @@ export class DrainingDeploymentService {
       [[], []]
     );
 
-    if (missingIds.length && !dryRun) {
-      await this.deploymentSettingRepository.markAsClosed(missingIds);
-      instrumentation.recordDeploymentsMarkedClosed(missingIds.length);
+    if (closedIds.length && !dryRun) {
+      await this.deploymentSettingRepository.markAsClosed(closedIds);
+      instrumentation.recordDeploymentsMarkedClosed(closedIds.length);
     }
 
     return active;

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -151,13 +151,19 @@ export class DrainingDeploymentService {
 
         if (deployment.isClosed || deployment.closedHeight) {
           acc[1].push(deploymentSetting.id);
-        } else {
-          acc[0].push({
-            ...deploymentSetting,
-            predictedClosedHeight: deployment.predictedClosedHeight,
-            blockRate: deployment.blockRate
-          });
+          return acc;
         }
+
+        if (deployment.hasNoLease) {
+          return acc;
+        }
+
+        acc[0].push({
+          ...deploymentSetting,
+          predictedClosedHeight: deployment.predictedClosedHeight,
+          blockRate: deployment.blockRate
+        });
+
         return acc;
       },
       [[], []]

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -48,6 +48,16 @@ describe(InitialDeploymentFundingService.name, () => {
     expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
   });
 
+  it("skips funding when a lease-less deployment has already closed instead of retrying for its lease", async () => {
+    const { service, drainingDeploymentService, managedSignerService, instrumentation } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment({ blockRate: 0, isClosed: true, hasNoLease: true })]);
+
+    await service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" });
+
+    expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    expect(instrumentation.recordSkipped).toHaveBeenCalledWith("deployment_closed", expect.objectContaining({ dseq: "123", address: "akash1owner" }));
+  });
+
   it("skips funding when the deployment is closed", async () => {
     const { service, drainingDeploymentService, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment({ closedHeight: 900 })]);

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -39,6 +39,15 @@ describe(InitialDeploymentFundingService.name, () => {
     expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
   });
 
+  it("throws when the chain has the deployment but not its lease yet", async () => {
+    const { service, drainingDeploymentService, managedSignerService } = setup();
+    drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment({ blockRate: 0, predictedClosedHeight: 0, hasNoLease: true })]);
+
+    await expect(service.fundOnLeaseStarted({ walletId: 1, address: "akash1owner", dseq: "123" })).rejects.toThrow("not visible on chain yet");
+
+    expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+  });
+
   it("skips funding when the deployment is closed", async () => {
     const { service, drainingDeploymentService, managedSignerService, instrumentation } = setup();
     drainingDeploymentService.findLeases.mockResolvedValue([createDrainingDeployment({ closedHeight: 900 })]);

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -94,13 +94,13 @@ export class InitialDeploymentFundingService {
   async #fundOnLeaseStarted({ walletId, address, dseq }: FundOnLeaseStartedInput): Promise<void> {
     const [deployment] = await this.drainingDeploymentService.findLeases(Number.MAX_SAFE_INTEGER, address, [dseq]);
 
-    if (!deployment || deployment.hasNoLease) {
-      throw new Error(`Lease for deployment ${dseq} owned by ${address} is not visible on chain yet`);
-    }
-
-    if (deployment.closedHeight) {
+    if (deployment?.isClosed || deployment?.closedHeight) {
       this.instrumentation.recordSkipped("deployment_closed", { dseq, address });
       return;
+    }
+
+    if (!deployment || deployment.hasNoLease) {
+      throw new Error(`Lease for deployment ${dseq} owned by ${address} is not visible on chain yet`);
     }
 
     const currentHeight = await this.blockHttpService.getCurrentHeight();

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.ts
@@ -94,7 +94,7 @@ export class InitialDeploymentFundingService {
   async #fundOnLeaseStarted({ walletId, address, dseq }: FundOnLeaseStartedInput): Promise<void> {
     const [deployment] = await this.drainingDeploymentService.findLeases(Number.MAX_SAFE_INTEGER, address, [dseq]);
 
-    if (!deployment) {
+    if (!deployment || deployment.hasNoLease) {
       throw new Error(`Lease for deployment ${dseq} owned by ${address} is not visible on chain yet`);
     }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
@@ -33,6 +33,7 @@ export interface DeploymentTopUpInstrumentation {
   recordMasterWalletInsufficientFundsError(details: { owner: string; items: FundingMessageItem[]; error: unknown }): void;
   recordClaimReleaseError(details: { owner: string; deploymentIds: string[]; error: unknown }): void;
   recordDeploymentsMarkedClosed(count: number): void;
+  recordSettingWithoutChainState(details: { dseq: string; address: string }): void;
   recordDeploymentClosedOnChain(details: { owner: string; deployment: DrainingDeployment; messageIndex?: number; error: unknown }): void;
   recordDeploymentCloseMarkFailed(details: { owner: string; deployment: DrainingDeployment; error: unknown }): void;
   recordClosedDeploymentRetryLimit(details: { owner: string; remainingCount: number }): void;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
@@ -235,6 +235,16 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordSettingWithoutChainState", () => {
+    it("counts a deployment record no chain state could be found for", () => {
+      const { service, settingsWithoutChainState } = setup();
+
+      service.recordSettingWithoutChainState({ dseq: "42", address: "akash1owner" });
+
+      expect(settingsWithoutChainState.add).toHaveBeenCalledWith(1);
+    });
+  });
+
   describe("recordDeploymentClosedOnChain", () => {
     it("credits the marked-closed counter and warns rather than reporting a chain tx error", () => {
       const { service, deploymentsMarkedClosed, chainTxErrors } = setup();
@@ -380,6 +390,7 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
       chainTxErrors: counters["fund_draining_deployments_chain_tx_errors_total"],
       masterWalletInsufficientFunds: counters["fund_draining_deployments_master_wallet_insufficient_funds_total"],
       deploymentsMarkedClosed: counters["fund_draining_deployments_deployments_marked_closed_total"],
+      settingsWithoutChainState: counters["fund_draining_settings_without_chain_state_total"],
       claimReleaseErrors: counters["fund_draining_deployments_claim_release_errors_total"],
       headroomConcessions: counters["fund_draining_deployments_headroom_concessions_total"],
       jobDuration: histograms["fund_draining_deployments_job_duration_ms"],

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -44,6 +44,7 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
   private readonly undecidedTxOutcomes: Counter;
   private readonly masterWalletInsufficientFunds: Counter;
   private readonly deploymentsMarkedClosed: Counter;
+  private readonly settingsWithoutChainState: Counter;
   private readonly claimReleaseErrors: Counter;
   private readonly headroomConcessions: Counter;
 
@@ -100,6 +101,10 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
 
     this.masterWalletInsufficientFunds = this.metricsService.createCounter(this.meter, "fund_draining_deployments_master_wallet_insufficient_funds_total", {
       description: "Total number of immediate funding deposits aborted because the master wallet had insufficient funds"
+    });
+
+    this.settingsWithoutChainState = this.metricsService.createCounter(this.meter, "fund_draining_settings_without_chain_state_total", {
+      description: "Deployment records the pass could not resolve to any chain state, so it neither funded nor closed them"
     });
 
     this.deploymentsMarkedClosed = this.metricsService.createCounter(this.meter, "fund_draining_deployments_deployments_marked_closed_total", {
@@ -255,6 +260,13 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
     this.deploymentsMarkedClosed.add(count);
   }
 
+  /** Logged at debug because a churning owner produces one per pass, while the counter is what says whether the number is falling. */
+  recordSettingWithoutChainState({ dseq, address }: { dseq: string; address: string }): void {
+    this.settingsWithoutChainState.add(1);
+
+    this.emitLog("debug", { event: "FUND_DRAINING_SETTING_WITHOUT_CHAIN_STATE", dseq, address });
+  }
+
   recordCreditsLowScheduleError({ walletId, error }: { walletId: number; error: unknown }): void {
     this.emitLog("error", { event: "FUND_DRAINING_CREDITS_LOW_SCHEDULE_ERROR", walletId, error });
   }
@@ -318,7 +330,7 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
    * escaping a record* call would mark an already-completed deposit as failed and trigger a retry.
    * Metrics are emitted before logging because the OTel spec guarantees instrument writes never throw.
    */
-  private emitLog(level: "info" | "warn" | "error", payload: Record<string, unknown>): void {
+  private emitLog(level: "debug" | "info" | "warn" | "error", payload: Record<string, unknown>): void {
     try {
       this.logger[level](payload);
     } catch {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -100,6 +100,28 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordSettingWithoutChainState", () => {
+    it("counts a deployment record no chain state could be found for", () => {
+      const { service, countersByName } = setup();
+      service.start(100, { dryRun: false });
+
+      service.recordSettingWithoutChainState({ dseq: "42", address: "akash1owner" });
+
+      expect(countersByName["auto_top_up_settings_without_chain_state_total"].add).toHaveBeenCalledWith(1);
+    });
+
+    it("logs the record it could not resolve", () => {
+      const { service, logger } = setup();
+      service.start(100, { dryRun: false });
+
+      service.recordSettingWithoutChainState({ dseq: "42", address: "akash1owner" });
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "TOP_UP_SETTING_WITHOUT_CHAIN_STATE", dseq: "42", address: "akash1owner", dryRun: false })
+      );
+    });
+  });
+
   describe("recordDeploymentCloseMarkFailed", () => {
     it("warns without claiming the deployment was marked closed", () => {
       const { service, logger, summarizer } = setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -18,6 +18,7 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
   private readonly undecidedTxOutcomes: Counter;
   private readonly messagePreparationErrors: Counter;
   private readonly deploymentsMarkedClosed: Counter;
+  private readonly settingsWithoutChainState: Counter;
   private readonly deploymentsScanned: Counter;
   private readonly depositAmount: Histogram;
   private readonly predictedCloseBlocks: Histogram;
@@ -64,6 +65,10 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
 
     this.deploymentsMarkedClosed = this.metricsService.createCounter(this.meter, "auto_top_up_deployments_marked_closed_total", {
       description: "Total number of deployments marked as closed by the auto top-up job"
+    });
+
+    this.settingsWithoutChainState = this.metricsService.createCounter(this.meter, "auto_top_up_settings_without_chain_state_total", {
+      description: "Deployment records the sweep could not resolve to any chain state, so it neither funded nor closed them"
     });
 
     this.deploymentsScanned = this.metricsService.createCounter(this.meter, "auto_top_up_deployments_scanned_total", {
@@ -283,6 +288,15 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
     this.execWhenEnabled(() => {
       this.deploymentsMarkedClosed.add(count);
     });
+  }
+
+  /** Logged at debug because a churning owner produces one per pass, while the counter is what says whether the number is falling. */
+  recordSettingWithoutChainState({ dseq, address }: { dseq: string; address: string }): void {
+    this.execWhenEnabled(() => {
+      this.settingsWithoutChainState.add(1);
+    });
+
+    this.logger.debug({ event: "TOP_UP_SETTING_WITHOUT_CHAIN_STATE", dseq, address, dryRun: this.options?.dryRun });
   }
 
   recordDeploymentClosedOnChain({

--- a/apps/api/src/deployment/types/draining-deployment.ts
+++ b/apps/api/src/deployment/types/draining-deployment.ts
@@ -13,6 +13,8 @@ export type ActiveLeaseRate = {
 
 export type RpcDeploymentInfo = {
   dseq: string;
+  owner: string;
+  denom: string;
   escrowBalance: number;
   createdHeight: number;
   isEscrowOpen: boolean;

--- a/apps/api/test/seeders/draining-deployment.seeder.ts
+++ b/apps/api/test/seeders/draining-deployment.seeder.ts
@@ -11,7 +11,8 @@ export function createDrainingDeployment({
   predictedClosedHeight = faker.number.int({ min: 1, max: 99999999 }),
   owner = faker.string.alpha(),
   closedHeight = undefined,
-  isClosed = undefined
+  isClosed = undefined,
+  hasNoLease = undefined
 }: Partial<DrainingDeploymentOutput> = {}): DrainingDeploymentOutput {
   return {
     dseq,
@@ -20,6 +21,7 @@ export function createDrainingDeployment({
     predictedClosedHeight,
     owner,
     closedHeight,
-    isClosed
+    isClosed,
+    hasNoLease
   };
 }


### PR DESCRIPTION
## Why

Stacked on #3807, last of three. #3806 stops new drift at the source and #3807 drains the backlog; this one fixes the funding sweep so it stops carrying rows it can never close, and adds the counter the issue asks for.

`#resolveActiveDeployments` only ever marked a record closed when `findLeases` returned a lease for its dseq:

```ts
const deployment = byDseqOwner[Number(deploymentSetting.dseq)];

if (!deployment) {
  return acc;                          // skipped: no log, no state change
}

if (deployment.isClosed || deployment.closedHeight) {
  acc[1].push(deploymentSetting.id);   // the only path to markAsClosed
}
```

A deployment that closed without ever holding a lease, which is how a create that loses every bid ends, falls through that branch and can never be closed however often the sweep visits it. Four lines above, a second exit abandoned an owner's whole batch when no lease came back at all. The three instrumented ways a row could be dropped all logged zero occurrences across 24h of prod, which is what pointed at the one that says nothing.

Part of CON-923

## What

`DrainingDeploymentRpcService` already fetched the escrow state that settles this and then discarded it, since `#addPredictedClosedHeight` iterates only the lease map. It now also reports every deployment that has no lease, flagged `hasNoLease`, and sets `isClosed: true` on the ones whose escrow is closed so the caller can mark them closed.

The open ones are reported too, and the sweep skips them without counting them. Settings are written at create, before a lease exists, so a deployment still waiting on a bid would otherwise sit on `auto_top_up_settings_without_chain_state_total` for as long as it stayed open, which is the reading the counter was added to give. `hasNoLease` also keeps them out of the fundable set, so their zero block rate never reaches the balance and rate checks.

Initial funding reads the same source and treats an empty result as a lease that has not landed yet. A lease-less row trips that check too, so the deployment retries instead of being funded at a zero rate. Its closed check runs ahead of that one and covers `isClosed` as well as `closedHeight`, so a deployment that closed stays terminal rather than retrying for a lease it will never get.

The batch-level `if (!leases.length) return []` is gone. It cost nothing to remove, because the reduce below it already returns an empty list for an empty source; the exit only ever suppressed the `markAsClosed` write.

The remaining skip is counted rather than silent, on `auto_top_up_settings_without_chain_state_total` and its event-driven twin `fund_draining_settings_without_chain_state_total`, with a debug log carrying the dseq. Once the reconcile in #3807 has run this should read near zero, and a non-zero reading means the chain source and the indexer disagree about a deployment, which is worth knowing on its own.

`RpcDeploymentInfo` gained `owner` and `denom` for the lease-less entries. Nothing on the draining path reads `denom`, so it comes off the escrow account the way `DeploymentReaderService` already derives it. `missingIds` is renamed `closedIds`: it holds closed ids, and the misnomer is part of what made that branch easy to overlook.

## Verification

12 new unit tests across the RPC source, the sweep, initial funding and both instrumentation services. I mutation-checked the six load-bearing ones: putting the `!leases.length` exit back fails the batch test, dropping the counter call fails the skip test, restoring the closed-only filter fails the open-deployment test, dropping the `hasNoLease` branch in the sweep fails the not-counted test, dropping it from the initial-funding guard fails the retry test, and narrowing that guard's closed check back to `closedHeight` fails the terminal-skip test.

Suites in `apps/api`: unit green (192 files, 2642 tests), functional green (385 passed, 1 skipped), integration green apart from the same 4 failures in the user and api-key repositories that fail on a clean tree. `tsc --noEmit` baseline unchanged at 42.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployment results now include the deployment owner and escrow denomination.
  - Closed deployments without active leases remain visible in draining deployment results.
  - Open deployments without leases are identified as unresolved with zero block rate.

- **Bug Fixes**
  - Improved handling of deployments with missing or unresolved chain state.
  - Prevented open, lease-less deployments from being incorrectly marked for closure or funded before lease visibility.

- **Monitoring**
  - Added metrics and diagnostic logging for deployment settings without matching chain state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

