### PR TITLE
refactor(deployment): log the owner's account state on unfunded deployment events

### DIFF
--- a/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
@@ -5,6 +5,17 @@ export type FundingMessageItem = { deployment: DrainingDeployment; input: Deposi
 
 export type OwnerInsufficientBalanceItem = { deployment: DrainingDeployment; desiredAmount: number };
 
+export type UnfundedOwner = { userId: string; isTrialing: boolean; autoReloadEnabled: boolean };
+
+/** Lets the "could not fund" logs tell a paid account from a trial or Auto Recharge one without a database lookup. */
+export function describeUnfundedOwner(deployment: DrainingDeployment): UnfundedOwner {
+  return {
+    userId: deployment.userId,
+    isTrialing: deployment.walletIsTrialing,
+    autoReloadEnabled: deployment.isWalletAutoTopUpEnabled
+  };
+}
+
 /**
  * Telemetry sink shared by the two deployment top-up paths: the hourly cron and the event-driven
  * immediate funding that runs when credits land. The cron's summarizer-backed instrumentation and the
@@ -15,7 +26,7 @@ export interface DeploymentTopUpInstrumentation {
   recordDeploymentPreparation(ownerAddress: string, predictedClosedHeight: number): void;
   recordInvalidDepositAmount(details: { desiredAmount: number; dseq: string; address: string; blockRate: number }): void;
   recordRuntimeLimitReached(details: { dseq: string; address: string; runtimeEndsAt: Date }): void;
-  recordDepositBelowUsefulRunway(details: { dseq: string; address: string; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void;
+  recordDepositBelowUsefulRunway(details: { deployment: DrainingDeployment; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void;
   recordHeadroomConceded(details: {
     dseq: string;
     address: string;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
@@ -130,8 +130,20 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
   describe("recordOwnerInsufficientBalance", () => {
     it("counts every deployment as insufficient balance and warns once for the owner", () => {
       const { service, messagePreparationErrors, insufficientBalanceWithAutoReload } = setup();
-      const first = mock<DrainingDeployment>({ dseq: "123", address: "akash1owner", isWalletAutoTopUpEnabled: true });
-      const second = mock<DrainingDeployment>({ dseq: "456", address: "akash1owner", isWalletAutoTopUpEnabled: true });
+      const first = mock<DrainingDeployment>({
+        dseq: "123",
+        address: "akash1owner",
+        userId: "user-1",
+        walletIsTrialing: false,
+        isWalletAutoTopUpEnabled: true
+      });
+      const second = mock<DrainingDeployment>({
+        dseq: "456",
+        address: "akash1owner",
+        userId: "user-1",
+        walletIsTrialing: false,
+        isWalletAutoTopUpEnabled: true
+      });
 
       service.recordOwnerInsufficientBalance({
         owner: "akash1owner",
@@ -147,6 +159,9 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
       expect(mockLogger.warn).toHaveBeenCalledExactlyOnceWith({
         event: "FUND_DRAINING_OWNER_INSUFFICIENT_BALANCE",
         owner: "akash1owner",
+        userId: "user-1",
+        isTrialing: false,
+        autoReloadEnabled: true,
         spendable: 0,
         deploymentCount: 2,
         deployments: [
@@ -163,6 +178,34 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
       service.recordOwnerInsufficientBalance({ owner: "akash1owner", spendable: 0, deployments: [{ deployment, desiredAmount: 1_000_000 }] });
 
       expect(insufficientBalanceWithAutoReload.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("recordDepositBelowUsefulRunway", () => {
+    it("increments skips with a below_useful_runway reason and warns with the owner's account state", () => {
+      const { service, skips } = setup();
+      const deployment = mock<DrainingDeployment>({
+        dseq: "123",
+        address: "akash1owner",
+        userId: "user-1",
+        walletIsTrialing: true,
+        isWalletAutoTopUpEnabled: false
+      });
+
+      service.recordDepositBelowUsefulRunway({ deployment, desiredAmount: 50_000_000, affordableAmount: 500_000, runwayMinutes: 17 });
+
+      expect(skips.add).toHaveBeenCalledWith(1, { reason: "below_useful_runway" });
+      expect(mockLogger.warn).toHaveBeenCalledWith({
+        event: "FUND_DRAINING_DEPOSIT_BELOW_USEFUL_RUNWAY",
+        dseq: "123",
+        address: "akash1owner",
+        userId: "user-1",
+        isTrialing: true,
+        autoReloadEnabled: false,
+        desiredAmount: 50_000_000,
+        affordableAmount: 500_000,
+        runwayMinutes: 17
+      });
     });
   });
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -4,7 +4,12 @@ import { singleton } from "tsyringe";
 
 import { MetricsService } from "@src/core";
 import type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
-import type { DeploymentTopUpInstrumentation, FundingMessageItem, OwnerInsufficientBalanceItem } from "./deployment-top-up-instrumentation";
+import {
+  type DeploymentTopUpInstrumentation,
+  describeUnfundedOwner,
+  type FundingMessageItem,
+  type OwnerInsufficientBalanceItem
+} from "./deployment-top-up-instrumentation";
 
 export type FundDrainingFailureReason = "master_wallet_insufficient_funds" | "deposit_tx_failed" | "unknown";
 
@@ -160,9 +165,23 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
     this.emitLog("info", { event: "FUND_DRAINING_RUNTIME_LIMIT_REACHED", ...details });
   }
 
-  recordDepositBelowUsefulRunway(details: { dseq: string; address: string; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void {
+  recordDepositBelowUsefulRunway({
+    deployment,
+    ...amounts
+  }: {
+    deployment: DrainingDeployment;
+    desiredAmount: number;
+    affordableAmount: number;
+    runwayMinutes: number;
+  }): void {
     this.skips.add(1, { reason: "below_useful_runway" satisfies FundDrainingSkipReason });
-    this.emitLog("warn", { event: "FUND_DRAINING_DEPOSIT_BELOW_USEFUL_RUNWAY", ...details });
+    this.emitLog("warn", {
+      event: "FUND_DRAINING_DEPOSIT_BELOW_USEFUL_RUNWAY",
+      dseq: deployment.dseq,
+      address: deployment.address,
+      ...describeUnfundedOwner(deployment),
+      ...amounts
+    });
   }
 
   recordHeadroomConceded(details: {
@@ -209,6 +228,7 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
     this.emitLog("warn", {
       event: "FUND_DRAINING_OWNER_INSUFFICIENT_BALANCE",
       owner,
+      ...describeUnfundedOwner(deployments[0].deployment),
       spendable,
       deploymentCount: deployments.length,
       deployments: deployments.map(({ deployment, desiredAmount }) => ({ dseq: deployment.dseq, desiredAmount }))

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -211,8 +211,8 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     it("counts every deployment as insufficient balance and warns once for the owner", () => {
       const { service, logger, summarizer, countersByName } = setup();
       service.start(100, { dryRun: false });
-      const first = createDrainingDeployment({ isWalletAutoTopUpEnabled: true });
-      const second = createDrainingDeployment({ isWalletAutoTopUpEnabled: true, address: first.address });
+      const first = createDrainingDeployment({ isWalletAutoTopUpEnabled: true, walletIsTrialing: true });
+      const second = createDrainingDeployment({ isWalletAutoTopUpEnabled: true, walletIsTrialing: true, address: first.address, userId: first.userId });
 
       service.recordOwnerInsufficientBalance({
         owner: first.address,
@@ -229,6 +229,9 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
       expect(logger.warn).toHaveBeenCalledExactlyOnceWith({
         event: "TOP_UP_OWNER_INSUFFICIENT_BALANCE",
         owner: first.address,
+        userId: first.userId,
+        isTrialing: true,
+        autoReloadEnabled: true,
         spendable: 0,
         deploymentCount: 2,
         deployments: [
@@ -259,6 +262,46 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
       expect(summarizer.get("insufficientBalanceCount")).toBe(1);
       expect(countersByName["auto_top_up_message_preparation_errors_total"].add).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ dryRun: true }));
+    });
+  });
+
+  describe("recordDepositBelowUsefulRunway", () => {
+    it("counts the decline, warns with the owner's account state, and carries the dry-run flag", () => {
+      const { service, logger, summarizer, countersByName } = setup();
+      service.start(100, { dryRun: false });
+      const deployment = createDrainingDeployment({ walletIsTrialing: false, isWalletAutoTopUpEnabled: false });
+
+      service.recordDepositBelowUsefulRunway({ deployment, desiredAmount: 50_000_000, affordableAmount: 500_000, runwayMinutes: 17 });
+
+      expect(summarizer.get("depositsBelowUsefulRunwayCount")).toBe(1);
+      expect(countersByName["auto_top_up_deposits_below_useful_runway_total"].add).toHaveBeenCalledWith(1);
+      expect(logger.warn).toHaveBeenCalledWith({
+        event: "DEPOSIT_BELOW_USEFUL_RUNWAY",
+        dseq: deployment.dseq,
+        address: deployment.address,
+        userId: deployment.userId,
+        isTrialing: false,
+        autoReloadEnabled: false,
+        desiredAmount: 50_000_000,
+        affordableAmount: 500_000,
+        runwayMinutes: 17,
+        dryRun: false
+      });
+    });
+
+    it("counts the decline without emitting a metric in dry run mode", () => {
+      const { service, summarizer, countersByName } = setup();
+      service.start(100, { dryRun: true });
+
+      service.recordDepositBelowUsefulRunway({
+        deployment: createDrainingDeployment(),
+        desiredAmount: 50_000_000,
+        affordableAmount: 500_000,
+        runwayMinutes: 17
+      });
+
+      expect(summarizer.get("depositsBelowUsefulRunwayCount")).toBe(1);
+      expect(countersByName["auto_top_up_deposits_below_useful_runway_total"].add).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -6,7 +6,12 @@ import { type CreateLogger, LOGGER_FACTORY, MetricsService } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { TopUpSummarizer } from "@src/deployment/lib/top-up-summarizer/top-up-summarizer";
 import { DrainingDeployment } from "@src/deployment/types/draining-deployment";
-import type { DeploymentTopUpInstrumentation, FundingMessageItem, OwnerInsufficientBalanceItem } from "./deployment-top-up-instrumentation";
+import {
+  type DeploymentTopUpInstrumentation,
+  describeUnfundedOwner,
+  type FundingMessageItem,
+  type OwnerInsufficientBalanceItem
+} from "./deployment-top-up-instrumentation";
 
 @scoped(Lifecycle.ResolutionScoped)
 export class TopUpManagedDeploymentsInstrumentationService implements DeploymentTopUpInstrumentation {
@@ -251,6 +256,7 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
     this.logger.warn({
       event: "TOP_UP_OWNER_INSUFFICIENT_BALANCE",
       owner,
+      ...describeUnfundedOwner(deployments[0].deployment),
       spendable,
       deploymentCount: deployments.length,
       deployments: deployments.map(({ deployment, desiredAmount }) => ({ dseq: deployment.dseq, desiredAmount })),
@@ -268,12 +274,23 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
     });
   }
 
-  recordDepositBelowUsefulRunway(details: { dseq: string; address: string; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void {
+  recordDepositBelowUsefulRunway({
+    deployment,
+    ...amounts
+  }: {
+    deployment: DrainingDeployment;
+    desiredAmount: number;
+    affordableAmount: number;
+    runwayMinutes: number;
+  }): void {
     this.topUpSummarizer.inc("depositsBelowUsefulRunwayCount");
 
     this.logger.warn({
       event: "DEPOSIT_BELOW_USEFUL_RUNWAY",
-      ...details,
+      dseq: deployment.dseq,
+      address: deployment.address,
+      ...describeUnfundedOwner(deployment),
+      ...amounts,
       dryRun: this.options?.dryRun
     });
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -1034,8 +1034,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       await service.topUpDrainingDeploymentsForOwner({ walletId, address: owner });
 
       expect(fundDrainingInstrumentation.recordDepositBelowUsefulRunway).toHaveBeenCalledWith({
-        dseq: deployment.dseq,
-        address: deployment.address,
+        deployment,
         desiredAmount: 1000000,
         affordableAmount: 1000,
         runwayMinutes: DEDUP_COOLDOWN_IN_MIN - 1
@@ -1157,7 +1156,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
       expect(fundDrainingInstrumentation.recordHeadroomConceded).not.toHaveBeenCalled();
       expect(fundDrainingInstrumentation.recordDepositBelowUsefulRunway).toHaveBeenCalledWith(
-        expect.objectContaining({ dseq: deployment.dseq, affordableAmount: 600_000 })
+        expect.objectContaining({ deployment, affordableAmount: 600_000 })
       );
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -357,8 +357,7 @@ export class TopUpManagedDeploymentsService {
 
           if (this.#isCappedBelowUsefulRunway({ desiredAmount, affordableAmount, runwayMinutes })) {
             instrumentation.recordDepositBelowUsefulRunway({
-              dseq: deployment.dseq,
-              address: deployment.address,
+              deployment,
               desiredAmount,
               affordableAmount,
               runwayMinutes


### PR DESCRIPTION
## Why

Ref CON-908

CON-908 asks for a second warning when a deployment is hours from closing for lack of credits, but only if paid accounts actually reach that point. The two log events that mark "automatic funding could not fund this deployment" carry the wallet address and the amounts, nothing about the account. Checking prod this week, every case I could trace was a trial wallet created within the previous hour or so, and the two older wallets could not be classified from the logs at all. Without the account state on the event, Loki cannot say whether a paid user has ever hit it.

## What

Adds `userId`, `isTrialing` and `autoReloadEnabled` to the four "could not fund" log lines, in both funding paths:

- `TOP_UP_OWNER_INSUFFICIENT_BALANCE` and `DEPOSIT_BELOW_USEFUL_RUNWAY` (hourly sweep)
- `FUND_DRAINING_OWNER_INSUFFICIENT_BALANCE` and `FUND_DRAINING_DEPOSIT_BELOW_USEFUL_RUNWAY` (event-driven funding)

The values already sit on every `DrainingDeployment`, so there is no extra query. `recordDepositBelowUsefulRunway` now takes the deployment instead of its picked `dseq` and `address`, the same shape `recordMessagePreparationError` uses. Counters, summarizer fields and the skip reasons are unchanged, so no dashboard or alert moves.

Follow-up query once this is deployed, to decide whether CON-908 is worth building:

```
{namespace="prod", service_name=~"console-api-.*"} |~ "OWNER_INSUFFICIENT_BALANCE|DEPOSIT_BELOW_USEFUL_RUNWAY" | json | isTrialing="false" | autoReloadEnabled="false"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking for unresolved funding transactions, including reconciliation when transaction details are available.
  * Added monitoring for deployment settings that lack corresponding chain state.
  * Added owner account details to insufficient-balance and low-runway warning logs, including user, trial, and automatic reload status.
  * Improved funding instrumentation to associate warnings with the relevant deployment and owner context.

* **Tests**
  * Expanded coverage for unresolved transactions, low-runway tracking, warning metadata, metrics, skip counts, and dry-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->