### PR TITLE
fix(billing): bound the refusal loop from zero-balance clients retrying deployment creates

### DIFF
--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -51,6 +51,8 @@ export const envSchema = z.object({
   CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: z.number({ coerce: true }).min(0).default(30),
   /** How long credits must keep reading low before the email goes out, so a single misread cannot send one. */
   CREDITS_LOW_CONFIRM_WINDOW_MIN: z.number({ coerce: true }).min(0).default(30),
+  /** Safety net only: a cached refusal is dropped as soon as any funding path rewrites the wallet row, so this bounds nothing but the residual race. */
+  DEPLOYMENT_CREATE_REFUSAL_CACHE_TTL_SECONDS: z.number({ coerce: true }).int().min(1).default(300),
   MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: z
     .string()
     .default("nvidia/b300,nvidia/b200,nvidia/h200,nvidia/h100,nvidia/pro6000se,nvidia/pro6000we,nvidia/a100,nvidia/rtx5090,nvidia/rtx4090,nvidia/rtx3090")

--- a/apps/api/src/billing/services/deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service.spec.ts
+++ b/apps/api/src/billing/services/deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service.spec.ts
@@ -1,0 +1,109 @@
+import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
+
+import { cacheRegistry } from "@src/caching/cache-registry";
+import type { BillingConfigService } from "../billing-config/billing-config.service";
+import { DeploymentDepositRefusalCache } from "./deployment-deposit-refusal-cache.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+describe(DeploymentDepositRefusalCache.name, () => {
+  describe("find", () => {
+    it("returns nothing for a wallet that was never refused", () => {
+      const { cache, wallet } = setup();
+
+      expect(cache.find(wallet, 500000)).toBeUndefined();
+    });
+
+    it("returns the refusal while the wallet row still shows the refused snapshot and the deposit still exceeds the allowance", () => {
+      const { cache, wallet } = setup({ ttlSeconds: 300 });
+      cache.remember(wallet, { chainDeploymentAllowance: 400000, reloadScheduled: true });
+
+      const cached = cache.find(wallet, 500000);
+
+      expect(cached).toMatchObject({ chainDeploymentAllowance: 400000, reloadScheduled: true, suppressedAttempts: 1 });
+      expect(cached!.retryAfterSeconds).toBeGreaterThan(0);
+      expect(cached!.retryAfterSeconds).toBeLessThanOrEqual(300);
+    });
+
+    it("drops the refusal once the wallet row shows a different allowance", () => {
+      const { cache, wallet } = setup();
+      cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
+
+      expect(cache.find({ ...wallet, deploymentAllowance: wallet.deploymentAllowance + 1 }, 500000)).toBeUndefined();
+      expect(cache.find(wallet, 500000)).toBeUndefined();
+    });
+
+    it("misses without dropping the refusal when the cached allowance covers a smaller deposit", () => {
+      const { cache, wallet } = setup();
+      cache.remember(wallet, { chainDeploymentAllowance: 400000, reloadScheduled: false });
+
+      expect(cache.find(wallet, 300000)).toBeUndefined();
+      expect(cache.find(wallet, 500000)).toBeDefined();
+    });
+
+    it("refuses any deposit when the cached allowance is zero", () => {
+      const { cache, wallet } = setup();
+      cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
+
+      expect(cache.find(wallet, 1)).toBeDefined();
+    });
+
+    it("counts every attempt answered from the cache", () => {
+      const { cache, wallet } = setup();
+      cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
+
+      cache.find(wallet, 500000);
+      cache.find(wallet, 500000);
+
+      expect(cache.find(wallet, 500000)?.suppressedAttempts).toBe(3);
+    });
+  });
+
+  describe("remember", () => {
+    it("answers with the full ttl as the retry delay", () => {
+      const { cache, wallet } = setup({ ttlSeconds: 300 });
+
+      expect(cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false })).toEqual({ retryAfterSeconds: 300 });
+    });
+  });
+
+  describe("markReloadScheduled", () => {
+    it("flags a remembered refusal as having its reload scheduled", () => {
+      const { cache, wallet } = setup();
+      cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
+
+      cache.markReloadScheduled(wallet.userId);
+
+      expect(cache.find(wallet, 500000)?.reloadScheduled).toBe(true);
+    });
+
+    it("does nothing for a wallet that was never refused", () => {
+      const { cache, wallet } = setup();
+
+      cache.markReloadScheduled(wallet.userId);
+
+      expect(cache.find(wallet, 500000)).toBeUndefined();
+    });
+  });
+
+  it("registers itself so a registry-wide clear empties it", () => {
+    const { cache, wallet } = setup();
+    cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
+
+    cacheRegistry.clearAll();
+
+    expect(cacheRegistry.getStats().some(stats => stats.name.startsWith(DeploymentDepositRefusalCache.name))).toBe(true);
+    expect(cache.find(wallet, 500000)).toBeUndefined();
+  });
+
+  function setup(input?: { ttlSeconds?: number }) {
+    const cache = new DeploymentDepositRefusalCache(
+      mockConfigService<BillingConfigService>({ DEPLOYMENT_CREATE_REFUSAL_CACHE_TTL_SECONDS: input?.ttlSeconds ?? 300 })
+    );
+    const wallet = createUserWallet({ userId: faker.string.uuid(), deploymentAllowance: 1000000 });
+
+    return { cache, wallet };
+  }
+});

