### PR TITLE
fix(stats): bound the gpu breakdown to a date range and drop the per-row gpu count subqueries

### DIFF
--- a/apps/api/src/gpu/http-schemas/gpu.schema.spec.ts
+++ b/apps/api/src/gpu/http-schemas/gpu.schema.spec.ts
@@ -1,25 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { GpuBreakdownQuerySchema } from "./gpu.schema";
 
 describe("GpuBreakdownQuerySchema", () => {
-  it("derives startDate as 30 days before the provided endDate", () => {
+  it("defaults startDate so the window covers the 30 days ending at endDate", () => {
     const result = GpuBreakdownQuerySchema.parse({ endDate: "2024-01-31" });
 
-    expect(result.startDate).toBe("2024-01-01");
+    expect(result.startDate).toBe("2024-01-02");
     expect(result.endDate).toBe("2024-01-31");
   });
 
   it("computes startDate in UTC regardless of the process timezone", () => {
-    const originalTimezone = process.env.TZ;
-    process.env.TZ = "America/New_York";
+    vi.stubEnv("TZ", "America/New_York");
 
     try {
       const result = GpuBreakdownQuerySchema.parse({ endDate: "2024-11-15" });
 
-      expect(result.startDate).toBe("2024-10-16");
+      expect(result.startDate).toBe("2024-10-17");
     } finally {
-      process.env.TZ = originalTimezone;
+      vi.unstubAllEnvs();
     }
   });
 
@@ -29,12 +28,12 @@ describe("GpuBreakdownQuerySchema", () => {
     expect(result).toEqual({ startDate: "2024-01-01", endDate: "2024-01-31", vendor: "nvidia", model: "h100" });
   });
 
-  it("defaults endDate to today and spans a 30-day window when both dates are omitted", () => {
+  it("defaults endDate to today and covers 30 days when both dates are omitted", () => {
     const result = GpuBreakdownQuerySchema.parse({});
 
     expect(result.endDate).toBe(new Date().toISOString().split("T")[0]);
-    const spanInDays = (Date.parse(result.endDate) - Date.parse(result.startDate)) / (24 * 60 * 60 * 1000);
-    expect(spanInDays).toBe(30);
+    const windowDays = (Date.parse(result.endDate) - Date.parse(result.startDate)) / (24 * 60 * 60 * 1000) + 1;
+    expect(windowDays).toBe(30);
   });
 
   it("accepts a single-day range", () => {
@@ -43,15 +42,21 @@ describe("GpuBreakdownQuerySchema", () => {
     expect(result.startDate).toBe("2024-01-31");
   });
 
-  it("rejects a range wider than 366 days", () => {
-    expect(() => GpuBreakdownQuerySchema.parse({ startDate: "2023-01-01", endDate: "2024-12-31" })).toThrow(
-      "Date range cannot exceed 366 days and startDate must be before endDate"
+  it("accepts a range of exactly 366 days", () => {
+    const result = GpuBreakdownQuerySchema.parse({ startDate: "2024-01-01", endDate: "2024-12-31" });
+
+    expect(result).toEqual({ startDate: "2024-01-01", endDate: "2024-12-31" });
+  });
+
+  it("rejects a range of 367 days", () => {
+    expect(() => GpuBreakdownQuerySchema.parse({ startDate: "2024-01-01", endDate: "2025-01-01" })).toThrow(
+      "Date range cannot exceed 366 days and startDate must not be after endDate"
     );
   });
 
   it("rejects a startDate after the endDate", () => {
     expect(() => GpuBreakdownQuerySchema.parse({ startDate: "2024-02-01", endDate: "2024-01-01" })).toThrow(
-      "Date range cannot exceed 366 days and startDate must be before endDate"
+      "Date range cannot exceed 366 days and startDate must not be after endDate"
     );
   });
 

--- a/apps/api/src/gpu/http-schemas/gpu.schema.spec.ts
+++ b/apps/api/src/gpu/http-schemas/gpu.schema.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { GpuBreakdownQuerySchema } from "./gpu.schema";
+
+describe("GpuBreakdownQuerySchema", () => {
+  it("derives startDate as 30 days before the provided endDate", () => {
+    const result = GpuBreakdownQuerySchema.parse({ endDate: "2024-01-31" });
+
+    expect(result.startDate).toBe("2024-01-01");
+    expect(result.endDate).toBe("2024-01-31");
+  });
+
+  it("computes startDate in UTC regardless of the process timezone", () => {
+    const originalTimezone = process.env.TZ;
+    process.env.TZ = "America/New_York";
+
+    try {
+      const result = GpuBreakdownQuerySchema.parse({ endDate: "2024-11-15" });
+
+      expect(result.startDate).toBe("2024-10-16");
+    } finally {
+      process.env.TZ = originalTimezone;
+    }
+  });
+
+  it("keeps the provided dates and filters untouched", () => {
+    const result = GpuBreakdownQuerySchema.parse({ startDate: "2024-01-01", endDate: "2024-01-31", vendor: "nvidia", model: "h100" });
+
+    expect(result).toEqual({ startDate: "2024-01-01", endDate: "2024-01-31", vendor: "nvidia", model: "h100" });
+  });
+
+  it("defaults endDate to today and spans a 30-day window when both dates are omitted", () => {
+    const result = GpuBreakdownQuerySchema.parse({});
+
+    expect(result.endDate).toBe(new Date().toISOString().split("T")[0]);
+    const spanInDays = (Date.parse(result.endDate) - Date.parse(result.startDate)) / (24 * 60 * 60 * 1000);
+    expect(spanInDays).toBe(30);
+  });
+
+  it("accepts a single-day range", () => {
+    const result = GpuBreakdownQuerySchema.parse({ startDate: "2024-01-31", endDate: "2024-01-31" });
+
+    expect(result.startDate).toBe("2024-01-31");
+  });
+
+  it("rejects a range wider than 366 days", () => {
+    expect(() => GpuBreakdownQuerySchema.parse({ startDate: "2023-01-01", endDate: "2024-12-31" })).toThrow(
+      "Date range cannot exceed 366 days and startDate must be before endDate"
+    );
+  });
+
+  it("rejects a startDate after the endDate", () => {
+    expect(() => GpuBreakdownQuerySchema.parse({ startDate: "2024-02-01", endDate: "2024-01-01" })).toThrow(
+      "Date range cannot exceed 366 days and startDate must be before endDate"
+    );
+  });
+
+  it("rejects a date that is not YYYY-MM-DD", () => {
+    expect(() => GpuBreakdownQuerySchema.parse({ startDate: "01/01/2024" })).toThrow();
+  });
+});

--- a/apps/api/src/gpu/http-schemas/gpu.schema.ts
+++ b/apps/api/src/gpu/http-schemas/gpu.schema.ts
@@ -51,10 +51,14 @@ function toIsoDate(date: Date) {
   return date.toISOString().split("T")[0];
 }
 
-function daysBefore(isoDate: string, days: number) {
-  const date = new Date(`${isoDate}T00:00:00.000Z`);
-  date.setUTCDate(date.getUTCDate() - days);
+function startOfInclusiveWindow(endDate: string, windowDays: number) {
+  const date = new Date(`${endDate}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() - (windowDays - 1));
   return toIsoDate(date);
+}
+
+function countInclusiveDays(startDate: string, endDate: string) {
+  return (Date.parse(endDate) - Date.parse(startDate)) / MS_PER_DAY + 1;
 }
 
 export const GpuBreakdownQuerySchema = z
@@ -66,7 +70,7 @@ export const GpuBreakdownQuerySchema = z
       .date()
       .optional()
       .openapi({
-        description: `Start date (YYYY-MM-DD). Defaults to ${DEFAULT_BREAKDOWN_WINDOW_DAYS} days before endDate`,
+        description: `Start date (YYYY-MM-DD), inclusive. Defaults to a ${DEFAULT_BREAKDOWN_WINDOW_DAYS}-day window ending at endDate`,
         example: "2024-01-01"
       }),
     endDate: z.string().date().optional().openapi({
@@ -76,18 +80,18 @@ export const GpuBreakdownQuerySchema = z
   })
   .transform(data => {
     const endDate = data.endDate ?? toIsoDate(new Date());
-    const startDate = data.startDate ?? daysBefore(endDate, DEFAULT_BREAKDOWN_WINDOW_DAYS);
+    const startDate = data.startDate ?? startOfInclusiveWindow(endDate, DEFAULT_BREAKDOWN_WINDOW_DAYS);
 
     return { ...data, startDate, endDate };
   })
   .refine(
     data => {
-      const spanInDays = Math.ceil((Date.parse(data.endDate) - Date.parse(data.startDate)) / MS_PER_DAY);
+      const windowDays = countInclusiveDays(data.startDate, data.endDate);
 
-      return spanInDays >= 0 && spanInDays <= MAX_BREAKDOWN_WINDOW_DAYS;
+      return windowDays >= 1 && windowDays <= MAX_BREAKDOWN_WINDOW_DAYS;
     },
     {
-      message: `Date range cannot exceed ${MAX_BREAKDOWN_WINDOW_DAYS} days and startDate must be before endDate`
+      message: `Date range cannot exceed ${MAX_BREAKDOWN_WINDOW_DAYS} days and startDate must not be after endDate`
     }
   );
 export const GpuBreakdownResponseSchema = z.array(

--- a/apps/api/src/gpu/http-schemas/gpu.schema.ts
+++ b/apps/api/src/gpu/http-schemas/gpu.schema.ts
@@ -43,10 +43,53 @@ export const ListGpuModelsResponseSchema = z.array(
   })
 );
 
-export const GpuBreakdownQuerySchema = z.object({
-  vendor: z.string().optional(),
-  model: z.string().optional()
-});
+const DEFAULT_BREAKDOWN_WINDOW_DAYS = 30;
+const MAX_BREAKDOWN_WINDOW_DAYS = 366;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function toIsoDate(date: Date) {
+  return date.toISOString().split("T")[0];
+}
+
+function daysBefore(isoDate: string, days: number) {
+  const date = new Date(`${isoDate}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() - days);
+  return toIsoDate(date);
+}
+
+export const GpuBreakdownQuerySchema = z
+  .object({
+    vendor: z.string().optional(),
+    model: z.string().optional(),
+    startDate: z
+      .string()
+      .date()
+      .optional()
+      .openapi({
+        description: `Start date (YYYY-MM-DD). Defaults to ${DEFAULT_BREAKDOWN_WINDOW_DAYS} days before endDate`,
+        example: "2024-01-01"
+      }),
+    endDate: z.string().date().optional().openapi({
+      description: "End date (YYYY-MM-DD), inclusive. Defaults to today (UTC)",
+      example: "2024-01-31"
+    })
+  })
+  .transform(data => {
+    const endDate = data.endDate ?? toIsoDate(new Date());
+    const startDate = data.startDate ?? daysBefore(endDate, DEFAULT_BREAKDOWN_WINDOW_DAYS);
+
+    return { ...data, startDate, endDate };
+  })
+  .refine(
+    data => {
+      const spanInDays = Math.ceil((Date.parse(data.endDate) - Date.parse(data.startDate)) / MS_PER_DAY);
+
+      return spanInDays >= 0 && spanInDays <= MAX_BREAKDOWN_WINDOW_DAYS;
+    },
+    {
+      message: `Date range cannot exceed ${MAX_BREAKDOWN_WINDOW_DAYS} days and startDate must be before endDate`
+    }
+  );
 export const GpuBreakdownResponseSchema = z.array(
   z.object({
     date: z.string(),

--- a/apps/api/src/gpu/repositories/gpu.repository.ts
+++ b/apps/api/src/gpu/repositories/gpu.repository.ts
@@ -1,4 +1,4 @@
-import { sub } from "date-fns";
+import { addDays, sub } from "date-fns";
 import { QueryTypes, Sequelize } from "sequelize";
 import { inject, injectable } from "tsyringe";
 
@@ -78,7 +78,10 @@ export class GpuRepository {
     );
   }
 
-  async getGpuBreakdown({ vendor, model }: GpuBreakdownQuery) {
+  async getGpuBreakdown({ vendor, model, startDate, endDate }: GpuBreakdownQuery) {
+    const windowStart = new Date(`${startDate}T00:00:00.000Z`);
+    const windowEndExclusive = addDays(new Date(`${endDate}T00:00:00.000Z`), 1);
+
     const result = await this.#chainDb.query<{
       date: Date;
       vendor: string;
@@ -90,54 +93,65 @@ export class GpuRepository {
       gpuUtilization: number;
     }>(
       `/* gpu:breakdown */
-        WITH UTILIZATION AS (
+        WITH daily_snapshots AS (
+          SELECT DISTINCT ON (p."hostUri", DATE(ps."checkDate"))
+            ps.id AS "snapshotId",
+            p."hostUri",
+            DATE(ps."checkDate") AS date
+          FROM "providerSnapshot" ps
+          INNER JOIN "provider" p ON p."owner" = ps."owner"
+          WHERE ps."isLastSuccessOfDay" = TRUE
+            AND ps."checkDate" >= :window_start
+            AND ps."checkDate" < :window_end_exclusive
+          ORDER BY p."hostUri", DATE(ps."checkDate"), ps."checkDate" DESC
+        ),
+        gpu_nodes AS (
           SELECT
-              d."date",
-              COALESCE(gpu."vendor", 'Unknown') as "vendor",
-              COALESCE(gpu."name", 'Unknown') as "model",
-              COALESCE(COUNT(DISTINCT "dailyProviderStats"."hostUri"), 0) as provider_count,
-              COALESCE(COUNT(DISTINCT n.id), 0) as node_count,
-              COALESCE(COUNT(gpu.id), 0) as total_gpus,
-              LEAST(COALESCE(CAST(ROUND(SUM(
-                  CAST(n."gpuAllocated" as float) /
-                  NULLIF((SELECT COUNT(*)
-                          FROM "providerSnapshotNodeGPU" subgpu
-                          WHERE subgpu."snapshotNodeId" = n.id), 0)
-              )) as int), 0), COUNT(gpu.id))  as leased_gpus,
-              LEAST(CAST(COALESCE(
-                  SUM(
-                      CAST(n."gpuAllocated" as float) /
-                      NULLIF((SELECT COUNT(*)
-                              FROM "providerSnapshotNodeGPU" subgpu
-                              WHERE subgpu."snapshotNodeId" = n.id), 0)
-                  ) * 100.0 / NULLIF(COUNT(gpu.id), 0)
-              , 0) as numeric(10,2)), 100.00) as "gpuUtilization"
-          FROM "day" d
-          INNER JOIN (
-              SELECT DISTINCT ON("hostUri", DATE("checkDate"))
-                  ps.id as "snapshotId",
-                  "hostUri",
-                  DATE("checkDate") AS date,
-                  ps."isOnline"
-              FROM "providerSnapshot" ps
-              INNER JOIN "provider" ON "provider"."owner" = ps."owner"
-              WHERE ps."isLastSuccessOfDay" = TRUE
-              ORDER BY "hostUri", DATE("checkDate"), "checkDate" DESC
-          ) "dailyProviderStats" ON DATE(d."date") = "dailyProviderStats"."date"
-          INNER JOIN "providerSnapshotNode" n ON n."snapshotId" = "dailyProviderStats"."snapshotId" AND n."gpuAllocatable" > 0
-          LEFT JOIN "providerSnapshotNodeGPU" gpu ON gpu."snapshotNodeId" = n.id
-          WHERE (:vendor IS NULL OR LOWER(gpu."vendor") = LOWER(:vendor))
+            n.id,
+            n."gpuAllocated",
+            s."hostUri",
+            s.date,
+            gpu_count.total AS gpu_count
+          FROM daily_snapshots s
+          INNER JOIN "providerSnapshotNode" n ON n."snapshotId" = s."snapshotId" AND n."gpuAllocatable" > 0
+          LEFT JOIN LATERAL (
+            SELECT COUNT(*) AS total
+            FROM "providerSnapshotNodeGPU" g
+            WHERE g."snapshotNodeId" = n.id
+          ) gpu_count ON TRUE
+        )
+        SELECT
+          d."date",
+          COALESCE(gpu."vendor", 'Unknown') AS "vendor",
+          COALESCE(gpu."name", 'Unknown') AS "model",
+          COUNT(DISTINCT n."hostUri") AS provider_count,
+          COUNT(DISTINCT n.id) AS node_count,
+          COUNT(gpu.id) AS total_gpus,
+          LEAST(
+            ROUND(COALESCE(SUM(n."gpuAllocated"::float / NULLIF(n.gpu_count, 0)), 0))::int,
+            COUNT(gpu.id)
+          ) AS leased_gpus,
+          LEAST(
+            ROUND(COALESCE(SUM(n."gpuAllocated"::float / NULLIF(n.gpu_count, 0)) * 100.0 / NULLIF(COUNT(gpu.id), 0), 0)::numeric, 2),
+            100
+          )::float AS "gpuUtilization"
+        FROM "day" d
+        INNER JOIN gpu_nodes n ON n.date = DATE(d."date")
+        LEFT JOIN "providerSnapshotNodeGPU" gpu ON gpu."snapshotNodeId" = n.id
+        WHERE d."date" >= :window_start
+          AND d."date" < :window_end_exclusive
+          AND (:vendor IS NULL OR LOWER(gpu."vendor") = LOWER(:vendor))
           AND (:model IS NULL OR LOWER(gpu."name") = LOWER(:model))
-          GROUP BY d."date", gpu."vendor", gpu."name"
-          ORDER BY d."date" ASC, gpu."vendor", gpu."name"
-      )
-      SELECT * FROM UTILIZATION
-        `,
+        GROUP BY d."date", gpu."vendor", gpu."name"
+        ORDER BY d."date" ASC, gpu."vendor", gpu."name"
+      `,
       {
         type: QueryTypes.SELECT,
         replacements: {
           vendor: vendor ?? null,
-          model: model ?? null
+          model: model ?? null,
+          window_start: windowStart,
+          window_end_exclusive: windowEndExclusive
         }
       }
     );

--- a/apps/api/src/gpu/routes/gpu.router.ts
+++ b/apps/api/src/gpu/routes/gpu.router.ts
@@ -147,6 +147,9 @@ const gpuBreakdownRoute = createRoute({
           schema: GpuBreakdownResponseSchema
         }
       }
+    },
+    400: {
+      description: "Invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days"
     }
   }
 });

--- a/apps/api/src/gpu/routes/gpu.router.ts
+++ b/apps/api/src/gpu/routes/gpu.router.ts
@@ -134,13 +134,14 @@ const gpuBreakdownRoute = createRoute({
   tags: ["Gpu"],
   security: SECURITY_NONE,
   cache: { maxAge: 120, staleWhileRevalidate: 300 },
-  summary: "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
+  summary:
+    "Gets the daily gpu analytics breakdown by vendor and model over a date range (default: last 30 days, max 366 days). If no vendor or model is provided, all GPUs are returned.",
   request: {
     query: GpuBreakdownQuerySchema
   },
   responses: {
     200: {
-      description: "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
+      description: "Daily gpu breakdown rows for the requested date range, one per date, vendor and model.",
       content: {
         "application/json": {
           schema: GpuBreakdownResponseSchema

--- a/apps/api/src/gpu/services/gpu.service.spec.ts
+++ b/apps/api/src/gpu/services/gpu.service.spec.ts
@@ -25,12 +25,14 @@ describe(GpuService.name, () => {
   });
 
   describe("getGpuBreakdown", () => {
+    const window = { startDate: "2024-01-01", endDate: "2024-01-31" };
+
     it("serves a repeated query from cache", async () => {
       const { service, gpuRepository } = setup();
       gpuRepository.getGpuBreakdown.mockResolvedValue([]);
 
-      await service.getGpuBreakdown({ vendor: "nvidia" });
-      await service.getGpuBreakdown({ vendor: "nvidia" });
+      await service.getGpuBreakdown({ ...window, vendor: "nvidia" });
+      await service.getGpuBreakdown({ ...window, vendor: "nvidia" });
 
       expect(gpuRepository.getGpuBreakdown).toHaveBeenCalledTimes(1);
     });
@@ -39,8 +41,8 @@ describe(GpuService.name, () => {
       const { service, gpuRepository } = setup();
       gpuRepository.getGpuBreakdown.mockResolvedValue([]);
 
-      await service.getGpuBreakdown({ vendor: "a", model: "b#c" });
-      await service.getGpuBreakdown({ vendor: "a#b", model: "c" });
+      await service.getGpuBreakdown({ ...window, vendor: "a", model: "b#c" });
+      await service.getGpuBreakdown({ ...window, vendor: "a#b", model: "c" });
 
       expect(gpuRepository.getGpuBreakdown).toHaveBeenCalledTimes(2);
     });
@@ -49,11 +51,21 @@ describe(GpuService.name, () => {
       const { service, gpuRepository } = setup();
       gpuRepository.getGpuBreakdown.mockResolvedValue([]);
 
-      await service.getGpuBreakdown({});
-      await service.getGpuBreakdown({ vendor: "nvidia" });
-      await service.getGpuBreakdown({ model: "nvidia" });
+      await service.getGpuBreakdown({ ...window });
+      await service.getGpuBreakdown({ ...window, vendor: "nvidia" });
+      await service.getGpuBreakdown({ ...window, model: "nvidia" });
 
       expect(gpuRepository.getGpuBreakdown).toHaveBeenCalledTimes(3);
+    });
+
+    it("fetches fresh results when the date range differs", async () => {
+      const { service, gpuRepository } = setup();
+      gpuRepository.getGpuBreakdown.mockResolvedValue([]);
+
+      await service.getGpuBreakdown({ ...window, vendor: "nvidia" });
+      await service.getGpuBreakdown({ startDate: "2024-02-01", endDate: "2024-02-29", vendor: "nvidia" });
+
+      expect(gpuRepository.getGpuBreakdown).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/api/src/gpu/services/gpu.service.ts
+++ b/apps/api/src/gpu/services/gpu.service.ts
@@ -90,7 +90,7 @@ export class GpuService {
   readonly getGpuBreakdown = memoizeAsync((query: GpuBreakdownQuery) => this.gpuRepository.getGpuBreakdown(query), {
     cacheItemLimit: 500,
     ttl: minutesToSeconds(5) * 1000,
-    getCacheKey: query => JSON.stringify([query.vendor, query.model]),
+    getCacheKey: query => JSON.stringify([query.vendor, query.model, query.startDate, query.endDate]),
     name: "GpuService#getGpuBreakdown"
   });
 }

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -15542,7 +15542,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "description": "Start date (YYYY-MM-DD), inclusive. Defaults to a 30-day window ending at endDate",
               "example": "2024-01-01"
             },
             "required": false,
@@ -15610,6 +15610,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days"
           }
         }
       }

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -15520,7 +15520,7 @@
           "Gpu"
         ],
         "security": [],
-        "summary": "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
+        "summary": "Gets the daily gpu analytics breakdown by vendor and model over a date range (default: last 30 days, max 366 days). If no vendor or model is provided, all GPUs are returned.",
         "parameters": [
           {
             "schema": {
@@ -15537,11 +15537,33 @@
             "required": false,
             "name": "model",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "example": "2024-01-01"
+            },
+            "required": false,
+            "name": "startDate",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "description": "End date (YYYY-MM-DD), inclusive. Defaults to today (UTC)",
+              "example": "2024-01-31"
+            },
+            "required": false,
+            "name": "endDate",
+            "in": "query"
           }
         ],
         "responses": {
           "200": {
-            "description": "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
+            "description": "Daily gpu breakdown rows for the requested date range, one per date, vendor and model.",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -8513,6 +8513,28 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
               "type": "string",
             },
           },
+          {
+            "in": "query",
+            "name": "startDate",
+            "required": false,
+            "schema": {
+              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "example": "2024-01-01",
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "required": false,
+            "schema": {
+              "description": "End date (YYYY-MM-DD), inclusive. Defaults to today (UTC)",
+              "example": "2024-01-31",
+              "format": "date",
+              "type": "string",
+            },
+          },
         ],
         "responses": {
           "200": {
@@ -8562,11 +8584,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 },
               },
             },
-            "description": "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
+            "description": "Daily gpu breakdown rows for the requested date range, one per date, vendor and model.",
           },
         },
         "security": [],
-        "summary": "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
+        "summary": "Gets the daily gpu analytics breakdown by vendor and model over a date range (default: last 30 days, max 366 days). If no vendor or model is provided, all GPUs are returned.",
         "tags": [
           "Gpu",
         ],

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -8518,7 +8518,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "startDate",
             "required": false,
             "schema": {
-              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "description": "Start date (YYYY-MM-DD), inclusive. Defaults to a 30-day window ending at endDate",
               "example": "2024-01-01",
               "format": "date",
               "type": "string",
@@ -8585,6 +8585,9 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
               },
             },
             "description": "Daily gpu breakdown rows for the requested date range, one per date, vendor and model.",
+          },
+          "400": {
+            "description": "Invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days",
           },
         },
         "security": [],

--- a/apps/api/test/functional/gpu.spec.ts
+++ b/apps/api/test/functional/gpu.spec.ts
@@ -5,6 +5,7 @@ import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
 import type { ProviderSnapshot, ProviderSnapshotNode } from "@akashnetwork/database/dbSchemas/akash";
 import type { Day, Transaction } from "@akashnetwork/database/dbSchemas/base";
 import { faker } from "@faker-js/faker";
+import { sub } from "date-fns";
 import nock from "nock";
 import { afterAll, describe, expect, it } from "vitest";
 
@@ -30,6 +31,8 @@ describe("GPU API", () => {
   const now = new Date();
   now.setUTCHours(12, 0, 0, 0);
   const date = formatUTCDate(now);
+  const beforeDefaultWindow = sub(now, { days: 45 });
+  const dateBeforeDefaultWindow = formatUTCDate(beforeDefaultWindow);
 
   afterAll(async () => {
     nock.cleanAll();
@@ -214,56 +217,73 @@ describe("GPU API", () => {
   });
 
   describe("GET /v1/gpu-breakdown", () => {
-    it("returns GPU breakdown data", async () => {
+    const todayRows = [
+      { date: `${date}T00:00:00.000Z`, vendor: "amd", model: "gpu2", providerCount: 1, nodeCount: 1, totalGpus: 1, leasedGpus: 1, gpuUtilization: 100 },
+      { date: `${date}T00:00:00.000Z`, vendor: "amd", model: "gpu3", providerCount: 1, nodeCount: 1, totalGpus: 1, leasedGpus: 1, gpuUtilization: 100 },
+      { date: `${date}T00:00:00.000Z`, vendor: "nvidia", model: "gpu0", providerCount: 1, nodeCount: 1, totalGpus: 1, leasedGpus: 1, gpuUtilization: 100 },
+      { date: `${date}T00:00:00.000Z`, vendor: "nvidia", model: "gpu1", providerCount: 1, nodeCount: 1, totalGpus: 1, leasedGpus: 1, gpuUtilization: 100 }
+    ];
+    const rowBeforeDefaultWindow = {
+      date: `${dateBeforeDefaultWindow}T00:00:00.000Z`,
+      vendor: "nvidia",
+      model: "gpu0",
+      providerCount: 1,
+      nodeCount: 1,
+      totalGpus: 2,
+      leasedGpus: 1,
+      gpuUtilization: 50
+    };
+
+    it("returns the last 30 days of GPU breakdown data by default", async () => {
       await setup();
 
       const response = await app.request(`/v1/gpu-breakdown`);
 
       expect(response.status).toBe(200);
-      const data = await response.json();
+      expect(await response.json()).toEqual(todayRows);
+    });
 
-      expect(data).toEqual([
-        {
-          date: `${date}T00:00:00.000Z`,
-          vendor: "amd",
-          model: "gpu2",
-          providerCount: 1,
-          nodeCount: 1,
-          totalGpus: 1,
-          leasedGpus: 1,
-          gpuUtilization: "100.00"
-        },
-        {
-          date: `${date}T00:00:00.000Z`,
-          vendor: "amd",
-          model: "gpu3",
-          providerCount: 1,
-          nodeCount: 1,
-          totalGpus: 1,
-          leasedGpus: 1,
-          gpuUtilization: "100.00"
-        },
-        {
-          date: `${date}T00:00:00.000Z`,
-          vendor: "nvidia",
-          model: "gpu0",
-          providerCount: 1,
-          nodeCount: 1,
-          totalGpus: 1,
-          leasedGpus: 1,
-          gpuUtilization: "100.00"
-        },
-        {
-          date: `${date}T00:00:00.000Z`,
-          vendor: "nvidia",
-          model: "gpu1",
-          providerCount: 1,
-          nodeCount: 1,
-          totalGpus: 1,
-          leasedGpus: 1,
-          gpuUtilization: "100.00"
-        }
-      ]);
+    it("returns GPU breakdown data for the requested date range", async () => {
+      await setup();
+
+      const response = await app.request(`/v1/gpu-breakdown?startDate=${dateBeforeDefaultWindow}&endDate=${dateBeforeDefaultWindow}`);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual([rowBeforeDefaultWindow]);
+    });
+
+    it("filters GPU breakdown data by vendor", async () => {
+      await setup();
+
+      const response = await app.request(`/v1/gpu-breakdown?vendor=AMD`);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual(todayRows.filter(row => row.vendor === "amd"));
+    });
+
+    it("filters GPU breakdown data by model across the requested date range", async () => {
+      await setup();
+
+      const response = await app.request(`/v1/gpu-breakdown?model=gpu0&startDate=${dateBeforeDefaultWindow}&endDate=${date}`);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual([rowBeforeDefaultWindow, ...todayRows.filter(row => row.model === "gpu0")]);
+    });
+
+    it("rejects a date range wider than 366 days", async () => {
+      await setup();
+
+      const response = await app.request(`/v1/gpu-breakdown?startDate=2023-01-01&endDate=2024-12-31`);
+
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects a startDate after the endDate", async () => {
+      await setup();
+
+      const response = await app.request(`/v1/gpu-breakdown?startDate=${date}&endDate=${dateBeforeDefaultWindow}`);
+
+      expect(response.status).toBe(400);
     });
   });
 
@@ -398,6 +418,40 @@ describe("GPU API", () => {
     transactions?: Transaction[];
   } = {};
   let isDbInitialized = false;
+
+  async function seedGpuSnapshotBeforeDefaultWindow(owner: string) {
+    await createDay({
+      date: dateBeforeDefaultWindow,
+      aktPrice: 1,
+      firstBlockHeight: 1000,
+      lastBlockHeight: 1100,
+      lastBlockHeightYet: 1100
+    });
+    const snapshot = await createProviderSnapshot({
+      owner,
+      checkDate: beforeDefaultWindow,
+      isOnline: true,
+      isLastSuccessOfDay: true
+    });
+    const node = await createProviderSnapshotNode({
+      snapshotId: snapshot.id,
+      name: "GPU 0",
+      gpuAllocatable: 2,
+      gpuAllocated: 1
+    });
+    await Promise.all(
+      ["pcie", "sxm"].map(gpuInterface =>
+        createProviderSnapshotNodeGpu({
+          snapshotNodeId: node.id,
+          vendor: "nvidia",
+          name: "gpu0",
+          modelId: faker.string.alpha(10),
+          interface: gpuInterface,
+          memorySize: 1024
+        })
+      )
+    );
+  }
 
   async function setup() {
     if (isDbInitialized) {
@@ -572,6 +626,8 @@ describe("GPU API", () => {
         lastSuccessfulSnapshotId: testData.providerSnapshots[1].id
       })
     ]);
+
+    await seedGpuSnapshotBeforeDefaultWindow(testData.providers[0].owner);
 
     const block = await createAkashBlock({
       dayId: testData.day.id,

--- a/apps/api/test/functional/gpu.spec.ts
+++ b/apps/api/test/functional/gpu.spec.ts
@@ -273,7 +273,7 @@ describe("GPU API", () => {
     it("rejects a date range wider than 366 days", async () => {
       await setup();
 
-      const response = await app.request(`/v1/gpu-breakdown?startDate=2023-01-01&endDate=2024-12-31`);
+      const response = await app.request(`/v1/gpu-breakdown?startDate=2024-01-01&endDate=2025-01-01`);
 
       expect(response.status).toBe(400);
     });

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -5775,6 +5775,13 @@ export interface paths {
             }[];
           };
         };
+        /** @description Invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
       };
     };
     put?: never;

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -5742,12 +5742,14 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned. */
+    /** Gets the daily gpu analytics breakdown by vendor and model over a date range (default: last 30 days, max 366 days). If no vendor or model is provided, all GPUs are returned. */
     get: {
       parameters: {
         query?: {
           vendor?: string;
           model?: string;
+          startDate?: string;
+          endDate?: string;
         };
         header?: never;
         path?: never;
@@ -5755,7 +5757,7 @@ export interface paths {
       };
       requestBody?: never;
       responses: {
-        /** @description Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned. */
+        /** @description Daily gpu breakdown rows for the requested date range, one per date, vendor and model. */
         200: {
           headers: {
             [name: string]: unknown;


### PR DESCRIPTION
## Why

`GET /v1/gpu-breakdown` is the slowest route on the API. In prod an unfiltered call takes 42 to 50 seconds, a vendor+model call 12 to 15 seconds, and every response is the full history since February 2024 as one row per day, vendor and model, about 15k rows. Nothing in this repo calls the route. The traffic is external scripts and curl, roughly 180 calls a week, spread out enough that the 5 minute in-process cache almost never hits.

The query had no date bound. The `day` scan and the `DISTINCT ON (hostUri, DATE(checkDate))` over `providerSnapshot` covered the whole table, so the partial index on `checkDate WHERE isLastSuccessOfDay` was never used. It also ran the same correlated `COUNT(*)` over `providerSnapshotNodeGPU` twice for every GPU row.

## What

The route takes `startDate` and `endDate` (YYYY-MM-DD), both inclusive. Without them it returns the last 30 days, exactly 30 dates ending today. The span is capped at 366 dates and anything wider, or a start after the end, is a 400, which the route now declares in the OpenAPI spec. This is the same shape `/v1/usage/history` uses, except that the default and the cap here count inclusive calendar days rather than the gap between the two dates.

The window is pushed into the snapshot subquery so the partial index applies, and the per node GPU count is computed once with a lateral join instead of two correlated subqueries. `gpuUtilization` now comes back as a number; the schema and the OpenAPI spec already said `number`, but the Postgres `numeric` was serialised as `"100.00"`.

`openapi.json`, the `console-api-types` schema and the docs snapshot are regenerated. Unrelated spec drift already on main (`reclaimNotifiedAt`) was left out on purpose.

BREAKING CHANGE for external callers: a call with no dates returns 30 days instead of the whole history, and `gpuUtilization` is a number instead of a string. History is still available by passing `startDate`/`endDate` in slices of up to 366 days.

Tests: new schema spec, a cache key case in the service spec, and functional cases for the default window, an explicit range, vendor and model filters and both 400s.

Measured after the fact on a copy of the production database (715 GB, snapshots through 2026-03-12), two runs per window with the session pinned to UTC:

| Window | Filter | First run | Warm |
|---|---|---|---|
| unbounded (old query) | none | 12.9 s | |
| 30 d | none | 26 ms | 21 ms |
| 30 d | nvidia/h100 | 27 ms | 27 ms |
| 90 d | none | 96 ms | 79 ms |
| 180 d | none | 4.9 s | 4.8 s |
| 366 d | none | 9.1 s | 8.2 s |
| 366 d | nvidia/h100 | 6.6 s | 7.2 s |

The 30-day default is fast, so the change is a clear win for the common call. Windows past roughly 120 days flip to hashing the node and GPU tables whole, which is a planner statistics problem rather than a query one; #3836 fixes it and brings the 366-day window to 224 ms warm on the same copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GPU breakdown analytics support optional start and end dates.
  - Results are provided as daily rows by date, vendor, and model.
  - Date ranges default to the most recent 30 days and support periods up to 366 days.
  - Vendor and model filtering remain available within the selected period.

- **Bug Fixes**
  - Invalid, reversed, or incorrectly formatted date ranges are rejected.
  - GPU utilization values are returned as numbers.

- **Documentation**
  - Updated API documentation to describe date-range parameters, daily results, and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

