### PR TITLE
feat(billing): attribute automatic charges to their trigger

### DIFF
--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -73,6 +73,8 @@ Checks are **spend-event-driven**, not fixed to a daily cadence. A check is enqu
 3. After every spending broadcast, after initial deployment funding, and after each escrow top-up cycle.
 4. On a self-rescheduled job that acts only as a safety net: 24h out normally, or at the charge-window reopen when the previous check was rate-limited.
 
+Every `WALLET_BALANCE_RELOADED`, `WALLET_BALANCE_RELOAD_SKIPPED`, and `WALLET_BALANCE_RELOAD_FAILED` line and the matching counters carry `triggeredByDeployment` (`triggered_by_deployment` on the counters), so a charge caused by a refused deployment create or by initial funding is distinguishable from one caused by spend (CON-843).
+
 Because pg-boss's `singleton` policy uniqueness applies only to *active* jobs, an immediate enqueue is never swallowed by the pending daily safety-net job. Top-ups therefore happen within seconds of the balance crossing the threshold.
 
 ## Validation flow

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
@@ -27,10 +27,11 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
         balance: faker.number.float({ min: 0, max: 100 })
       };
 
-      service.recordReloadFailed({ mode: "threshold", error, logContext });
+      service.recordReloadFailed({ mode: "threshold", triggeredByDeployment: false, error, logContext });
 
       expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, {
         mode: "threshold",
+        triggered_by_deployment: "false",
         error_type: "TypeError",
         decline_code: "none"
       });
@@ -52,10 +53,11 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
         balance: faker.number.float({ min: 0, max: 100 })
       };
 
-      service.recordReloadFailed({ mode: "prediction", error, logContext });
+      service.recordReloadFailed({ mode: "prediction", triggeredByDeployment: false, error, logContext });
 
       expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, {
         mode: "prediction",
+        triggered_by_deployment: "false",
         error_type: "Unknown",
         decline_code: "none"
       });
@@ -73,10 +75,11 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
       const { service, counters } = setup();
       const error = new TypeError(faker.lorem.sentence());
 
-      service.recordReloadFailed({ mode: "threshold", error, declineCode: "stolen_card", logContext: {} });
+      service.recordReloadFailed({ mode: "threshold", triggeredByDeployment: false, error, declineCode: "stolen_card", logContext: {} });
 
       expect(counters.wallet_balance_reload_check_reload_failures_total.add).toHaveBeenCalledWith(1, {
         mode: "threshold",
+        triggered_by_deployment: "false",
         error_type: "TypeError",
         decline_code: "stolen_card"
       });
@@ -101,9 +104,12 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
       const { service, histograms, counters } = setup();
       const logContext = { walletAddress: faker.string.alphanumeric(44), balance: 10 };
 
-      service.recordReloadTriggered({ mode: "prediction", amount: 40, coverageRatio: 0.2, projectedCost: 50, logContext });
+      service.recordReloadTriggered({ mode: "prediction", triggeredByDeployment: false, amount: 40, coverageRatio: 0.2, projectedCost: 50, logContext });
 
