### PR TITLE
refactor(billing): make Console the only source of truth for the default payment method

### DIFF
--- a/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.integration.ts
@@ -28,19 +28,17 @@ describe(PaymentMethodService.name, () => {
     const payingUser = () => mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
     const listResponse = (data: Stripe.PaymentMethod[]) => ({ data, has_more: false }) as unknown as Stripe.Response<Stripe.ApiList<Stripe.PaymentMethod>>;
 
-    it("repairs an unsynced remote method by syncing it and pushing the Stripe default", async () => {
+    it("repairs an unsynced remote method by syncing it as the local default", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
       const remote = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
       const healed = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" }), isDefault: true };
       vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue(listResponse([remote]));
       paymentMethodRepository.findByUserId.mockResolvedValueOnce([]).mockResolvedValueOnce([healed]);
       paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: healed, isNew: true });
-      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
 
       const result = await service.getPaymentMethods(payingUser(), ability);
 
       expect(paymentMethodRepository.upsert).toHaveBeenCalledWith({ userId: "user_1", fingerprint: "fp_1", paymentMethodId: "pm_1" });
-      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
       expect(result).toEqual([{ ...remote, validated: false, isDefault: true }]);
     });
 
@@ -51,7 +49,6 @@ describe(PaymentMethodService.name, () => {
       vi.spyOn(stripe.paymentMethods, "list").mockResolvedValue(listResponse([newer, older]));
       paymentMethodRepository.findByUserId.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
       paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: generateDatabasePaymentMethod({ paymentMethodId: "pm_old" }), isNew: true });
-      vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
 
       await service.getPaymentMethods(payingUser(), ability);
 
@@ -73,18 +70,19 @@ describe(PaymentMethodService.name, () => {
   });
 
   describe("markPaymentMethodAsDefault", () => {
-    it("sets an already-synced method as default locally and on Stripe", async () => {
+    it("sets an already-synced method as the local default without touching the Stripe customer", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
       const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
       const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1" });
-      const remote = generatePaymentMethod({ id: "pm_1" });
+      const remote = generatePaymentMethod({ id: "pm_1", customer: "cus_1" });
       paymentMethodRepository.markAsDefault.mockResolvedValue(local);
       vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asPaymentMethodResponse(remote));
-      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+      const update = vi.spyOn(stripe.customers, "update");
 
       const result = await service.markPaymentMethodAsDefault("pm_1", user, ability);
 
-      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
+      expect(paymentMethodRepository.markAsDefault).toHaveBeenCalledWith("pm_1");
+      expect(update).not.toHaveBeenCalled();
       expect(paymentMethodRepository.createAsDefault).not.toHaveBeenCalled();
       expect(result).toEqual({ ...remote, validated: local.isValidated, isDefault: local.isDefault });
     });
@@ -92,12 +90,11 @@ describe(PaymentMethodService.name, () => {
     it("creates a local record for an unsynced method, then sets it as default", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
       const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
-      const remote = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
+      const remote = generatePaymentMethod({ id: "pm_1", customer: "cus_1", card: { fingerprint: "fp_1" } });
       const created = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
       paymentMethodRepository.markAsDefault.mockResolvedValue(undefined);
       paymentMethodRepository.createAsDefault.mockResolvedValue(created);
       vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asPaymentMethodResponse(remote));
-      vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
 
       const result = await service.markPaymentMethodAsDefault("pm_1", user, ability);
 
@@ -105,11 +102,38 @@ describe(PaymentMethodService.name, () => {
       expect(result).toEqual({ ...remote, validated: created.isValidated, isDefault: created.isDefault });
     });
 
+    it("rejects with 404 without touching local rows when the method belongs to another customer", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asPaymentMethodResponse(generatePaymentMethod({ id: "pm_1", customer: "cus_other" })));
+
+      await expect(service.markPaymentMethodAsDefault("pm_1", user, ability)).rejects.toMatchObject({ status: 404 });
+      expect(paymentMethodRepository.markAsDefault).not.toHaveBeenCalled();
+      expect(paymentMethodRepository.createAsDefault).not.toHaveBeenCalled();
+    });
+
+    it("rejects with 404 when Stripe reports the method missing", async () => {
+      const { service, stripe, paymentMethodRepository } = setup();
+      const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(
+        new Stripe.errors.StripeInvalidRequestError({
+          type: "invalid_request_error",
+          code: "resource_missing",
+          message: "No such PaymentMethod"
+        } as Stripe.StripeRawError)
+      );
+
+      await expect(service.markPaymentMethodAsDefault("pm_1", user, ability)).rejects.toMatchObject({ status: 404 });
+      expect(paymentMethodRepository.markAsDefault).not.toHaveBeenCalled();
+    });
+
     it("rejects with 403 when an unsynced method has no identifiable fingerprint", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
       const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
       paymentMethodRepository.markAsDefault.mockResolvedValue(undefined);
-      const remote = generatePaymentMethod({ type: "us_bank_account", card: null } as unknown as Parameters<typeof generatePaymentMethod>[0]);
+      const remote = generatePaymentMethod({ type: "us_bank_account", customer: "cus_1", card: null } as unknown as Parameters<
+        typeof generatePaymentMethod
+      >[0]);
       vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asPaymentMethodResponse(remote));
 
       await expect(service.markPaymentMethodAsDefault("pm_1", user, ability)).rejects.toMatchObject({ status: 403 });
@@ -118,28 +142,27 @@ describe(PaymentMethodService.name, () => {
   });
 
   describe("syncAttached", () => {
-    it("upserts and marks a newly created default method as default on Stripe", async () => {
+    it("upserts a first card as the local default without touching the Stripe customer", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
       const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
       const paymentMethod = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
       const local = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1" }), isDefault: true };
       paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: local, isNew: true });
-      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+      const update = vi.spyOn(stripe.customers, "update");
 
       const result = await service.syncAttached({ user, paymentMethod });
 
       expect(paymentMethodRepository.upsert).toHaveBeenCalledWith({ userId: "user_1", fingerprint: "fp_1", paymentMethodId: "pm_1" });
-      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
+      expect(update).not.toHaveBeenCalled();
       expect(result).toEqual({ isNew: true, isDefault: true });
     });
 
     it("resumes auto top-up so a wallet paused by declines can charge the new default card", async () => {
-      const { service, stripe, paymentMethodRepository, autoReloadPauseService } = setup();
+      const { service, paymentMethodRepository, autoReloadPauseService } = setup();
       const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
       const paymentMethod = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
       const local = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1" }), isDefault: true };
       paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: local, isNew: true });
-      vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
 
       await service.syncAttached({ user, paymentMethod });
 
@@ -147,12 +170,11 @@ describe(PaymentMethodService.name, () => {
     });
 
     it("keeps the upserted method when resuming auto top-up fails", async () => {
-      const { service, stripe, paymentMethodRepository, autoReloadPauseService } = setup();
+      const { service, paymentMethodRepository, autoReloadPauseService } = setup();
       const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
       const paymentMethod = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
       const local = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1" }), isDefault: true };
       paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: local, isNew: true });
-      vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
       autoReloadPauseService.resume.mockRejectedValue(new Error("queue unavailable"));
 
       const result = await service.syncAttached({ user, paymentMethod });
@@ -172,17 +194,16 @@ describe(PaymentMethodService.name, () => {
       expect(autoReloadPauseService.resume).not.toHaveBeenCalled();
     });
 
-    it("upserts without a remote default sync for an already-synced method", async () => {
-      const { service, stripe, paymentMethodRepository } = setup();
+    it("leaves auto top-up alone for an already-synced method", async () => {
+      const { service, paymentMethodRepository, autoReloadPauseService } = setup();
       const user = mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
       const paymentMethod = generatePaymentMethod({ id: "pm_1", card: { fingerprint: "fp_1" } });
       const local = { ...generateDatabasePaymentMethod({ paymentMethodId: "pm_1" }), isDefault: true };
       paymentMethodRepository.upsert.mockResolvedValue({ paymentMethod: local, isNew: false });
-      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
 
       const result = await service.syncAttached({ user, paymentMethod });
 
-      expect(update).not.toHaveBeenCalled();
+      expect(autoReloadPauseService.resume).not.toHaveBeenCalled();
       expect(result).toEqual({ isNew: false, isDefault: true });
     });
 

--- a/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.spec.ts
@@ -17,6 +17,12 @@ import { TEST_CONSTANTS } from "@test/seeders/stripe-test-data.seeder";
 
 const ability = createMongoAbility([{ action: "manage", subject: "all" }]);
 const asResponse = <T>(value: T) => value as unknown as Stripe.Response<T>;
+const resourceMissingError = () =>
+  new Stripe.errors.StripeInvalidRequestError({
+    type: "invalid_request_error",
+    code: "resource_missing",
+    message: "No such PaymentMethod"
+  } as Stripe.StripeRawError);
 
 describe(PaymentMethodService.name, () => {
   describe("getPaymentMethods", () => {
@@ -127,137 +133,73 @@ describe(PaymentMethodService.name, () => {
   });
 
   describe("getDefaultPaymentMethod", () => {
-    it("merges the remote default with the local record", async () => {
+    const user = () => mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" });
+
+    it("returns undefined without calling Stripe when there is no local default", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
-      const remote = generatePaymentMethod({ id: "pm_default" });
-      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_default" });
-      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
-        invoice_settings: { default_payment_method: remote }
-      } as unknown as Stripe.Response<Stripe.Customer>);
-      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
-
-      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
-
-      expect(result).toEqual({ ...remote, validated: local.isValidated, isDefault: local.isDefault });
-    });
-
-    it("returns undefined when there is no local record for the remote default", async () => {
-      const { service, stripe, paymentMethodRepository } = setup();
-      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
-        invoice_settings: { default_payment_method: generatePaymentMethod() }
-      } as unknown as Stripe.Response<Stripe.Customer>);
       paymentMethodRepository.findDefaultByUserId.mockResolvedValue(undefined);
+      const retrieve = vi.spyOn(stripe.paymentMethods, "retrieve");
 
-      expect(await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability)).toBeUndefined();
+      const result = await service.getDefaultPaymentMethod(user(), ability);
+
+      expect(result).toBeUndefined();
+      expect(retrieve).not.toHaveBeenCalled();
     });
 
-    it("re-pushes the local default to Stripe when the remote default is missing", async () => {
+    it("merges the Stripe method with the local default when it is attached to the user's customer", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
-      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
-      const remotePaymentMethod = generatePaymentMethod({ id: "pm_1", customer: "cus_1" });
-      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
-        invoice_settings: { default_payment_method: null }
-      } as unknown as Stripe.Response<Stripe.Customer>);
+      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true, isValidated: true });
+      const remote = generatePaymentMethod({ id: "pm_1", customer: "cus_1" });
       paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
-      const retrieve = vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(remotePaymentMethod));
-      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+      const retrieve = vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(remote));
 
-      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+      const result = await service.getDefaultPaymentMethod(user(), ability);
 
       expect(retrieve).toHaveBeenCalledWith("pm_1", undefined, { timeout: 3_000 });
-      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
-      expect(result).toEqual({ ...remotePaymentMethod, validated: local.isValidated, isDefault: local.isDefault });
+      expect(result).toEqual({ ...remote, validated: true, isDefault: true });
     });
 
-    it("realigns Stripe to the local default when the remote default is a different method", async () => {
-      const { service, stripe, paymentMethodRepository } = setup();
-      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
-      const remotePaymentMethod = generatePaymentMethod({ id: "pm_1", customer: "cus_1" });
-      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
-        invoice_settings: { default_payment_method: generatePaymentMethod({ id: "pm_other" }) }
-      } as unknown as Stripe.Response<Stripe.Customer>);
-      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
-      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(remotePaymentMethod));
-      const update = vi.spyOn(stripe.customers, "update").mockResolvedValue(mock<Stripe.Response<Stripe.Customer>>());
+    it("returns undefined and warns when the method belongs to a different customer", async () => {
+      const { service, stripe, paymentMethodRepository, logger } = setup();
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(generatePaymentMethod({ id: "pm_1", customer: "cus_other" })));
 
-      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+      const result = await service.getDefaultPaymentMethod(user(), ability);
 
-      expect(update).toHaveBeenCalledWith("cus_1", { invoice_settings: { default_payment_method: "pm_1" } }, { timeout: 3_000 });
-      expect(result).toEqual({ ...remotePaymentMethod, validated: local.isValidated, isDefault: local.isDefault });
+      expect(result).toBeUndefined();
+      expect(paymentMethodRepository.deleteByFingerprint).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith({ event: "DEFAULT_PAYMENT_METHOD_NOT_ATTACHED", userId: "user_1", paymentMethodId: "pm_1" });
     });
 
-    it("removes the stale local default and returns undefined when the card is detached", async () => {
-      const { service, stripe, paymentMethodRepository } = setup();
-      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
-      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
-        invoice_settings: { default_payment_method: null }
-      } as unknown as Stripe.Response<Stripe.Customer>);
-      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
+    it("returns undefined and warns when the method is detached", async () => {
+      const { service, stripe, paymentMethodRepository, logger } = setup();
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
       vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(generatePaymentMethod({ id: "pm_1", customer: null })));
 
-      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+      const result = await service.getDefaultPaymentMethod(user(), ability);
 
-      expect(paymentMethodRepository.deleteByFingerprint).toHaveBeenCalledWith("fp_1", "pm_1", "user_1");
       expect(result).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEFAULT_PAYMENT_METHOD_NOT_ATTACHED", paymentMethodId: "pm_1" }));
     });
 
