### PR TITLE
fix(billing): decline auto-recharge charges that need authentication instead of stalling them

### DIFF
--- a/apps/api/src/billing/lib/auto-reload/charge-cooldown.ts
+++ b/apps/api/src/billing/lib/auto-reload/charge-cooldown.ts
@@ -1,0 +1,19 @@
+/** Guards `2 ** exponent` against a raised decline limit, since the result is interpolated into a Postgres interval. */
+const MAX_BACKOFF_DOUBLINGS = 16;
+
+export type ChargeCooldownConfig = { baseMinutes: number; maxMinutes: number };
+
+/**
+ * Doubles the gap after each consecutive decline, so the attempts a dead card is allowed span
+ * hours instead of landing back to back. A base of 0 keeps meaning "no cap at all".
+ */
+export function calculateChargeCooldownMinutes(config: ChargeCooldownConfig, failureCount: number): number {
+  if (config.baseMinutes === 0 || failureCount <= 0) {
+    return config.baseMinutes;
+  }
+
+  const doublings = Math.min(failureCount - 1, MAX_BACKOFF_DOUBLINGS);
+  const backedOff = Math.min(config.baseMinutes * 2 ** doublings, config.maxMinutes);
+
+  return Math.max(config.baseMinutes, backedOff);
+}

--- a/apps/api/src/billing/lib/auto-reload/charge-cooldown.ts
+++ b/apps/api/src/billing/lib/auto-reload/charge-cooldown.ts
@@ -3,10 +3,7 @@ const MAX_BACKOFF_DOUBLINGS = 16;
 
 export type ChargeCooldownConfig = { baseMinutes: number; maxMinutes: number };
 
