### PR TITLE
feat(user): require accepting the fair use policy before a trial deploys

### DIFF
--- a/apps/api/drizzle/0050_fair_use_policy_accepted_at.sql
+++ b/apps/api/drizzle/0050_fair_use_policy_accepted_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "userSetting" ADD COLUMN "fair_use_policy_accepted_at" timestamp with time zone;

--- a/apps/api/drizzle/meta/0050_snapshot.json
+++ b/apps/api/drizzle/meta/0050_snapshot.json
@@ -1,0 +1,1577 @@
+{
+  "id": "6294f4f2-593f-40c1-9178-2ce5d2339d18",
+  "prevId": "02b235d4-0ed8-42f8-afd5-51982c078331",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_sufficient_since": {
+          "name": "credits_sufficient_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_since": {
+          "name": "credits_low_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reload_failure_count": {
+          "name": "auto_reload_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_reload_paused_at": {
+          "name": "auto_reload_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fair_use_policy_accepted_at": {
+          "name": "fair_use_policy_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_secrets": {
+          "name": "sealed_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1788379408171,
       "tag": "0049_auto_top_up_decline_pause",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1788714893741,
+      "tag": "0050_fair_use_policy_accepted_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -148,6 +148,7 @@ async function executeCliHandler(name: string, handler: () => Promise<unknown>, 
           twitterUsername: null,
           githubUsername: null,
           onboardingSkippedAt: null,
+          fairUsePolicyAcceptedAt: null,
           userId: "system:cli-user",
           username: "___cli_user___",
           trial: false

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -124,7 +124,8 @@ export class ManagedSignerService {
       this.anonymousValidateService.validateDeploymentGpuModels(messages, userWallet),
       this.anonymousValidateService.validateDeploymentGpuInterconnect(messages, userWallet),
       this.anonymousValidateService.validateDeploymentResources(messages, userWallet),
-      this.anonymousValidateService.validateLeaseGpuModels(messages, userWallet)
+      this.anonymousValidateService.validateLeaseGpuModels(messages, userWallet),
+      this.anonymousValidateService.validateFairUsePolicyAccepted(messages, userWallet)
     ]);
 
     const createLeaseMessage: { typeUrl: string; value: MsgCreateLease } | undefined = messages.find(message => message.typeUrl.endsWith(".MsgCreateLease"));

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
@@ -7,12 +7,15 @@ import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import type { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
-import { TrialValidationService } from "./trial-validation.service";
+import type { UserRepository } from "@src/user/repositories";
+import { FAIR_USE_POLICY_REQUIRED_ERROR_CODE, TrialValidationService } from "./trial-validation.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createBid } from "@test/seeders/bid.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(TrialValidationService.name, () => {
@@ -265,6 +268,61 @@ describe(TrialValidationService.name, () => {
     return bid;
   }
 
+  describe("validateFairUsePolicyAccepted", () => {
+    it("skips validation when wallet is not trialing", async () => {
+      const wallet = createUserWallet({ isTrialing: false });
+      const { service, userRepository } = setupFairUse({ flagEnabled: true });
+
+      await service.validateFairUsePolicyAccepted([createDeploymentMessage()], wallet);
+
+      expect(userRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it("skips validation when there is no MsgCreateDeployment", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service, userRepository } = setupFairUse({ flagEnabled: true });
+
+      await service.validateFairUsePolicyAccepted([createLeaseMessage()], wallet);
+
+      expect(userRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it("skips validation when the gate flag is disabled", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service, userRepository } = setupFairUse({ flagEnabled: false });
+
+      await service.validateFairUsePolicyAccepted([createDeploymentMessage()], wallet);
+
+      expect(userRepository.findById).not.toHaveBeenCalled();
+    });
+
+    it("passes when the trial user has accepted the policy", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service, userRepository } = setupFairUse({ flagEnabled: true, user: createUser({ fairUsePolicyAcceptedAt: new Date() }) });
+
+      await expect(service.validateFairUsePolicyAccepted([createDeploymentMessage()], wallet)).resolves.toBeUndefined();
+
+      expect(userRepository.findById).toHaveBeenCalledWith(wallet.userId);
+    });
+
+    it("rejects with 403 and the fair_use_policy_required code when the trial user has not accepted", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setupFairUse({ flagEnabled: true, user: createUser({ fairUsePolicyAcceptedAt: null }) });
+
+      await expect(service.validateFairUsePolicyAccepted([createDeploymentMessage()], wallet)).rejects.toMatchObject({
+        status: 403,
+        errorCode: FAIR_USE_POLICY_REQUIRED_ERROR_CODE
+      });
+    });
+
+    it("rejects with 403 when the user row cannot be found", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setupFairUse({ flagEnabled: true, user: undefined });
+
+      await expect(service.validateFairUsePolicyAccepted([createDeploymentMessage()], wallet)).rejects.toMatchObject({ status: 403 });
+    });
+  });
+
   describe("validateDeploymentResources", () => {
     it("skips validation when wallet is not trialing", async () => {
       const wallet = createUserWallet({ isTrialing: false });
@@ -451,6 +509,8 @@ describe(TrialValidationService.name, () => {
       mock<ProviderRepository>(),
       mock<BidHttpService>(),
       mock<BlockedGpuService>(),
+      mock<UserRepository>(),
+      mock<FeatureFlagsService>(),
       createLoggerStub().createLogger
     );
     return { service };
@@ -463,7 +523,15 @@ describe(TrialValidationService.name, () => {
     const config = mockConfigService<BillingConfigService>({
       MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT: input.trialMin
     });
-    const service = new TrialValidationService(config, providerRepository, bidHttpService, blockedGpuService, createLoggerStub().createLogger);
+    const service = new TrialValidationService(
+      config,
+      providerRepository,
+      bidHttpService,
+      blockedGpuService,
+      mock<UserRepository>(),
+      mock<FeatureFlagsService>(),
+      createLoggerStub().createLogger
+    );
     return { service };
   }
 
@@ -476,7 +544,15 @@ describe(TrialValidationService.name, () => {
       MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: input.blockedGpuModels
     });
     const blockedGpuService = new BlockedGpuService(blockedGpuConfig);
-    const service = new TrialValidationService(config, providerRepository, bidHttpService, blockedGpuService, createLoggerStub().createLogger);
+    const service = new TrialValidationService(
+      config,
+      providerRepository,
+      bidHttpService,
+      blockedGpuService,
+      mock<UserRepository>(),
+      mock<FeatureFlagsService>(),
+      createLoggerStub().createLogger
+    );
     return { service, config, providerRepository, bidHttpService, blockedGpuService };
   }
 
@@ -486,8 +562,33 @@ describe(TrialValidationService.name, () => {
       MANAGED_WALLET_TRIAL_MAX_MEMORY_GI: input.maxMemoryGi
     });
     const { createLogger, logger } = createLoggerStub();
-    const service = new TrialValidationService(config, mock<ProviderRepository>(), mock<BidHttpService>(), mock<BlockedGpuService>(), createLogger);
+    const service = new TrialValidationService(
+      config,
+      mock<ProviderRepository>(),
+      mock<BidHttpService>(),
+      mock<BlockedGpuService>(),
+      mock<UserRepository>(),
+      mock<FeatureFlagsService>(),
+      createLogger
+    );
     return { service, logger };
+  }
+
+  function setupFairUse(input: { flagEnabled: boolean; user?: ReturnType<typeof createUser> }) {
+    const userRepository = mock<UserRepository>();
+    userRepository.findById.mockResolvedValue(input.user);
+    const featureFlagsService = mock<FeatureFlagsService>();
+    featureFlagsService.isEnabled.mockReturnValue(input.flagEnabled);
+    const service = new TrialValidationService(
+      mock<BillingConfigService>(),
+      mock<ProviderRepository>(),
+      mock<BidHttpService>(),
+      mock<BlockedGpuService>(),
+      userRepository,
+      featureFlagsService,
+      createLoggerStub().createLogger
+    );
+    return { service, userRepository, featureFlagsService };
   }
 
   function createLoggerStub() {

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
@@ -4,6 +4,7 @@ import { BidHttpService } from "@akashnetwork/http-sdk";
 import { Trace } from "@akashnetwork/instrumentation";
 import { EncodeObject } from "@cosmjs/proto-signing";
 import assert from "http-assert";
+import createError from "http-errors";
 import { inject, singleton } from "tsyringe";
 
 import { STANDARD_TOP_UP_MIN_AMOUNT_USD } from "@src/billing/config";
@@ -11,12 +12,17 @@ import { getTrialEndsAt } from "@src/billing/lib/trial-window/trial-window";
 import type { TrialWindow, UserWalletOutput } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { AUDITOR, TRIAL_ATTRIBUTE, TRIAL_REGISTERED_ATTRIBUTE } from "@src/deployment/config/provider.config";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
 import { groupSpecsRequestGpuInterconnect } from "@src/deployment/utils/gpu-interconnect/gpu-interconnect";
 import { findTrialResourceViolation } from "@src/deployment/utils/group-resources/group-resources";
 import { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
 import type { UserOutput } from "@src/user/repositories";
+import { UserRepository } from "@src/user/repositories";
+
+export const FAIR_USE_POLICY_REQUIRED_ERROR_CODE = "fair_use_policy_required";
 
 @singleton()
 export class TrialValidationService {
@@ -27,6 +33,8 @@ export class TrialValidationService {
     private readonly providerRepository: ProviderRepository,
     private readonly bidHttpService: BidHttpService,
     private readonly blockedGpuService: BlockedGpuService,
+    private readonly userRepository: UserRepository,
+    private readonly featureFlagsService: FeatureFlagsService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: TrialValidationService.name });
@@ -154,6 +162,23 @@ export class TrialValidationService {
 
       assert(false, 403, violation.message);
     }
+  }
+
+  @Trace()
+  async validateFairUsePolicyAccepted(messages: EncodeObject[], userWallet: UserWalletOutput) {
+    if (!userWallet.isTrialing) return;
+    if (!messages.some(message => message.typeUrl === `/${MsgCreateDeployment.$type}`)) return;
+    if (!this.featureFlagsService.isEnabled(FeatureFlags.FAIR_USE_POLICY_GATE)) return;
+
+    const user = await this.userRepository.findById(userWallet.userId);
+
+    if (user?.fairUsePolicyAcceptedAt) return;
+
+    this.logger.info({ event: "FAIR_USE_POLICY_NOT_ACCEPTED", userId: userWallet.userId, owner: userWallet.address });
+
+    throw createError(403, "Accept the Fair Use Policy in Akash Console before deploying on the free trial", {
+      errorCode: FAIR_USE_POLICY_REQUIRED_ERROR_CODE
+    });
   }
 
   @Trace()

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -2,7 +2,8 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_CREATE: "notifications_general_alerts_create",
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
-  TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check"
+  TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check",
+  FAIR_USE_POLICY_GATE: "fair_use_policy_gate"
 } as const;
 
 export type FeatureFlagValue = (typeof FeatureFlags)[keyof typeof FeatureFlags];

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -316,6 +316,7 @@ export class JobQueueService implements Disposable {
                 twitterUsername: null,
                 githubUsername: null,
                 onboardingSkippedAt: null,
+                fairUsePolicyAcceptedAt: null,
                 userId: "system:bg-job-user",
                 username: "___bg_job_user___",
                 trial: false

--- a/apps/api/src/user/controllers/user/user.controller.ts
+++ b/apps/api/src/user/controllers/user/user.controller.ts
@@ -83,4 +83,10 @@ export class UserController {
     const userId = this.authService.currentUser.id;
     await this.userService.skipOnboarding(userId);
   }
+
+  async acceptFairUsePolicy() {
+    assert(this.authService.currentUser?.id, 401);
+    const userId = this.authService.currentUser.id;
+    await this.userService.acceptFairUsePolicy(userId);
+  }
 }

--- a/apps/api/src/user/model-schemas/user/user.schema.ts
+++ b/apps/api/src/user/model-schemas/user/user.schema.ts
@@ -28,6 +28,7 @@ export const Users = pgTable("userSetting", {
   lastUserAgent: varchar("last_user_agent", { length: userAgentMaxLength }),
   lastFingerprint: varchar("last_fingerprint", { length: 255 }),
   onboardingSkippedAt: timestamp("onboardingSkippedAt"),
+  fairUsePolicyAcceptedAt: timestamp("fair_use_policy_accepted_at", { withTimezone: true }),
   createdAt: timestamp("created_at").defaultNow()
 });
 

--- a/apps/api/src/user/routes/user-settings/user-settings.router.ts
+++ b/apps/api/src/user/routes/user-settings/user-settings.router.ts
@@ -156,3 +156,24 @@ userSettingsRouter.openapi(skipOnboardingRoute, async function skipOnboarding(c)
   await container.resolve(UserController).skipOnboarding();
   return c.body(null, 204);
 });
+
+const acceptFairUsePolicyRoute = createRoute({
+  method: "post",
+  path: "/v1/user/acceptFairUsePolicy",
+  summary: "Accept the Fair Use Policy",
+  tags: ["Users"],
+  security: SECURITY_BEARER_OR_API_KEY,
+  responses: {
+    204: {
+      description: "Fair Use Policy accepted"
+    },
+    401: {
+      description: "Unauthorized"
+    }
+  }
+});
+
+userSettingsRouter.openapi(acceptFairUsePolicyRoute, async function acceptFairUsePolicy(c) {
+  await container.resolve(UserController).acceptFairUsePolicy();
+  return c.body(null, 204);
+});

--- a/apps/api/src/user/routes/user-settings/user-settings.router.ts
+++ b/apps/api/src/user/routes/user-settings/user-settings.router.ts
@@ -160,6 +160,7 @@ userSettingsRouter.openapi(skipOnboardingRoute, async function skipOnboarding(c)
 const acceptFairUsePolicyRoute = createRoute({
   method: "post",
   path: "/v1/user/acceptFairUsePolicy",
+  operationId: "acceptFairUsePolicy",
   summary: "Accept the Fair Use Policy",
   tags: ["Users"],
   security: SECURITY_BEARER_OR_API_KEY,

--- a/apps/api/src/user/schemas/user.schema.ts
+++ b/apps/api/src/user/schemas/user.schema.ts
@@ -12,7 +12,8 @@ export const UserSchema = z.object({
   youtubeUsername: z.string().optional().nullable(),
   twitterUsername: z.string().optional().nullable(),
   githubUsername: z.string().optional().nullable(),
-  onboardingSkippedAt: z.string().datetime().nullable().optional()
+  onboardingSkippedAt: z.string().datetime().nullable().optional(),
+  fairUsePolicyAcceptedAt: z.string().datetime().nullable().optional()
 });
 
 export type UserSchema = z.infer<typeof UserSchema>;

--- a/apps/api/src/user/services/user/user.service.integration.ts
+++ b/apps/api/src/user/services/user/user.service.integration.ts
@@ -398,6 +398,43 @@ describe(UserService.name, () => {
     });
   });
 
+  describe("acceptFairUsePolicy", () => {
+    it("sets fairUsePolicyAcceptedAt when it has not been set", async () => {
+      const { service, userRepository } = setup();
+      const user = await userRepository.create({
+        userId: faker.string.uuid(),
+        username: `test-user-${faker.string.uuid()}`,
+        email: faker.internet.email(),
+        emailVerified: false,
+        subscribedToNewsletter: false
+      });
+
+      await service.acceptFairUsePolicy(user.id);
+
+      const updatedUser = await userRepository.findById(user.id);
+      expect(updatedUser?.fairUsePolicyAcceptedAt).toBeInstanceOf(Date);
+    });
+
+    it("preserves the original timestamp when called again", async () => {
+      const { service, userRepository } = setup();
+      const user = await userRepository.create({
+        userId: faker.string.uuid(),
+        username: `test-user-${faker.string.uuid()}`,
+        email: faker.internet.email(),
+        emailVerified: false,
+        subscribedToNewsletter: false
+      });
+
+      await service.acceptFairUsePolicy(user.id);
+      const firstAcceptedAt = (await userRepository.findById(user.id))?.fairUsePolicyAcceptedAt;
+
+      await service.acceptFairUsePolicy(user.id);
+      const secondAcceptedAt = (await userRepository.findById(user.id))?.fairUsePolicyAcceptedAt;
+
+      expect(secondAcceptedAt).toEqual(firstAcceptedAt);
+    });
+  });
+
   function createRegisterInput(overrides: Partial<RegisterUserInput> = {}): RegisterUserInput {
     return {
       userId: faker.string.uuid(),

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -150,6 +150,17 @@ describe(UserService.name, () => {
     });
   });
 
+  describe("acceptFairUsePolicy", () => {
+    it("persists the acceptance time with a set-if-null guard so it is written once and never overwritten", async () => {
+      const userId = faker.string.uuid();
+      const { service, userRepository } = setup();
+
+      await service.acceptFairUsePolicy(userId);
+
+      expect(userRepository.updateBy).toHaveBeenCalledWith({ id: userId, fairUsePolicyAcceptedAt: null }, { fairUsePolicyAcceptedAt: expect.any(Date) });
+    });
+  });
+
   it("creates the logger with the service context", () => {
     const { createLogger } = setup();
 

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -204,6 +204,10 @@ export class UserService {
   async skipOnboarding(userId: string) {
     await this.userRepository.updateBy({ id: userId, onboardingSkippedAt: null }, { onboardingSkippedAt: new Date() });
   }
+
+  async acceptFairUsePolicy(userId: string) {
+    await this.userRepository.updateBy({ id: userId, fairUsePolicyAcceptedAt: null }, { fairUsePolicyAcceptedAt: new Date() });
+  }
 }
 
 function adjustUsername(wantedUsername: string) {

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -2054,6 +2054,11 @@
                           "type": "string",
                           "nullable": true,
                           "format": "date-time"
+                        },
+                        "fairUsePolicyAcceptedAt": {
+                          "type": "string",
+                          "nullable": true,
+                          "format": "date-time"
                         }
                       },
                       "required": [
@@ -2144,6 +2149,11 @@
                           "nullable": true
                         },
                         "onboardingSkippedAt": {
+                          "type": "string",
+                          "nullable": true,
+                          "format": "date-time"
+                        },
+                        "fairUsePolicyAcceptedAt": {
                           "type": "string",
                           "nullable": true,
                           "format": "date-time"
@@ -2364,6 +2374,30 @@
         "responses": {
           "204": {
             "description": "Onboarding skipped"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/v1/user/acceptFairUsePolicy": {
+      "post": {
+        "summary": "Accept the Fair Use Policy",
+        "tags": [
+          "Users"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Fair Use Policy accepted"
           },
           "401": {
             "description": "Unauthorized"
@@ -18475,6 +18509,9 @@
                       },
                       "suppressedBySystem": {
                         "type": "boolean"
+                      },
+                      "reclaimNotifiedAt": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -18755,6 +18792,9 @@
                       },
                       "suppressedBySystem": {
                         "type": "boolean"
+                      },
+                      "reclaimNotifiedAt": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -19581,6 +19621,9 @@
                       },
                       "suppressedBySystem": {
                         "type": "boolean"
+                      },
+                      "reclaimNotifiedAt": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -19882,6 +19925,9 @@
                       },
                       "suppressedBySystem": {
                         "type": "boolean"
+                      },
+                      "reclaimNotifiedAt": {
+                        "type": "string"
                       }
                     },
                     "required": [
@@ -20842,6 +20888,9 @@
                         },
                         "suppressedBySystem": {
                           "type": "boolean"
+                        },
+                        "reclaimNotifiedAt": {
+                          "type": "string"
                         }
                       },
                       "required": [
@@ -21143,6 +21192,9 @@
                         },
                         "suppressedBySystem": {
                           "type": "boolean"
+                        },
+                        "reclaimNotifiedAt": {
+                          "type": "string"
                         }
                       },
                       "required": [

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -2383,6 +2383,7 @@
     },
     "/v1/user/acceptFairUsePolicy": {
       "post": {
+        "operationId": "acceptFairUsePolicy",
         "summary": "Accept the Fair Use Policy",
         "tags": [
           "Users"

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -14391,6 +14391,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
     },
     "/v1/user/acceptFairUsePolicy": {
       "post": {
+        "operationId": "acceptFairUsePolicy",
         "responses": {
           "204": {
             "description": "Fair Use Policy accepted",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -13412,6 +13412,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "emailVerified": {
                           "type": "boolean",
                         },
+                        "fairUsePolicyAcceptedAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "githubUsername": {
                           "nullable": true,
                           "type": "string",
@@ -14384,6 +14389,30 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/v1/user/acceptFairUsePolicy": {
+      "post": {
+        "responses": {
+          "204": {
+            "description": "Fair Use Policy accepted",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+          {
+            "ApiKeyAuth": [],
+          },
+        ],
+        "summary": "Accept the Fair Use Policy",
+        "tags": [
+          "Users",
+        ],
+      },
+    },
     "/v1/user/addFavoriteTemplate/{templateId}": {
       "post": {
         "parameters": [
@@ -14589,6 +14618,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         },
                         "emailVerified": {
                           "type": "boolean",
+                        },
+                        "fairUsePolicyAcceptedAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
                         },
                         "githubUsername": {
                           "nullable": true,

--- a/apps/api/test/functional/user-fair-use-policy.spec.ts
+++ b/apps/api/test/functional/user-fair-use-policy.spec.ts
@@ -42,9 +42,10 @@ describe("Fair Use Policy acceptance", () => {
 
       await app.request("/v1/user/acceptFairUsePolicy", { method: "POST", headers });
       const firstAcceptedAt = (await userRepository.findById(user.id))?.fairUsePolicyAcceptedAt;
-      await app.request("/v1/user/acceptFairUsePolicy", { method: "POST", headers });
+      const secondResponse = await app.request("/v1/user/acceptFairUsePolicy", { method: "POST", headers });
       const secondAcceptedAt = (await userRepository.findById(user.id))?.fairUsePolicyAcceptedAt;
 
+      expect(secondResponse.status).toBe(204);
       expect(firstAcceptedAt).toBeInstanceOf(Date);
       expect(secondAcceptedAt).toEqual(firstAcceptedAt);
     });

--- a/apps/api/test/functional/user-fair-use-policy.spec.ts
+++ b/apps/api/test/functional/user-fair-use-policy.spec.ts
@@ -1,0 +1,61 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UserAuthTokenService } from "@src/auth/services/user-auth-token/user-auth-token.service";
+import { app } from "@src/rest-app";
+import { UserRepository } from "@src/user/repositories/user/user.repository";
+
+describe("Fair Use Policy acceptance", () => {
+  const userRepository = container.resolve(UserRepository);
+  const userAuthTokenService = container.resolve(UserAuthTokenService);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("POST /v1/user/acceptFairUsePolicy", () => {
+    it("returns 401 when the user is not authenticated", async () => {
+      const response = await app.request("/v1/user/acceptFairUsePolicy", { method: "POST" });
+
+      expect(response.status).toBe(401);
+    });
+
+    it("records the acceptance and exposes it on the current user", async () => {
+      const { user, token } = await setup();
+
+      const response = await app.request("/v1/user/acceptFairUsePolicy", {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` }
+      });
+      const meResponse = await app.request("/v1/user/me", { headers: { authorization: `Bearer ${token}` } });
+      const me = (await meResponse.json()) as { data: { id: string; fairUsePolicyAcceptedAt: string | null } };
+
+      expect(response.status).toBe(204);
+      expect(me.data.id).toBe(user.id);
+      expect(me.data.fairUsePolicyAcceptedAt).toEqual(expect.any(String));
+    });
+
+    it("keeps the first acceptance time when called again", async () => {
+      const { user, token } = await setup();
+      const headers = { authorization: `Bearer ${token}` };
+
+      await app.request("/v1/user/acceptFairUsePolicy", { method: "POST", headers });
+      const firstAcceptedAt = (await userRepository.findById(user.id))?.fairUsePolicyAcceptedAt;
+      await app.request("/v1/user/acceptFairUsePolicy", { method: "POST", headers });
+      const secondAcceptedAt = (await userRepository.findById(user.id))?.fairUsePolicyAcceptedAt;
+
+      expect(firstAcceptedAt).toBeInstanceOf(Date);
+      expect(secondAcceptedAt).toEqual(firstAcceptedAt);
+    });
+  });
+
+  async function setup() {
+    const user = await userRepository.create({ userId: faker.string.uuid(), username: `user-${faker.string.alphanumeric(12)}` });
+    const token = faker.string.alphanumeric(40);
+
+    vi.spyOn(userAuthTokenService, "getValidUserId").mockImplementation(async header => (header.replace(/^Bearer +/i, "") === token ? user.userId! : null));
+
+    return { user, token };
+  }
+});

--- a/apps/api/test/seeders/user.seeder.ts
+++ b/apps/api/test/seeders/user.seeder.ts
@@ -19,6 +19,7 @@ export function createUser({
   lastUserAgent = faker.internet.userAgent(),
   lastFingerprint = faker.word.noun(),
   onboardingSkippedAt = null,
+  fairUsePolicyAcceptedAt = faker.date.recent(),
   createdAt = faker.date.recent(),
   trial = false
 }: Partial<UserOutput> = {}): UserOutput {
@@ -39,6 +40,7 @@ export function createUser({
     lastUserAgent,
     lastFingerprint,
     onboardingSkippedAt,
+    fairUsePolicyAcceptedAt,
     createdAt,
     trial
   };

--- a/apps/api/test/services/wallet-testing.service.ts
+++ b/apps/api/test/services/wallet-testing.service.ts
@@ -12,7 +12,7 @@ import { WalletInitializerService } from "@src/billing/services";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
-import type { UserOutput } from "@src/user/repositories";
+import { type UserOutput, UserRepository } from "@src/user/repositories";
 
 export class WalletTestingService<T extends Hono<any>> {
   constructor(private readonly app: T) {}
@@ -136,7 +136,14 @@ export class WalletTestingService<T extends Hono<any>> {
       throw new Error("User registration failed");
     }
 
+    await this.acceptFairUsePolicy(body.data.id);
+
     return { user: body.data, token: access_token };
+  }
+
+  /** Registration leaves the policy unaccepted, and a trial create without it is refused, so every test user accepts up front. */
+  async acceptFairUsePolicy(userId: string) {
+    await container.resolve(UserRepository).updateById(userId, { fairUsePolicyAcceptedAt: new Date() });
   }
 
   async getWalletByUserId(userId: string, token: string): Promise<{ id: number; address: string; creditAmount: number }> {

--- a/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal.spec.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal.spec.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FairUsePolicyModal } from "./FairUsePolicyModal";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+describe(FairUsePolicyModal.name, () => {
+  it("lists the prohibited workloads and accepts on the single action", () => {
+    const { onAccept } = setup({ isAccepting: false });
+
+    fireEvent.click(screen.getByTestId("fair-use-policy-accept-button"));
+
+    expect(screen.getByText("Crypto miners")).toBeInTheDocument();
+    expect(screen.getByText("Anything illegal")).toBeInTheDocument();
+    expect(onAccept).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the action while the acceptance is in flight", () => {
+    setup({ isAccepting: true });
+
+    expect(screen.getByTestId("fair-use-policy-accept-button")).toBeDisabled();
+  });
+
+  function setup(input: { isAccepting: boolean }) {
+    const onAccept = vi.fn();
+    render(<FairUsePolicyModal onAccept={onAccept} isAccepting={input.isAccepting} />);
+    return { onAccept };
+  }
+});

--- a/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal.tsx
@@ -1,0 +1,67 @@
+"use client";
+import type { ComponentType } from "react";
+import { Popup } from "@akashnetwork/ui/components";
+import { Ban, Coins, Copyright, CreditCard, Mail, ShieldAlert } from "lucide-react";
+import Link from "next/link";
+
+import { UrlService } from "@src/utils/urlUtils";
+
+type Props = {
+  onAccept: () => void;
+  isAccepting: boolean;
+};
+
+const PROHIBITED_WORKLOADS: { label: string; Icon: ComponentType<{ className?: string }> }[] = [
+  { label: "Crypto miners", Icon: Coins },
+  { label: "Phishing", Icon: ShieldAlert },
+  { label: "Card fraud & testing", Icon: CreditCard },
+  { label: "Spam", Icon: Mail },
+  { label: "Pirated content", Icon: Copyright },
+  { label: "Anything illegal", Icon: Ban }
+];
+
+export function FairUsePolicyModal({ onAccept, isAccepting }: Props) {
+  return (
+    <Popup
+      open
+      fullWidth
+      hideCloseButton
+      maxWidth="sm"
+      variant="custom"
+      title="Review and accept our Fair Use Policy before you deploy on Akash Console"
+      testId="fair-use-policy-modal"
+      actions={[
+        {
+          label: "I agree to the Fair Use Policy",
+          side: "right",
+          color: "primary",
+          className: "w-full",
+          isLoading: isAccepting,
+          disabled: isAccepting,
+          onClick: onAccept,
+          "data-testid": "fair-use-policy-accept-button"
+        }
+      ]}
+    >
+      <div className="space-y-4">
+        <p className="text-sm font-medium text-destructive">Hosting or distributing any of the following will permanently close your account.</p>
+        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {PROHIBITED_WORKLOADS.map(({ label, Icon }) => (
+            <li key={label} className="flex items-center gap-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm">
+              <Icon className="h-4 w-4 shrink-0 text-destructive" />
+              <span>{label}</span>
+            </li>
+          ))}
+        </ul>
+        <p className="text-sm text-muted-foreground">
+          Akash Console is for building and deploying software. We do not allow the kind of resource abuse that degrades the network for everyone else. The full
+          list of prohibited uses is in section 7 of the{" "}
+          <Link href={UrlService.prohibitedUse()} target="_blank" className="underline">
+            Terms of Service
+          </Link>
+          .
+        </p>
+      </div>
+    </Popup>
+  );
+}

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CustomUserProfile } from "@src/types/user";
+import type { DEPENDENCIES } from "./RequireFairUsePolicy";
+import { RequireFairUsePolicy } from "./RequireFairUsePolicy";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const ACCEPTED_AT = "2026-09-06T00:00:00.000Z";
+
+describe(RequireFairUsePolicy.name, () => {
+  it("shows the modal over the page for a signed-in user who has not accepted", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: null });
+
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.getByTestId("fair-use-policy-modal")).toBeInTheDocument();
+  });
+
+  it("renders only the page once the user has accepted", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: ACCEPTED_AT });
+
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
+  });
+
+  it("never demands acceptance on a public page", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: null, isPublic: true });
+
+    expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
+  });
+
+  it("never demands acceptance from a logged-out visitor", () => {
+    setup({ loggedOut: true });
+
+    expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
+  });
+
+  it("accepts the policy when the modal action is used", () => {
+    const { accept } = setup({ userId: "u1", fairUsePolicyAcceptedAt: null });
+
+    fireEvent.click(screen.getByTestId("fair-use-policy-accept-button"));
+
+    expect(accept).toHaveBeenCalledTimes(1);
+  });
+
+  function setup(input: { userId?: string; fairUsePolicyAcceptedAt?: string | null; isPublic?: boolean; loggedOut?: boolean }) {
+    const accept = vi.fn();
+    const dependencies: typeof DEPENDENCIES = {
+      useUser: (() =>
+        mock<ReturnType<typeof DEPENDENCIES.useUser>>({
+          user: input.loggedOut
+            ? undefined
+            : mock<CustomUserProfile>({ userId: input.userId ?? "u1", fairUsePolicyAcceptedAt: input.fairUsePolicyAcceptedAt ?? null }),
+          isLoading: false
+        })) as typeof DEPENDENCIES.useUser,
+      useAcceptFairUsePolicy: () => ({ accept, isAccepting: false }),
+      FairUsePolicyModal: ({ onAccept }) => (
+        <div data-testid="fair-use-policy-modal">
+          <button data-testid="fair-use-policy-accept-button" onClick={onAccept}>
+            agree
+          </button>
+        </div>
+      )
+    };
+
+    render(
+      <RequireFairUsePolicy isPublic={input.isPublic} dependencies={dependencies}>
+        <div>child</div>
+      </RequireFairUsePolicy>
+    );
+
+    return { accept };
+  }
+});

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
@@ -24,6 +24,12 @@ describe(RequireFairUsePolicy.name, () => {
     expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
   });
 
+  it("stops demanding acceptance once it is confirmed, even while the profile still lacks the timestamp", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: null, hasAccepted: true });
+
+    expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
+  });
+
   it("never demands acceptance while the gate flag is off", () => {
     setup({ userId: "u1", fairUsePolicyAcceptedAt: null, isGateEnabled: false });
 
@@ -63,6 +69,7 @@ describe(RequireFairUsePolicy.name, () => {
     loggedOut?: boolean;
     isTrialing?: boolean;
     isGateEnabled?: boolean;
+    hasAccepted?: boolean;
   }) {
     const accept = vi.fn();
     const dependencies: typeof DEPENDENCIES = {
@@ -75,7 +82,7 @@ describe(RequireFairUsePolicy.name, () => {
         })) as typeof DEPENDENCIES.useUser,
       useWallet: () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? true }),
       useFlag: flag => flag === "fair_use_policy_gate" && (input.isGateEnabled ?? true),
-      useAcceptFairUsePolicy: () => ({ accept, isAccepting: false }),
+      useAcceptFairUsePolicy: () => ({ accept, isAccepting: false, hasAccepted: input.hasAccepted ?? false }),
       FairUsePolicyModal: ({ onAccept }) => (
         <div data-testid="fair-use-policy-modal">
           <button data-testid="fair-use-policy-accept-button" onClick={onAccept}>

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
@@ -10,7 +10,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 const ACCEPTED_AT = "2026-09-06T00:00:00.000Z";
 
 describe(RequireFairUsePolicy.name, () => {
-  it("shows the modal over the page for a signed-in user who has not accepted", () => {
+  it("shows the modal over the page for a trialing user who has not accepted", () => {
     setup({ userId: "u1", fairUsePolicyAcceptedAt: null });
 
     expect(screen.getByText("child")).toBeInTheDocument();
@@ -21,6 +21,18 @@ describe(RequireFairUsePolicy.name, () => {
     setup({ userId: "u1", fairUsePolicyAcceptedAt: ACCEPTED_AT });
 
     expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
+  });
+
+  it("never demands acceptance while the gate flag is off", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: null, isGateEnabled: false });
+
+    expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
+  });
+
+  it("never demands acceptance from a paying wallet", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: null, isTrialing: false });
+
     expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
   });
 
@@ -44,7 +56,14 @@ describe(RequireFairUsePolicy.name, () => {
     expect(accept).toHaveBeenCalledTimes(1);
   });
 
-  function setup(input: { userId?: string; fairUsePolicyAcceptedAt?: string | null; isPublic?: boolean; loggedOut?: boolean }) {
+  function setup(input: {
+    userId?: string;
+    fairUsePolicyAcceptedAt?: string | null;
+    isPublic?: boolean;
+    loggedOut?: boolean;
+    isTrialing?: boolean;
+    isGateEnabled?: boolean;
+  }) {
     const accept = vi.fn();
     const dependencies: typeof DEPENDENCIES = {
       useUser: (() =>
@@ -54,6 +73,8 @@ describe(RequireFairUsePolicy.name, () => {
             : mock<CustomUserProfile>({ userId: input.userId ?? "u1", fairUsePolicyAcceptedAt: input.fairUsePolicyAcceptedAt ?? null }),
           isLoading: false
         })) as typeof DEPENDENCIES.useUser,
+      useWallet: () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? true }),
+      useFlag: flag => flag === "fair_use_policy_gate" && (input.isGateEnabled ?? true),
       useAcceptFairUsePolicy: () => ({ accept, isAccepting: false }),
       FairUsePolicyModal: ({ onAccept }) => (
         <div data-testid="fair-use-policy-modal">

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
@@ -30,8 +30,8 @@ export function RequireFairUsePolicy({ children, isPublic, dependencies: d = DEP
   const { user } = d.useUser();
   const { isTrialing } = d.useWallet();
   const isGateEnabled = d.useFlag("fair_use_policy_gate");
-  const { accept, isAccepting } = d.useAcceptFairUsePolicy();
-  const mustAccept = !isPublic && isGateEnabled && isTrialing && !!user?.userId && !user.fairUsePolicyAcceptedAt;
+  const { accept, isAccepting, hasAccepted } = d.useAcceptFairUsePolicy();
+  const mustAccept = !isPublic && isGateEnabled && isTrialing && !!user?.userId && !user.fairUsePolicyAcceptedAt && !hasAccepted;
 
   return (
     <>

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
@@ -1,0 +1,33 @@
+"use client";
+import type { ReactNode } from "react";
+
+import { FairUsePolicyModal } from "@src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal";
+import { useAcceptFairUsePolicy } from "@src/hooks/useAcceptFairUsePolicy";
+import { useUser } from "@src/hooks/useUser";
+
+export const DEPENDENCIES = {
+  useUser,
+  useAcceptFairUsePolicy,
+  FairUsePolicyModal
+};
+
+type Props = {
+  children: ReactNode;
+  /** True on `definePublicPage` routes (login/signup/marketing), which never demand acceptance. */
+  isPublic?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/** Keeps the page mounted behind a non-dismissible modal until a signed-in user has accepted the Fair Use Policy once. */
+export function RequireFairUsePolicy({ children, isPublic, dependencies: d = DEPENDENCIES }: Props) {
+  const { user } = d.useUser();
+  const { accept, isAccepting } = d.useAcceptFairUsePolicy();
+  const mustAccept = !isPublic && !!user?.userId && !user.fairUsePolicyAcceptedAt;
+
+  return (
+    <>
+      {children}
+      {mustAccept && <d.FairUsePolicyModal onAccept={accept} isAccepting={isAccepting} />}
+    </>
+  );
+}

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
@@ -2,11 +2,15 @@
 import type { ReactNode } from "react";
 
 import { FairUsePolicyModal } from "@src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal";
+import { useWallet } from "@src/context/WalletProvider";
 import { useAcceptFairUsePolicy } from "@src/hooks/useAcceptFairUsePolicy";
+import { useFlag } from "@src/hooks/useFlag";
 import { useUser } from "@src/hooks/useUser";
 
 export const DEPENDENCIES = {
   useUser,
+  useWallet,
+  useFlag,
   useAcceptFairUsePolicy,
   FairUsePolicyModal
 };
@@ -18,11 +22,16 @@ type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-/** Keeps the page mounted behind a non-dismissible modal until a signed-in user has accepted the Fair Use Policy once. */
+/**
+ * Keeps the page mounted behind a non-dismissible modal until a trialing user has accepted the Fair Use Policy once.
+ * Mirrors the server gate, which only refuses deployments from trial wallets and only while the same flag is on.
+ */
 export function RequireFairUsePolicy({ children, isPublic, dependencies: d = DEPENDENCIES }: Props) {
   const { user } = d.useUser();
+  const { isTrialing } = d.useWallet();
+  const isGateEnabled = d.useFlag("fair_use_policy_gate");
   const { accept, isAccepting } = d.useAcceptFairUsePolicy();
-  const mustAccept = !isPublic && !!user?.userId && !user.fairUsePolicyAcceptedAt;
+  const mustAccept = !isPublic && isGateEnabled && isTrialing && !!user?.userId && !user.fairUsePolicyAcceptedAt;
 
   return (
     <>

--- a/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.spec.ts
+++ b/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.spec.ts
@@ -1,0 +1,54 @@
+import type { AxiosInstance } from "axios";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import type { ErrorHandlerService } from "@src/services/error-handler/error-handler.service";
+import type { DEPENDENCIES } from "./useAcceptFairUsePolicy";
+import { useAcceptFairUsePolicy } from "./useAcceptFairUsePolicy";
+
+import { act } from "@testing-library/react";
+import { setupQuery } from "@tests/unit/query-client";
+
+describe(useAcceptFairUsePolicy.name, () => {
+  it("persists the acceptance and refreshes the session profile", async () => {
+    const { result, consoleApiHttpClient, checkSession, analyticsService } = setup({});
+
+    await act(() => result.current.accept());
+
+    expect(consoleApiHttpClient.post).toHaveBeenCalledWith("/v1/user/acceptFairUsePolicy");
+    expect(checkSession).toHaveBeenCalledTimes(1);
+    expect(analyticsService.track).toHaveBeenCalledWith("fair_use_policy_accepted", { category: "user" });
+  });
+
+  it("reports a failed acceptance without throwing so the modal stays up for a retry", async () => {
+    const error = new Error("network down");
+    const { result, errorHandler, checkSession } = setup({ postError: error });
+
+    await act(() => result.current.accept());
+
+    expect(errorHandler.reportError).toHaveBeenCalledWith({ error, tags: { category: "user" } });
+    expect(checkSession).not.toHaveBeenCalled();
+    expect(result.current.isAccepting).toBe(false);
+  });
+
+  function setup(input: { postError?: Error }) {
+    const consoleApiHttpClient = mock<AxiosInstance>();
+    if (input.postError) consoleApiHttpClient.post.mockRejectedValue(input.postError);
+    else consoleApiHttpClient.post.mockResolvedValue({ data: undefined });
+    const analyticsService = mock<AnalyticsService>();
+    const errorHandler = mock<ErrorHandlerService>();
+    const checkSession = vi.fn().mockResolvedValue(undefined);
+    const useUser: typeof DEPENDENCIES.useUser = () => mock<ReturnType<typeof DEPENDENCIES.useUser>>({ checkSession });
+
+    const { result } = setupQuery(() => useAcceptFairUsePolicy({ useUser }), {
+      services: {
+        consoleApiHttpClient: () => consoleApiHttpClient,
+        analyticsService: () => analyticsService,
+        errorHandler: () => errorHandler
+      }
+    });
+
+    return { result, consoleApiHttpClient, analyticsService, errorHandler, checkSession };
+  }
+});

--- a/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.spec.ts
+++ b/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.spec.ts
@@ -1,4 +1,4 @@
-import type { AxiosInstance } from "axios";
+import { createProxy } from "@akashnetwork/react-query-proxy";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -8,22 +8,24 @@ import type { DEPENDENCIES } from "./useAcceptFairUsePolicy";
 import { useAcceptFairUsePolicy } from "./useAcceptFairUsePolicy";
 
 import { act } from "@testing-library/react";
-import { setupQuery } from "@tests/unit/query-client";
+import { type RenderAppHookOptions, setupQuery } from "@tests/unit/query-client";
+
+type ApiService = ReturnType<NonNullable<NonNullable<RenderAppHookOptions["services"]>["api"]>>;
 
 describe(useAcceptFairUsePolicy.name, () => {
   it("persists the acceptance and refreshes the session profile", async () => {
-    const { result, consoleApiHttpClient, checkSession, analyticsService } = setup({});
+    const { result, acceptFairUsePolicy, checkSession, analyticsService } = setup({});
 
     await act(() => result.current.accept());
 
-    expect(consoleApiHttpClient.post).toHaveBeenCalledWith("/v1/user/acceptFairUsePolicy");
+    expect(acceptFairUsePolicy).toHaveBeenCalledTimes(1);
     expect(checkSession).toHaveBeenCalledTimes(1);
     expect(analyticsService.track).toHaveBeenCalledWith("fair_use_policy_accepted", { category: "user" });
   });
 
   it("reports a failed acceptance without throwing so the modal stays up for a retry", async () => {
     const error = new Error("network down");
-    const { result, errorHandler, checkSession, analyticsService } = setup({ postError: error });
+    const { result, errorHandler, checkSession, analyticsService } = setup({ acceptError: error });
 
     await act(() => result.current.accept());
 
@@ -33,10 +35,9 @@ describe(useAcceptFairUsePolicy.name, () => {
     expect(result.current.isAccepting).toBe(false);
   });
 
-  function setup(input: { postError?: Error }) {
-    const consoleApiHttpClient = mock<AxiosInstance>();
-    if (input.postError) consoleApiHttpClient.post.mockRejectedValue(input.postError);
-    else consoleApiHttpClient.post.mockResolvedValue({ data: undefined });
+  function setup(input: { acceptError?: Error }) {
+    const acceptFairUsePolicy = input.acceptError ? vi.fn().mockRejectedValue(input.acceptError) : vi.fn().mockResolvedValue(undefined);
+    const api = createProxy({ v1: { acceptFairUsePolicy } }) as unknown as ApiService;
     const analyticsService = mock<AnalyticsService>();
     const errorHandler = mock<ErrorHandlerService>();
     const checkSession = vi.fn().mockResolvedValue(undefined);
@@ -44,12 +45,12 @@ describe(useAcceptFairUsePolicy.name, () => {
 
     const { result } = setupQuery(() => useAcceptFairUsePolicy({ useUser }), {
       services: {
-        consoleApiHttpClient: () => consoleApiHttpClient,
+        api: () => api,
         analyticsService: () => analyticsService,
         errorHandler: () => errorHandler
       }
     });
 
-    return { result, consoleApiHttpClient, analyticsService, errorHandler, checkSession };
+    return { result, acceptFairUsePolicy, analyticsService, errorHandler, checkSession };
   }
 });

--- a/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.spec.ts
+++ b/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.spec.ts
@@ -23,12 +23,13 @@ describe(useAcceptFairUsePolicy.name, () => {
 
   it("reports a failed acceptance without throwing so the modal stays up for a retry", async () => {
     const error = new Error("network down");
-    const { result, errorHandler, checkSession } = setup({ postError: error });
+    const { result, errorHandler, checkSession, analyticsService } = setup({ postError: error });
 
     await act(() => result.current.accept());
 
     expect(errorHandler.reportError).toHaveBeenCalledWith({ error, tags: { category: "user" } });
     expect(checkSession).not.toHaveBeenCalled();
+    expect(analyticsService.track).not.toHaveBeenCalled();
     expect(result.current.isAccepting).toBe(false);
   });
 

--- a/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.spec.ts
+++ b/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.spec.ts
@@ -33,6 +33,16 @@ describe(useAcceptFairUsePolicy.name, () => {
     expect(checkSession).not.toHaveBeenCalled();
     expect(analyticsService.track).not.toHaveBeenCalled();
     expect(result.current.isAccepting).toBe(false);
+    expect(result.current.hasAccepted).toBe(false);
+  });
+
+  it("keeps the acceptance once the api confirms it, even though the refreshed profile never carries the timestamp", async () => {
+    const { result, checkSession } = setup({});
+
+    await act(() => result.current.accept());
+
+    expect(checkSession).toHaveBeenCalledTimes(1);
+    expect(result.current.hasAccepted).toBe(true);
   });
 
   function setup(input: { acceptError?: Error }) {

--- a/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
+++ b/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useUser } from "@src/hooks/useUser";
@@ -8,16 +8,18 @@ export const DEPENDENCIES = {
 };
 
 /**
- * Persists the acceptance, then refreshes the profile: the gate reads the same profile, so the modal closes only once
- * the refreshed session carries the timestamp. A failure is reported and leaves the modal up for a retry.
+ * Closes the gate on the server's confirmation rather than on the refreshed profile, which resolves stale both when
+ * Auth0 swallows a failed profile fetch and when the profile route fails open without the timestamp.
  */
 export function useAcceptFairUsePolicy(dependencies: typeof DEPENDENCIES = DEPENDENCIES) {
   const { api, analyticsService, errorHandler } = useServices();
   const { checkSession } = dependencies.useUser();
+  const [hasAccepted, setHasAccepted] = useState(false);
 
   const { mutateAsync, isPending } = api.v1.acceptFairUsePolicy.useMutation({
     onSuccess: async () => {
       analyticsService.track("fair_use_policy_accepted", { category: "user" });
+      setHasAccepted(true);
       await checkSession();
     },
     onError: error => errorHandler.reportError({ error, tags: { category: "user" } })
@@ -27,5 +29,5 @@ export function useAcceptFairUsePolicy(dependencies: typeof DEPENDENCIES = DEPEN
     await mutateAsync().catch(() => undefined);
   }, [mutateAsync]);
 
-  return { accept, isAccepting: isPending };
+  return { accept, isAccepting: isPending, hasAccepted };
 }

--- a/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
+++ b/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
@@ -1,5 +1,4 @@
 import { useCallback } from "react";
-import { useMutation } from "@tanstack/react-query";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useUser } from "@src/hooks/useUser";
@@ -13,12 +12,11 @@ export const DEPENDENCIES = {
  * the refreshed session carries the timestamp. A failure is reported and leaves the modal up for a retry.
  */
 export function useAcceptFairUsePolicy(dependencies: typeof DEPENDENCIES = DEPENDENCIES) {
-  const { consoleApiHttpClient, analyticsService, errorHandler } = useServices();
+  const { api, analyticsService, errorHandler } = useServices();
   const { checkSession } = dependencies.useUser();
 
-  const { mutateAsync, isPending } = useMutation({
-    mutationFn: async () => {
-      await consoleApiHttpClient.post("/v1/user/acceptFairUsePolicy");
+  const { mutateAsync, isPending } = api.v1.acceptFairUsePolicy.useMutation({
+    onSuccess: async () => {
       analyticsService.track("fair_use_policy_accepted", { category: "user" });
       await checkSession();
     },

--- a/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
+++ b/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
@@ -18,8 +18,8 @@ export function useAcceptFairUsePolicy(dependencies: typeof DEPENDENCIES = DEPEN
 
   const { mutateAsync, isPending } = useMutation({
     mutationFn: async () => {
-      analyticsService.track("fair_use_policy_accepted", { category: "user" });
       await consoleApiHttpClient.post("/v1/user/acceptFairUsePolicy");
+      analyticsService.track("fair_use_policy_accepted", { category: "user" });
       await checkSession();
     },
     onError: error => errorHandler.reportError({ error, tags: { category: "user" } })

--- a/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
+++ b/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useUser } from "@src/hooks/useUser";
+
+export const DEPENDENCIES = {
+  useUser
+};
+
+/**
+ * Persists the acceptance, then refreshes the profile: the gate reads the same profile, so the modal closes only once
+ * the refreshed session carries the timestamp. A failure is reported and leaves the modal up for a retry.
+ */
+export function useAcceptFairUsePolicy(dependencies: typeof DEPENDENCIES = DEPENDENCIES) {
+  const { consoleApiHttpClient, analyticsService, errorHandler } = useServices();
+  const { checkSession } = dependencies.useUser();
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: async () => {
+      analyticsService.track("fair_use_policy_accepted", { category: "user" });
+      await consoleApiHttpClient.post("/v1/user/acceptFairUsePolicy");
+      await checkSession();
+    },
+    onError: error => errorHandler.reportError({ error, tags: { category: "user" } })
+  });
+
+  const accept = useCallback(async () => {
+    await mutateAsync().catch(() => undefined);
+  }, [mutateAsync]);
+
+  return { accept, isAccepting: isPending };
+}

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -61,22 +61,22 @@ const App: React.FunctionComponent<Props> = props => {
         <UserProviders>
           <AccountCreatedTracker />
           <RequireAuth isPublic={isPublic}>
-            <RequireFairUsePolicy isPublic={isPublic}>
-              <FlagProvider>
-                <WalletProvider>
-                  <PaymentPollingProvider>
-                    <AddCreditsHost />
-                    <NavigationGuardProvider>
-                      <RequireOnboarding isPublic={isPublic}>
-                        <WaitForFeatureFlags>
+            <FlagProvider>
+              <WalletProvider>
+                <PaymentPollingProvider>
+                  <AddCreditsHost />
+                  <NavigationGuardProvider>
+                    <RequireOnboarding isPublic={isPublic}>
+                      <WaitForFeatureFlags>
+                        <RequireFairUsePolicy isPublic={isPublic}>
                           <Component {...pageProps} />
-                        </WaitForFeatureFlags>
-                      </RequireOnboarding>
-                    </NavigationGuardProvider>
-                  </PaymentPollingProvider>
-                </WalletProvider>
-              </FlagProvider>
-            </RequireFairUsePolicy>
+                        </RequireFairUsePolicy>
+                      </WaitForFeatureFlags>
+                    </RequireOnboarding>
+                  </NavigationGuardProvider>
+                </PaymentPollingProvider>
+              </WalletProvider>
+            </FlagProvider>
           </RequireAuth>
         </UserProviders>
       </BootLoadingProvider>

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -21,6 +21,7 @@ import { AccountCreatedTracker } from "@src/components/analytics/AccountCreatedT
 import { AppBootstrap } from "@src/components/AppBootstrap/AppBootstrap";
 import { RequireAuth } from "@src/components/auth/RequireAuth/RequireAuth";
 import { AddCreditsHost } from "@src/components/billing-usage/AddCreditsHost/AddCreditsHost";
+import { RequireFairUsePolicy } from "@src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy";
 import { AppThemeProvider } from "@src/components/layout/AppThemeProvider";
 import { CustomIntlProvider } from "@src/components/layout/CustomIntlProvider";
 import { PageHead } from "@src/components/layout/PageHead";
@@ -60,20 +61,22 @@ const App: React.FunctionComponent<Props> = props => {
         <UserProviders>
           <AccountCreatedTracker />
           <RequireAuth isPublic={isPublic}>
-            <FlagProvider>
-              <WalletProvider>
-                <PaymentPollingProvider>
-                  <AddCreditsHost />
-                  <NavigationGuardProvider>
-                    <RequireOnboarding isPublic={isPublic}>
-                      <WaitForFeatureFlags>
-                        <Component {...pageProps} />
-                      </WaitForFeatureFlags>
-                    </RequireOnboarding>
-                  </NavigationGuardProvider>
-                </PaymentPollingProvider>
-              </WalletProvider>
-            </FlagProvider>
+            <RequireFairUsePolicy isPublic={isPublic}>
+              <FlagProvider>
+                <WalletProvider>
+                  <PaymentPollingProvider>
+                    <AddCreditsHost />
+                    <NavigationGuardProvider>
+                      <RequireOnboarding isPublic={isPublic}>
+                        <WaitForFeatureFlags>
+                          <Component {...pageProps} />
+                        </WaitForFeatureFlags>
+                      </RequireOnboarding>
+                    </NavigationGuardProvider>
+                  </PaymentPollingProvider>
+                </WalletProvider>
+              </FlagProvider>
+            </RequireFairUsePolicy>
           </RequireAuth>
         </UserProviders>
       </BootLoadingProvider>

--- a/apps/deploy-web/src/pages/terms-of-service/index.tsx
+++ b/apps/deploy-web/src/pages/terms-of-service/index.tsx
@@ -325,7 +325,9 @@ export function TermsOfService() {
           own independent analysis of the risks specific to your use of the Services.
         </p>
 
-        <h2 className="mb-2 text-xl">7. Prohibited Use</h2>
+        <h2 id="prohibited-use" className="mb-2 text-xl">
+          7. Prohibited Use
+        </h2>
         <p className="mb-4">
           You may not use the Services to engage in the following categories of activity (each a &quot;Prohibited Use&quot;). The specific types of activities
           listed below are representative, but not exhaustive.

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -106,6 +106,7 @@ export type AnalyticsEvent =
   | "onboarding_deploy_click"
   | "onboarding_choose_provider_click"
   | "onboarding_skipped"
+  | "fair_use_policy_accepted"
   | "add_credits_opened"
   | "add_credits_amount_selected"
   | "add_credits_payment_method_selected"

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -10,4 +10,5 @@ export type FeatureFlag =
   | "hackathons"
   | "deployment_runtime_limit"
   | "ui_sdl_proxy_http_options"
-  | "ui_sdl_cpu_arch";
+  | "ui_sdl_cpu_arch"
+  | "fair_use_policy_gate";

--- a/apps/deploy-web/src/types/user.ts
+++ b/apps/deploy-web/src/types/user.ts
@@ -15,6 +15,7 @@ export interface UserSettings {
   plan?: IPlan;
   emailVerified?: boolean;
   onboardingSkippedAt?: string | null;
+  fairUsePolicyAcceptedAt?: string | null;
 }
 
 export type CustomUserProfile = UserProfile & UserSettings;

--- a/apps/deploy-web/src/utils/urlUtils.ts
+++ b/apps/deploy-web/src/utils/urlUtils.ts
@@ -68,6 +68,7 @@ export const UrlService = {
   faq: (q?: FaqAnchorType) => `/faq${q ? "#" + q : ""}`,
   privacyPolicy: () => "/privacy-policy",
   termsOfService: () => "/terms-of-service",
+  prohibitedUse: () => "/terms-of-service#prohibited-use",
 
   // User
   userSettings: () => "/user/settings",

--- a/packages/console-api-types/src/operations.gen.ts
+++ b/packages/console-api-types/src/operations.gen.ts
@@ -96,6 +96,14 @@ export const operations = {
       queryParams: ["timezone", "startDate", "endDate"],
       hasBody: false
     },
+    acceptFairUsePolicy: {
+      path: "/v1/user/acceptFairUsePolicy",
+      method: "post",
+      operationId: "acceptFairUsePolicy",
+      pathParams: [],
+      queryParams: [],
+      hasBody: false
+    },
     getDeploymentFundingConfig: {
       path: "/v1/deployment-funding-config",
       method: "get",

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -936,31 +936,7 @@ export interface paths {
     get?: never;
     put?: never;
     /** Accept the Fair Use Policy */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Fair Use Policy accepted */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Unauthorized */
-        401: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
+    post: operations["acceptFairUsePolicy"];
     delete?: never;
     options?: never;
     head?: never;
@@ -7918,6 +7894,31 @@ export interface operations {
         content: {
           "text/csv": string;
         };
+      };
+    };
+  };
+  acceptFairUsePolicy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Fair Use Policy accepted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -628,6 +628,8 @@ export interface paths {
                 githubUsername?: string | null;
                 /** Format: date-time */
                 onboardingSkippedAt?: string | null;
+                /** Format: date-time */
+                fairUsePolicyAcceptedAt?: string | null;
               };
               isNewUser: boolean;
             };
@@ -679,6 +681,8 @@ export interface paths {
                 githubUsername?: string | null;
                 /** Format: date-time */
                 onboardingSkippedAt?: string | null;
+                /** Format: date-time */
+                fairUsePolicyAcceptedAt?: string | null;
               };
             };
           };
@@ -901,6 +905,47 @@ export interface paths {
       requestBody?: never;
       responses: {
         /** @description Onboarding skipped */
+        204: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Unauthorized */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/user/acceptFairUsePolicy": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Accept the Fair Use Policy */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Fair Use Policy accepted */
         204: {
           headers: {
             [name: string]: unknown;
@@ -6459,6 +6504,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -6499,6 +6545,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -6635,6 +6682,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -6682,6 +6730,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -6851,6 +6900,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -6898,6 +6948,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {

--- a/packages/dev-config/eslint/base.mjs
+++ b/packages/dev-config/eslint/base.mjs
@@ -55,7 +55,11 @@ export default [
       "simple-import-sort/imports": [
         "error",
         {
-          groups: [["^\\u0000"], ["^react", "^(?!(@src|@test))@?\\w"], ["^@src", "^\\.\\.(?!/?$)", "^\\.\\./?$", "^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"]]
+          groups: [
+            ["^\\u0000"],
+            ["^react", "^(?!(@src|@test))@?\\w"],
+            ["^@src", "^\\.\\.(?!/?$)", "^\\.\\./?$", "^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"]
+          ]
         }
       ],
       "@stylistic/space-infix-ops": ["error", { int32Hint: false }],
@@ -70,7 +74,7 @@ export default [
         {
           additionalVerbs: {
             get: { collection: ["export"] },
-            post: { collection: ["deposit", "screen", "apply", "validate", "confirm"] },
+            post: { collection: ["deposit", "screen", "apply", "validate", "confirm", "accept"] },
             delete: { single: ["close"] }
           }
         }


### PR DESCRIPTION
## Why

The Terms of Service already list the workloads Console does not allow, but nothing on an account records that the user has seen or agreed to that list. This makes the agreement explicit, in the product, before a user deploys, and gives the free trial a server-side check to lean on.

First of three stacked PRs. The next two add monitoring and enforcement of the same policy for trial deployments.

## What

**API**
- New nullable `userSetting.fair_use_policy_accepted_at` column (migration `0050`). Plain `ADD COLUMN` with no default or backfill, so it does not lock the table.
- `POST /v1/user/acceptFairUsePolicy` (204), set-if-null like `skipOnboarding`, and `fairUsePolicyAcceptedAt` on `GET /v1/user/me` so the web session carries it.
- A trial wallet creating a deployment without acceptance gets a 403 with `code: fair_use_policy_required`. The check runs in the managed signer, so it covers `POST /v1/deployments` and raw `/v1/tx` alike. Paying wallets are not gated. Behind the new Unleash flag `fair_use_policy_gate` so it can be turned on after deploy-web ships.
- Functional test users accept the policy right after registration so existing trial tests keep working.

**deploy-web**
- `RequireFairUsePolicy`, mounted inside `RequireAuth`: signed-in users see a non-dismissible `FairUsePolicyModal` until they click "I agree to the Fair Use Policy". Public pages and logged-out visitors are unaffected.
- `useAcceptFairUsePolicy` posts the acceptance and refreshes the session, so the modal only closes once the profile carries the timestamp.
- The modal lists the prohibited categories and links to the ToS section (`/terms-of-service#prohibited-use`, anchor added). Copy is a first draft.
- New analytics event `fair_use_policy_accepted`.

Rollout: merge, deploy deploy-web, check the modal on a real account, then enable `fair_use_policy_gate`.

### Verification

apps/api unit and functional suites green, plus the user repository integration specs. deploy-web specs for the three new units pass; `eslint --quiet` and `tsc --noEmit` clean on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Fair Use Policy modal describing prohibited workloads and linking to the relevant Terms of Service section.
  - Users can accept the policy in the application; acceptance is saved to their account.
  - Added an authenticated API endpoint and analytics tracking for policy acceptance.

- **Bug Fixes**
  - Trial deployments now require policy acceptance when the feature is enabled.
  - Prompts are skipped for public pages, non-trial users, and users who have already accepted the policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->