-      expect(counters.wallet_balance_reload_check_reloads_triggered_total.add).toHaveBeenCalledWith(1, { mode: "prediction" });
+      expect(counters.wallet_balance_reload_check_reloads_triggered_total.add).toHaveBeenCalledWith(1, {
+        mode: "prediction",
+        triggered_by_deployment: "false"
+      });
       expect(histograms.wallet_balance_reload_check_balance_coverage_ratio.record).toHaveBeenCalledWith(0.2, { mode: "prediction" });
       expect(histograms.wallet_balance_reload_check_projected_cost_usd.record).toHaveBeenCalledWith(50, { mode: "prediction" });
       expect(mockLogger.info).toHaveBeenCalledWith(
@@ -114,11 +120,28 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
     it("omits the projected cost histogram in threshold mode", () => {
       const { service, histograms, counters } = setup();
 
-      service.recordReloadTriggered({ mode: "threshold", amount: 100, coverageRatio: 0.5, logContext: { threshold: 20 } });
+      service.recordReloadTriggered({ mode: "threshold", triggeredByDeployment: false, amount: 100, coverageRatio: 0.5, logContext: { threshold: 20 } });
 
-      expect(counters.wallet_balance_reload_check_reloads_triggered_total.add).toHaveBeenCalledWith(1, { mode: "threshold" });
+      expect(counters.wallet_balance_reload_check_reloads_triggered_total.add).toHaveBeenCalledWith(1, {
+        mode: "threshold",
+        triggered_by_deployment: "false"
+      });
       expect(histograms.wallet_balance_reload_check_balance_coverage_ratio.record).toHaveBeenCalledWith(0.5, { mode: "threshold" });
       expect(histograms.wallet_balance_reload_check_projected_cost_usd.record).not.toHaveBeenCalled();
+    });
+
+    it("labels a deployment-triggered reload so refusal-loop charges are distinguishable from spend-driven ones", () => {
+      const { service, counters } = setup();
+
+      service.recordReloadTriggered({ mode: "prediction", triggeredByDeployment: true, amount: 20, coverageRatio: 0, logContext: { balance: 0 } });
+
+      expect(counters.wallet_balance_reload_check_reloads_triggered_total.add).toHaveBeenCalledWith(1, {
+        mode: "prediction",
+        triggered_by_deployment: "true"
+      });
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ balance: 0, triggeredByDeployment: true, amount: 20, event: "WALLET_BALANCE_RELOADED" })
+      );
     });
   });
 