-    it("removes the stale local default and returns undefined when Stripe reports the card is missing", async () => {
-      const { service, stripe, paymentMethodRepository } = setup();
-      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
-      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
-        invoice_settings: { default_payment_method: null }
-      } as unknown as Stripe.Response<Stripe.Customer>);
-      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
-      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(
-        new Stripe.errors.StripeInvalidRequestError({
-          type: "invalid_request_error",
-          code: "resource_missing",
-          message: "No such PaymentMethod"
-        } as Stripe.StripeRawError)
-      );
-
-      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
-
-      expect(paymentMethodRepository.deleteByFingerprint).toHaveBeenCalledWith("fp_1", "pm_1", "user_1");
-      expect(result).toBeUndefined();
-    });
-
-    it("returns undefined without throwing when removing the stale local default fails", async () => {
+    it("returns undefined and warns when Stripe reports the method missing", async () => {
       const { service, stripe, paymentMethodRepository, logger } = setup();
-      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
-      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
-        invoice_settings: { default_payment_method: null }
-      } as unknown as Stripe.Response<Stripe.Customer>);
-      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
-      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(
-        new Stripe.errors.StripeInvalidRequestError({
-          type: "invalid_request_error",
-          code: "resource_missing",
-          message: "No such PaymentMethod"
-        } as Stripe.StripeRawError)
-      );
-      paymentMethodRepository.deleteByFingerprint.mockRejectedValue(new Error("db unavailable"));
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(resourceMissingError());
 
-      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
+      const result = await service.getDefaultPaymentMethod(user(), ability);
 
       expect(result).toBeUndefined();
-      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVE_FAILED", paymentMethodId: "pm_1" }));
+      expect(paymentMethodRepository.deleteByFingerprint).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEFAULT_PAYMENT_METHOD_NOT_ATTACHED", paymentMethodId: "pm_1" }));
     });
 