--- a/apps/api/src/billing/services/deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service.spec.ts
+++ b/apps/api/src/billing/services/deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service.spec.ts
@@ -18,18 +18,18 @@ describe(DeploymentDepositRefusalCache.name, () => {
 
     it("returns the refusal while the wallet row still shows the refused snapshot and the deposit still exceeds the allowance", () => {
       const { cache, wallet } = setup({ ttlSeconds: 300 });
-      cache.remember(wallet, { chainDeploymentAllowance: 400000, reloadScheduled: true });
+      cache.remember(wallet, 400000);
 
       const cached = cache.find(wallet, 500000);
 
-      expect(cached).toMatchObject({ chainDeploymentAllowance: 400000, reloadScheduled: true, suppressedAttempts: 1 });
+      expect(cached).toMatchObject({ chainDeploymentAllowance: 400000, suppressedAttempts: 1 });
       expect(cached!.retryAfterSeconds).toBeGreaterThan(0);
       expect(cached!.retryAfterSeconds).toBeLessThanOrEqual(300);
     });
 
     it("drops the refusal once the wallet row shows a different allowance", () => {
       const { cache, wallet } = setup();
-      cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
+      cache.remember(wallet, 0);
 
       expect(cache.find({ ...wallet, deploymentAllowance: wallet.deploymentAllowance + 1 }, 500000)).toBeUndefined();
       expect(cache.find(wallet, 500000)).toBeUndefined();
@@ -37,7 +37,7 @@ describe(DeploymentDepositRefusalCache.name, () => {
 
     it("misses without dropping the refusal when the cached allowance covers a smaller deposit", () => {
       const { cache, wallet } = setup();
-      cache.remember(wallet, { chainDeploymentAllowance: 400000, reloadScheduled: false });
+      cache.remember(wallet, 400000);
 
       expect(cache.find(wallet, 300000)).toBeUndefined();
       expect(cache.find(wallet, 500000)).toBeDefined();
@@ -45,14 +45,14 @@ describe(DeploymentDepositRefusalCache.name, () => {
 
     it("refuses any deposit when the cached allowance is zero", () => {
       const { cache, wallet } = setup();
-      cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
+      cache.remember(wallet, 0);
 
       expect(cache.find(wallet, 1)).toBeDefined();
     });
 
     it("counts every attempt answered from the cache", () => {
       const { cache, wallet } = setup();
-      cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
+      cache.remember(wallet, 0);
 
       cache.find(wallet, 500000);
       cache.find(wallet, 500000);
@@ -65,32 +65,13 @@ describe(DeploymentDepositRefusalCache.name, () => {
     it("answers with the full ttl as the retry delay", () => {
       const { cache, wallet } = setup({ ttlSeconds: 300 });
 
-      expect(cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false })).toEqual({ retryAfterSeconds: 300 });
-    });
-  });
-
-  describe("markReloadScheduled", () => {
-    it("flags a remembered refusal as having its reload scheduled", () => {
-      const { cache, wallet } = setup();
-      cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
-
-      cache.markReloadScheduled(wallet.userId);
-
-      expect(cache.find(wallet, 500000)?.reloadScheduled).toBe(true);
-    });
-
-    it("does nothing for a wallet that was never refused", () => {
-      const { cache, wallet } = setup();
-
-      cache.markReloadScheduled(wallet.userId);
-
-      expect(cache.find(wallet, 500000)).toBeUndefined();
+      expect(cache.remember(wallet, 0)).toEqual({ retryAfterSeconds: 300 });
     });
   });
 
   it("registers itself so a registry-wide clear empties it", () => {
     const { cache, wallet } = setup();
-    cache.remember(wallet, { chainDeploymentAllowance: 0, reloadScheduled: false });
+    cache.remember(wallet, 0);
 
     cacheRegistry.clearAll();
 

--- a/apps/api/src/billing/services/deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service.ts
+++ b/apps/api/src/billing/services/deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service.ts
@@ -1,0 +1,94 @@
+import { LRUCache } from "lru-cache";
+import { singleton } from "tsyringe";
+
+import type { UserWalletOutput } from "@src/billing/repositories";
+import { cacheRegistry, nominalEntrySizing } from "@src/caching/cache-registry";
+import { BillingConfigService } from "../billing-config/billing-config.service";
+
+const MAX_TRACKED_WALLETS = 10_000;
+/** A few numbers under a user id, so the registry ranks this cache far below the ones holding response payloads. */
+const ENTRY_BYTES = 128;
+
+type RefusedWallet = Pick<UserWalletOutput, "userId" | "deploymentAllowance">;
+
+export interface DepositRefusal {
+  chainDeploymentAllowance: number;
+  reloadScheduled: boolean;
+}
+
+export interface CachedDepositRefusal extends DepositRefusal {
+  suppressedAttempts: number;
+  retryAfterSeconds: number;
+}
+
+interface DepositRefusalEntry extends DepositRefusal {
+  /** Every funding path writes the fresh grant to the wallet row, so a row that still shows this value has not been funded since the refusal. */
+  walletDeploymentAllowanceSnapshot: number;
+  suppressedAttempts: number;
+}
+
+@singleton()
+export class DeploymentDepositRefusalCache {
+  readonly #entries: LRUCache<string, DepositRefusalEntry>;
+
+  constructor(billingConfigService: BillingConfigService) {
+    this.#entries = new LRUCache({
+      max: MAX_TRACKED_WALLETS,
+      ttl: billingConfigService.get("DEPLOYMENT_CREATE_REFUSAL_CACHE_TTL_SECONDS") * 1000,
+      ...nominalEntrySizing(MAX_TRACKED_WALLETS, ENTRY_BYTES)
+    });
+    cacheRegistry.register(DeploymentDepositRefusalCache.name, this.#entries);
+  }
+
+  find(userWallet: RefusedWallet, requiredDeposit: number): CachedDepositRefusal | undefined {
+    const entry = this.#entries.get(userWallet.userId);
+
+    if (!entry) {
+      return undefined;
+    }
+
+    if (entry.walletDeploymentAllowanceSnapshot !== userWallet.deploymentAllowance) {
+      this.#entries.delete(userWallet.userId);
+      return undefined;
+    }
+
+    if (!isInsufficient(entry.chainDeploymentAllowance, requiredDeposit)) {
+      return undefined;
+    }
+
+    entry.suppressedAttempts += 1;
+
+    return {
+      chainDeploymentAllowance: entry.chainDeploymentAllowance,
+      reloadScheduled: entry.reloadScheduled,
+      suppressedAttempts: entry.suppressedAttempts,
+      retryAfterSeconds: this.#getRetryAfterSeconds(userWallet.userId)
+    };
+  }
+
+  remember(userWallet: RefusedWallet, refusal: DepositRefusal): { retryAfterSeconds: number } {
+    this.#entries.set(userWallet.userId, {
+      ...refusal,
+      walletDeploymentAllowanceSnapshot: userWallet.deploymentAllowance,
+      suppressedAttempts: 0
+    });
+
+    return { retryAfterSeconds: this.#getRetryAfterSeconds(userWallet.userId) };
+  }
+
+  markReloadScheduled(userId: string): void {
+    const entry = this.#entries.peek(userId);
+
+    if (entry) {
+      entry.reloadScheduled = true;
+    }
+  }
+
+  #getRetryAfterSeconds(userId: string): number {
+    return Math.max(1, Math.ceil(this.#entries.getRemainingTTL(userId) / 1000));
+  }
+}
+
+export function isInsufficient(deploymentAllowance: number, requiredDeposit: number): boolean {
+  return deploymentAllowance <= 0 || deploymentAllowance < requiredDeposit;
+}

--- a/apps/api/src/billing/services/deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service.ts
+++ b/apps/api/src/billing/services/deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service.ts
@@ -11,17 +11,14 @@ const ENTRY_BYTES = 128;
 
 type RefusedWallet = Pick<UserWalletOutput, "userId" | "deploymentAllowance">;
 
-export interface DepositRefusal {
+export interface CachedDepositRefusal {
   chainDeploymentAllowance: number;
-  reloadScheduled: boolean;
-}
-
-export interface CachedDepositRefusal extends DepositRefusal {
   suppressedAttempts: number;
   retryAfterSeconds: number;
 }
 
-interface DepositRefusalEntry extends DepositRefusal {
+interface DepositRefusalEntry {
+  chainDeploymentAllowance: number;
   /** Every funding path writes the fresh grant to the wallet row, so a row that still shows this value has not been funded since the refusal. */
   walletDeploymentAllowanceSnapshot: number;
   suppressedAttempts: number;
@@ -60,28 +57,19 @@ export class DeploymentDepositRefusalCache {
 
     return {
       chainDeploymentAllowance: entry.chainDeploymentAllowance,
-      reloadScheduled: entry.reloadScheduled,
       suppressedAttempts: entry.suppressedAttempts,
       retryAfterSeconds: this.#getRetryAfterSeconds(userWallet.userId)
     };
   }
 
-  remember(userWallet: RefusedWallet, refusal: DepositRefusal): { retryAfterSeconds: number } {
+  remember(userWallet: RefusedWallet, chainDeploymentAllowance: number): { retryAfterSeconds: number } {
     this.#entries.set(userWallet.userId, {
-      ...refusal,
+      chainDeploymentAllowance,
       walletDeploymentAllowanceSnapshot: userWallet.deploymentAllowance,
       suppressedAttempts: 0
     });
 
     return { retryAfterSeconds: this.#getRetryAfterSeconds(userWallet.userId) };
-  }
-
-  markReloadScheduled(userId: string): void {
-    const entry = this.#entries.peek(userId);
-
-    if (entry) {
-      entry.reloadScheduled = true;
-    }
   }
 
   #getRetryAfterSeconds(userId: string): number {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -17,6 +17,7 @@ import type { UserWalletRepository } from "@src/billing/repositories";
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
+import { DeploymentDepositRefusalCache } from "@src/billing/services/deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service";
 import type { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
 import type { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
 import type { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
@@ -183,6 +184,106 @@ describe(ManagedSignerService.name, () => {
       );
 
       expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith(expect.anything(), { triggeredByDeployment: true });
+    });
+
+    it("tells a refused client when to retry", async () => {
+      const { service } = setupForCreate({ deploymentLimit: 0 });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toMatchObject({
+        status: 402,
+        headers: { "Retry-After": "300" }
+      });
+    });
+
+    it("answers a repeated refusal from cache without re-reading the chain, re-queueing the reload or warning again", async () => {
+      const { service, balancesService, walletReloadJobService, logger } = setupForCreate({
+        deploymentLimit: 0,
+        scheduleImmediate: vi.fn().mockResolvedValue(true)
+      });
+      const refusal = expect.objectContaining({ status: 402, headers: { "Retry-After": expect.stringMatching(/^\d+$/) } });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toEqual(refusal);
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toEqual(refusal);
+
+      expect(balancesService.retrieveDeploymentLimit).toHaveBeenCalledTimes(1);
+      expect(balancesService.retrieveAndCalcFeeLimit).toHaveBeenCalledTimes(1);
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "DEPLOYMENT_CREATE_REFUSED_FROM_CACHE", userId: "user-123", reloadScheduled: true, suppressedAttempts: 1 })
+      );
+    });
+
+    it("re-reads the chain when a repeated create asks for a deposit the refused allowance covers", async () => {
+      const { service, balancesService, txManagerService } = setupForCreate({ deploymentLimit: 400000 });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow("Not enough balance");
+      await service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(300000)]);
+
+      expect(balancesService.retrieveDeploymentLimit).toHaveBeenCalledTimes(2);
+      expect(txManagerService.signAndBroadcastWithDerivedWallet).toHaveBeenCalledTimes(1);
+    });
+
+    it("lets a create through as soon as the wallet row shows that credits were added", async () => {
+      const refusedWallet = createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 0 });
+      const { service, balancesService, txManagerService } = setup({
+        findOneByUserId: vi
+          .fn()
+          .mockResolvedValueOnce(refusedWallet)
+          .mockResolvedValue({ ...refusedWallet, deploymentAllowance: 5000000 }),
+        findById: vi.fn().mockResolvedValue(createUser({ userId: "user-123" })),
+        retrieveDeploymentLimit: vi.fn().mockResolvedValueOnce(0).mockResolvedValue(5000000),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" }),
+        refreshUserWalletLimits: vi.fn()
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow("Not enough balance");
+      await service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)]);
+
+      expect(balancesService.retrieveDeploymentLimit).toHaveBeenCalledTimes(2);
+      expect(txManagerService.signAndBroadcastWithDerivedWallet).toHaveBeenCalledTimes(1);
+    });
+
+    it("still requests one reload from cache when auto recharge was off at the first refusal and is on now", async () => {
+      const { service, walletReloadJobService } = setupForCreate({
+        deploymentLimit: 0,
+        scheduleImmediate: vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true)
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "Add credits or turn on auto recharge to continue."
+      );
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "A top up from your saved payment method is on the way, so try again in a moment."
+      );
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "A top up from your saved payment method is on the way, so try again in a moment."
+      );
+
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not cache a refusal for a missing fee allowance", async () => {
+      const { service, balancesService } = setupForCreate({ deploymentLimit: 5000000, retrieveAndCalcFeeLimit: vi.fn().mockResolvedValue(0) });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow("transaction fee");
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow("transaction fee");
+
+      expect(balancesService.retrieveDeploymentLimit).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not cache a refusal the chain made after the pre-flight check passed", async () => {
+      const { service, balancesService, walletReloadJobService } = setupForCreate({
+        deploymentLimit: 500000,
+        signAndBroadcastWithDerivedWallet: vi.fn().mockRejectedValue(new Error("deposit invalid: insufficient balance")),
+        transformChainError: vi.fn().mockResolvedValue(createError(402, "Not enough balance to cover the deployment deposit."))
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow("Not enough balance");
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow("Not enough balance");
+
+      expect(balancesService.retrieveDeploymentLimit).toHaveBeenCalledTimes(2);
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledTimes(2);
     });
 
     it("does not schedule a reload when the broadcast fails for a reason other than balance", async () => {
@@ -1136,11 +1237,13 @@ describe(ManagedSignerService.name, () => {
     });
   }
 
-  function setupForCreate(input: { deploymentLimit: number } & Omit<NonNullable<Parameters<typeof setup>[0]>, "retrieveDeploymentLimit">) {
-    const { deploymentLimit, ...rest } = input;
+  function setupForCreate(
+    input: { deploymentLimit: number; walletDeploymentAllowance?: number } & Omit<NonNullable<Parameters<typeof setup>[0]>, "retrieveDeploymentLimit">
+  ) {
+    const { deploymentLimit, walletDeploymentAllowance = deploymentLimit, ...rest } = input;
 
     return setup({
-      findOneByUserId: vi.fn().mockResolvedValue(createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: deploymentLimit })),
+      findOneByUserId: vi.fn().mockResolvedValue(createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: walletDeploymentAllowance })),
       findById: vi.fn().mockResolvedValue(createUser({ userId: "user-123" })),
       retrieveDeploymentLimit: vi.fn().mockResolvedValue(deploymentLimit),
       signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({ code: 0, hash: "TESTHASH", rawLog: "[]" }),
@@ -1209,7 +1312,8 @@ describe(ManagedSignerService.name, () => {
         DEPLOYMENT_GRANT_DENOM: "uakt",
         FEE_ALLOWANCE_REFILL_AMOUNT: 1000000,
         FEE_ALLOWANCE_REFILL_THRESHOLD: 100000,
-        TRIAL_ALLOWANCE_EXPIRATION_DAYS: 30
+        TRIAL_ALLOWANCE_EXPIRATION_DAYS: 30,
+        DEPLOYMENT_CREATE_REFUSAL_CACHE_TTL_SECONDS: 300
       }),
       managedUserWalletService: mock<ManagedUserWalletService>({
         refillWalletFees: vi.fn()
@@ -1220,7 +1324,8 @@ describe(ManagedSignerService.name, () => {
       }),
       logger: mock<ReturnType<CreateLogger>>({
         error: vi.fn(),
-        warn: vi.fn()
+        warn: vi.fn(),
+        debug: vi.fn()
       })
     };
 
@@ -1246,6 +1351,7 @@ describe(ManagedSignerService.name, () => {
       mocks.managedUserWalletService,
       mocks.trialActivationJobService,
       mocks.deploymentSettingRepository,
+      new DeploymentDepositRefusalCache(mocks.billingConfigService),
       createLogger
     );
 

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -195,8 +195,8 @@ describe(ManagedSignerService.name, () => {
       });
     });
 
-    it("answers a repeated refusal from cache without re-reading the chain, re-queueing the reload or warning again", async () => {
-      const { service, balancesService, walletReloadJobService, logger } = setupForCreate({
+    it("answers a repeated refusal from cache without re-reading the chain or warning again", async () => {
+      const { service, balancesService, logger } = setupForCreate({
         deploymentLimit: 0,
         scheduleImmediate: vi.fn().mockResolvedValue(true)
       });
@@ -207,10 +207,23 @@ describe(ManagedSignerService.name, () => {
 
       expect(balancesService.retrieveDeploymentLimit).toHaveBeenCalledTimes(1);
       expect(balancesService.retrieveAndCalcFeeLimit).toHaveBeenCalledTimes(1);
-      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledTimes(1);
       expect(logger.warn).toHaveBeenCalledTimes(1);
       expect(logger.debug).toHaveBeenCalledWith(
         expect.objectContaining({ event: "DEPLOYMENT_CREATE_REFUSED_FROM_CACHE", userId: "user-123", reloadScheduled: true, suppressedAttempts: 1 })
+      );
+    });
+
+    it("stops promising a top up once auto recharge is paused between retries", async () => {
+      const { service } = setupForCreate({
+        deploymentLimit: 0,
+        scheduleImmediate: vi.fn().mockResolvedValueOnce(true).mockResolvedValue(false)
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "A top up from your saved payment method is on the way, so try again in a moment."
+      );
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toThrow(
+        "Add credits or turn on auto recharge to continue."
       );
     });
 
@@ -244,7 +257,7 @@ describe(ManagedSignerService.name, () => {
       expect(txManagerService.signAndBroadcastWithDerivedWallet).toHaveBeenCalledTimes(1);
     });
 
-    it("still requests one reload from cache when auto recharge was off at the first refusal and is on now", async () => {
+    it("picks up auto recharge being turned on between retries", async () => {
       const { service, walletReloadJobService } = setupForCreate({
         deploymentLimit: 0,
         scheduleImmediate: vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true)
@@ -260,7 +273,7 @@ describe(ManagedSignerService.name, () => {
         "A top up from your saved payment method is on the way, so try again in a moment."
       );
 
-      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledTimes(2);
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledTimes(3);
     });
 
     it("does not cache a refusal for a missing fee allowance", async () => {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -285,7 +285,7 @@ export class ManagedSignerService {
 
       if (hasDeploymentMessage && isInsufficient(deploymentAllowance, requiredDeposit)) {
         const reloadScheduled = await this.#scheduleReloadForInsufficientBalance(userWallet);
-        const { retryAfterSeconds } = this.depositRefusalCache.remember(userWallet, { chainDeploymentAllowance: deploymentAllowance, reloadScheduled });
+        const { retryAfterSeconds } = this.depositRefusalCache.remember(userWallet, deploymentAllowance);
 
         this.logger.warn({
           event: "DEPLOYMENT_CREATE_REFUSED_INSUFFICIENT_ALLOWANCE",
@@ -301,7 +301,7 @@ export class ManagedSignerService {
     });
   }
 
-  /** Re-serves a recent refusal until a funding path rewrites the wallet row, still requesting one reload if auto recharge was off at the first refusal. */
+  /** Re-serves a recent refusal until a funding path rewrites the wallet row, re-reading auto recharge every time so a pause mid-window still changes the answer. */
   async #refuseFromCache(userWallet: UserWalletOutput, requiredDeposit: number): Promise<void> {
     const cached = this.depositRefusalCache.find(userWallet, requiredDeposit);
 
@@ -309,15 +309,7 @@ export class ManagedSignerService {
       return;
     }
 
-    let reloadScheduled = cached.reloadScheduled;
-
-    if (!reloadScheduled) {
-      reloadScheduled = await this.#scheduleReloadForInsufficientBalance(userWallet);
-
-      if (reloadScheduled) {
-        this.depositRefusalCache.markReloadScheduled(userWallet.userId);
-      }
-    }
+    const reloadScheduled = await this.#scheduleReloadForInsufficientBalance(userWallet);
 
     this.logger.debug({
       event: "DEPLOYMENT_CREATE_REFUSED_FROM_CACHE",

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -7,7 +7,7 @@ import { EncodeObject, Registry } from "@cosmjs/proto-signing";
 import { IndexedTx } from "@cosmjs/stargate";
 import { context, trace } from "@opentelemetry/api";
 import assert from "http-assert";
-import { BadRequest, isHttpError } from "http-errors";
+import createError, { BadRequest, isHttpError } from "http-errors";
 import pick from "lodash/pick";
 import { inject, singleton } from "tsyringe";
 
@@ -30,6 +30,7 @@ import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
 import { BalancesService } from "../balances/balances.service";
 import { BillingConfigService } from "../billing-config/billing-config.service";
 import { ChainErrorService } from "../chain-error/chain-error.service";
+import { DeploymentDepositRefusalCache, isInsufficient } from "../deployment-deposit-refusal-cache/deployment-deposit-refusal-cache.service";
 import { TrialValidationService } from "../trial-validation/trial-validation.service";
 
 type StringifiedEncodeObject = Omit<EncodeObject, "value"> & { value: string };
@@ -60,6 +61,7 @@ export class ManagedSignerService {
     private readonly managedUserWalletService: ManagedUserWalletService,
     private readonly trialActivationJobService: TrialActivationJobService,
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly depositRefusalCache: DeploymentDepositRefusalCache,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: ManagedSignerService.name });
@@ -263,21 +265,17 @@ export class ManagedSignerService {
     await this.trialActivationJobService.assertActivated(userWallet);
   }
 
-  /**
-   * Validates that the user wallet has sufficient balances to cover transaction fees and deployment costs.
-   * Always fetches fee allowance from the chain to ensure accuracy, as database values may be out of sync.
-   * Fetches deployment allowance from the chain only when a deployment message is present, otherwise uses cached value.
-   * Automatically refills fee authorization for eligible trial wallets if fee allowance is below FEE_ALLOWANCE_REFILL_THRESHOLD.
-   *
-   * @param userWallet - The user wallet to validate balances for
-   * @param messages - Array of transaction messages to check for deployment messages
-   * @throws {HttpError} 402 if there are not enough funds to cover the transaction fee
-   * @throws {HttpError} 402 if the deployment allowance cannot cover the deposits the create messages ask for
-   */
+  /** Fee allowance always comes from the chain and the deployment allowance only when a create is present, since the row can lag behind the chain. */
   async #validateBalances(userWallet: UserWalletOutput, messages: EncodeObject[]) {
     return withSpan("ManagedSignerService.validateBalances", async () => {
       const createDeploymentMessages = this.#getCreateDeploymentMessages(messages);
       const hasDeploymentMessage = createDeploymentMessages.length > 0;
+      const requiredDeposit = this.#sumDepositsDrawnFromGrant(createDeploymentMessages);
+
+      if (hasDeploymentMessage) {
+        await this.#refuseFromCache(userWallet, requiredDeposit);
+      }
+
       const [feeAllowance, deploymentAllowance] = await Promise.all([
         this.ensureFeeGrants(userWallet),
         !hasDeploymentMessage ? Promise.resolve(userWallet.deploymentAllowance) : this.balancesService.retrieveDeploymentLimit(userWallet)
@@ -285,10 +283,9 @@ export class ManagedSignerService {
 
       assert(feeAllowance > 0, 402, "Not enough funds to cover the transaction fee");
 
-      const requiredDeposit = this.#sumDepositsDrawnFromGrant(createDeploymentMessages);
-
-      if (hasDeploymentMessage && (deploymentAllowance <= 0 || deploymentAllowance < requiredDeposit)) {
+      if (hasDeploymentMessage && isInsufficient(deploymentAllowance, requiredDeposit)) {
         const reloadScheduled = await this.#scheduleReloadForInsufficientBalance(userWallet);
+        const { retryAfterSeconds } = this.depositRefusalCache.remember(userWallet, { chainDeploymentAllowance: deploymentAllowance, reloadScheduled });
 
         this.logger.warn({
           event: "DEPLOYMENT_CREATE_REFUSED_INSUFFICIENT_ALLOWANCE",
@@ -299,9 +296,45 @@ export class ManagedSignerService {
           reloadScheduled
         });
 
-        assert(false, 402, reloadScheduled ? INSUFFICIENT_DEPOSIT_BALANCE_RELOADING_MESSAGE : INSUFFICIENT_DEPOSIT_BALANCE_MESSAGE);
+        this.#throwInsufficientDepositBalance(reloadScheduled, retryAfterSeconds);
       }
     });
+  }
+
+  /** Re-serves a recent refusal until a funding path rewrites the wallet row, still requesting one reload if auto recharge was off at the first refusal. */
+  async #refuseFromCache(userWallet: UserWalletOutput, requiredDeposit: number): Promise<void> {
+    const cached = this.depositRefusalCache.find(userWallet, requiredDeposit);
+
+    if (!cached) {
+      return;
+    }
+
+    let reloadScheduled = cached.reloadScheduled;
+
+    if (!reloadScheduled) {
+      reloadScheduled = await this.#scheduleReloadForInsufficientBalance(userWallet);
+
+      if (reloadScheduled) {
+        this.depositRefusalCache.markReloadScheduled(userWallet.userId);
+      }
+    }
+
+    this.logger.debug({
+      event: "DEPLOYMENT_CREATE_REFUSED_FROM_CACHE",
+      userId: userWallet.userId,
+      deploymentAllowance: cached.chainDeploymentAllowance,
+      requiredDeposit,
+      reloadScheduled,
+      suppressedAttempts: cached.suppressedAttempts
+    });
+
+    this.#throwInsufficientDepositBalance(reloadScheduled, cached.retryAfterSeconds);
+  }
+
+  #throwInsufficientDepositBalance(reloadScheduled: boolean, retryAfterSeconds: number): never {
+    const message = reloadScheduled ? INSUFFICIENT_DEPOSIT_BALANCE_RELOADING_MESSAGE : INSUFFICIENT_DEPOSIT_BALANCE_MESSAGE;
+
+    throw createError(402, message, { headers: { "Retry-After": String(retryAfterSeconds) } });
   }
 
   #getCreateDeploymentMessages(messages: EncodeObject[]): { typeUrl: string; value: MsgCreateDeployment }[] {

--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.spec.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.spec.ts
@@ -89,6 +89,20 @@ describe(HonoErrorHandlerService.name, () => {
     });
   });
 
+  describe("when an HttpError carries headers", () => {
+    it("forwards them on the response alongside the payment_required code", async () => {
+      const { service, mockContext } = setup();
+      const error = createHttpError(402, "Not enough balance to cover the deployment deposit.", { headers: { "Retry-After": "300" } });
+
+      await service.handle(error, mockContext);
+
+      expect(mockContext.body).toHaveBeenCalledWith(
+        expect.stringContaining('"code":"payment_required"'),
+        expect.objectContaining({ status: 402, headers: expect.objectContaining({ "Retry-After": "300" }) })
+      );
+    });
+  });
+
   describe("when error contains non-JSON values", () => {
     it("handles bigint values in http errors", async () => {
       const { service, mockContext } = setup();

--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
@@ -49,7 +49,7 @@ export class HonoErrorHandlerService {
           type: errorType,
           data: error.data
         },
-        { status: error.status }
+        { status: error.status, headers: error.headers }
       );
     }
 
@@ -109,6 +109,8 @@ export class HonoErrorHandlerService {
         return "bad_request";
       case 401:
         return "unauthorized";
+      case 402:
+        return "payment_required";
       case 403:
         return "forbidden";
       case 404:

--- a/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
+++ b/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
@@ -60,10 +60,32 @@ describe("Tx Sign", () => {
       });
 
       expect(res.status).toBe(402);
+      expect(res.headers.get("Retry-After")).toMatch(/^[1-9]\d*$/);
       expect(await res.json()).toMatchObject({
         error: "PaymentRequiredError",
+        code: "payment_required",
         message: "Not enough balance to cover the deployment deposit. Add credits or turn on auto recharge to continue."
       });
+    });
+
+    it("keeps refusing a retried create with the same answer while the wallet stays unfunded", async () => {
+      const { user, token, wallet } = await setup({
+        deploymentAllowance: DEPLOYMENT_DEPOSIT_UDENOM - 1
+      });
+      const request = async () =>
+        app.request("/v1/tx", {
+          method: "POST",
+          body: await createMessageForDeployment(user.id, wallet.address),
+          headers: { "Content-Type": "application/json", authorization: `Bearer ${token}` }
+        });
+
+      const first = await request();
+      const second = await request();
+
+      expect(first.status).toBe(402);
+      expect(second.status).toBe(402);
+      expect(second.headers.get("Retry-After")).toMatch(/^[1-9]\d*$/);
+      expect(await second.json()).toEqual(await first.json());
     });
 
     it("creates blockchain transaction", async () => {


### PR DESCRIPTION
## Why

Two automated clients with zero credits retry deployment creates in a tight loop, one of them about 10,600 times a day. Each attempt reads the chain twice, cancels and re-queues the wallet's reload check, and logs a `DEPLOYMENT_CREATE_REFUSED_INSUFFICIENT_ALLOWANCE` warn. Nothing reaches the chain, so the damage is log volume and wasted work rather than a user-facing failure.

Fixes CON-942

## What

- A refused create is remembered per user for `DEPLOYMENT_CREATE_REFUSAL_CACHE_TTL_SECONDS` (default 300). While the wallet row still shows the allowance the refusal saw and the requested deposit still exceeds the chain allowance seen then, a repeat is refused straight from the cache: no chain reads, no reload re-queue, and no second warn. The hit is logged at debug.
- Invalidation comes from the wallet row, not the TTL. Every funding path (checkout, auto-reload charge, manual credit, refund) writes the fresh grant into `user_wallets.deployment_allowance`, and the signer re-reads that row on every request. A top-up on any pod therefore drops every pod's entry on the next attempt. The TTL only covers the rare case of a top-up landing exactly on a stale row value.
- A cached hit whose first refusal found auto recharge off still asks for a reload once, so a user who turns auto recharge on after the first refusal gets charged. Once a reload is scheduled, this path never schedules another.
- The 402 carries `Retry-After` (seconds left on the entry) and its body `code` is now `payment_required` instead of `unknown_error`.
- Left alone: the fee-allowance 402, the post-broadcast chain 402, and the deployment writer's work before the signer runs (SDL resolve, record + compensation job). A loop on `/v1/deployments` still pays for those.

Worst case per abusive user with 3 replicas: 3 × 86400 / 300 = 864 warns a day, down from about 10,600.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployment requests with insufficient funds now return clearer `payment_required` errors.
  - Responses include a numeric `Retry-After` value indicating when retrying may be appropriate.
  - Repeated unfunded deployment attempts receive consistent responses while funds remain insufficient.
  - Deployment attempts can proceed again after the account balance becomes sufficient.
  - Successfully broadcast transactions now record closed deployments.

- **Bug Fixes**
  - HTTP error responses preserve response headers, including retry guidance.
  - Status 402 errors are correctly mapped to `payment_required`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->