@@ -126,13 +149,28 @@ describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
     it("increments the skipped counter with the mode and reason and logs the skip", () => {
       const { service, counters } = setup();
 
-      service.recordReloadSkipped({ mode: "threshold", reason: "sufficient_balance", coverageRatio: 1.5, logContext: { threshold: 20 } });
+      service.recordReloadSkipped({
+        mode: "threshold",
+        triggeredByDeployment: true,
+        reason: "sufficient_balance",
+        coverageRatio: 1.5,
+        logContext: { threshold: 20 }
+      });
 
       expect(counters.wallet_balance_reload_check_reloads_skipped_total.add).toHaveBeenCalledWith(1, {
         mode: "threshold",
+        triggered_by_deployment: "true",
         reason: "sufficient_balance"
       });
-      expect(mockLogger.info).toHaveBeenCalledWith(expect.objectContaining({ threshold: 20, mode: "threshold", event: "WALLET_BALANCE_RELOAD_SKIPPED" }));
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threshold: 20,
+          mode: "threshold",
+          triggeredByDeployment: true,
+          reason: "sufficient_balance",
+          event: "WALLET_BALANCE_RELOAD_SKIPPED"
+        })
+      );
     });
   });
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -7,6 +7,7 @@ import { MetricsService } from "@src/core";
 
 type ReloadMetricInput = {
   mode: WalletSettingOutput["autoReloadMode"];
+  triggeredByDeployment: boolean;
   coverageRatio?: number;
   projectedCost?: number;
   logContext: Record<string, unknown>;
@@ -92,12 +93,14 @@ export class WalletBalanceReloadCheckInstrumentationService {
 
   recordReloadTriggered(input: ReloadMetricInput & { amount: number }): void {
     this.reloadsTriggered.add(1, {
-      mode: input.mode
+      mode: input.mode,
+      triggered_by_deployment: String(input.triggeredByDeployment)
     });
     this.#recordCoverage(input);
     this.logger.info({
       ...input.logContext,
       mode: input.mode,
+      triggeredByDeployment: input.triggeredByDeployment,
       amount: input.amount,
       event: "WALLET_BALANCE_RELOADED"
     });
@@ -106,12 +109,15 @@ export class WalletBalanceReloadCheckInstrumentationService {
   recordReloadSkipped(input: ReloadMetricInput & { reason: "zero_cost" | "sufficient_balance" | "no_active_deployments" | "charge_rate_limited" }): void {
     this.reloadsSkipped.add(1, {
       mode: input.mode,
+      triggered_by_deployment: String(input.triggeredByDeployment),
       reason: input.reason
     });
     this.#recordCoverage(input);
     this.logger.info({
       ...input.logContext,
       mode: input.mode,
+      triggeredByDeployment: input.triggeredByDeployment,
+      reason: input.reason,
       event: "WALLET_BALANCE_RELOAD_SKIPPED"
     });
   }
@@ -125,15 +131,17 @@ export class WalletBalanceReloadCheckInstrumentationService {
     }
   }
 
-  recordReloadFailed(input: Pick<ReloadMetricInput, "mode" | "logContext"> & { error: unknown; declineCode?: string }): void {
+  recordReloadFailed(input: Pick<ReloadMetricInput, "mode" | "triggeredByDeployment" | "logContext"> & { error: unknown; declineCode?: string }): void {
     this.reloadFailures.add(1, {
       mode: input.mode,
+      triggered_by_deployment: String(input.triggeredByDeployment),
       error_type: input.error instanceof Error ? input.error.constructor.name : "Unknown",
       decline_code: input.declineCode ?? "none"
     });
     this.logger.error({
       ...input.logContext,
       mode: input.mode,
+      triggeredByDeployment: input.triggeredByDeployment,
       event: "WALLET_BALANCE_RELOAD_FAILED",
       declineCode: input.declineCode,
       error: input.error

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -310,6 +310,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith({
         mode: "prediction",
+        triggeredByDeployment: false,
         error,
         logContext: expect.objectContaining({
           walletAddress: expect.any(String),
@@ -518,7 +519,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     });
 
     it("charges on a deployment-triggered check without consulting the active-deployment count", async () => {
-      const { handler, stripeTransactionService, deploymentRepository, job, jobMeta } = setup({
+      const { handler, stripeTransactionService, deploymentRepository, instrumentationService, job, jobMeta } = setup({
         autoReloadMode: "threshold",
         balance: 0,
         autoReloadThresholdUsd: 20,
@@ -531,10 +532,11 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       expect(deploymentRepository.countActiveByOwner).not.toHaveBeenCalled();
       expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
+      expect(instrumentationService.recordReloadTriggered).toHaveBeenCalledWith(expect.objectContaining({ triggeredByDeployment: true }));
     });
 
     it("charges when at or below the threshold and there is at least one active deployment", async () => {
-      const { handler, stripeTransactionService, deploymentRepository, wallet, job, jobMeta } = setup({
+      const { handler, stripeTransactionService, deploymentRepository, instrumentationService, wallet, job, jobMeta } = setup({
         autoReloadMode: "threshold",
         balance: 10,
         autoReloadThresholdUsd: 20,
@@ -546,6 +548,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       expect(deploymentRepository.countActiveByOwner).toHaveBeenCalledWith(wallet.address);
       expect(stripeTransactionService.createPaymentIntent).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
+      expect(instrumentationService.recordReloadTriggered).toHaveBeenCalledWith(expect.objectContaining({ triggeredByDeployment: false }));
     });
 
     it("clamps the charge to the $25 minimum when the stored amount is below it", async () => {
@@ -575,6 +578,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
       expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith({
         mode: "threshold",
+        triggeredByDeployment: false,
         error,
         logContext: expect.objectContaining({ walletAddress: expect.any(String), balance: 10, threshold: 20, reloadAmount: 100 })
       });

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -215,14 +215,26 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     const coverageRatio = threshold > 0 ? balance / threshold : undefined;
 
     if (balance > threshold) {
-      this.instrumentationService.recordReloadSkipped({ mode, reason: "sufficient_balance", coverageRatio, logContext: log });
+      this.instrumentationService.recordReloadSkipped({
+        mode,
+        triggeredByDeployment: resources.triggeredByDeployment,
+        reason: "sufficient_balance",
+        coverageRatio,
+        logContext: log
+      });
       return;
     }
 
     if (!resources.triggeredByDeployment) {
       const activeDeploymentCount = await this.deploymentRepository.countActiveByOwner(resources.wallet.address);
       if (activeDeploymentCount === 0) {
-        this.instrumentationService.recordReloadSkipped({ mode, reason: "no_active_deployments", coverageRatio, logContext: log });
+        this.instrumentationService.recordReloadSkipped({
+          mode,
+          triggeredByDeployment: resources.triggeredByDeployment,
+          reason: "no_active_deployments",
+          coverageRatio,
+          logContext: log
+        });
         return;
       }
     }
@@ -245,13 +257,21 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     const coverageRatio = costUntilTargetDateInFiat > 0 ? resources.balance / costUntilTargetDateInFiat : undefined;
 
     if (costUntilTargetDateInFiat === 0) {
-      this.instrumentationService.recordReloadSkipped({ mode, reason: "zero_cost", coverageRatio, projectedCost: costUntilTargetDateInFiat, logContext: log });
+      this.instrumentationService.recordReloadSkipped({
+        mode,
+        triggeredByDeployment: resources.triggeredByDeployment,
+        reason: "zero_cost",
+        coverageRatio,
+        projectedCost: costUntilTargetDateInFiat,
+        logContext: log
+      });
       return;
     }
 
     if (resources.balance >= threshold) {
       this.instrumentationService.recordReloadSkipped({
         mode,
+        triggeredByDeployment: resources.triggeredByDeployment,
         reason: "sufficient_balance",
         coverageRatio,
         projectedCost: costUntilTargetDateInFiat,
@@ -288,6 +308,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       const nextCheckAt = this.#calculateChargeWindowReopenDate(attempt.secondsUntilWindowReopen);
       this.instrumentationService.recordReloadSkipped({
         mode,
+        triggeredByDeployment: resources.triggeredByDeployment,
         reason: "charge_rate_limited",
         coverageRatio,
         projectedCost,
@@ -317,10 +338,23 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
         await this.walletSettingRepository.resetChargeFailures(resources.walletSetting.id);
       }
 
-      this.instrumentationService.recordReloadTriggered({ mode, amount, coverageRatio, projectedCost, logContext });
+      this.instrumentationService.recordReloadTriggered({
+        mode,
+        triggeredByDeployment: resources.triggeredByDeployment,
+        amount,
+        coverageRatio,
+        projectedCost,
+        logContext
+      });
     } catch (error) {
       const decline = toCardDecline(error);
-      this.instrumentationService.recordReloadFailed({ mode, error, declineCode: decline?.declineCode, logContext });
+      this.instrumentationService.recordReloadFailed({
+        mode,
+        triggeredByDeployment: resources.triggeredByDeployment,
+        error,
+        declineCode: decline?.declineCode,
+        logContext
+      });
 
       if (decline) {
         await this.#recordDecline(attempt.claim, resources, decline);


### PR DESCRIPTION
## Why

Part of CON-843

Between 2026-09-02 and 2026-09-05 one wallet logged a `WALLET_BALANCE_RELOADED` every 61 minutes, 78 in a row, while every other wallet peaked at one a day. Nothing paged, and the log lines could not say whether those checks came from spend or from the refused-create loop the same client was running (CON-942). The reloads turned out to be phantom `requires_action` intents (fixed in #3809), but a working card in the same loop would have been charged $480 a day with the same silence.

CON-904 and CON-927 cap automatic charges at one per wallet per hour, so CON-843's original "several charges within an hour" burst cannot happen any more. The issue was re-scoped to what the data shows is still undetected: a wallet reloading at the hourly ceiling for a day, and charges that cannot be attributed to their trigger.

## What

- `WALLET_BALANCE_RELOADED`, `WALLET_BALANCE_RELOAD_SKIPPED` and `WALLET_BALANCE_RELOAD_FAILED` log lines carry `triggeredByDeployment`, and the skipped line now also carries its `reason` (it was only on the counter before).
- The `reloads_triggered`, `reloads_skipped` and `reload_failures` counters gain a `triggered_by_deployment` label.
- README notes the new field.

Outside the repo, done alongside this PR:

- Grafana alert `Auto Recharge Sustained On One Wallet` (folder console, group `1m`, uid `efxdbaao0ly4gc`): fires when one wallet has more than 5 automatic reloads in 24h, one instance per wallet, `for: 10m`, Slack Console Alerts. Baseline over the 10 days to 2026-09-05: every normal wallet peaked at 1/day, the refusal-loop wallet sat at 24/day. It went Pending on that wallet within two minutes of being created (19 reloads in the trailing 24h; the last phantom one was at 15:05 UTC, right after #3809 deployed).
- Dashboard panel "Automatic Charges per Wallet (24h)" on Billing Pipeline Overview (count and USD per wallet from the reloaded log line) is being added separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wallet balance reload events now indicate whether they were triggered by a deployment or by spending activity.
  - Billing metrics and logs distinguish deployment-triggered reloads from regular reloads, including skipped and failed attempts.

- **Documentation**
  - Added documentation describing the new deployment-trigger metadata and metric labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->