### PR TITLE
fix(auth): redirect to login on identity provider callback errors instead of returning a 500

### DIFF
--- a/apps/deploy-web/src/components/auth/AuthPage/AuthPage.spec.tsx
+++ b/apps/deploy-web/src/components/auth/AuthPage/AuthPage.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { DEPENDENCIES } from "./AuthPage";
-import { AuthPage } from "./AuthPage";
+import { AuthPage, PROVIDER_LOGIN_FAILED_ERROR } from "./AuthPage";
 
 import { render, screen } from "@testing-library/react";
 
@@ -34,10 +34,21 @@ describe(AuthPage.name, () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
-  function setup(input: { authParam?: string; tab?: string }) {
+  it("shows a provider failure message when ?error=provider_login_failed is present", () => {
+    setup({ error: PROVIDER_LOGIN_FAILED_ERROR });
+    expect(screen.getByText(/Sign-in with your provider did not complete/)).toBeInTheDocument();
+  });
+
+  it("does not show a provider failure message without the error param", () => {
+    setup({});
+    expect(screen.queryByText(/Sign-in with your provider did not complete/)).not.toBeInTheDocument();
+  });
+
+  function setup(input: { authParam?: string; tab?: string; error?: string }) {
     const params = new URLSearchParams();
     if (input.authParam) params.set("auth", input.authParam);
     if (input.tab) params.set("tab", input.tab);
+    if (input.error) params.set("error", input.error);
     const replace = vi.fn();
     const dependencies: typeof DEPENDENCIES = {
       AuthLayout: (({ children }: { children?: React.ReactNode }) => <div data-testid="layout">{children}</div>) as never,

--- a/apps/deploy-web/src/components/auth/AuthPage/AuthPage.tsx
+++ b/apps/deploy-web/src/components/auth/AuthPage/AuthPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { Alert, AlertDescription } from "@akashnetwork/ui/components";
 import { useSearchParams } from "next/navigation";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
@@ -9,6 +10,8 @@ import { AuthLayout } from "@src/components/auth/AuthLayout/AuthLayout";
 import { H100PriceStatus } from "@src/components/gpu/H100PriceStatus/H100PriceStatus";
 import { PasswordAuth } from "../PasswordAuth/PasswordAuth";
 import { PasswordlessAuthClient } from "../PasswordlessAuth/PasswordlessAuth";
+
+export const PROVIDER_LOGIN_FAILED_ERROR = "provider_login_failed";
 
 export const DEPENDENCIES = {
   AuthLayout,
@@ -29,6 +32,7 @@ export function AuthPage({ dependencies: d = DEPENDENCIES }: Props = {}) {
   const searchParams = d.useSearchParams();
   const forcePassword = searchParams.get("auth") === "password";
   const showPasswordless = !forcePassword;
+  const hasProviderLoginFailed = searchParams.get("error") === PROVIDER_LOGIN_FAILED_ERROR;
 
   useEffect(
     function stripTabParamWhenPasswordless() {
@@ -45,6 +49,11 @@ export function AuthPage({ dependencies: d = DEPENDENCIES }: Props = {}) {
     <d.AuthLayout topRightContent={<d.H100PriceStatus />}>
       <d.NextSeo title="Sign in to Akash Console" />
       <div className="flex w-full max-w-[420px] flex-col items-center gap-6 px-3 py-4 sm:px-6 lg:px-0">
+        {hasProviderLoginFailed && (
+          <Alert variant="destructive">
+            <AlertDescription>Sign-in with your provider did not complete. Please try again or use another sign-in method.</AlertDescription>
+          </Alert>
+        )}
         {showPasswordless ? <d.PasswordlessAuth /> : <d.PasswordAuth />}
       </div>
     </d.AuthLayout>

--- a/apps/deploy-web/src/lib/auth0/getIdentityProviderError/getIdentityProviderError.spec.ts
+++ b/apps/deploy-web/src/lib/auth0/getIdentityProviderError/getIdentityProviderError.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { CallbackHandlerError, IdentityProviderError, MissingStateCookieError } from "@src/lib/auth0";
+import { getIdentityProviderError } from "./getIdentityProviderError";
+
+describe(getIdentityProviderError.name, () => {
+  it("returns the identity provider error wrapped by a callback handler error", () => {
+    const cause = new IdentityProviderError({
+      message: "invalid_request (InternalOAuthError: failed to fetch user profile)",
+      error: "invalid_request",
+      error_description: "InternalOAuthError: failed to fetch user profile"
+    });
+
+    const result = getIdentityProviderError(new CallbackHandlerError(cause));
+
+    expect(result).toBe(cause);
+    expect(result?.error).toBe("invalid_request");
+  });
+
+  it("returns undefined for a callback handler error with another cause", () => {
+    expect(getIdentityProviderError(new CallbackHandlerError(new MissingStateCookieError()))).toBeUndefined();
+  });
+
+  it("returns undefined for a bare identity provider error", () => {
+    const error = new IdentityProviderError({ message: "access_denied", error: "access_denied", error_description: "denied" });
+    expect(getIdentityProviderError(error)).toBeUndefined();
+  });
+
+  it("returns undefined for non-auth errors", () => {
+    expect(getIdentityProviderError(new Error("boom"))).toBeUndefined();
+    expect(getIdentityProviderError(undefined)).toBeUndefined();
+  });
+});

--- a/apps/deploy-web/src/lib/auth0/getIdentityProviderError/getIdentityProviderError.ts
+++ b/apps/deploy-web/src/lib/auth0/getIdentityProviderError/getIdentityProviderError.ts
@@ -1,0 +1,9 @@
+import { CallbackHandlerError, IdentityProviderError } from "@src/lib/auth0";
+
+export function getIdentityProviderError(error: unknown): IdentityProviderError | undefined {
+  if (!(error instanceof CallbackHandlerError)) {
+    return undefined;
+  }
+
+  return error.cause instanceof IdentityProviderError ? error.cause : undefined;
+}

--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -5,7 +5,7 @@ import { once } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { setAccountCreatedCookie } from "@src/lib/analytics/account-created-cookie";
-import type { IdentityProviderError, Session } from "@src/lib/auth0";
+import type { Session } from "@src/lib/auth0";
 import { CallbackHandlerError, MissingStateCookieError } from "@src/lib/auth0";
 import { handleAuth, handleCallback, handleLogin, handleLogout } from "@src/lib/auth0";
 import { clearSessionCookies } from "@src/lib/auth0/clearSessionCookies/clearSessionCookies";
@@ -64,13 +64,20 @@ const authHandler = once((services: AppServices) =>
         }
 
         const identityProviderError = getIdentityProviderError(error);
+        if (identityProviderError?.error === "access_denied") {
+          services.logger.info({ event: "AUTH_CALLBACK_ACCESS_DENIED" });
+          res.writeHead(302, { Location: "/login" });
+          res.end();
+          return;
+        }
+
         if (identityProviderError) {
           services.logger.warn({
             event: "AUTH_CALLBACK_IDENTITY_PROVIDER_ERROR",
             error: identityProviderError.error,
             errorDescription: identityProviderError.errorDescription
           });
-          res.writeHead(302, { Location: getLoginUrlAfterIdentityProviderError(identityProviderError) });
+          res.writeHead(302, { Location: "/login?error=provider_login_failed" });
           res.end();
           return;
         }
@@ -133,10 +140,6 @@ function isGeneralAxiosError(error: unknown): error is AxiosError {
 
 function isMissingStateCookieError(error: unknown): boolean {
   return error instanceof CallbackHandlerError && error.cause instanceof MissingStateCookieError;
-}
-
-function getLoginUrlAfterIdentityProviderError(error: IdentityProviderError): string {
-  return error.error === "access_denied" ? "/login" : "/login?error=provider_login_failed";
 }
 
 function clearSessionAndRedirectToLogin(req: NextApiRequest, res: NextApiResponse): void {

--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -5,10 +5,11 @@ import { once } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { setAccountCreatedCookie } from "@src/lib/analytics/account-created-cookie";
-import type { Session } from "@src/lib/auth0";
-import { CallbackHandlerError, IdentityProviderError, MissingStateCookieError } from "@src/lib/auth0";
+import type { IdentityProviderError, Session } from "@src/lib/auth0";
+import { CallbackHandlerError, MissingStateCookieError } from "@src/lib/auth0";
 import { handleAuth, handleCallback, handleLogin, handleLogout } from "@src/lib/auth0";
 import { clearSessionCookies } from "@src/lib/auth0/clearSessionCookies/clearSessionCookies";
+import { getIdentityProviderError } from "@src/lib/auth0/getIdentityProviderError/getIdentityProviderError";
 import { isAccessTokenExpired } from "@src/lib/auth0/isAccessTokenExpired/isAccessTokenExpired";
 import { isInvalidSessionError } from "@src/lib/auth0/isInvalidSessionError/isInvalidSessionError";
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
@@ -62,9 +63,14 @@ const authHandler = once((services: AppServices) =>
           return;
         }
 
-        if (isAccessDeniedError(error)) {
-          services.logger.info({ event: "AUTH_CALLBACK_ACCESS_DENIED" });
-          res.writeHead(302, { Location: "/login" });
+        const identityProviderError = getIdentityProviderError(error);
+        if (identityProviderError) {
+          services.logger.warn({
+            event: "AUTH_CALLBACK_IDENTITY_PROVIDER_ERROR",
+            error: identityProviderError.error,
+            errorDescription: identityProviderError.errorDescription
+          });
+          res.writeHead(302, { Location: getLoginUrlAfterIdentityProviderError(identityProviderError) });
           res.end();
           return;
         }
@@ -129,8 +135,8 @@ function isMissingStateCookieError(error: unknown): boolean {
   return error instanceof CallbackHandlerError && error.cause instanceof MissingStateCookieError;
 }
 
-function isAccessDeniedError(error: unknown): boolean {
-  return error instanceof CallbackHandlerError && error.cause instanceof IdentityProviderError && error.cause.error === "access_denied";
+function getLoginUrlAfterIdentityProviderError(error: IdentityProviderError): string {
+  return error.error === "access_denied" ? "/login" : "/login?error=provider_login_failed";
 }
 
 function clearSessionAndRedirectToLogin(req: NextApiRequest, res: NextApiResponse): void {


### PR DESCRIPTION
## Why

Sentry and Loki keep reporting `CallbackHandlerError ... invalid_request (InternalOAuthError: failed to fetch user profile (status: 401 ... UNAUTHENTICATED))` from `/api/auth/callback`.

That text comes from Auth0's own Google connection: Auth0 exchanged the Google code, then Google rejected the token on the userinfo call. Auth0 forwards it to us as `error=invalid_request`, and nextjs-auth0 wraps it in `IdentityProviderError`, the same class as the `access_denied` case we already handle. Nothing in deploy-web triggers it. In prod it hit 3 Google login attempts out of roughly 2,350 over the last 30 days (Aug 25 twice, Sep 5 once), across two releases, so it is neither a regression nor a broken connection config.

What we do get wrong is the handling. Every identity-provider error other than `access_denied` was treated as an application failure: a Sentry error plus a raw JSON 500 body shown to the user. The Sep 5 user refreshed that JSON page, hit the missing-state-cookie path and landed on `/login` with no explanation.

## What

- New `getIdentityProviderError` helper returns the `IdentityProviderError` cause of a `CallbackHandlerError`, with a spec.
- The callback now treats any identity-provider error as an expected upstream failure instead of a 500. `access_denied` keeps its existing info-level `AUTH_CALLBACK_ACCESS_DENIED` log and silent redirect to `/login`. Every other code logs `AUTH_CALLBACK_IDENTITY_PROVIDER_ERROR` at warn with the `error` and `error_description` fields and redirects to `/login?error=provider_login_failed`.
- `AUTH_CALLBACK_ERROR` and the Sentry report now only fire for genuinely unexpected errors (state mismatch, discovery or network failures, thrown application code).
- The login page shows a destructive alert when `?error=provider_login_failed` is present, with a spec for both presence and absence.
