### PR TITLE
feat(provider): show the cpu architecture a provider's nodes actually report

### DIFF
--- a/apps/api/src/provider/http-schemas/provider.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider.schema.ts
@@ -161,6 +161,14 @@ export const ProviderResponseSchema = z.object({
   hostingProvider: z.string().nullable(),
   hardwareCpu: z.string().nullable(),
   hardwareCpuArch: z.string().nullable(),
+  reportedCpuArchs: z.array(z.string()).openapi({
+    description:
+      "Distinct CPU architectures the provider's nodes reported in its last successful snapshot, normalised to amd64 or arm64. Empty when no node reports one.",
+    example: ["arm64"]
+  }),
+  cpuArchAgreement: z.enum(["match", "mismatch", "unknown"]).openapi({
+    description: "Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing."
+  }),
   hardwareGpuVendor: z.string().nullable(),
   hardwareGpuModels: z.array(z.string()),
   hardwareDisk: z.array(z.string()),

--- a/apps/api/src/provider/http-schemas/provider.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider.schema.ts
@@ -163,11 +163,12 @@ export const ProviderResponseSchema = z.object({
   hardwareCpuArch: z.string().nullable(),
   reportedCpuArchs: z.array(z.string()).openapi({
     description:
-      "Distinct CPU architectures the provider's nodes reported in its last successful snapshot, normalised to amd64 or arm64. Empty when no node reports one.",
+      "Distinct CPU architectures the provider's nodes reported in its last successful snapshot. Known spellings such as x86_64 or aarch64 are folded onto amd64 or arm64; any other reported value is kept as reported. Empty when no node reports one.",
     example: ["arm64"]
   }),
   cpuArchAgreement: z.enum(["match", "mismatch", "unknown"]).openapi({
-    description: "Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing."
+    description:
+      "Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing or the declared value is not a recognised architecture."
   }),
   hardwareGpuVendor: z.string().nullable(),
   hardwareGpuModels: z.array(z.string()),

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -1,4 +1,4 @@
-import { Provider, ProviderSnapshot, ProviderSnapshotNode, ProviderSnapshotNodeGPU } from "@akashnetwork/database/dbSchemas/akash";
+import { Provider, ProviderSnapshot, ProviderSnapshotNode, ProviderSnapshotNodeCPU, ProviderSnapshotNodeGPU } from "@akashnetwork/database/dbSchemas/akash";
 import type { ProviderAttributesSchema } from "@akashnetwork/http-sdk";
 import { AxiosError } from "axios";
 import { add } from "date-fns";
@@ -13,9 +13,10 @@ import type { Auditor } from "@src/provider/http-schemas/auditor.schema";
 import { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
 import { ProviderAuth, ProviderIdentity, ProviderProxyService } from "@src/provider/services/provider/provider-proxy.service";
 import { ProviderJwtTokenService } from "@src/provider/services/provider-jwt-token/provider-jwt-token.service";
-import { ProviderList } from "@src/types/provider";
+import { ProviderDetail, ProviderList } from "@src/types/provider";
 import { toUTC } from "@src/utils";
 import { forEachInChunks } from "@src/utils/array/array";
+import { getCpuArchAgreement, getReportedCpuArchs } from "@src/utils/cpu-arch/cpu-arch";
 import { mapProviderToList } from "@src/utils/map/provider";
 import { AuditorService } from "../auditors/auditors.service";
 import { ProviderAttributesSchemaService } from "../provider-attributes-schema/provider-attributes-schema.service";
@@ -218,7 +219,7 @@ export class ProviderService {
   }
 
   @Memoize({ ttlInSeconds: 30, maxEntries: 500 })
-  async getProvider(address: string) {
+  async getProvider(address: string): Promise<ProviderDetail | null> {
     const nowUtc = toUTC(new Date());
     const provider = await this.providerRepository.getProviderByAddressWithAttributes(address);
 
@@ -243,7 +244,7 @@ export class ProviderService {
           include: [
             {
               model: ProviderSnapshotNode,
-              include: [{ model: ProviderSnapshotNodeGPU }]
+              include: [{ model: ProviderSnapshotNodeGPU }, { model: ProviderSnapshotNodeCPU, attributes: ["arch"] }]
             }
           ]
         })
@@ -254,8 +255,13 @@ export class ProviderService {
       this.providerAttributesSchemaService.getProviderAttributesSchema()
     ]);
 
+    const providerList = mapProviderToList(provider, providerAttributeSchema, auditors, lastSuccessfulSnapshot ?? undefined);
+    const reportedCpuArchs = getReportedCpuArchs(lastSuccessfulSnapshot?.nodes ?? []);
+
     return {
-      ...mapProviderToList(provider, providerAttributeSchema, auditors, lastSuccessfulSnapshot ?? undefined),
+      ...providerList,
+      reportedCpuArchs,
+      cpuArchAgreement: getCpuArchAgreement(providerList.hardwareCpuArch, reportedCpuArchs),
       uptime: uptimeSnapshots.map(ps => ({
         id: ps.id,
         isOnline: ps.isOnline,

--- a/apps/api/src/types/provider.ts
+++ b/apps/api/src/types/provider.ts
@@ -1,3 +1,5 @@
+import type { CpuArchAgreement } from "@src/utils/cpu-arch/cpu-arch";
+
 export interface ProviderList {
   owner: string;
   name: string | null;
@@ -76,6 +78,8 @@ export interface ProviderCapacityStats {
 }
 
 export interface ProviderDetail extends ProviderList {
+  reportedCpuArchs: string[];
+  cpuArchAgreement: CpuArchAgreement;
   uptime: {
     id: string;
     isOnline: boolean;

--- a/apps/api/src/utils/cpu-arch/cpu-arch.spec.ts
+++ b/apps/api/src/utils/cpu-arch/cpu-arch.spec.ts
@@ -66,8 +66,8 @@ describe(getCpuArchAgreement.name, () => {
     expect(getCpuArchAgreement("x86-64", ["arm64"])).toBe("mismatch");
   });
 
-  it("mismatches when the declared value is not an architecture at all", () => {
-    expect(getCpuArchAgreement("Zen 4", ["amd64"])).toBe("mismatch");
+  it.each(["x86", "Zen 4", "riscv64"])("is unknown rather than a mismatch when the declared value %j is not a requestable architecture", declared => {
+    expect(getCpuArchAgreement(declared, ["amd64"])).toBe("unknown");
   });
 
   it("is unknown when nothing is declared", () => {

--- a/apps/api/src/utils/cpu-arch/cpu-arch.spec.ts
+++ b/apps/api/src/utils/cpu-arch/cpu-arch.spec.ts
@@ -1,0 +1,80 @@
+import type { ProviderSnapshotNode, ProviderSnapshotNodeCPU } from "@akashnetwork/database/dbSchemas/akash";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { getCpuArchAgreement, getReportedCpuArchs, normalizeCpuArch } from "./cpu-arch";
+
+describe(normalizeCpuArch.name, () => {
+  it.each([
+    ["amd64", "amd64"],
+    ["x86_64", "amd64"],
+    ["X86-64", "amd64"],
+    ["arm64", "arm64"],
+    ["aarch64", "arm64"],
+    [" arm-64 ", "arm64"]
+  ])("folds %s onto %s", (input, expected) => {
+    expect(normalizeCpuArch(input)).toBe(expected);
+  });
+
+  it.each([null, undefined, "", "   "])("returns null for %j", input => {
+    expect(normalizeCpuArch(input)).toBeNull();
+  });
+
+  it("keeps an unrecognised architecture instead of dropping or defaulting it", () => {
+    expect(normalizeCpuArch("RISCV64")).toBe("riscv64");
+  });
+});
+
+describe(getReportedCpuArchs.name, () => {
+  it("returns the distinct normalised architectures across every node, sorted", () => {
+    const nodes = [buildNode(["arm64", "aarch64"]), buildNode(["x86_64"]), buildNode(["arm64"])];
+
+    expect(getReportedCpuArchs(nodes)).toEqual(["amd64", "arm64"]);
+  });
+
+  it("ignores CPUs that report no architecture", () => {
+    const nodes = [buildNode([null, "", "arm64"])];
+
+    expect(getReportedCpuArchs(nodes)).toEqual(["arm64"]);
+  });
+
+  it("returns an empty list when no node reports an architecture", () => {
+    const nodes = [buildNode([null]), buildNode([])];
+
+    expect(getReportedCpuArchs(nodes)).toEqual([]);
+  });
+
+  it("tolerates nodes loaded without their CPUs", () => {
+    const nodes = [mock<ProviderSnapshotNode>({ cpus: undefined })];
+
+    expect(getReportedCpuArchs(nodes)).toEqual([]);
+  });
+
+  function buildNode(archs: (string | null)[]) {
+    return mock<ProviderSnapshotNode>({
+      cpus: archs.map(arch => mock<ProviderSnapshotNodeCPU>({ arch }))
+    });
+  }
+});
+
+describe(getCpuArchAgreement.name, () => {
+  it("matches when the declared architecture is one the nodes report, whatever the spelling", () => {
+    expect(getCpuArchAgreement("arm-64", ["amd64", "arm64"])).toBe("match");
+  });
+
+  it("mismatches when the nodes report a different architecture than the one declared", () => {
+    expect(getCpuArchAgreement("x86-64", ["arm64"])).toBe("mismatch");
+  });
+
+  it("mismatches when the declared value is not an architecture at all", () => {
+    expect(getCpuArchAgreement("Zen 4", ["amd64"])).toBe("mismatch");
+  });
+
+  it("is unknown when nothing is declared", () => {
+    expect(getCpuArchAgreement(null, ["arm64"])).toBe("unknown");
+  });
+
+  it("is unknown when the nodes report no architecture", () => {
+    expect(getCpuArchAgreement("arm-64", [])).toBe("unknown");
+  });
+});

--- a/apps/api/src/utils/cpu-arch/cpu-arch.ts
+++ b/apps/api/src/utils/cpu-arch/cpu-arch.ts
@@ -12,6 +12,8 @@ const CPU_ARCH_ALIASES: Record<string, string> = {
   "arm-64": "arm64"
 };
 
+const REQUESTABLE_CPU_ARCHS = new Set(Object.values(CPU_ARCH_ALIASES));
+
 export function normalizeCpuArch(arch: string | null | undefined): string | null {
   const trimmed = arch?.trim().toLowerCase();
   if (!trimmed) return null;
@@ -28,9 +30,10 @@ export function getReportedCpuArchs(nodes: ProviderSnapshotNode[]): string[] {
   return Array.from(new Set(archs)).sort();
 }
 
+/** An unrecognised declaration counts as no declaration, as it does in bid screening, so mainnet values like "x86" or "Zen 4" are never called a mismatch. */
 export function getCpuArchAgreement(declaredCpuArch: string | null, reportedCpuArchs: string[]): CpuArchAgreement {
   const declared = normalizeCpuArch(declaredCpuArch);
-  if (!declared || reportedCpuArchs.length === 0) return "unknown";
+  if (!declared || !REQUESTABLE_CPU_ARCHS.has(declared) || reportedCpuArchs.length === 0) return "unknown";
 
   return reportedCpuArchs.includes(declared) ? "match" : "mismatch";
 }

--- a/apps/api/src/utils/cpu-arch/cpu-arch.ts
+++ b/apps/api/src/utils/cpu-arch/cpu-arch.ts
@@ -1,0 +1,36 @@
+import type { ProviderSnapshotNode } from "@akashnetwork/database/dbSchemas/akash";
+
+export type CpuArchAgreement = "match" | "mismatch" | "unknown";
+
+/** Folds the spellings node inventory and self-declared attributes use in the wild onto the two architectures an SDL can request. */
+const CPU_ARCH_ALIASES: Record<string, string> = {
+  amd64: "amd64",
+  x86_64: "amd64",
+  "x86-64": "amd64",
+  arm64: "arm64",
+  aarch64: "arm64",
+  "arm-64": "arm64"
+};
+
+export function normalizeCpuArch(arch: string | null | undefined): string | null {
+  const trimmed = arch?.trim().toLowerCase();
+  if (!trimmed) return null;
+
+  return CPU_ARCH_ALIASES[trimmed] ?? trimmed;
+}
+
+export function getReportedCpuArchs(nodes: ProviderSnapshotNode[]): string[] {
+  const archs = nodes
+    .flatMap(node => node.cpus ?? [])
+    .map(cpu => normalizeCpuArch(cpu.arch))
+    .filter((arch): arch is string => arch !== null);
+
+  return Array.from(new Set(archs)).sort();
+}
+
+export function getCpuArchAgreement(declaredCpuArch: string | null, reportedCpuArchs: string[]): CpuArchAgreement {
+  const declared = normalizeCpuArch(declaredCpuArch);
+  if (!declared || reportedCpuArchs.length === 0) return "unknown";
+
+  return reportedCpuArchs.includes(declared) ? "match" : "mismatch";
+}

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -10713,6 +10713,25 @@
                       "type": "string",
                       "nullable": true
                     },
+                    "reportedCpuArchs": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Distinct CPU architectures the provider's nodes reported in its last successful snapshot, normalised to amd64 or arm64. Empty when no node reports one.",
+                      "example": [
+                        "arm64"
+                      ]
+                    },
+                    "cpuArchAgreement": {
+                      "type": "string",
+                      "enum": [
+                        "match",
+                        "mismatch",
+                        "unknown"
+                      ],
+                      "description": "Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing."
+                    },
                     "hardwareGpuVendor": {
                       "type": "string",
                       "nullable": true
@@ -10833,6 +10852,8 @@
                     "hostingProvider",
                     "hardwareCpu",
                     "hardwareCpuArch",
+                    "reportedCpuArchs",
+                    "cpuArchAgreement",
                     "hardwareGpuVendor",
                     "hardwareGpuModels",
                     "hardwareDisk",

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -10718,7 +10718,7 @@
                       "items": {
                         "type": "string"
                       },
-                      "description": "Distinct CPU architectures the provider's nodes reported in its last successful snapshot, normalised to amd64 or arm64. Empty when no node reports one.",
+                      "description": "Distinct CPU architectures the provider's nodes reported in its last successful snapshot. Known spellings such as x86_64 or aarch64 are folded onto amd64 or arm64; any other reported value is kept as reported. Empty when no node reports one.",
                       "example": [
                         "arm64"
                       ]
@@ -10730,7 +10730,7 @@
                         "mismatch",
                         "unknown"
                       ],
-                      "description": "Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing."
+                      "description": "Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing or the declared value is not a recognised architecture."
                     },
                     "hardwareGpuVendor": {
                       "type": "string",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -12596,6 +12596,15 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "nullable": true,
                       "type": "string",
                     },
+                    "cpuArchAgreement": {
+                      "description": "Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing.",
+                      "enum": [
+                        "match",
+                        "mismatch",
+                        "unknown",
+                      ],
+                      "type": "string",
+                    },
                     "createdHeight": {
                       "type": "number",
                     },
@@ -12758,6 +12767,16 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     },
                     "owner": {
                       "type": "string",
+                    },
+                    "reportedCpuArchs": {
+                      "description": "Distinct CPU architectures the provider's nodes reported in its last successful snapshot, normalised to amd64 or arm64. Empty when no node reports one.",
+                      "example": [
+                        "arm64",
+                      ],
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
                     },
                     "stats": {
                       "properties": {
@@ -12970,6 +12989,8 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "hostingProvider",
                     "hardwareCpu",
                     "hardwareCpuArch",
+                    "reportedCpuArchs",
+                    "cpuArchAgreement",
                     "hardwareGpuVendor",
                     "hardwareGpuModels",
                     "hardwareDisk",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -12597,7 +12597,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "type": "string",
                     },
                     "cpuArchAgreement": {
-                      "description": "Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing.",
+                      "description": "Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing or the declared value is not a recognised architecture.",
                       "enum": [
                         "match",
                         "mismatch",
@@ -12769,7 +12769,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "type": "string",
                     },
                     "reportedCpuArchs": {
-                      "description": "Distinct CPU architectures the provider's nodes reported in its last successful snapshot, normalised to amd64 or arm64. Empty when no node reports one.",
+                      "description": "Distinct CPU architectures the provider's nodes reported in its last successful snapshot. Known spellings such as x86_64 or aarch64 are folded onto amd64 or arm64; any other reported value is kept as reported. Empty when no node reports one.",
                       "example": [
                         "arm64",
                       ],

--- a/apps/api/test/functional/providers.spec.ts
+++ b/apps/api/test/functional/providers.spec.ts
@@ -1,5 +1,5 @@
 import type { Provider, ProviderSnapshot } from "@akashnetwork/database/dbSchemas/akash";
-import { ProviderAttributeSignature } from "@akashnetwork/database/dbSchemas/akash";
+import { ProviderAttribute, ProviderAttributeSignature } from "@akashnetwork/database/dbSchemas/akash";
 import subDays from "date-fns/subDays";
 import map from "lodash/map";
 import nock from "nock";
@@ -11,7 +11,16 @@ import { AUDITOR, TRIAL_ATTRIBUTE } from "@src/deployment/config/provider.config
 import type { ProviderListResponse, ProviderResponse } from "@src/provider/http-schemas/provider.schema";
 import { app, initDb } from "@src/rest-app";
 
-import { createDay, createDeployment, createDeploymentGroup, createLease, createProvider, createProviderSnapshot } from "@test/seeders";
+import {
+  createDay,
+  createDeployment,
+  createDeploymentGroup,
+  createLease,
+  createProvider,
+  createProviderSnapshot,
+  createProviderSnapshotNode,
+  createProviderSnapshotNodeCpu
+} from "@test/seeders";
 
 describe("Providers", () => {
   let providers: Provider[];
@@ -174,6 +183,53 @@ describe("Providers", () => {
 
       expect(response.status).toBe(404);
     });
+
+    it("reports the architectures its nodes run and flags a declaration they contradict", async () => {
+      const provider = await createProviderWithNodeCpus(["arm64", null], "x86-64");
+
+      const response = await app.request(`/v1/providers/${provider.owner}`);
+
+      const data = (await response.json()) as ProviderResponse;
+      expect(response.status).toBe(200);
+      expect(data.hardwareCpuArch).toBe("x86-64");
+      expect(data.reportedCpuArchs).toEqual(["arm64"]);
+      expect(data.cpuArchAgreement).toBe("mismatch");
+    });
+
+    it("agrees when the declared architecture is spelled differently from the one the nodes report", async () => {
+      const provider = await createProviderWithNodeCpus(["x86_64"], "x86-64");
+
+      const response = await app.request(`/v1/providers/${provider.owner}`);
+
+      const data = (await response.json()) as ProviderResponse;
+      expect(data.reportedCpuArchs).toEqual(["amd64"]);
+      expect(data.cpuArchAgreement).toBe("match");
+    });
+
+    it("leaves the architecture unknown instead of assuming amd64 when nodes report none", async () => {
+      const provider = await createProviderWithNodeCpus([null], undefined);
+
+      const response = await app.request(`/v1/providers/${provider.owner}`);
+
+      const data = (await response.json()) as ProviderResponse;
+      expect(data.hardwareCpuArch).toBeNull();
+      expect(data.reportedCpuArchs).toEqual([]);
+      expect(data.cpuArchAgreement).toBe("unknown");
+    });
+
+    async function createProviderWithNodeCpus(archs: (string | null)[], declaredArch: string | undefined) {
+      const provider = await createProvider();
+      const snapshot = await createProviderSnapshot({ owner: provider.owner, isOnline: true });
+      await provider.update({ lastSuccessfulSnapshotId: snapshot.id });
+      const node = await createProviderSnapshotNode({ snapshotId: snapshot.id });
+      await Promise.all(archs.map(arch => createProviderSnapshotNodeCpu({ snapshotNodeId: node.id, arch })));
+
+      if (declaredArch) {
+        await ProviderAttribute.create({ provider: provider.owner, key: "capabilities/cpu/arch", value: declaredArch });
+      }
+
+      return provider;
+    }
   });
 
   describe("GET /v1/providers/{providerAddress}/active-leases-graph-data", () => {

--- a/apps/api/test/seeders/index.ts
+++ b/apps/api/test/seeders/index.ts
@@ -5,6 +5,7 @@ export * from "./provider.seeder";
 export * from "./provider-snapshot.seeder";
 export * from "./provider-snapshot-node.seeder";
 export * from "./provider-snapshot-node-gpu.seeder";
+export * from "./provider-snapshot-node-cpu.seeder";
 export * from "./deployment.seeder";
 export * from "./deployment-group.seeder";
 export * from "./deployment-group-resource.seeder";

--- a/apps/api/test/seeders/provider-snapshot-node-cpu.seeder.ts
+++ b/apps/api/test/seeders/provider-snapshot-node-cpu.seeder.ts
@@ -1,0 +1,13 @@
+import { ProviderSnapshotNodeCPU } from "@akashnetwork/database/dbSchemas/akash";
+import { faker } from "@faker-js/faker";
+import type { CreationAttributes } from "sequelize";
+
+export const createProviderSnapshotNodeCpu = async (overrides: Partial<CreationAttributes<ProviderSnapshotNodeCPU>> = {}): Promise<ProviderSnapshotNodeCPU> => {
+  return await ProviderSnapshotNodeCPU.create({
+    snapshotNodeId: overrides.snapshotNodeId ?? faker.string.uuid(),
+    vendor: overrides.vendor ?? faker.string.alphanumeric(10),
+    model: overrides.model ?? faker.string.alphanumeric(10),
+    vcores: overrides.vcores ?? faker.number.int({ min: 1, max: 128 }),
+    arch: overrides.arch === undefined ? "amd64" : overrides.arch
+  });
+};

--- a/apps/deploy-web/src/components/providers/ProviderSpecs.spec.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderSpecs.spec.tsx
@@ -31,6 +31,13 @@ describe(ProviderSpecs.name, () => {
     expect(screen.queryByText("amd64")).not.toBeInTheDocument();
   });
 
+  it("shows unknown instead of crashing on a response that predates the reported architectures", () => {
+    setup({ hardwareCpuArch: "x86-64", reportedCpuArchs: undefined, cpuArchAgreement: undefined });
+
+    expect(screen.getByText("x86-64")).toBeInTheDocument();
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
   function setup(overrides: Partial<Parameters<typeof buildProvider>[0]>) {
     const provider = mock<ClientProviderDetailWithStatus>(
       buildProvider({ hardwareGpuVendor: "nvidia", hardwareCpu: "epyc", hardwareMemory: "ddr5", ...overrides })

--- a/apps/deploy-web/src/components/providers/ProviderSpecs.spec.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderSpecs.spec.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ClientProviderDetailWithStatus } from "@src/types/provider";
+import { ProviderSpecs } from "./ProviderSpecs";
+
+import { render, screen } from "@testing-library/react";
+import { buildProvider } from "@tests/seeders/provider";
+
+describe(ProviderSpecs.name, () => {
+  it("shows the architectures the nodes report next to the declared one", () => {
+    setup({ hardwareCpuArch: "x86-64", reportedCpuArchs: ["amd64", "arm64"], cpuArchAgreement: "match" });
+
+    expect(screen.getByText("x86-64")).toBeInTheDocument();
+    expect(screen.getByText("amd64")).toBeInTheDocument();
+    expect(screen.getByText("arm64")).toBeInTheDocument();
+    expect(screen.queryByText("Differs from the declared architecture")).not.toBeInTheDocument();
+  });
+
+  it("warns when the nodes contradict the declared architecture", () => {
+    setup({ hardwareCpuArch: "x86-64", reportedCpuArchs: ["arm64"], cpuArchAgreement: "mismatch" });
+
+    expect(screen.getByText("arm64")).toBeInTheDocument();
+    expect(screen.getByText("Differs from the declared architecture")).toBeInTheDocument();
+  });
+
+  it("shows unknown instead of assuming amd64 when nothing is reported or declared", () => {
+    setup({ hardwareCpuArch: "", reportedCpuArchs: [], cpuArchAgreement: "unknown" });
+
+    expect(screen.getAllByText("Unknown").length).toBeGreaterThanOrEqual(2);
+    expect(screen.queryByText("amd64")).not.toBeInTheDocument();
+  });
+
+  function setup(overrides: Partial<Parameters<typeof buildProvider>[0]>) {
+    const provider = mock<ClientProviderDetailWithStatus>(
+      buildProvider({ hardwareGpuVendor: "nvidia", hardwareCpu: "epyc", hardwareMemory: "ddr5", ...overrides })
+    );
+    render(<ProviderSpecs provider={provider} />);
+    return { provider };
+  }
+});

--- a/apps/deploy-web/src/components/providers/ProviderSpecs.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderSpecs.tsx
@@ -41,7 +41,7 @@ export const ProviderSpecs: React.FunctionComponent<Props> = ({ provider }) => {
           <LabelValue label="CPU Architecture (declared)" value={provider.hardwareCpuArch || "Unknown"} />
           <LabelValue
             label="CPU Architecture (reported)"
-            value={<ReportedCpuArchitectures archs={provider.reportedCpuArchs} agreement={provider.cpuArchAgreement} />}
+            value={<ReportedCpuArchitectures archs={provider.reportedCpuArchs ?? []} agreement={provider.cpuArchAgreement} />}
           />
           <LabelValue label="Disk Storage" value={provider.hardwareDisk} />
           <LabelValue label="Persistent Disk Storage" value={provider.featPersistentStorageType} />

--- a/apps/deploy-web/src/components/providers/ProviderSpecs.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderSpecs.tsx
@@ -1,9 +1,9 @@
 "use client";
 import { Badge, Card, CardContent } from "@akashnetwork/ui/components";
-import { Check } from "iconoir-react";
+import { Check, WarningCircle } from "iconoir-react";
 
 import { LabelValue } from "@src/components/shared/LabelValue";
-import type { ClientProviderDetailWithStatus } from "@src/types/provider";
+import type { ClientProviderDetailWithStatus, CpuArchAgreement } from "@src/types/provider";
 import { createFilterUnique } from "@src/utils/array";
 
 type Props = {
@@ -38,12 +38,34 @@ export const ProviderSpecs: React.FunctionComponent<Props> = ({ provider }) => {
               </Badge>
             ))}
           />
-          <LabelValue label="CPU Architecture" value={provider.hardwareCpuArch} />
+          <LabelValue label="CPU Architecture (declared)" value={provider.hardwareCpuArch || "Unknown"} />
+          <LabelValue
+            label="CPU Architecture (reported)"
+            value={<ReportedCpuArchitectures archs={provider.reportedCpuArchs} agreement={provider.cpuArchAgreement} />}
+          />
           <LabelValue label="Disk Storage" value={provider.hardwareDisk} />
           <LabelValue label="Persistent Disk Storage" value={provider.featPersistentStorageType} />
           <LabelValue label="Upload speed" value={provider.networkSpeedUp} />
         </div>
       </CardContent>
     </Card>
+  );
+};
+
+const ReportedCpuArchitectures: React.FunctionComponent<{ archs: string[]; agreement: CpuArchAgreement }> = ({ archs, agreement }) => {
+  if (archs.length === 0) return <>Unknown</>;
+
+  return (
+    <span className="flex flex-wrap items-center gap-2">
+      {archs.map(arch => (
+        <Badge key={arch}>{arch}</Badge>
+      ))}
+      {agreement === "mismatch" && (
+        <span className="flex items-center text-xs text-warning">
+          <WarningCircle className="mr-1" />
+          Differs from the declared architecture
+        </span>
+      )}
+    </span>
   );
 };

--- a/apps/deploy-web/src/types/provider.ts
+++ b/apps/deploy-web/src/types/provider.ts
@@ -239,7 +239,11 @@ export interface ClientProviderList extends ApiProviderList {
   userActiveLeases?: number;
 }
 
+export type CpuArchAgreement = "match" | "mismatch" | "unknown";
+
 export interface ApiProviderDetail extends ApiProviderList {
+  reportedCpuArchs: string[];
+  cpuArchAgreement: CpuArchAgreement;
   uptime: Array<{
     id: string;
     isOnline: boolean;

--- a/apps/deploy-web/tests/seeders/provider.ts
+++ b/apps/deploy-web/tests/seeders/provider.ts
@@ -100,6 +100,8 @@ export function buildProvider(overrides?: Partial<ApiProviderDetail>): ApiProvid
     workloadSupportChia: faker.datatype.boolean(),
     workloadSupportChiaCapabilities: [],
     featEndpointIp: faker.datatype.boolean(),
+    reportedCpuArchs: [],
+    cpuArchAgreement: "unknown",
     uptime: [],
     ...overrides
   } as ApiProviderDetail;

--- a/apps/indexer/drizzle/0010_add_arch_to_provider_snapshot_node_cpu.sql
+++ b/apps/indexer/drizzle/0010_add_arch_to_provider_snapshot_node_cpu.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "providerSnapshotNodeCPU" ADD COLUMN IF NOT EXISTS "arch" varchar(255);

--- a/apps/indexer/drizzle/meta/_journal.json
+++ b/apps/indexer/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1763000000000,
       "tag": "0009_drop_monitored_value",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1763100000000,
+      "tag": "0010_add_arch_to_provider_snapshot_node_cpu",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/indexer/drizzle/schema.ts
+++ b/apps/indexer/drizzle/schema.ts
@@ -373,7 +373,8 @@ export const providerSnapshotNodeCpu = pgTable(
     snapshotNodeId: uuid().notNull(),
     vendor: varchar({ length: 255 }),
     model: varchar({ length: 255 }),
-    vcores: smallint()
+    vcores: smallint(),
+    arch: varchar({ length: 255 })
   },
   table => [
     index("provider_snapshot_node_c_p_u_snapshot_node_id").using("btree", table.snapshotNodeId.asc().nullsLast().op("uuid_ops")),

--- a/apps/indexer/src/providers/providerStatusProvider.ts
+++ b/apps/indexer/src/providers/providerStatusProvider.ts
@@ -190,7 +190,8 @@ async function saveProviderStatus(
             snapshotNodeId: providerSnapshotNode.id,
             vendor: cpuInfo.vendor,
             model: cpuInfo.model,
-            vcores: cpuInfo.vcores
+            vcores: cpuInfo.vcores,
+            arch: cpuInfo.arch
           })),
           { transaction: t }
         );

--- a/apps/indexer/src/providers/statusEndpointHandlers/grpc.spec.ts
+++ b/apps/indexer/src/providers/statusEndpointHandlers/grpc.spec.ts
@@ -1,0 +1,35 @@
+import type { CPUInfo } from "@akashnetwork/chain-sdk/private-types/provider.akash.v1";
+import { describe, expect, it } from "vitest";
+
+import { mapCpuInfo } from "./grpc";
+
+describe(mapCpuInfo.name, () => {
+  it("keeps the architecture a node reports", () => {
+    const result = mapCpuInfo(buildCpuInfo({ arch: "arm64" }));
+
+    expect(result.arch).toBe("arm64");
+  });
+
+  it("records no architecture when the inventory operator reports an empty one", () => {
+    const result = mapCpuInfo(buildCpuInfo({ arch: "" }));
+
+    expect(result.arch).toBeNull();
+  });
+
+  it("carries the vendor, model and vcores through unchanged", () => {
+    const result = mapCpuInfo(buildCpuInfo({ vendor: "GenuineIntel", model: "Xeon", vcores: 16 }));
+
+    expect(result).toEqual({ vendor: "GenuineIntel", model: "Xeon", vcores: 16, arch: null });
+  });
+
+  function buildCpuInfo(overrides: Partial<CPUInfo> = {}): CPUInfo {
+    return {
+      id: "cpu-0",
+      vendor: "AuthenticAMD",
+      model: "EPYC",
+      vcores: 8,
+      arch: "",
+      ...overrides
+    };
+  }
+});

--- a/apps/indexer/src/providers/statusEndpointHandlers/grpc.ts
+++ b/apps/indexer/src/providers/statusEndpointHandlers/grpc.ts
@@ -1,5 +1,5 @@
 import { createProviderSDK } from "@akashnetwork/chain-sdk";
-import type { NodeResources, ResourcesMetric, Status as ProviderStatus } from "@akashnetwork/chain-sdk/private-types/provider.akash.v1";
+import type { CPUInfo, NodeResources, ResourcesMetric, Status as ProviderStatus } from "@akashnetwork/chain-sdk/private-types/provider.akash.v1";
 import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
 import { minutesToMilliseconds } from "date-fns";
 import memoize from "lodash/memoize";
@@ -73,11 +73,7 @@ export async function fetchProviderStatusFromGRPC(provider: Provider, timeout: n
         capabilitiesStorageNVME: !!node.capabilities?.storageClasses.includes("beta3"),
         gpuAllocatable: parsedResources.allocatableGPU,
         gpuAllocated: parsedResources.allocatedGPU,
-        cpus: (node.resources?.cpu?.info ?? []).map(cpuInfo => ({
-          vendor: cpuInfo.vendor,
-          model: cpuInfo.model,
-          vcores: cpuInfo.vcores
-        })),
+        cpus: (node.resources?.cpu?.info ?? []).map(mapCpuInfo),
         gpus: (node.resources?.gpu?.info ?? []).map(gpuInfo => ({
           vendor: gpuInfo.vendor,
           name: gpuInfo.name,
@@ -88,6 +84,15 @@ export async function fetchProviderStatusFromGRPC(provider: Provider, timeout: n
       };
     }),
     storage: storage as unknown as ProviderStatusInfo["storage"]
+  };
+}
+
+export function mapCpuInfo(cpuInfo: CPUInfo): ProviderStatusInfo["nodes"][number]["cpus"][number] {
+  return {
+    vendor: cpuInfo.vendor,
+    model: cpuInfo.model,
+    vcores: cpuInfo.vcores,
+    arch: cpuInfo.arch || null
   };
 }
 

--- a/apps/indexer/src/providers/statusEndpointHandlers/types.ts
+++ b/apps/indexer/src/providers/statusEndpointHandlers/types.ts
@@ -37,7 +37,7 @@ export type ProviderStatusInfo = {
     gpuAllocatable: number;
     gpuAllocated: number;
 
-    cpus: { vendor: string; model: string; vcores: number }[];
+    cpus: { vendor: string; model: string; vcores: number; arch: string | null }[];
     gpus: { vendor: string; name: string; modelId: string; interface: string; memorySize: string }[];
   }[];
 };

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -3547,6 +3547,18 @@ export interface paths {
               hostingProvider: string | null;
               hardwareCpu: string | null;
               hardwareCpuArch: string | null;
+              /**
+               * @description Distinct CPU architectures the provider's nodes reported in its last successful snapshot, normalised to amd64 or arm64. Empty when no node reports one.
+               * @example [
+               *       "arm64"
+               *     ]
+               */
+              reportedCpuArchs: string[];
+              /**
+               * @description Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing.
+               * @enum {string}
+               */
+              cpuArchAgreement: "match" | "mismatch" | "unknown";
               hardwareGpuVendor: string | null;
               hardwareGpuModels: string[];
               hardwareDisk: string[];

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -3548,14 +3548,14 @@ export interface paths {
               hardwareCpu: string | null;
               hardwareCpuArch: string | null;
               /**
-               * @description Distinct CPU architectures the provider's nodes reported in its last successful snapshot, normalised to amd64 or arm64. Empty when no node reports one.
+               * @description Distinct CPU architectures the provider's nodes reported in its last successful snapshot. Known spellings such as x86_64 or aarch64 are folded onto amd64 or arm64; any other reported value is kept as reported. Empty when no node reports one.
                * @example [
                *       "arm64"
                *     ]
                */
               reportedCpuArchs: string[];
               /**
-               * @description Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing.
+               * @description Whether the self-declared capabilities/cpu/arch attribute agrees with the architecture the nodes report. Unknown when either side is missing or the declared value is not a recognised architecture.
                * @enum {string}
                */
               cpuArchAgreement: "match" | "mismatch" | "unknown";

--- a/packages/database/dbSchemas/akash/providerSnapshotNodeCPU.ts
+++ b/packages/database/dbSchemas/akash/providerSnapshotNodeCPU.ts
@@ -37,4 +37,9 @@ export class ProviderSnapshotNodeCPU extends Model {
    * 1 vCPUs = 1 CPU
    */
   @Column(DataTypes.SMALLINT) vcores!: number;
+  /**
+   * The CPU architecture the node reports, null when its inventory operator predates architecture reporting
+   * ex: amd64, arm64
+   */
+  @Column(DataTypes.STRING) arch!: string | null;
 }


### PR DESCRIPTION
## Why

Refs CON-936

The only CPU architecture Console knows about a provider is the one it declares about itself through the `capabilities/cpu/arch` attribute, and nothing ever checks that against what its cluster runs. A provider can declare amd64 while running arm64 nodes, declare nothing, or run a mix, and Console shows the same thing every time. Now that tenants can ask for arm64, we need to be able to say which providers actually have it.

The provider poll already collects each node's CPU details and stores them. The architecture the inventory operator reports alongside them was simply dropped on the way in, and the stored CPU rows had no reader at all.

The network-level "arm64 capacity over time" part of CON-936 is deliberately left out of this PR. Recording the column makes it possible later without another migration.

## What

- **indexer**: `providerSnapshotNodeCPU` gains a nullable `arch` column (drizzle migration `0010`, `ADD COLUMN IF NOT EXISTS`, catalog-only on Postgres so it does not block). The gRPC status handler keeps `CPUInfo.arch` and stores an empty value as `null`, so an inventory operator that predates the field stays unknown instead of becoming amd64.
- **api**: `GET /v1/providers/{address}` returns `reportedCpuArchs` (distinct architectures the nodes of the last successful snapshot reported; known spellings are folded onto `amd64`/`arm64`, anything else is kept as reported) and `cpuArchAgreement` (`match`, `mismatch` or `unknown` against the self-declared attribute). On-chain declarations use `x86-64`/`arm-64` while inventory uses `amd64`/`arm64`, so both are normalised before comparing. A declared value that is not one of those spellings counts as no declaration, the same rule bid screening applies, because mainnet declares things like `x86` and `Zen 4` under this attribute. The list endpoint is untouched to avoid joining CPU rows for every provider.
- **deploy-web**: the provider page shows "CPU Architecture (declared)" and "CPU Architecture (reported)" side by side, warns when they disagree, and reads "Unknown" when neither side says anything, including a cached response that predates the new fields.

No breaking changes. `openapi.json`, `console-api-types` and the docs snapshot are regenerated for the two new detail fields only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider details now show declared and node-reported CPU architectures.
  * Known architecture aliases are normalized to standard values, while unsupported values are preserved.
  * Architecture status indicates a match, mismatch, or unknown result.
  * Mismatches are highlighted with a warning.
  * Provider API responses now include reported architectures and agreement status.

* **Bug Fixes**
  * CPU architecture information is preserved when collecting provider status data.

* **Tests**
  * Added coverage for normalization, reporting, agreement states, and UI warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