-/**
- * Doubles the gap after each consecutive decline, so the attempts a dead card is allowed span
- * hours instead of landing back to back. A base of 0 keeps meaning "no cap at all".
- */
+/** Doubles the gap after each consecutive decline so a dead card's allowed attempts span hours; a base of 0 keeps meaning no cap at all. */
 export function calculateChargeCooldownMinutes(config: ChargeCooldownConfig, failureCount: number): number {
   if (config.baseMinutes === 0 || failureCount <= 0) {
     return config.baseMinutes;

--- a/apps/api/src/billing/lib/card-decline/card-decline.spec.ts
+++ b/apps/api/src/billing/lib/card-decline/card-decline.spec.ts
@@ -21,12 +21,18 @@ describe("toCardDecline", () => {
     expect(toCardDecline(cardError(undefined))).toEqual({ isTerminal: false });
   });
 
-  it.each(["lost_card", "stolen_card", "fraudulent", "pickup_card", "revocation_of_all_authorizations", "stop_payment_order", "merchant_blacklist"])(
-    "treats %s as terminal",
-    declineCode => {
-      expect(toCardDecline(cardError(declineCode))).toEqual({ declineCode, isTerminal: true });
-    }
-  );
+  it.each([
+    "lost_card",
+    "stolen_card",
+    "fraudulent",
+    "pickup_card",
+    "revocation_of_all_authorizations",
+    "stop_payment_order",
+    "merchant_blacklist",
+    "authentication_required"
+  ])("treats %s as terminal", declineCode => {
+    expect(toCardDecline(cardError(declineCode))).toEqual({ declineCode, isTerminal: true });
+  });
 
   it("ignores a Stripe outage", () => {
     expect(toCardDecline(new Stripe.errors.StripeAPIError({ type: "api_error", message: "Service unavailable" }))).toBeUndefined();

--- a/apps/api/src/billing/lib/card-decline/card-decline.ts
+++ b/apps/api/src/billing/lib/card-decline/card-decline.ts
@@ -2,7 +2,10 @@ import Stripe from "stripe";
 
 export const CARD_DECLINED_ERROR_CODE = "card_declined";
 
-/** Codes the issuer will never approve on a retry, and reattempting them is exactly what card networks penalise. */
+/** Stripe's decline code when the issuer demands 3DS on a charge the absent customer cannot authenticate. */
+export const AUTHENTICATION_REQUIRED_DECLINE_CODE = "authentication_required";
+
+/** Codes no off-session retry can clear: the issuer will never approve them, or only the absent customer could. */
 const TERMINAL_DECLINE_CODES: ReadonlySet<string> = new Set([
   "lost_card",
   "stolen_card",
@@ -10,7 +13,8 @@ const TERMINAL_DECLINE_CODES: ReadonlySet<string> = new Set([
   "pickup_card",
   "revocation_of_all_authorizations",
   "stop_payment_order",
-  "merchant_blacklist"
+  "merchant_blacklist",
+  AUTHENTICATION_REQUIRED_DECLINE_CODE
 ]);
 
 export type CardDecline = {

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.spec.ts
@@ -98,6 +98,22 @@ describe(AutoReloadPauseService.name, () => {
       );
     });
 
+    it("sends the add-funds email instead of the declined-card one when the bank demanded authentication", async () => {
+      const { service, walletSettingRepository, notificationService, claim, user } = setup();
+      const pausedAt = new Date("2026-09-01T12:00:00.000Z");
+      walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 1, pausedAt });
+
+      await service.recordDecline({ claim, user, decline: { declineCode: "authentication_required", isTerminal: true } });
+
+      expect(notificationService.createNotification).toHaveBeenCalledTimes(1);
+      expect(notificationService.createNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notificationId: `autoTopUpAuthenticationRequired.${user.id}.${pausedAt.toISOString()}`,
+          payload: expect.objectContaining({ actions: [{ label: "Add funds", url: "https://console.akash.network/billing?openPayment=true" }] })
+        })
+      );
+    });
+
     it("leaves the wallet alone while the card still has chances left", async () => {
       const { service, walletSettingRepository, walletReloadJobService, notificationService, claim, user } = setup();
       walletSettingRepository.recordChargeDecline.mockResolvedValue({ failureCount: 2, pausedAt: null });

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
@@ -1,5 +1,6 @@
 import { inject, singleton } from "tsyringe";
 
+import { calculateChargeCooldownMinutes } from "@src/billing/lib/auto-reload/charge-cooldown";
 import { AUTHENTICATION_REQUIRED_DECLINE_CODE, type CardDecline } from "@src/billing/lib/card-decline/card-decline";
 import { type ChargeClaim, UserWalletRepository, type WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
@@ -16,9 +17,6 @@ import type { UserOutput } from "@src/user/repositories";
  * send one message per attempt, and the user still hears within minutes rather than at the pause.
  */
 const FIRST_DECLINE = 1;
-
-/** Guards `2 ** exponent` against a raised decline limit, since the result is interpolated into a Postgres interval. */
-const MAX_BACKOFF_DOUBLINGS = 16;
 
 /**
  * Owns when Console stops charging a declining card and when it starts again. It lives apart from
@@ -40,21 +38,14 @@ export class AutoReloadPauseService {
     this.logger = createLogger({ context: AutoReloadPauseService.name });
   }
 
-  /**
-   * Doubles the gap after each consecutive decline, so the attempts a dead card is allowed span
-   * hours instead of landing back to back. A base of 0 keeps meaning "no cap at all".
-   */
   calculateChargeCooldownMinutes(failureCount: number): number {
-    const base = this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN");
-
-    if (base === 0 || failureCount <= 0) {
-      return base;
-    }
-
-    const doublings = Math.min(failureCount - 1, MAX_BACKOFF_DOUBLINGS);
-    const backedOff = Math.min(base * 2 ** doublings, this.billingConfig.get("AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN"));
-
-    return Math.max(base, backedOff);
+    return calculateChargeCooldownMinutes(
+      {
+        baseMinutes: this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN"),
+        maxMinutes: this.billingConfig.get("AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN")
+      },
+      failureCount
+    );
   }
 
   async recordDecline(input: { claim: ChargeClaim; user: UserOutput; decline: CardDecline }): Promise<void> {

--- a/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
+++ b/apps/api/src/billing/services/auto-reload-pause/auto-reload-pause.service.ts
@@ -1,11 +1,12 @@
 import { inject, singleton } from "tsyringe";
 
-import type { CardDecline } from "@src/billing/lib/card-decline/card-decline";
+import { AUTHENTICATION_REQUIRED_DECLINE_CODE, type CardDecline } from "@src/billing/lib/card-decline/card-decline";
 import { type ChargeClaim, UserWalletRepository, type WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { type CreateNotificationInput, NotificationService } from "@src/notifications/services/notification/notification.service";
+import { autoTopUpAuthenticationRequiredNotification } from "@src/notifications/services/notification-templates/auto-top-up-authentication-required-notification";
 import { autoTopUpChargeFailedNotification } from "@src/notifications/services/notification-templates/auto-top-up-charge-failed-notification";
 import { autoTopUpPausedNotification } from "@src/notifications/services/notification-templates/auto-top-up-paused-notification";
 import type { UserOutput } from "@src/user/repositories";
@@ -75,9 +76,17 @@ export class AutoReloadPauseService {
 
     this.logger.warn({ event: "AUTO_RELOAD_PAUSED", userId: user.id, failureCount, declineCode: decline.declineCode });
 
-    await this.#notifyUser(autoTopUpPausedNotification(user, { pausedAt, billingUrl: this.#billingUrl() }));
+    await this.#notifyUser(this.#pausedNotification(user, pausedAt, decline));
     await this.#cancelPendingReloadCheck(user.id);
     await this.walletReloadJobService.scheduleCreditsLowCheck(user.id, { withCleanup: true });
+  }
+
+  #pausedNotification(user: UserOutput, pausedAt: Date, decline: CardDecline): CreateNotificationInput {
+    if (decline.declineCode === AUTHENTICATION_REQUIRED_DECLINE_CODE) {
+      return autoTopUpAuthenticationRequiredNotification(user, { pausedAt, paymentUrl: this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK") });
+    }
+
+    return autoTopUpPausedNotification(user, { pausedAt, billingUrl: this.#billingUrl() });
   }
 
   /**

--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.spec.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.spec.ts
@@ -57,6 +57,23 @@ describe(StripeTransactionService.name, () => {
       });
     });
 
+    it("marks an off-session charge so Stripe fails it instead of parking it on authentication", async () => {
+      const { service, stripe } = setup();
+
+      await service.createPaymentIntent({ ...mockPaymentParams, offSession: true });
+
+      expect(stripe.paymentIntents.create).toHaveBeenCalledWith(expect.objectContaining({ off_session: true, error_on_requires_action: true }));
+    });
+
+    it("leaves an on-session charge free to ask the present customer to authenticate", async () => {
+      const { service, stripe } = setup();
+
+      await service.createPaymentIntent(mockPaymentParams);
+
+      expect(stripe.paymentIntents.create).toHaveBeenCalledWith(expect.not.objectContaining({ off_session: expect.anything() }));
+      expect(stripe.paymentIntents.create).toHaveBeenCalledWith(expect.not.objectContaining({ error_on_requires_action: expect.anything() }));
+    });
+
     it("does not consult the idempotency-key row lookup on keyless calls", async () => {
       const { service, stripe, stripeTransactionRepository } = setup();
 
@@ -375,6 +392,27 @@ describe(StripeTransactionService.name, () => {
     });
   });
 
+  describe("cancelUnauthenticatedPaymentIntent", () => {
+    it("cancels the intent at Stripe and records the row as canceled", async () => {
+      const { service, stripe, stripeTransactionRepository } = setup();
+
+      await service.cancelUnauthenticatedPaymentIntent("pi_stalled");
+
+      expect(stripe.paymentIntents.cancel).toHaveBeenCalledWith("pi_stalled", { cancellation_reason: "abandoned" });
+      expect(stripeTransactionRepository.updateByPaymentIntentId).toHaveBeenCalledWith("pi_stalled", { status: "canceled" });
+    });
+
+    it("logs a refused cancel instead of throwing, so the decline it accompanies is still recorded", async () => {
+      const { service, stripe, logger } = setup();
+      const error = new Stripe.errors.StripeAPIError({ type: "api_error", message: "Service unavailable" });
+      vi.mocked(stripe.paymentIntents.cancel).mockRejectedValue(error);
+
+      await expect(service.cancelUnauthenticatedPaymentIntent("pi_stalled")).resolves.toBeUndefined();
+
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "PAYMENT_INTENT_CANCEL_FAILED", paymentIntentId: "pi_stalled", error }));
+    });
+  });
+
   describe("resolveTransaction", () => {
     it("returns transaction once it reaches terminal status", async () => {
       const { service, stripeTransactionRepository } = setup();
@@ -456,6 +494,7 @@ describe(StripeTransactionService.name, () => {
   function setup(params: { paymentIntent?: Stripe.Response<Stripe.PaymentIntent> } = {}) {
     const stripeTransactionRepository = mock<StripeTransactionRepository>();
     const timerService = mock<TimerService>();
+    const logger = mock<LoggerService>();
 
     const stripe = new Stripe(`sk_test_${faker.string.alphanumeric(32)}`, { apiVersion: "2025-10-29.clover", httpClient: Stripe.createFetchHttpClient() });
 
@@ -467,7 +506,7 @@ describe(StripeTransactionService.name, () => {
       timerService,
       mock<UserRepository>(),
       mock<DomainEventsService>(),
-      () => mock<LoggerService>()
+      () => logger
     );
 
     stripeTransactionRepository.create.mockImplementation(async input => ({
@@ -500,12 +539,14 @@ describe(StripeTransactionService.name, () => {
     const paymentIntentToReturn = params.paymentIntent || stripeData.paymentIntent;
     vi.spyOn(stripe.paymentIntents, "create").mockResolvedValue(paymentIntentToReturn);
     vi.spyOn(stripe.paymentIntents, "retrieve").mockResolvedValue(paymentIntentToReturn);
+    vi.spyOn(stripe.paymentIntents, "cancel").mockResolvedValue(paymentIntentToReturn);
 
     return {
       service,
       stripe,
       stripeTransactionRepository,
-      timerService
+      timerService,
+      logger
     };
   }
 });

--- a/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
+++ b/apps/api/src/billing/services/stripe-transaction/stripe-transaction.service.ts
@@ -43,6 +43,12 @@ export const AUTO_RECHARGE_METADATA_KEY = "auto_recharge";
 
 const CARD_DECLINED_MESSAGE = "Payment method was declined. Please try a different card.";
 
+/** Without both, an issuer that wants 3DS leaves the intent stalled in requires_action instead of declining it. */
+const OFF_SESSION_CHARGE_OPTIONS = { off_session: true, error_on_requires_action: true } as const satisfies Pick<
+  Stripe.PaymentIntentCreateParams,
+  "off_session" | "error_on_requires_action"
+>;
+
 /** The decline code lets the reload job tell a card it can retry from one the issuer will never approve. */
 function declineCodeOf(paymentIntent: Stripe.PaymentIntent): { declineCode?: string } {
   const declineCode = paymentIntent.last_payment_error?.decline_code;
@@ -109,6 +115,7 @@ export class StripeTransactionService {
     payment_method: string;
     amount: number;
     confirm: boolean;
+    offSession?: boolean;
     metadata?: Record<string, string>;
     idempotencyKey?: string;
     onAmountMismatch: OnAmountMismatch;
@@ -294,7 +301,7 @@ export class StripeTransactionService {
 
   async #chargePaymentIntent(
     transaction: StripeTransactionOutput,
-    params: { customer: string; payment_method: string; confirm: boolean; metadata?: Record<string, string>; idempotencyKey?: string }
+    params: { customer: string; payment_method: string; confirm: boolean; offSession?: boolean; metadata?: Record<string, string>; idempotencyKey?: string }
   ): Promise<PaymentIntentResult> {
     const createOptions: Parameters<Stripe["paymentIntents"]["create"]> = [
       {
@@ -303,6 +310,7 @@ export class StripeTransactionService {
         amount: transaction.amount,
         currency: STRIPE_CURRENCY,
         confirm: params.confirm,
+        ...(params.offSession && OFF_SESSION_CHARGE_OPTIONS),
         metadata: {
           ...params.metadata,
           internal_transaction_id: transaction.id
@@ -385,6 +393,16 @@ export class StripeTransactionService {
       }
 
       throw error;
+    }
+  }
+
+  /** Best-effort: a refused cancel is logged so the authentication decline the caller is recording still lands. */
+  async cancelUnauthenticatedPaymentIntent(paymentIntentId: string): Promise<void> {
+    try {
+      await this.stripe.paymentIntents.cancel(paymentIntentId, { cancellation_reason: "abandoned" });
+      await this.stripeTransactionRepository.updateByPaymentIntentId(paymentIntentId, { status: "canceled" });
+    } catch (error) {
+      this.loggerService.error({ event: "PAYMENT_INTENT_CANCEL_FAILED", paymentIntentId, error });
     }
   }
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -74,6 +74,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
         payment_method: expect.any(String),
         amount: expectedReloadAmount,
         confirm: true,
+        offSession: true,
         metadata: { auto_recharge: "true" },
         idempotencyKey: `${WalletBalanceReloadCheck.name}.${jobMeta.id}`,
         onAmountMismatch: "tolerate"
@@ -115,6 +116,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
         payment_method: expect.any(String),
         amount: expectedReloadAmount,
         confirm: true,
+        offSession: true,
         metadata: { auto_recharge: "true" },
         idempotencyKey: `${WalletBalanceReloadCheck.name}.${jobMeta.id}`,
         onAmountMismatch: "tolerate"
@@ -447,6 +449,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
         payment_method: expect.any(String),
         amount: 100,
         confirm: true,
+        offSession: true,
         metadata: { auto_recharge: "true" },
         idempotencyKey: `${WalletBalanceReloadCheck.name}.${jobMeta.id}`,
         onAmountMismatch: "tolerate"
@@ -827,12 +830,36 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       expect(walletSettingRepository.resetChargeFailures).toHaveBeenCalledWith(walletSetting.id);
     });
+  });
 
-    it("keeps the declines when the card only asked for authentication", async () => {
-      const { handler, walletSettingRepository, job, jobMeta } = setup({ balance: 10.0, autoReloadFailureCount: 2, chargeRequiresAction: true });
+  describe("when the card asks for authentication nobody is present to give", () => {
+    it("cancels the stalled intent so it does not linger as Incomplete", async () => {
+      const { handler, stripeTransactionService, job, jobMeta } = setup({ balance: 10.0, chargeRequiresAction: true });
 
-      await handler.handle(job, jobMeta);
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow();
 
+      expect(stripeTransactionService.cancelUnauthenticatedPaymentIntent).toHaveBeenCalledWith("pi_requires_action");
+    });
+
+    it("records a terminal authentication decline so the wallet pauses instead of retrying every cooldown", async () => {
+      const { handler, autoReloadPauseService, claim, job, jobMeta } = setup({ balance: 10.0, chargeRequiresAction: true });
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow();
+
+      expect(autoReloadPauseService.recordDecline).toHaveBeenCalledWith({
+        claim,
+        user: expect.objectContaining({ id: job.userId }),
+        decline: { declineCode: "authentication_required", isTerminal: true }
+      });
+    });
+
+    it("reports the charge as failed rather than triggered", async () => {
+      const { handler, instrumentationService, walletSettingRepository, job, jobMeta } = setup({ balance: 10.0, chargeRequiresAction: true });
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow();
+
+      expect(instrumentationService.recordReloadTriggered).not.toHaveBeenCalled();
+      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith(expect.objectContaining({ declineCode: "authentication_required" }));
       expect(walletSettingRepository.resetChargeFailures).not.toHaveBeenCalled();
     });
   });
@@ -921,7 +948,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     const stripeTransactionService = mock<StripeTransactionService>();
     stripeTransactionService.createPaymentIntent.mockResolvedValue({
       success: input?.chargeRequiresAction ? false : true,
-      ...(input?.chargeRequiresAction && { requiresAction: true }),
+      ...(input?.chargeRequiresAction && { requiresAction: true, paymentIntentId: "pi_requires_action" }),
       transactionId: faker.string.uuid(),
       transactionStatus: "succeeded"
     });

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -1,12 +1,14 @@
 import { createMongoAbility } from "@casl/ability";
 import { addMilliseconds, millisecondsInHour, millisecondsInMinute, millisecondsInSecond } from "date-fns";
+import createError from "http-errors";
 import { Err, Ok, Result } from "ts-results";
 import { singleton } from "tsyringe";
 
 import { AUTO_RELOAD_AMOUNT_MIN_USD } from "@src/billing/config";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import type { GetBalancesResponseOutput } from "@src/billing/http-schemas/balance.schema";
-import { type CardDecline, toCardDecline } from "@src/billing/lib/card-decline/card-decline";
+import type { PaymentIntentResult } from "@src/billing/http-schemas/stripe.schema";
+import { AUTHENTICATION_REQUIRED_DECLINE_CODE, CARD_DECLINED_ERROR_CODE, type CardDecline, toCardDecline } from "@src/billing/lib/card-decline/card-decline";
 import { centsToUsd } from "@src/billing/lib/currency/currency";
 import { type ChargeClaim, UserWalletOutput, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { AutoReloadPauseService } from "@src/billing/services/auto-reload-pause/auto-reload-pause.service";
@@ -42,6 +44,8 @@ type ReloadContext = AllResources & { job: JobMeta; triggeredByDeployment: boole
 type ReloadOutcome = { nextCheckAt: Date } | undefined;
 
 const millisecondsInDay = 24 * millisecondsInHour;
+
+const AUTHENTICATION_REQUIRED_MESSAGE = "The card requires authentication, which an automatic charge cannot provide.";
 
 @singleton()
 export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalanceReloadCheck> {
@@ -299,10 +303,15 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
         payment_method: resources.paymentMethod.id,
         amount,
         confirm: true,
+        offSession: true,
         metadata: { [AUTO_RECHARGE_METADATA_KEY]: "true" },
         idempotencyKey: `${WalletBalanceReloadCheck.name}.${resources.job.id}`,
         onAmountMismatch: "tolerate"
       });
+
+      if (result.requiresAction) {
+        throw await this.#abandonUnauthenticatedCharge(result);
+      }
 
       if (result.success) {
         await this.walletSettingRepository.resetChargeFailures(resources.walletSetting.id);
@@ -319,6 +328,22 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
 
       throw error;
     }
+  }
+
+  /**
+   * Stripe is asked to decline these outright, so an intent that still comes back waiting on authentication is
+   * cancelled and reported as the decline it amounts to: nobody is present to authenticate a background charge.
+   */
+  async #abandonUnauthenticatedCharge(result: PaymentIntentResult): Promise<Error> {
+    if (result.paymentIntentId) {
+      await this.stripeTransactionService.cancelUnauthenticatedPaymentIntent(result.paymentIntentId);
+    }
+
+    return createError(402, AUTHENTICATION_REQUIRED_MESSAGE, {
+      errorCode: CARD_DECLINED_ERROR_CODE,
+      errorType: "payment_error",
+      declineCode: AUTHENTICATION_REQUIRED_DECLINE_CODE
+    });
   }
 
   /**

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -330,10 +330,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     }
   }
 
-  /**
-   * Stripe is asked to decline these outright, so an intent that still comes back waiting on authentication is
-   * cancelled and reported as the decline it amounts to: nobody is present to authenticate a background charge.
-   */
+  /** Stripe is asked to decline these outright, so one that still stalls on authentication is cancelled and reported as the decline it amounts to. */
   async #abandonUnauthenticatedCharge(result: PaymentIntentResult): Promise<Error> {
     if (result.paymentIntentId) {
       await this.stripeTransactionService.cancelUnauthenticatedPaymentIntent(result.paymentIntentId);

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -119,6 +119,19 @@ describe(WalletReloadJobService.name, () => {
       expect(options).toMatchObject({ startAfter: expectedReopen });
     });
 
+    it("drops the deployment trigger from a deferred check so it re-checks active deployments when it runs", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup({ cooldownMinutes: 60 });
+      const lastAutoChargeAt = new Date(Date.now() - 20 * 60_000);
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: true, lastAutoChargeAt }));
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleImmediate({ userId: faker.string.uuid() }, { triggeredByDeployment: true });
+
+      const [job, options] = jobQueueService.enqueue.mock.calls[0];
+      expect(options).toHaveProperty("startAfter");
+      expect((job as WalletBalanceReloadCheck).data.triggeredByDeployment).toBeUndefined();
+    });
+
     it("never defers when the charge cooldown is disabled", async () => {
       const { service, walletSettingRepository, jobQueueService } = setup({ cooldownMinutes: 0 });
       walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: true, lastAutoChargeAt: new Date() }));

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -106,6 +106,30 @@ describe(WalletReloadJobService.name, () => {
       expect(options).toMatchObject({ startAfter: expectedReopen });
     });
 
+    it("defers by the backed-off cooldown the wallet's declines have earned", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup({ cooldownMinutes: 60 });
+      const lastAutoChargeAt = new Date(Date.now() - 90 * 60_000);
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: true, lastAutoChargeAt, autoReloadFailureCount: 2 }));
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleImmediate({ userId: faker.string.uuid() });
+
+      const [, options] = jobQueueService.enqueue.mock.calls[0];
+      const expectedReopen = new Date(lastAutoChargeAt.getTime() + 121 * 60_000).toISOString();
+      expect(options).toMatchObject({ startAfter: expectedReopen });
+    });
+
+    it("never defers when the charge cooldown is disabled", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup({ cooldownMinutes: 0 });
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: true, lastAutoChargeAt: new Date() }));
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleImmediate({ userId: faker.string.uuid() });
+
+      const [, options] = jobQueueService.enqueue.mock.calls[0];
+      expect(options).not.toHaveProperty("startAfter");
+    });
+
     it("runs the check right away once the charge cooldown has passed", async () => {
       const { service, walletSettingRepository, jobQueueService } = setup({ cooldownMinutes: 60 });
       const lastAutoChargeAt = new Date(Date.now() - 90 * 60_000);
@@ -413,7 +437,10 @@ describe(WalletReloadJobService.name, () => {
     const walletSettingRepository = mock<WalletSettingRepository>();
     const userWalletRepository = mock<UserWalletRepository>();
     const jobQueueService = mock<JobQueueService>();
-    const billingConfig = mockConfigService<BillingConfigService>({ AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: input?.cooldownMinutes ?? 60 });
+    const billingConfig = mockConfigService<BillingConfigService>({
+      AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: input?.cooldownMinutes ?? 60,
+      AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN: 1440
+    });
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);
 

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -5,10 +5,12 @@ import { mock } from "vitest-mock-extended";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
 import type { UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { JobQueueService } from "@src/core";
 import type { CreateLogger } from "@src/core/providers/logging.provider";
 import { WalletReloadJobService } from "./wallet-reload-job.service";
 
+import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
@@ -89,6 +91,42 @@ describe(WalletReloadJobService.name, () => {
 
       const [job] = jobQueueService.enqueue.mock.calls[0];
       expect((job as WalletBalanceReloadCheck).data).toMatchObject({ userId: walletSetting.userId, triggeredByDeployment: true });
+    });
+
+    it("queues a check inside the charge cooldown for the window reopen instead of running it now", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup({ cooldownMinutes: 60 });
+      const lastAutoChargeAt = new Date(Date.now() - 20 * 60_000);
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: true, lastAutoChargeAt }));
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleImmediate({ userId: faker.string.uuid() });
+
+      const [, options] = jobQueueService.enqueue.mock.calls[0];
+      const expectedReopen = new Date(lastAutoChargeAt.getTime() + 61 * 60_000).toISOString();
+      expect(options).toMatchObject({ startAfter: expectedReopen });
+    });
+
+    it("runs the check right away once the charge cooldown has passed", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup({ cooldownMinutes: 60 });
+      const lastAutoChargeAt = new Date(Date.now() - 90 * 60_000);
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: true, lastAutoChargeAt }));
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleImmediate({ userId: faker.string.uuid() });
+
+      const [, options] = jobQueueService.enqueue.mock.calls[0];
+      expect(options).not.toHaveProperty("startAfter");
+    });
+
+    it("runs the check right away for a wallet that has never been charged", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup();
+      walletSettingRepository.findByUserId.mockResolvedValue(generateWalletSetting({ autoReloadEnabled: true, lastAutoChargeAt: null }));
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      await service.scheduleImmediate({ userId: faker.string.uuid() });
+
+      const [, options] = jobQueueService.enqueue.mock.calls[0];
+      expect(options).not.toHaveProperty("startAfter");
     });
 
     it("looks up the wallet setting by walletId when given a walletId", async () => {
@@ -371,14 +409,15 @@ describe(WalletReloadJobService.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: WalletReloadJobService.name });
   });
 