-    it("returns undefined without removing the local default when the Stripe push fails", async () => {
+    it("rethrows other Stripe errors", async () => {
       const { service, stripe, paymentMethodRepository } = setup();
-      const local = generateDatabasePaymentMethod({ paymentMethodId: "pm_1", fingerprint: "fp_1" });
-      vi.spyOn(stripe.customers, "retrieve").mockResolvedValue({
-        invoice_settings: { default_payment_method: null }
-      } as unknown as Stripe.Response<Stripe.Customer>);
-      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(local);
-      vi.spyOn(stripe.paymentMethods, "retrieve").mockResolvedValue(asResponse(generatePaymentMethod({ id: "pm_1", customer: "cus_1" })));
-      vi.spyOn(stripe.customers, "update").mockRejectedValue(new Error("stripe unavailable"));
+      paymentMethodRepository.findDefaultByUserId.mockResolvedValue(generateDatabasePaymentMethod({ paymentMethodId: "pm_1", isDefault: true }));
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(new Error("stripe unavailable"));
 
-      const result = await service.getDefaultPaymentMethod(mock<PayingUser>({ id: "user_1", stripeCustomerId: "cus_1" }), ability);
-
-      expect(paymentMethodRepository.deleteByFingerprint).not.toHaveBeenCalled();
-      expect(result).toBeUndefined();
+      await expect(service.getDefaultPaymentMethod(user(), ability)).rejects.toThrow("stripe unavailable");
     });
   });
 