-  function setup() {
+  function setup(input?: { cooldownMinutes?: number }) {
     const walletSettingRepository = mock<WalletSettingRepository>();
     const userWalletRepository = mock<UserWalletRepository>();
     const jobQueueService = mock<JobQueueService>();
+    const billingConfig = mockConfigService<BillingConfigService>({ AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: input?.cooldownMinutes ?? 60 });
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);
 
-    const service = new WalletReloadJobService(walletSettingRepository, userWalletRepository, jobQueueService, createLogger);
+    const service = new WalletReloadJobService(walletSettingRepository, userWalletRepository, jobQueueService, billingConfig, createLogger);
 
     return {
       service,

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -4,6 +4,7 @@ import { inject, singleton } from "tsyringe";
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
 import { isAutoReloadActive } from "@src/billing/lib/auto-reload/auto-reload";
+import { calculateChargeCooldownMinutes } from "@src/billing/lib/auto-reload/charge-cooldown";
 import { UserWalletRepository, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { EnqueueOptions, JobQueueService } from "@src/core";
@@ -49,13 +50,20 @@ export class WalletReloadJobService {
    * A check inside the charge cooldown can only lose the claim and defer itself to the reopen, so a spend
    * event that lands there is queued straight for the reopen instead of running a full check per event.
    */
-  #chargeWindowReopenAfter(walletSetting: Pick<WalletSettingOutput, "lastAutoChargeAt">): string | undefined {
-    if (!walletSetting.lastAutoChargeAt) {
+  #chargeWindowReopenAfter(walletSetting: Pick<WalletSettingOutput, "lastAutoChargeAt" | "autoReloadFailureCount">): string | undefined {
+    const cooldownMinutes = calculateChargeCooldownMinutes(
+      {
+        baseMinutes: this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN"),
+        maxMinutes: this.billingConfig.get("AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN")
+      },
+      walletSetting.autoReloadFailureCount
+    );
+
+    if (!walletSetting.lastAutoChargeAt || cooldownMinutes === 0) {
       return undefined;
     }
 
-    const cooldownInMs = this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN") * millisecondsInMinute;
-    const reopenAt = addMilliseconds(walletSetting.lastAutoChargeAt, cooldownInMs + CHARGE_WINDOW_REOPEN_BUFFER_IN_MS);
+    const reopenAt = addMilliseconds(walletSetting.lastAutoChargeAt, cooldownMinutes * millisecondsInMinute + CHARGE_WINDOW_REOPEN_BUFFER_IN_MS);
 
     return reopenAt > new Date() ? reopenAt.toISOString() : undefined;
   }

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -35,10 +35,11 @@ export class WalletReloadJobService {
         : await this.walletSettingRepository.findOneBy({ walletId: input.walletId });
 
     if (isAutoReloadActive(walletSetting)) {
+      const startAfter = this.#chargeWindowReopenAfter(walletSetting);
       await this.scheduleForWalletSetting(walletSetting, {
         withCleanup: true,
-        triggeredByDeployment: options?.triggeredByDeployment,
-        startAfter: this.#chargeWindowReopenAfter(walletSetting)
+        startAfter,
+        triggeredByDeployment: startAfter ? undefined : options?.triggeredByDeployment
       });
       return true;
     }
@@ -46,7 +47,7 @@ export class WalletReloadJobService {
     return false;
   }
 
-  /** A check inside the charge cooldown can only lose the claim and defer to the reopen, so a spend event there is queued straight for the reopen. */
+  /** A check inside the cooldown can only defer to the reopen, so it is queued there directly; the deployment flag vouches for a create that just happened and is dropped on the way. */
   #chargeWindowReopenAfter(walletSetting: Pick<WalletSettingOutput, "lastAutoChargeAt" | "autoReloadFailureCount">): string | undefined {
     const cooldownMinutes = calculateChargeCooldownMinutes(
       {

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -46,10 +46,7 @@ export class WalletReloadJobService {
     return false;
   }
 
-  /**
-   * A check inside the charge cooldown can only lose the claim and defer itself to the reopen, so a spend
-   * event that lands there is queued straight for the reopen instead of running a full check per event.
-   */
+  /** A check inside the charge cooldown can only lose the claim and defer to the reopen, so a spend event there is queued straight for the reopen. */
   #chargeWindowReopenAfter(walletSetting: Pick<WalletSettingOutput, "lastAutoChargeAt" | "autoReloadFailureCount">): string | undefined {
     const cooldownMinutes = calculateChargeCooldownMinutes(
       {

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -1,11 +1,16 @@
+import { addMilliseconds, millisecondsInMinute } from "date-fns";
 import { inject, singleton } from "tsyringe";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
 import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
 import { isAutoReloadActive } from "@src/billing/lib/auto-reload/auto-reload";
 import { UserWalletRepository, WalletSettingOutput, WalletSettingRepository } from "@src/billing/repositories";
+import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { EnqueueOptions, JobQueueService } from "@src/core";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+
+/** Landing slightly past the reopen keeps the deferred check from losing the claim on the boundary and deferring again. */
+const CHARGE_WINDOW_REOPEN_BUFFER_IN_MS = millisecondsInMinute;
 
 @singleton()
 export class WalletReloadJobService {
@@ -15,6 +20,7 @@ export class WalletReloadJobService {
     private readonly walletSettingRepository: WalletSettingRepository,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly jobQueueService: JobQueueService,
+    private readonly billingConfig: BillingConfigService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: WalletReloadJobService.name });
@@ -28,11 +34,30 @@ export class WalletReloadJobService {
         : await this.walletSettingRepository.findOneBy({ walletId: input.walletId });
 
     if (isAutoReloadActive(walletSetting)) {
-      await this.scheduleForWalletSetting(walletSetting, { withCleanup: true, triggeredByDeployment: options?.triggeredByDeployment });
+      await this.scheduleForWalletSetting(walletSetting, {
+        withCleanup: true,
+        triggeredByDeployment: options?.triggeredByDeployment,
+        startAfter: this.#chargeWindowReopenAfter(walletSetting)
+      });
       return true;
     }
 
     return false;
+  }
+
+  /**
+   * A check inside the charge cooldown can only lose the claim and defer itself to the reopen, so a spend
+   * event that lands there is queued straight for the reopen instead of running a full check per event.
+   */
+  #chargeWindowReopenAfter(walletSetting: Pick<WalletSettingOutput, "lastAutoChargeAt">): string | undefined {
+    if (!walletSetting.lastAutoChargeAt) {
+      return undefined;
+    }
+
+    const cooldownInMs = this.billingConfig.get("AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN") * millisecondsInMinute;
+    const reopenAt = addMilliseconds(walletSetting.lastAutoChargeAt, cooldownInMs + CHARGE_WINDOW_REOPEN_BUFFER_IN_MS);
+
+    return reopenAt > new Date() ? reopenAt.toISOString() : undefined;
   }
 
   async scheduleCreditsLowCheckIfAutoReloadOff(input: { walletId: number }): Promise<void> {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -1746,7 +1746,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       walletSettingRepository,
       userWalletRepository,
       jobQueueService,
-      mockConfigService<BillingConfigService>({ AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: 60 }),
+      mockConfigService<BillingConfigService>({ AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: 60, AUTO_RELOAD_CHARGE_BACKOFF_MAX_IN_MIN: 1440 }),
       createLogger
     );
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -1742,7 +1742,13 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);
     jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
-    const walletReloadService = new WalletReloadJobService(walletSettingRepository, userWalletRepository, jobQueueService, createLogger);
+    const walletReloadService = new WalletReloadJobService(
+      walletSettingRepository,
+      userWalletRepository,
+      jobQueueService,
+      mockConfigService<BillingConfigService>({ AUTO_RELOAD_CHARGE_COOLDOWN_IN_MIN: 60 }),
+      createLogger
+    );
 
     return {
       ...setup({ ...input, walletReloadService }),

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-authentication-required-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-authentication-required-notification.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { autoTopUpAuthenticationRequiredNotification } from "./auto-top-up-authentication-required-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(autoTopUpAuthenticationRequiredNotification.name, () => {
+  it("tells the user to pay by hand and links to the add funds modal", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = autoTopUpAuthenticationRequiredNotification(user, {
+      pausedAt: new Date("2026-09-01T12:00:00.000Z"),
+      paymentUrl: "https://console.akash.network/billing?openPayment=true"
+    });
+
+    expect(result.payload.summary).toBe("Auto top-up needs a card we can charge without you");
+    expect(result.payload.description).toContain("confirm");
+    expect(result.payload.actions).toEqual([{ label: "Add funds", url: "https://console.akash.network/billing?openPayment=true" }]);
+    expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
+  });
+
+  it("keys the notification on the pause so a later one is not swallowed as a duplicate", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+    const vars = { paymentUrl: "https://console.akash.network/billing?openPayment=true" };
+
+    const first = autoTopUpAuthenticationRequiredNotification(user, { ...vars, pausedAt: new Date("2026-09-01T12:00:00.000Z") });
+    const second = autoTopUpAuthenticationRequiredNotification(user, { ...vars, pausedAt: new Date("2026-09-20T08:30:00.000Z") });
+
+    expect(first.notificationId).toBe("autoTopUpAuthenticationRequired.user-123.2026-09-01T12:00:00.000Z");
+    expect(second.notificationId).not.toBe(first.notificationId);
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-authentication-required-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-authentication-required-notification.ts
@@ -1,10 +1,7 @@
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
 
-/**
- * Links to the Add Funds modal rather than the payment methods page: paying by hand is the one flow
- * where the user is present to give the bank the confirmation it asked for.
- */
+/** Links to Add Funds rather than payment methods: paying by hand is the one flow where the user is present to confirm with the bank. */
 export function autoTopUpAuthenticationRequiredNotification(user: UserOutput, vars: { pausedAt: Date; paymentUrl: string }): CreateNotificationInput {
   return {
     notificationId: `autoTopUpAuthenticationRequired.${user.id}.${vars.pausedAt.toISOString()}`,

--- a/apps/api/src/notifications/services/notification-templates/auto-top-up-authentication-required-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/auto-top-up-authentication-required-notification.ts
@@ -1,0 +1,25 @@
+import type { UserOutput } from "@src/user/repositories";
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+/**
+ * Links to the Add Funds modal rather than the payment methods page: paying by hand is the one flow
+ * where the user is present to give the bank the confirmation it asked for.
+ */
+export function autoTopUpAuthenticationRequiredNotification(user: UserOutput, vars: { pausedAt: Date; paymentUrl: string }): CreateNotificationInput {
+  return {
+    notificationId: `autoTopUpAuthenticationRequired.${user.id}.${vars.pausedAt.toISOString()}`,
+    payload: {
+      summary: "Auto top-up needs a card we can charge without you",
+      description:
+        `Your bank wants you to confirm our last automatic charge, and we can't do that for you while you're away, so we've paused auto top-up rather than keep trying. ` +
+        `Your deployments keep running on the credits you already have. ` +
+        `To add credits now, add funds yourself and confirm the payment when your bank asks. ` +
+        `Auto top-up starts again once you set a card that doesn't ask for confirmation as your default payment method.`,
+      actions: [{ label: "Add funds", url: vars.paymentUrl }]
+    },
+    user: {
+      id: user.id,
+      email: user.email
+    }
+  };
+}


### PR DESCRIPTION
## Why

A customer's Stripe account shows one $20 "Incomplete" PaymentIntent every 61 minutes since Sep 2. All of them come from the auto-recharge job, and none of them charged anything.

The chain of events: the customer runs a script that posts to `/v1/deployments` about nine times a minute. Each call is refused for insufficient allowance, and each refusal schedules an immediate reload check. Those checks lose the 60 minute charge claim and queue themselves for the window reopen. When the window reopens the charge fires, the issuer asks for 3DS, and Stripe returns `requires_action`. The handler treated that as neither success nor decline: it logged `WALLET_BALANCE_RELOADED`, never counted a failure, never paused, never emailed anyone, and left the intent stalled in Stripe. Then the cycle repeated.

## What

- Auto-recharge intents are created with `off_session: true` and `error_on_requires_action: true`. Stripe now declines an authentication demand with `authentication_required` instead of parking the intent. Manual "Add Funds" charges are unchanged: the customer is present and can complete 3DS there.
- `authentication_required` is a terminal decline code. A background retry can never clear it, so the wallet pauses on the first one rather than after the usual run of declines.
- A paused-for-authentication wallet gets a new email that links to Add Funds, where the user can confirm the payment with their bank, instead of the generic "declined several times" email that points at payment methods.
- If an intent still comes back waiting on authentication, the handler cancels it at Stripe, marks the row canceled, and records the same terminal decline. A refused cancel is logged so the decline still lands.
- A spend event that lands inside the charge cooldown is queued for the window reopen instead of running a full balance check per event. Behaviour outside the cooldown is unchanged.

The roughly 80 intents already stalled in Stripe are not touched by this PR. I will cancel them with a one-off local script once this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Billing**
  - Automatic wallet reloads now use off-session payments and better handle authentication-required payments.
  - Authentication-required payment attempts are cancelled safely and reported as card-declined payments with clear next steps.
  - Reload retries now use configurable cooldowns with progressive backoff.

- **Notifications**
  - Added a dedicated notification when automatic reloads pause because authentication is required.
  - Notifications include a direct “Add funds” action.

- **Bug Fixes**
  - Improved handling of incomplete payment attempts to prevent unintended failures and duplicate notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->