@@ -278,13 +220,7 @@ describe(PaymentMethodService.name, () => {
 
     it("returns false when Stripe reports the method is missing", async () => {
       const { service, stripe } = setup();
-      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(
-        new Stripe.errors.StripeInvalidRequestError({
-          type: "invalid_request_error",
-          code: "resource_missing",
-          message: "No such PaymentMethod"
-        } as Stripe.StripeRawError)
-      );
+      vi.spyOn(stripe.paymentMethods, "retrieve").mockRejectedValue(resourceMissingError());
 
       expect(await service.hasPaymentMethod("pm_missing", mock<UserOutput>({ stripeCustomerId: "cus_1" }))).toBe(false);
     });

--- a/apps/api/src/billing/services/payment-method/payment-method.service.ts
+++ b/apps/api/src/billing/services/payment-method/payment-method.service.ts
@@ -15,6 +15,16 @@ import { assertIsPayingUser, type PayingUser } from "../paying-user/paying-user"
 
 export type PaymentMethod = Stripe.PaymentMethod & { validated: boolean; isDefault: boolean };
 
+const STRIPE_RETRIEVE_TIMEOUT_MS = 3_000;
+
+function getCustomerId(paymentMethod: Stripe.PaymentMethod): string | undefined {
+  return typeof paymentMethod.customer === "string" ? paymentMethod.customer : paymentMethod.customer?.id;
+}
+
+function isResourceMissing(error: unknown): boolean {
+  return error instanceof Stripe.errors.StripeInvalidRequestError && error.code === "resource_missing";
+}
+
 @singleton()
 export class PaymentMethodService {
   private readonly loggerService: LoggerService;
@@ -124,12 +134,7 @@ export class PaymentMethodService {
     return removedIds.length > 0;
   }
 
-  /**
-   * Creates the missing local row for remote methods that never got one, e.g. a missed
-   * payment_method.attached webhook (always the case in local dev). syncAttached is idempotent and
-   * pushes the Stripe default for a first card, so this heals the sync on read. Oldest first so the
-   * genuine first card wins the default. Never lets a single failure fail the whole read.
-   */
+  /** Heals a missed payment_method.attached webhook on read, oldest first so the genuine first card wins the default. */
   async #repairUnsyncedRemotePaymentMethods(params: { user: PayingUser; remotes: Stripe.PaymentMethod[]; locals: PaymentMethodOutput[] }): Promise<boolean> {
     const { user, remotes, locals } = params;
     const localIds = new Set(locals.map(local => local.paymentMethodId));
@@ -167,87 +172,24 @@ export class PaymentMethodService {
   }
 
   async getDefaultPaymentMethod(user: PayingUser, ability: AnyAbility): Promise<PaymentMethod | undefined> {
-    const [customer, local] = await Promise.all([
-      this.stripe.customers.retrieve(user.stripeCustomerId, {
-        expand: ["invoice_settings.default_payment_method"]
-      }),
-      this.paymentMethodRepository.accessibleBy(ability, "read").findDefaultByUserId(user.id)
-    ]);
+    const local = await this.paymentMethodRepository.accessibleBy(ability, "read").findDefaultByUserId(user.id);
 
-    assert(!customer.deleted, 402, "Payment account has been deleted");
-
-    const remote = customer.invoice_settings.default_payment_method;
-
-    if (typeof remote === "object" && remote && local && remote.id === local.paymentMethodId) {
-      return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
+    if (!local) {
+      return;
     }
 
-    if (local) {
-      return this.#healDefaultPaymentMethodDrift(user, local);
-    }
+    const remote = await this.#retrieveAttachedPaymentMethod(local.paymentMethodId, user.stripeCustomerId, { timeout: STRIPE_RETRIEVE_TIMEOUT_MS });
 
-    this.loggerService.warn({
-      event: "STRIPE_PAYMENT_METHOD_OUT_OF_SYNC",
-      userId: user.id,
-      remoteId: typeof remote === "string" ? remote : remote?.id
-    });
-  }
-
-  /**
-   * The local default is the source of truth. When Stripe's default is missing or points elsewhere,
-   * re-push the local default to Stripe. If the card is gone from Stripe (detached or deleted), the
-   * local row is stale, so drop it. Never throws: this runs inside the reload charging job and the
-   * wallet-settings enable validation, where a Stripe hiccup must not fail the whole operation.
-   */
-  async #healDefaultPaymentMethodDrift(user: PayingUser, local: PaymentMethodOutput): Promise<PaymentMethod | undefined> {
-    try {
-      const remotePaymentMethod = await this.stripe.paymentMethods.retrieve(local.paymentMethodId, undefined, { timeout: 3_000 });
-      const customerId = typeof remotePaymentMethod.customer === "string" ? remotePaymentMethod.customer : remotePaymentMethod.customer?.id;
-
-      if (customerId !== user.stripeCustomerId) {
-        await this.#removeStaleDefaultPaymentMethod(user, local);
-        return;
-      }
-
-      await this.markRemotePaymentMethodAsDefault(local.paymentMethodId, user);
-      this.loggerService.info({
-        event: "DEFAULT_PAYMENT_METHOD_DRIFT_HEALED",
+    if (!remote) {
+      this.loggerService.warn({
+        event: "DEFAULT_PAYMENT_METHOD_NOT_ATTACHED",
         userId: user.id,
         paymentMethodId: local.paymentMethodId
       });
-
-      return { ...remotePaymentMethod, validated: local.isValidated, isDefault: local.isDefault };
-    } catch (error) {
-      if (error instanceof Stripe.errors.StripeInvalidRequestError && error.code === "resource_missing") {
-        await this.#removeStaleDefaultPaymentMethod(user, local);
-        return;
-      }
-
-      this.loggerService.warn({
-        event: "DEFAULT_PAYMENT_METHOD_HEAL_FAILED",
-        userId: user.id,
-        paymentMethodId: local.paymentMethodId,
-        error
-      });
+      return;
     }
-  }
 
-  async #removeStaleDefaultPaymentMethod(user: PayingUser, local: PaymentMethodOutput): Promise<void> {
-    try {
-      await this.paymentMethodRepository.deleteByFingerprint(local.fingerprint, local.paymentMethodId, user.id);
-      this.loggerService.warn({
-        event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVED",
-        userId: user.id,
-        paymentMethodId: local.paymentMethodId
-      });
-    } catch (error) {
-      this.loggerService.warn({
-        event: "DEFAULT_PAYMENT_METHOD_STALE_REMOVE_FAILED",
-        userId: user.id,
-        paymentMethodId: local.paymentMethodId,
-        error
-      });
-    }
+    return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
   }
 
   async isDefaultPaymentMethod(paymentMethodId: string, userId: string): Promise<boolean> {
@@ -257,14 +199,21 @@ export class PaymentMethodService {
   }
 
   async hasPaymentMethod(paymentMethodId: string, user: UserOutput): Promise<boolean> {
-    try {
-      const paymentMethod = await this.stripe.paymentMethods.retrieve(paymentMethodId);
-      const customerId = typeof paymentMethod.customer === "string" ? paymentMethod.customer : paymentMethod.customer?.id;
+    return !!(await this.#retrieveAttachedPaymentMethod(paymentMethodId, user.stripeCustomerId));
+  }
 
-      return customerId === user.stripeCustomerId;
+  async #retrieveAttachedPaymentMethod(
+    paymentMethodId: string,
+    stripeCustomerId: UserOutput["stripeCustomerId"],
+    options?: Stripe.RequestOptions
+  ): Promise<Stripe.PaymentMethod | undefined> {
+    try {
+      const paymentMethod = await this.stripe.paymentMethods.retrieve(paymentMethodId, undefined, options);
+
+      return getCustomerId(paymentMethod) === stripeCustomerId ? paymentMethod : undefined;
     } catch (error: unknown) {
-      if (error instanceof Stripe.errors.StripeInvalidRequestError && error.code === "resource_missing") {
-        return false;
+      if (isResourceMissing(error)) {
+        return undefined;
       }
 
       throw error;
@@ -273,15 +222,13 @@ export class PaymentMethodService {
 
   @WithTransaction()
   async markPaymentMethodAsDefault(paymentMethodId: string, user: PayingUser, ability: AnyAbility): Promise<PaymentMethod> {
-    const [local, remote] = await Promise.all([
-      this.paymentMethodRepository.accessibleBy(ability, "update").markAsDefault(paymentMethodId),
-      this.stripe.paymentMethods.retrieve(paymentMethodId, undefined, { timeout: 3_000 })
-    ]);
+    const remote = await this.#retrieveAttachedPaymentMethod(paymentMethodId, user.stripeCustomerId, { timeout: STRIPE_RETRIEVE_TIMEOUT_MS });
 
     assert(remote, 404, "Payment method not found", { source: "stripe" });
 
+    const local = await this.paymentMethodRepository.accessibleBy(ability, "update").markAsDefault(paymentMethodId);
+
     if (local) {
-      await this.markRemotePaymentMethodAsDefault(paymentMethodId, user);
       return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
     }
 
@@ -295,19 +242,7 @@ export class PaymentMethodService {
       paymentMethodId
     });
 
-    await this.markRemotePaymentMethodAsDefault(paymentMethodId, user);
-
     return { ...remote, validated: newLocal.isValidated, isDefault: newLocal.isDefault };
-  }
-
-  async markRemotePaymentMethodAsDefault(paymentMethodId: string, user: PayingUser): Promise<void> {
-    await this.stripe.customers.update(
-      user.stripeCustomerId,
-      {
-        invoice_settings: { default_payment_method: paymentMethodId }
-      },
-      { timeout: 3_000 }
-    );
   }
 
   async syncAttachedFromEvent(event: Stripe.PaymentMethodAttachedEvent): Promise<void> {
@@ -392,27 +327,13 @@ export class PaymentMethodService {
       return;
     }
 
-    // Use upsert for idempotency - handles Stripe webhook retries gracefully
     const { paymentMethod: localPaymentMethod, isNew } = await this.paymentMethodRepository.upsert({
       userId: user.id,
       fingerprint,
       paymentMethodId: paymentMethod.id
     });
 
-    // Only set as default on Stripe if newly created AND is the first payment method (default)
     if (isNew && localPaymentMethod.isDefault) {
-      try {
-        await this.markRemotePaymentMethodAsDefault(paymentMethod.id, user);
-      } catch (error) {
-        // Log but don't fail - local record exists, Stripe sync can be retried manually if needed
-        this.loggerService.warn({
-          event: "STRIPE_DEFAULT_PAYMENT_METHOD_SYNC_FAILED",
-          paymentMethodId: paymentMethod.id,
-          userId: user.id,
-          error
-        });
-      }
-
       await this.#resumeAutoReloadAfterDefaultChange(user.id);
     }
 


### PR DESCRIPTION
## Why

The default card lived in two places: Console's `payment_methods.is_default` row and Stripe's customer `invoice_settings.default_payment_method`. Keeping them aligned took a best-effort push on attach, another push on set-default, and the read-time drift self-heal from #3559. None of that fed a charge. The auto top-up job and manual top-ups both pass `payment_method` explicitly, so the Stripe-side copy was only ever something that could drift.

Closes CON-795

## What

`PaymentMethodService` no longer reads or writes the Stripe customer default.

- `getDefaultPaymentMethod` reads the local default row and hydrates it with one `paymentMethods.retrieve`. If the card is missing from Stripe or attached to another customer, it warns `DEFAULT_PAYMENT_METHOD_NOT_ATTACHED` and returns undefined. It no longer deletes the stale local row. The list read-repair in `getPaymentMethods` and the `payment_method.detached` webhook already cover that, and the reload job calls this method with a read-only ability, so it should stay read-only.
- `markPaymentMethodAsDefault` drops the Stripe push. The `customers.update` call used to be what rejected a `pm_` id not attached to the user's customer, so the ownership check is now explicit and returns 404 before any local write.
- `syncAttached` still marks a first card as the local default and resumes auto top-up. The Stripe push and its `STRIPE_DEFAULT_PAYMENT_METHOD_SYNC_FAILED` warning are gone.
- Removed `markRemotePaymentMethodAsDefault`, `#healDefaultPaymentMethodDrift`, `#removeStaleDefaultPaymentMethod` and their log events.

No frontend change. deploy-web only ever consumed `isDefault` from the Console API.

### Support heads-up

New customers will not carry a Stripe-side default payment method anymore. Anyone charging a manual invoice from the Stripe dashboard has to pick the card explicitly. Existing customers keep whatever default Stripe holds today; nothing reads it, and it will go stale over time.

### Verification

- API unit specs for `payment-method` (26), integration specs (21), and the stripe-webhook and wallet-settings functional specs (21) pass.
- `eslint --quiet` is clean on the touched files. `tsc --noEmit` reports the same 42 pre-existing errors as `main`, none in billing.
- I did not run the manual Stripe test-mode walkthrough (add first card, switch default, enable auto top-up, remove default). It needs live test credentials and a browser session.
