### PR TITLE
feat(deployment): monitor trial deployments for fair use policy violations

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -62,6 +62,15 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - close-unreachable-deployments
+  # Offset from the sweeps above so no two of them hit deployment_settings on the same minute.
+  - name: probe-trial-deployments
+    schedule: "13,43 * * * *" # every 30 minutes
+    command:
+      - node
+      - --require
+      - ./dist/instrumentation.js
+      - ./dist/console.js
+      - probe-trial-deployments
   - name: mint-act
     schedule: "*/10 * * * *" # every 10 minutes
     concurrencyPolicy: Forbid

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -9,7 +9,7 @@ if (!POSTGRES_DB_URI) {
 }
 
 export default defineConfig({
-  schema: ["billing", "user", "deployment", "auth", "secret"].map(schema => `./src/${schema}/model-schemas`),
+  schema: ["billing", "user", "deployment", "auth", "secret", "workload-abuse"].map(schema => `./src/${schema}/model-schemas`),
   out: "./drizzle",
   dialect: "postgresql",
   dbCredentials: {

--- a/apps/api/drizzle/0051_workload_abuse_detections.sql
+++ b/apps/api/drizzle/0051_workload_abuse_detections.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "public"."workload_abuse_action" AS ENUM('detected', 'enforcing', 'enforced', 'enforcement_failed');--> statement-breakpoint
+CREATE TYPE "public"."workload_abuse_verdict" AS ENUM('hard', 'soft', 'proxy');--> statement-breakpoint
+CREATE TABLE "workload_abuse_detections" (
+	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v4() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"wallet_id" integer NOT NULL,
+	"dseq" varchar NOT NULL,
+	"provider" varchar(255) NOT NULL,
+	"verdict" "workload_abuse_verdict" NOT NULL,
+	"probe_status" varchar(64) NOT NULL,
+	"signals" jsonb NOT NULL,
+	"evidence_excerpt" text NOT NULL,
+	"action" "workload_abuse_action" DEFAULT 'detected' NOT NULL,
+	"enforcement_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "workload_abuse_detections" ADD CONSTRAINT "workload_abuse_detections_user_id_userSetting_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."userSetting"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "workload_abuse_detections_user_id_idx" ON "workload_abuse_detections" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "workload_abuse_detections_dseq_idx" ON "workload_abuse_detections" USING btree ("dseq");

--- a/apps/api/drizzle/0051_workload_abuse_detections.sql
+++ b/apps/api/drizzle/0051_workload_abuse_detections.sql
@@ -5,7 +5,7 @@ CREATE TABLE "workload_abuse_detections" (
 	"user_id" uuid NOT NULL,
 	"wallet_id" integer NOT NULL,
 	"dseq" varchar NOT NULL,
-	"provider" varchar(255) NOT NULL,
+	"provider" text NOT NULL,
 	"verdict" "workload_abuse_verdict" NOT NULL,
 	"probe_status" varchar(64) NOT NULL,
 	"signals" jsonb NOT NULL,

--- a/apps/api/drizzle/meta/0051_snapshot.json
+++ b/apps/api/drizzle/meta/0051_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "1baab3b2-77e6-45fc-a1a0-070eea5ed256",
+  "id": "0f93730b-52a1-4661-8558-cfe5a66a4c39",
   "prevId": "6294f4f2-593f-40c1-9178-2ce5d2339d18",
   "version": "7",
   "dialect": "postgresql",
@@ -1562,7 +1562,7 @@
         },
         "provider": {
           "name": "provider",
-          "type": "varchar(255)",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },

--- a/apps/api/drizzle/meta/0051_snapshot.json
+++ b/apps/api/drizzle/meta/0051_snapshot.json
@@ -1,0 +1,1738 @@
+{
+  "id": "1baab3b2-77e6-45fc-a1a0-070eea5ed256",
+  "prevId": "6294f4f2-593f-40c1-9178-2ce5d2339d18",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_sufficient_since": {
+          "name": "credits_sufficient_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_since": {
+          "name": "credits_low_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reload_failure_count": {
+          "name": "auto_reload_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_reload_paused_at": {
+          "name": "auto_reload_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fair_use_policy_accepted_at": {
+          "name": "fair_use_policy_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_secrets": {
+          "name": "sealed_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workload_abuse_detections": {
+      "name": "workload_abuse_detections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "workload_abuse_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probe_status": {
+          "name": "probe_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signals": {
+          "name": "signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_excerpt": {
+          "name": "evidence_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "workload_abuse_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "enforcement_error": {
+          "name": "enforcement_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workload_abuse_detections_user_id_idx": {
+          "name": "workload_abuse_detections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workload_abuse_detections_dseq_idx": {
+          "name": "workload_abuse_detections_dseq_idx",
+          "columns": [
+            {
+              "expression": "dseq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workload_abuse_detections_user_id_userSetting_id_fk": {
+          "name": "workload_abuse_detections_user_id_userSetting_id_fk",
+          "tableFrom": "workload_abuse_detections",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    },
+    "public.workload_abuse_action": {
+      "name": "workload_abuse_action",
+      "schema": "public",
+      "values": [
+        "detected",
+        "enforcing",
+        "enforced",
+        "enforcement_failed"
+      ]
+    },
+    "public.workload_abuse_verdict": {
+      "name": "workload_abuse_verdict",
+      "schema": "public",
+      "values": [
+        "hard",
+        "soft",
+        "proxy"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -362,7 +362,7 @@
     {
       "idx": 51,
       "version": "7",
-      "when": 1788716007615,
+      "when": 1788721188493,
       "tag": "0051_workload_abuse_detections",
       "breakpoints": true
     }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1788714893741,
       "tag": "0050_fair_use_policy_accepted_at",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1788716007615,
+      "tag": "0051_workload_abuse_detections",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/env/.env.sample
+++ b/apps/api/env/.env.sample
@@ -43,3 +43,7 @@ DEPLOY_WEB_BASE_URL=
 CONSOLE_WEB_PAYMENT_LINK=
 
 PROVIDER_INVENTORY_API_URL=http://localhost:3092
+
+# Trial workload abuse probing (signatures live in Doppler, never in git)
+WORKLOAD_ABUSE_PROBE_ENABLED=false
+WORKLOAD_ABUSE_SIGNATURES={}

--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -14,6 +14,7 @@ import { ExecutionContextService } from "@src/core/services/execution-context/ex
 import { TopUpDeploymentsController } from "@src/deployment/controllers/deployment/top-up-deployments.controller";
 import { GpuBotController } from "@src/deployment/controllers/gpu-bot/gpu-bot.controller";
 import { ProviderController } from "@src/provider/controllers/provider/provider.controller";
+import { WorkloadAbuseController } from "@src/workload-abuse/controllers/workload-abuse.controller";
 import { APP_INITIALIZER, ON_APP_START } from "../core/providers/app-initializer";
 
 const program = new Command();
@@ -87,6 +88,16 @@ program
   .action(async (options, command) => {
     await executeCliHandler(command.name(), async () => {
       return container.resolve(TopUpDeploymentsController).closeUnreachableProviderDeployments(options);
+    });
+  });
+
+program
+  .command("probe-trial-deployments")
+  .description("Schedule a workload probe for every live trial deployment that has none pending")
+  .option("-d, --dry-run", "Log which deployments would be probed without enqueuing", false)
+  .action(async (options, command) => {
+    await executeCliHandler(command.name(), async () => {
+      return container.resolve(WorkloadAbuseController).probeTrialDeployments(options);
     });
   });
 

--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -10,6 +10,7 @@ import { DeleteUnbackedDeploymentSettingHandler } from "@src/deployment/services
 import { ReconcileManagedTxHandler } from "@src/deployment/services/reconcile-managed-tx/reconcile-managed-tx.handler";
 import { RecordDeploymentSettingHandler } from "@src/deployment/services/record-deployment-setting/record-deployment-setting.handler";
 import { NotificationHandler } from "@src/notifications/services/notification-handler/notification.handler";
+import { ProbeTrialDeploymentHandler } from "@src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler";
 import { AutoRechargeSucceededHandler } from "../services/auto-recharge-succeeded/auto-recharge-succeeded.handler";
 import { CloseExpiredDeploymentHandler } from "../services/close-expired-deployment/close-expired-deployment.handler";
 import { CloseTrialDeploymentHandler } from "../services/close-trial-deployment/close-trial-deployment.handler";
@@ -42,7 +43,8 @@ export async function startJobQueues(): Promise<void> {
     container.resolve(ActivateTrialHandler),
     container.resolve(DeleteUnbackedDeploymentSettingHandler),
     container.resolve(RecordDeploymentSettingHandler),
-    container.resolve(ReconcileManagedTxHandler)
+    container.resolve(ReconcileManagedTxHandler),
+    container.resolve(ProbeTrialDeploymentHandler)
   ]);
 }
 

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
@@ -10,6 +10,7 @@ import { DOMAIN_EVENT_NAME } from "@src/core";
 import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { JobQueueService } from "@src/core/services/job-queue/job-queue.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
+import type { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
 import { CloseTrialDeployment } from "../close-trial-deployment/close-trial-deployment.handler";
 import { TrialDeploymentLeaseCreatedHandler } from "./trial-deployment-lease-created.handler";
 
@@ -214,6 +215,16 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: TrialDeploymentLeaseCreatedHandler.name });
   });
 
+  it("schedules the first workload probe for the lease", async () => {
+    const wallet = createUserWallet({ isTrialing: true });
+    const deploymentCreatedAt = new Date("2026-09-06T13:19:00.000Z");
+    const { handler, probeJobService } = setup({ findWalletById: vi.fn().mockResolvedValue(wallet) });
+
+    await handler.handle({ walletId: wallet.id, dseq: "test-dseq", createdAt: deploymentCreatedAt.toISOString(), version: 1, isFirstLease: false });
+
+    expect(probeJobService.scheduleInitial).toHaveBeenCalledWith({ walletId: wallet.id, dseq: "test-dseq", leaseCreatedAt: deploymentCreatedAt });
+  });
+
   function setup(input?: {
     findWalletById?: UserWalletRepository["findById"];
     enqueueJob?: JobQueueService["enqueue"];
@@ -230,12 +241,19 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
       billingConfig: mockConfigService<BillingConfigService>({
         TRIAL_DEPLOYMENT_CLEANUP_HOURS: input?.trialDeploymentLifetimeInHours ?? 24,
         CONSOLE_WEB_PAYMENT_LINK: PAYMENT_LINK
-      })
+      }),
+      probeJobService: mock<TrialWorkloadProbeJobService>()
     };
 
     const createLogger = vi.fn<CreateLogger>(() => mocks.logger);
 
-    const handler = new TrialDeploymentLeaseCreatedHandler(mocks.userWalletRepository, createLogger, mocks.jobQueueService, mocks.billingConfig);
+    const handler = new TrialDeploymentLeaseCreatedHandler(
+      mocks.userWalletRepository,
+      createLogger,
+      mocks.jobQueueService,
+      mocks.billingConfig,
+      mocks.probeJobService
+    );
 
     return { handler, createLogger, ...mocks };
   }

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
@@ -7,6 +7,7 @@ import { BillingConfigService } from "@src/billing/services/billing-config/billi
 import { type CreateLogger, DOMAIN_EVENT_NAME, EventPayload, JobHandler, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
+import { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
 import { CloseTrialDeployment } from "../close-trial-deployment/close-trial-deployment.handler";
 
 @singleton()
@@ -21,7 +22,8 @@ export class TrialDeploymentLeaseCreatedHandler implements JobHandler<TrialDeplo
     private readonly userWalletRepository: UserWalletRepository,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger,
     private readonly jobQueueService: JobQueueService,
-    private readonly billingConfig: BillingConfigService
+    private readonly billingConfig: BillingConfigService,
+    private readonly probeJobService: TrialWorkloadProbeJobService
   ) {
     this.logger = createLogger({ context: TrialDeploymentLeaseCreatedHandler.name });
   }
@@ -91,6 +93,7 @@ export class TrialDeploymentLeaseCreatedHandler implements JobHandler<TrialDeplo
         startAfter: addHours(deploymentCreatedAt, trialDeploymentLifetime).toISOString()
       }
     );
+    await this.probeJobService.scheduleInitial({ walletId: wallet.id, dseq: payload.dseq, leaseCreatedAt: deploymentCreatedAt });
 
     if (payload.isFirstLease) {
       await this.jobQueueService.enqueue(

--- a/apps/api/src/core/providers/postgres.provider.ts
+++ b/apps/api/src/core/providers/postgres.provider.ts
@@ -13,6 +13,7 @@ import { APP_INITIALIZER, ON_APP_START } from "@src/core/providers/app-initializ
 import * as deploymentSchemas from "@src/deployment/model-schemas";
 import * as secretSchemas from "@src/secret/model-schemas";
 import * as userSchemas from "@src/user/model-schemas";
+import * as workloadAbuseSchemas from "@src/workload-abuse/model-schemas";
 import type { CoreConfig } from "./config.provider";
 import { CORE_CONFIG } from "./config.provider";
 import { LOGGER_FACTORY } from "./logging.provider";
@@ -49,7 +50,7 @@ container.register(APP_INITIALIZER, {
   })
 });
 
-const schema = { ...userSchemas, ...billingSchemas, ...deploymentSchemas, ...authSchemas, ...secretSchemas };
+const schema = { ...userSchemas, ...billingSchemas, ...deploymentSchemas, ...authSchemas, ...secretSchemas, ...workloadAbuseSchemas };
 const getDrizzleOptions = (config: Pick<CoreConfig, "SQL_LOG_FORMAT">) => ({
   logger: new PostgresLoggerService(container.resolve(LOGGER_FACTORY), { useFormat: config.SQL_LOG_FORMAT === "pretty" }),
   schema

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -797,6 +797,25 @@ describe(DeploymentSettingRepository.name, () => {
     return faker.number.int({ min: 100000, max: 999999 }).toString();
   }
 
+  describe("findLiveTrialDeployments", () => {
+    it("returns open trial deployments created inside the window with their wallet id", async () => {
+      const { deploymentSettingRepository, trialUser, trialWallet, createSetting, db, deploymentSettingsTable } = await setup();
+      const liveDseq = faker.number.int({ min: 100000, max: 999999 }).toString();
+      await db.insert(deploymentSettingsTable).values({ userId: trialUser.id, dseq: liveDseq, autoTopUpEnabled: true });
+      await db.insert(deploymentSettingsTable).values({ userId: trialUser.id, dseq: `1`, autoTopUpEnabled: true, closed: true });
+      await db
+        .insert(deploymentSettingsTable)
+        .values({ userId: trialUser.id, dseq: `2`, autoTopUpEnabled: true, createdAt: new Date(Date.now() - hoursToMilliseconds(48)) });
+      await createSetting();
+
+      const deployments = await deploymentSettingRepository.findLiveTrialDeployments({ maxAgeHours: 26 });
+
+      const ofTrialUser = deployments.filter(deployment => deployment.userId === trialUser.id);
+      expect(ofTrialUser).toEqual([{ userId: trialUser.id, dseq: liveDseq, walletId: trialWallet.walletId, createdAt: expect.any(Date) }]);
+      expect(deployments.some(deployment => deployment.userId !== trialUser.id && deployment.walletId === undefined)).toBe(false);
+    });
+  });
+
   async function setup() {
     const userRepository = container.resolve(UserRepository);
     const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -46,6 +46,13 @@ export type OpenDeployment = {
   address: string;
 };
 
+export type LiveTrialDeployment = {
+  userId: string;
+  dseq: string;
+  walletId: number;
+  createdAt: Date;
+};
+
 export type AutoTopUpDeployment = {
   id: string;
   userId: string;
@@ -176,6 +183,34 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       .orderBy(desc(this.table.id));
 
     return deployments as AutoTopUpDeployment[];
+  }
+
+  /**
+   * Trial deployments the reconcile sweep should have a probe for. `closed` is Console bookkeeping that drifts from the
+   * chain, so this only picks candidates and the probe job re-checks liveness on chain.
+   */
+  async findLiveTrialDeployments({ maxAgeHours }: { maxAgeHours: number }): Promise<LiveTrialDeployment[]> {
+    const hours = Math.max(1, Math.trunc(maxAgeHours));
+    const deployments = await this.pg
+      .select({
+        userId: this.table.userId,
+        dseq: this.table.dseq,
+        walletId: UserWallets.id,
+        createdAt: this.table.createdAt
+      })
+      .from(this.table)
+      .innerJoin(UserWallets, eq(UserWallets.userId, this.table.userId))
+      .where(
+        and(
+          eq(this.table.closed, false),
+          eq(UserWallets.isTrialing, true),
+          isNotNull(UserWallets.address),
+          gt(this.table.createdAt, sql`(now() at time zone 'utc') - make_interval(hours => ${sql.raw(String(hours))})`)
+        )
+      )
+      .orderBy(desc(this.table.createdAt));
+
+    return deployments as LiveTrialDeployment[];
   }
 
   /**

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -185,10 +185,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return deployments as AutoTopUpDeployment[];
   }
 
-  /**
-   * Trial deployments the reconcile sweep should have a probe for. `closed` is Console bookkeeping that drifts from the
-   * chain, so this only picks candidates and the probe job re-checks liveness on chain.
-   */
+  /** `closed` is Console bookkeeping that drifts from the chain, so these are candidates the probe job re-checks on chain. */
   async findLiveTrialDeployments({ maxAgeHours }: { maxAgeHours: number }): Promise<LiveTrialDeployment[]> {
     const hours = Math.max(1, Math.trunc(maxAgeHours));
     const deployments = await this.pg

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -52,10 +52,12 @@ export class ProviderService {
 
   async toProviderAuth(
     auth: { walletId: number; provider: string },
-    scope: Parameters<ProviderJwtTokenService["getGranularLeases"]>[0]["scope"] = ["send-manifest"]
+    scope: Parameters<ProviderJwtTokenService["getGranularLeases"]>[0]["scope"] = ["send-manifest"],
+    options: { ttl?: number } = {}
   ): Promise<ProviderAuth> {
     const result = await this.jwtTokenService.generateJwtToken({
       walletId: auth.walletId,
+      ttl: options.ttl,
       leases: this.jwtTokenService.getGranularLeases({
         provider: auth.provider,
         scope

--- a/apps/api/src/workload-abuse/config/config.provider.ts
+++ b/apps/api/src/workload-abuse/config/config.provider.ts
@@ -1,0 +1,16 @@
+import type { InjectionToken } from "tsyringe";
+import { container, inject, instancePerContainerCachingFactory } from "tsyringe";
+
+import { RAW_APP_CONFIG } from "@src/core/providers/raw-app-config.provider";
+import type { WorkloadAbuseConfig } from "./env.config";
+import { envSchema } from "./env.config";
+
+export const WORKLOAD_ABUSE_CONFIG: InjectionToken<WorkloadAbuseConfig> = Symbol("WORKLOAD_ABUSE_CONFIG");
+
+container.register(WORKLOAD_ABUSE_CONFIG, {
+  useFactory: instancePerContainerCachingFactory(c => envSchema.parse(c.resolve(RAW_APP_CONFIG)))
+});
+
+export const InjectWorkloadAbuseConfig = () => inject(WORKLOAD_ABUSE_CONFIG);
+
+export type { WorkloadAbuseConfig };

--- a/apps/api/src/workload-abuse/config/env.config.spec.ts
+++ b/apps/api/src/workload-abuse/config/env.config.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { envSchema } from "./env.config";
+
+describe("workload abuse env config", () => {
+  it("defaults to probing disabled with no signatures", () => {
+    const config = envSchema.parse({});
+
+    expect(config.WORKLOAD_ABUSE_PROBE_ENABLED).toBe(false);
+    expect(config.WORKLOAD_ABUSE_SIGNATURES).toEqual([]);
+    expect(config.WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN).toEqual([5, 20, 60]);
+  });
+
+  it("compiles the signature document into case-insensitive regexes tagged with their bucket", () => {
+    const config = envSchema.parse({
+      WORKLOAD_ABUSE_PROBE_ENABLED: "true",
+      WORKLOAD_ABUSE_SIGNATURES: JSON.stringify({
+        hard: [{ category: "stratum-url", pattern: "stratum\\+tcp://" }],
+        soft: [{ category: "pool-port", pattern: ":3333\\b", flags: "" }]
+      })
+    });
+
+    expect(config.WORKLOAD_ABUSE_PROBE_ENABLED).toBe(true);
+    expect(config.WORKLOAD_ABUSE_SIGNATURES).toEqual([
+      { bucket: "hard", category: "stratum-url", pattern: /stratum\+tcp:\/\//i },
+      { bucket: "soft", category: "pool-port", pattern: /:3333\b/ }
+    ]);
+  });
+
+  it("rejects a signature document that is not JSON", () => {
+    expect(() => envSchema.parse({ WORKLOAD_ABUSE_SIGNATURES: "not json" })).toThrow(/valid signature document/);
+  });
+
+  it("rejects a signature whose pattern is not a valid regex", () => {
+    const document = JSON.stringify({ hard: [{ category: "broken", pattern: "(" }] });
+
+    expect(() => envSchema.parse({ WORKLOAD_ABUSE_SIGNATURES: document })).toThrow(/invalid pattern for hard\/broken/);
+  });
+
+  it("parses the initial delay list and rejects negative entries", () => {
+    expect(envSchema.parse({ WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: "2, 10" }).WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN).toEqual([2, 10]);
+    expect(() => envSchema.parse({ WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: "2,-1" })).toThrow(/non-negative integers/);
+  });
+});

--- a/apps/api/src/workload-abuse/config/env.config.ts
+++ b/apps/api/src/workload-abuse/config/env.config.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+const signaturePatternSchema = z.object({
+  category: z.string().min(1),
+  pattern: z.string().min(1),
+  flags: z
+    .string()
+    .regex(/^[imsu]*$/)
+    .optional()
+});
+
+const signatureGroupsSchema = z.object({
+  hard: z.array(signaturePatternSchema).default([]),
+  soft: z.array(signaturePatternSchema).default([]),
+  proxy: z.array(signaturePatternSchema).default([])
+});
+
+export const SIGNATURE_BUCKETS = ["hard", "soft", "proxy"] as const;
+export type SignatureBucket = (typeof SIGNATURE_BUCKETS)[number];
+export type CompiledSignature = { bucket: SignatureBucket; category: string; pattern: RegExp };
+
+/** The list itself lives in Doppler, so a reader of this open-source code learns how matching works but not what is matched. */
+export function compileSignatures(raw: string, ctx: z.RefinementCtx): CompiledSignature[] {
+  const groups = signatureGroupsSchema.safeParse(parseJson(raw));
+
+  if (!groups.success) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: `WORKLOAD_ABUSE_SIGNATURES is not a valid signature document: ${groups.error.message}` });
+    return z.NEVER;
+  }
+
+  const compiled: CompiledSignature[] = [];
+
+  for (const bucket of SIGNATURE_BUCKETS) {
+    for (const { category, pattern, flags } of groups.data[bucket]) {
+      try {
+        compiled.push({ bucket, category, pattern: new RegExp(pattern, flags ?? "i") });
+      } catch {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: `WORKLOAD_ABUSE_SIGNATURES has an invalid pattern for ${bucket}/${category}` });
+        return z.NEVER;
+      }
+    }
+  }
+
+  return compiled;
+}
+
+function parseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseMinutesList(raw: string, ctx: z.RefinementCtx): number[] {
+  const values = raw.split(",").map(value => Number(value.trim()));
+
+  if (values.length === 0 || values.some(value => !Number.isInteger(value) || value < 0)) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "must be a comma-separated list of non-negative integers" });
+    return z.NEVER;
+  }
+
+  return values;
+}
+
+export const envSchema = z.object({
+  WORKLOAD_ABUSE_PROBE_ENABLED: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform(value => value === "true"),
+  WORKLOAD_ABUSE_SIGNATURES: z.string().default("{}").transform(compileSignatures),
+  WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: z.string().default("5,20,60").transform(parseMinutesList),
+  WORKLOAD_ABUSE_PROBE_INTERVAL_MIN: z.number({ coerce: true }).int().positive().default(60),
+  WORKLOAD_ABUSE_PROBE_JITTER_MIN: z.number({ coerce: true }).int().nonnegative().default(10),
+  /** Trial deployments close after a day on their own, so this only bounds a deployment that close missed. */
+  WORKLOAD_ABUSE_PROBE_MAX_PER_DEPLOYMENT: z.number({ coerce: true }).int().positive().default(30),
+  WORKLOAD_ABUSE_PROBE_LOG_TAIL: z.number({ coerce: true }).int().positive().default(300),
+  WORKLOAD_ABUSE_PROBE_IDLE_TIMEOUT_MS: z.number({ coerce: true }).int().positive().default(5_000),
+  WORKLOAD_ABUSE_PROBE_HARD_TIMEOUT_MS: z.number({ coerce: true }).int().positive().default(30_000),
+  WORKLOAD_ABUSE_PROBE_MAX_OUTPUT_BYTES: z.number({ coerce: true }).int().positive().default(65_536),
+  /** Long enough for a shell round trip through the proxy, short enough that a leaked token is worthless minutes later. */
+  WORKLOAD_ABUSE_PROVIDER_JWT_TTL_SECONDS: z.number({ coerce: true }).int().positive().default(120),
+  /** How far back the reconcile sweep looks for live trial deployments without a pending probe. */
+  WORKLOAD_ABUSE_RECONCILE_MAX_AGE_HOURS: z.number({ coerce: true }).int().positive().default(26)
+});
+
+export type WorkloadAbuseConfig = z.infer<typeof envSchema>;

--- a/apps/api/src/workload-abuse/controllers/workload-abuse.controller.ts
+++ b/apps/api/src/workload-abuse/controllers/workload-abuse.controller.ts
@@ -1,0 +1,13 @@
+import { singleton } from "tsyringe";
+
+import type { DryRunOptions } from "@src/core/types/console";
+import { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
+
+@singleton()
+export class WorkloadAbuseController {
+  constructor(private readonly probeJobService: TrialWorkloadProbeJobService) {}
+
+  async probeTrialDeployments(options: DryRunOptions): Promise<void> {
+    await this.probeJobService.reconcile(options);
+  }
+}

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import type { CompiledSignature } from "@src/workload-abuse/config/env.config";
+import { scanForSignals, toVerdict } from "./evidence-scanner";
+
+const SIGNATURES: CompiledSignature[] = [
+  { bucket: "hard", category: "stratum-url", pattern: /stratum\+tcp:\/\//i },
+  { bucket: "soft", category: "hashrate", pattern: /\d+\s*h\/s/i },
+  { bucket: "soft", category: "pool-port", pattern: /:3333\b/ },
+  { bucket: "soft", category: "nonce", pattern: /\bnonce\b/i },
+  { bucket: "proxy", category: "proxy-tunnel", pattern: /\bxray\b/i }
+];
+
+describe("evidence scanner", () => {
+  describe("scanForSignals", () => {
+    it("tags each match with its bucket, category and the source it came from", () => {
+      const signals = scanForSignals([{ kind: "shell", service: "ssh", text: "1 comm=miner cmd=miner -o stratum+tcp://pool:3333" }], SIGNATURES);
+
+      expect(signals).toEqual([
+        { bucket: "hard", category: "stratum-url", source: "shell", service: "ssh", snippet: "1 comm=miner cmd=miner -o stratum+tcp://pool:3333" },
+        { bucket: "soft", category: "pool-port", source: "shell", service: "ssh", snippet: "1 comm=miner cmd=miner -o stratum+tcp://pool:3333" }
+      ]);
+    });
+
+    it("reports one signal per category per source however many lines match", () => {
+      const signals = scanForSignals([{ kind: "logs", text: "speed 10 H/s\nspeed 12 H/s\nspeed 15 H/s" }], SIGNATURES);
+
+      expect(signals).toHaveLength(1);
+    });
+
+    it("keeps the same category from two sources as two signals", () => {
+      const signals = scanForSignals(
+        [
+          { kind: "logs", text: "nonce found" },
+          { kind: "sdl", text: "env: NONCE=1" }
+        ],
+        SIGNATURES
+      );
+
+      expect(signals.map(signal => signal.source)).toEqual(["logs", "sdl"]);
+    });
+
+    it("bounds the snippet around the match", () => {
+      const line = `${"a".repeat(300)} stratum+tcp://pool ${"b".repeat(300)}`;
+
+      const [signal] = scanForSignals([{ kind: "logs", text: line }], SIGNATURES);
+
+      expect(signal.snippet.length).toBeLessThanOrEqual(180);
+      expect(signal.snippet).toContain("stratum+tcp://pool");
+    });
+
+    it("returns nothing for clean text or when there are no signatures", () => {
+      expect(scanForSignals([{ kind: "logs", text: "nginx started\n\n" }], SIGNATURES)).toEqual([]);
+      expect(scanForSignals([{ kind: "logs", text: "stratum+tcp://pool" }], [])).toEqual([]);
+    });
+  });
+
+  describe("toVerdict", () => {
+    it("is hard on any hard signal", () => {
+      const signals = scanForSignals([{ kind: "sdl", text: "stratum+tcp://pool" }], SIGNATURES);
+
+      expect(toVerdict(signals)).toBe("hard");
+    });
+
+    it("is soft only once three distinct soft categories agree", () => {
+      const two = scanForSignals([{ kind: "logs", text: "10 H/s\npool:3333" }], SIGNATURES);
+      const three = scanForSignals([{ kind: "logs", text: "10 H/s\npool:3333\nnonce" }], SIGNATURES);
+
+      expect(toVerdict(two)).toBe("clean");
+      expect(toVerdict(three)).toBe("soft");
+    });
+
+    it("reports proxy tunnels separately from mining", () => {
+      const signals = scanForSignals([{ kind: "shell", text: "1 comm=xray" }], SIGNATURES);
+
+      expect(toVerdict(signals)).toBe("proxy");
+    });
+  });
+});

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
@@ -40,6 +40,24 @@ describe("evidence scanner", () => {
       expect(signals.map(signal => signal.source)).toEqual(["logs", "sdl"]);
     });
 
+    it("keeps the same category from two services as two signals", () => {
+      const signals = scanForSignals(
+        [
+          { kind: "shell", service: "web", text: "nonce found" },
+          { kind: "shell", service: "worker", text: "nonce found" }
+        ],
+        SIGNATURES
+      );
+
+      expect(signals.map(signal => signal.service)).toEqual(["web", "worker"]);
+    });
+
+    it("trims the snippet it stores", () => {
+      const [signal] = scanForSignals([{ kind: "logs", text: "   stratum+tcp://pool   " }], SIGNATURES);
+
+      expect(signal.snippet).toBe("stratum+tcp://pool");
+    });
+
     it("bounds the snippet around the match", () => {
       const line = `${"a".repeat(300)} stratum+tcp://pool ${"b".repeat(300)}`;
 
@@ -68,6 +86,12 @@ describe("evidence scanner", () => {
 
       expect(toVerdict(two)).toBe("clean");
       expect(toVerdict(three)).toBe("soft");
+    });
+
+    it("stays proxy when soft signals are present but too few to count", () => {
+      const signals = scanForSignals([{ kind: "shell", text: "10 H/s\npool:3333\n1 comm=xray" }], SIGNATURES);
+
+      expect(toVerdict(signals)).toBe("proxy");
     });
 
     it("reports proxy tunnels separately from mining", () => {

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.ts
@@ -1,0 +1,61 @@
+import type { CompiledSignature, SignatureBucket } from "@src/workload-abuse/config/env.config";
+
+export type EvidenceSourceKind = "sdl" | "logs" | "shell";
+
+export type EvidenceSource = { kind: EvidenceSourceKind; service?: string; text: string };
+
+export type DetectionSignal = { bucket: SignatureBucket; category: string; source: EvidenceSourceKind; service?: string; snippet: string };
+
+export type WorkloadVerdict = "hard" | "soft" | "proxy" | "clean";
+
+const MAX_SNIPPET_LENGTH = 180;
+const SNIPPET_LEAD_IN = 60;
+/** Any one soft category alone (a port number, the word nonce) shows up in honest workloads. */
+const MIN_SOFT_CATEGORIES_FOR_VERDICT = 3;
+
+/** One signal per category per source, so a chatty miner log produces an auditable table rather than thousands of rows. */
+export function scanForSignals(sources: EvidenceSource[], signatures: CompiledSignature[]): DetectionSignal[] {
+  const signals: DetectionSignal[] = [];
+  const seen = new Set<string>();
+
+  for (const source of sources) {
+    for (const line of source.text.split("\n")) {
+      if (!line.trim()) continue;
+
+      for (const signature of signatures) {
+        const match = signature.pattern.exec(line);
+        if (!match) continue;
+
+        const key = `${signature.bucket}|${signature.category}|${source.kind}|${source.service ?? ""}`;
+        if (seen.has(key)) continue;
+
+        seen.add(key);
+        signals.push({
+          bucket: signature.bucket,
+          category: signature.category,
+          source: source.kind,
+          service: source.service,
+          snippet: toSnippet(line, match.index)
+        });
+      }
+    }
+  }
+
+  return signals;
+}
+
+export function toVerdict(signals: DetectionSignal[]): WorkloadVerdict {
+  if (signals.some(signal => signal.bucket === "hard")) return "hard";
+
+  const softCategories = new Set(signals.filter(signal => signal.bucket === "soft").map(signal => signal.category));
+  if (softCategories.size >= MIN_SOFT_CATEGORIES_FOR_VERDICT) return "soft";
+
+  if (signals.some(signal => signal.bucket === "proxy")) return "proxy";
+
+  return "clean";
+}
+
+function toSnippet(line: string, matchIndex: number): string {
+  const start = Math.max(0, matchIndex - SNIPPET_LEAD_IN);
+  return line.slice(start, start + MAX_SNIPPET_LENGTH).trim();
+}

--- a/apps/api/src/workload-abuse/lib/provider-frame/provider-frame.spec.ts
+++ b/apps/api/src/workload-abuse/lib/provider-frame/provider-frame.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeProviderFrame, parseShellExit } from "./provider-frame";
+
+function bufferFrame(bytes: number[]): string {
+  return JSON.stringify({ type: "websocket", message: { type: "Buffer", data: bytes } });
+}
+
+describe("provider frame", () => {
+  describe("decodeProviderFrame", () => {
+    it("splits a binary shell frame into its stream code and payload", () => {
+      const frame = decodeProviderFrame(bufferFrame([100, ...Buffer.from("hello")]));
+
+      expect(frame).toEqual({ kind: "shell", stream: "stdout", payload: "hello" });
+    });
+
+    it("maps every known stream code and falls back to unknown", () => {
+      expect(decodeProviderFrame(bufferFrame([101, 65]))).toMatchObject({ stream: "stderr" });
+      expect(decodeProviderFrame(bufferFrame([102, 65]))).toMatchObject({ stream: "result" });
+      expect(decodeProviderFrame(bufferFrame([103, 65]))).toMatchObject({ stream: "failure" });
+      expect(decodeProviderFrame(bufferFrame([7, 65]))).toMatchObject({ stream: "unknown" });
+    });
+
+    it("passes a text frame through as text", () => {
+      expect(decodeProviderFrame(JSON.stringify({ type: "websocket", message: '{"name":"web-1","message":"up"}' }))).toEqual({
+        kind: "text",
+        payload: '{"name":"web-1","message":"up"}'
+      });
+    });
+
+    it("recognises proxy close and error outcomes", () => {
+      expect(
+        decodeProviderFrame(JSON.stringify({ type: "websocket", message: "", closed: true, code: 1008, reason: "invalidCertificate.unknownCertificate" }))
+      ).toEqual({
+        kind: "closed",
+        code: 1008,
+        reason: "invalidCertificate.unknownCertificate"
+      });
+      expect(decodeProviderFrame(JSON.stringify({ type: "websocket", error: "tokenExpired" }))).toEqual({ kind: "error", error: "tokenExpired" });
+    });
+
+    it("ignores keepalives, empty frames and anything that is not JSON", () => {
+      expect(decodeProviderFrame(JSON.stringify({ type: "pong" }))).toEqual({ kind: "ignore" });
+      expect(decodeProviderFrame(bufferFrame([]))).toEqual({ kind: "ignore" });
+      expect(decodeProviderFrame(JSON.stringify({ type: "websocket", message: "" }))).toEqual({ kind: "ignore" });
+      expect(decodeProviderFrame("not json")).toEqual({ kind: "ignore" });
+    });
+  });
+
+  describe("parseShellExit", () => {
+    it("reads the exit code from a result payload", () => {
+      expect(parseShellExit('{"exit_code":0}')).toEqual({ exitCode: 0, message: undefined });
+      expect(parseShellExit('{"exit_code":127,"message":"not found"}')).toEqual({ exitCode: 127, message: "not found" });
+    });
+
+    it("returns nothing for a payload that is not a result", () => {
+      expect(parseShellExit("plain output")).toBeUndefined();
+      expect(parseShellExit('{"other":1}')).toBeUndefined();
+    });
+  });
+});

--- a/apps/api/src/workload-abuse/lib/provider-frame/provider-frame.ts
+++ b/apps/api/src/workload-abuse/lib/provider-frame/provider-frame.ts
@@ -1,0 +1,61 @@
+export type ShellStream = "stdout" | "stderr" | "result" | "failure" | "unknown";
+
+/** Akash provider shell frames carry the stream in their first byte and the payload after it. */
+const SHELL_STREAM_BY_CODE: Record<number, ShellStream> = { 100: "stdout", 101: "stderr", 102: "result", 103: "failure" };
+
+export type ProviderFrame =
+  | { kind: "shell"; stream: ShellStream; payload: string }
+  | { kind: "text"; payload: string }
+  | { kind: "closed"; code?: number; reason?: string }
+  | { kind: "error"; error: string }
+  | { kind: "ignore" };
+
+const IGNORED_FRAME: ProviderFrame = { kind: "ignore" };
+
+/**
+ * Decodes one provider-proxy client message. Binary provider frames reach the client as a JSON-serialized Buffer
+ * (`{type:"Buffer",data:[...]}`), text frames as a plain string, and proxy-level outcomes as `closed` / `error`.
+ */
+export function decodeProviderFrame(raw: string): ProviderFrame {
+  const parsed = parseJson(raw);
+  if (!isRecord(parsed)) return IGNORED_FRAME;
+  if (parsed.type === "ping" || parsed.type === "pong") return IGNORED_FRAME;
+  if (typeof parsed.error === "string") return { kind: "error", error: parsed.error };
+  if (parsed.closed === true) {
+    return {
+      kind: "closed",
+      code: typeof parsed.code === "number" ? parsed.code : undefined,
+      reason: typeof parsed.reason === "string" ? parsed.reason : undefined
+    };
+  }
+
+  const message = parsed.message;
+  if (typeof message === "string") return message.length > 0 ? { kind: "text", payload: message } : IGNORED_FRAME;
+
+  if (isRecord(message) && message.type === "Buffer" && Array.isArray(message.data)) {
+    const bytes = Buffer.from(message.data as number[]);
+    if (bytes.length === 0) return IGNORED_FRAME;
+    return { kind: "shell", stream: SHELL_STREAM_BY_CODE[bytes[0]] ?? "unknown", payload: bytes.subarray(1).toString("utf8") };
+  }
+
+  return IGNORED_FRAME;
+}
+
+export function parseShellExit(payload: string): { exitCode: number; message?: string } | undefined {
+  const parsed = parseJson(payload.trim());
+  if (!isRecord(parsed) || typeof parsed.exit_code !== "number") return undefined;
+
+  return { exitCode: parsed.exit_code, message: typeof parsed.message === "string" ? parsed.message : undefined };
+}
+
+function parseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/api/src/workload-abuse/lib/provider-frame/provider-frame.ts
+++ b/apps/api/src/workload-abuse/lib/provider-frame/provider-frame.ts
@@ -12,10 +12,7 @@ export type ProviderFrame =
 
 const IGNORED_FRAME: ProviderFrame = { kind: "ignore" };
 
-/**
- * Decodes one provider-proxy client message. Binary provider frames reach the client as a JSON-serialized Buffer
- * (`{type:"Buffer",data:[...]}`), text frames as a plain string, and proxy-level outcomes as `closed` / `error`.
- */
+/** Decodes one provider-proxy client message, where binary provider frames arrive as a JSON-serialized Buffer, text frames as a plain string, and proxy outcomes as `closed` / `error`. */
 export function decodeProviderFrame(raw: string): ProviderFrame {
   const parsed = parseJson(raw);
   if (!isRecord(parsed)) return IGNORED_FRAME;

--- a/apps/api/src/workload-abuse/model-schemas/index.ts
+++ b/apps/api/src/workload-abuse/model-schemas/index.ts
@@ -1,0 +1,1 @@
+export * from "./workload-abuse-detection/workload-abuse-detection.schema";

--- a/apps/api/src/workload-abuse/model-schemas/workload-abuse-detection/workload-abuse-detection.schema.ts
+++ b/apps/api/src/workload-abuse/model-schemas/workload-abuse-detection/workload-abuse-detection.schema.ts
@@ -20,7 +20,7 @@ export const WorkloadAbuseDetections = pgTable(
       .notNull(),
     walletId: integer("wallet_id").notNull(),
     dseq: varchar("dseq").notNull(),
-    provider: varchar("provider", { length: 255 }).notNull(),
+    provider: text("provider").notNull(),
     verdict: workloadAbuseVerdictEnum("verdict").notNull(),
     probeStatus: varchar("probe_status", { length: 64 }).notNull(),
     signals: jsonb("signals").$type<DetectionSignal[]>().notNull(),

--- a/apps/api/src/workload-abuse/model-schemas/workload-abuse-detection/workload-abuse-detection.schema.ts
+++ b/apps/api/src/workload-abuse/model-schemas/workload-abuse-detection/workload-abuse-detection.schema.ts
@@ -1,0 +1,37 @@
+import { sql } from "drizzle-orm";
+import { index, integer, jsonb, pgEnum, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+
+import { Users } from "@src/user/model-schemas";
+import type { DetectionSignal } from "@src/workload-abuse/lib/evidence-scanner/evidence-scanner";
+
+export const workloadAbuseVerdictEnum = pgEnum("workload_abuse_verdict", ["hard", "soft", "proxy"]);
+
+export const workloadAbuseActionEnum = pgEnum("workload_abuse_action", ["detected", "enforcing", "enforced", "enforcement_failed"]);
+
+export const WorkloadAbuseDetections = pgTable(
+  "workload_abuse_detections",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .notNull()
+      .default(sql`uuid_generate_v4()`),
+    userId: uuid("user_id")
+      .references(() => Users.id, { onDelete: "cascade" })
+      .notNull(),
+    walletId: integer("wallet_id").notNull(),
+    dseq: varchar("dseq").notNull(),
+    provider: varchar("provider", { length: 255 }).notNull(),
+    verdict: workloadAbuseVerdictEnum("verdict").notNull(),
+    probeStatus: varchar("probe_status", { length: 64 }).notNull(),
+    signals: jsonb("signals").$type<DetectionSignal[]>().notNull(),
+    evidenceExcerpt: text("evidence_excerpt").notNull(),
+    action: workloadAbuseActionEnum("action").notNull().default("detected"),
+    enforcementError: text("enforcement_error"),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull()
+  },
+  table => ({
+    userIdIdx: index("workload_abuse_detections_user_id_idx").on(table.userId),
+    dseqIdx: index("workload_abuse_detections_dseq_idx").on(table.dseq)
+  })
+);

--- a/apps/api/src/workload-abuse/providers/provider-proxy-socket.provider.ts
+++ b/apps/api/src/workload-abuse/providers/provider-proxy-socket.provider.ts
@@ -1,0 +1,28 @@
+import type { InjectionToken } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
+
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+
+export type ProviderProxySocketEvent = { data?: unknown; code?: number; reason?: string };
+
+/** The subset of the WHATWG WebSocket surface the probe uses, so tests can script a socket without a network. */
+export interface ProviderProxySocket {
+  addEventListener(type: "open" | "message" | "close" | "error", listener: (event: ProviderProxySocketEvent) => void): void;
+  send(data: string): void;
+  close(): void;
+}
+
+export type ProviderProxySocketFactory = () => ProviderProxySocket;
+
+export const PROVIDER_PROXY_SOCKET_FACTORY: InjectionToken<ProviderProxySocketFactory> = Symbol("PROVIDER_PROXY_SOCKET_FACTORY");
+
+type WebSocketConstructor = new (url: string) => ProviderProxySocket;
+
+container.register(PROVIDER_PROXY_SOCKET_FACTORY, {
+  useFactory: instancePerContainerCachingFactory(c => {
+    const url = c.resolve(DeploymentConfigService).get("PROVIDER_PROXY_URL").replace(/^http/, "ws");
+    const WebSocket = (globalThis as unknown as { WebSocket: WebSocketConstructor }).WebSocket;
+
+    return () => new WebSocket(url);
+  })
+});

--- a/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.integration.ts
+++ b/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.integration.ts
@@ -1,0 +1,46 @@
+import { faker } from "@faker-js/faker";
+import { subHours } from "date-fns";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import { UserRepository } from "@src/user/repositories";
+import { WorkloadAbuseDetectionRepository } from "./workload-abuse-detection.repository";
+
+describe(WorkloadAbuseDetectionRepository.name, () => {
+  describe("findRecentHardTargets", () => {
+    it("lists each deployment with a confirmed detection inside the window once", async () => {
+      const { repository, walletId, createDetection } = await setup();
+      await createDetection({ dseq: "1", verdict: "hard" });
+      await createDetection({ dseq: "1", verdict: "hard" });
+      await createDetection({ dseq: "2", verdict: "soft" });
+      await createDetection({ dseq: "3", verdict: "hard", createdAt: subHours(new Date(), 30) });
+
+      const targets = await repository.findRecentHardTargets({ since: subHours(new Date(), 26) });
+
+      expect(targets.filter(target => target.walletId === walletId)).toEqual([{ walletId, dseq: "1" }]);
+    });
+  });
+
+  async function setup() {
+    const userRepository = container.resolve(UserRepository);
+    const repository = container.resolve(WorkloadAbuseDetectionRepository);
+    const user = await userRepository.create({ userId: faker.string.uuid() });
+    const walletId = faker.number.int({ min: 1, max: 1_000_000_000 });
+
+    async function createDetection(input: { dseq: string; verdict: "hard" | "soft" | "proxy"; createdAt?: Date }) {
+      return repository.create({
+        userId: user.id,
+        walletId,
+        dseq: input.dseq,
+        provider: "akash1provider",
+        verdict: input.verdict,
+        probeStatus: "probed",
+        signals: [],
+        evidenceExcerpt: "",
+        createdAt: input.createdAt
+      });
+    }
+
+    return { repository, walletId, createDetection };
+  }
+});

--- a/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.ts
+++ b/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.ts
@@ -1,0 +1,24 @@
+import { singleton } from "tsyringe";
+
+import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
+import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
+import { TxService } from "@src/core/services";
+
+type Table = ApiPgTables["WorkloadAbuseDetections"];
+export type WorkloadAbuseDetectionInput = Partial<Table["$inferInsert"]>;
+export type WorkloadAbuseDetectionOutput = Table["$inferSelect"];
+
+@singleton()
+export class WorkloadAbuseDetectionRepository extends BaseRepository<Table, WorkloadAbuseDetectionInput, WorkloadAbuseDetectionOutput> {
+  constructor(
+    @InjectPg() protected readonly pg: ApiPgDatabase,
+    @InjectPgTable("WorkloadAbuseDetections") protected readonly table: Table,
+    protected readonly txManager: TxService
+  ) {
+    super(pg, table, txManager, "WorkloadAbuseDetection", "WorkloadAbuseDetections");
+  }
+
+  accessibleBy(...abilityParams: AbilityParams) {
+    return new WorkloadAbuseDetectionRepository(this.pg, this.table, this.txManager).withAbility(...abilityParams) as this;
+  }
+}

--- a/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.ts
+++ b/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.ts
@@ -1,3 +1,4 @@
+import { and, eq, gt } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -20,5 +21,12 @@ export class WorkloadAbuseDetectionRepository extends BaseRepository<Table, Work
 
   accessibleBy(...abilityParams: AbilityParams) {
     return new WorkloadAbuseDetectionRepository(this.pg, this.table, this.txManager).withAbility(...abilityParams) as this;
+  }
+
+  async findRecentHardTargets({ since }: { since: Date }): Promise<Array<{ walletId: number; dseq: string }>> {
+    return await this.cursor
+      .selectDistinct({ walletId: this.table.walletId, dseq: this.table.dseq })
+      .from(this.table)
+      .where(and(eq(this.table.verdict, "hard"), gt(this.table.createdAt, since)));
   }
 }

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
@@ -119,7 +119,25 @@ describe(ProbeTrialDeploymentHandler.name, () => {
     };
   }
 
-  function setup(input: { enabled?: boolean; wallet?: ReturnType<typeof createUserWallet> | null; report?: ProbeReport; maxAttempts?: number }) {
+  it("stops probing a deployment that already carries a confirmed detection", async () => {
+    const { handler, probeService, probeJobService, logger } = setup({ existingDetection: true });
+
+    await handler.handle(PAYLOAD);
+
+    expect(probeService.probe).not.toHaveBeenCalled();
+    expect(probeJobService.scheduleNext).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_FINISHED", reason: "ALREADY_DETECTED", detectionId: "detection-0" })
+    );
+  });
+
+  function setup(input: {
+    enabled?: boolean;
+    wallet?: ReturnType<typeof createUserWallet> | null;
+    report?: ProbeReport;
+    maxAttempts?: number;
+    existingDetection?: boolean;
+  }) {
     const wallet = input.wallet === undefined ? createUserWallet({ isTrialing: true }) : input.wallet;
     const userWalletRepository = mock<UserWalletRepository>();
     userWalletRepository.findById.mockResolvedValue(wallet ?? undefined);
@@ -128,6 +146,7 @@ describe(ProbeTrialDeploymentHandler.name, () => {
     const probeJobService = mock<TrialWorkloadProbeJobService>();
     const detectionRepository = mock<WorkloadAbuseDetectionRepository>();
     detectionRepository.create.mockResolvedValue(mock<WorkloadAbuseDetectionOutput>({ id: "detection-1" }));
+    detectionRepository.findOneBy.mockResolvedValue(input.existingDetection ? mock<WorkloadAbuseDetectionOutput>({ id: "detection-0" }) : undefined);
     const instrumentation = mock<WorkloadAbuseInstrumentationService>();
     const config = mockConfigService<WorkloadAbuseConfigService>({
       WORKLOAD_ABUSE_PROBE_ENABLED: input.enabled ?? true,

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { CreateLogger } from "@src/core";
+import type {
+  WorkloadAbuseDetectionOutput,
+  WorkloadAbuseDetectionRepository
+} from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import type { ProbeReport, TrialWorkloadProbeService } from "@src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service";
+import type { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
+import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import type { WorkloadAbuseInstrumentationService } from "@src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service";
+import { ProbeTrialDeploymentHandler } from "./probe-trial-deployment.handler";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const PAYLOAD = { walletId: 42, dseq: "1000001", attempt: 2, leaseCreatedAt: "2026-01-01T12:00:00.000Z", version: 1 as const };
+
+describe(ProbeTrialDeploymentHandler.name, () => {
+  it("does nothing while probing is disabled", async () => {
+    const { handler, probeService, probeJobService } = setup({ enabled: false });
+
+    await handler.handle(PAYLOAD);
+
+    expect(probeService.probe).not.toHaveBeenCalled();
+    expect(probeJobService.scheduleNext).not.toHaveBeenCalled();
+  });
+
+  it("stops without rescheduling when the wallet is gone or no longer on trial", async () => {
+    const { handler: missing, probeService: missingProbe } = setup({ wallet: null });
+    const { handler: paying, probeService: payingProbe, probeJobService } = setup({ wallet: createUserWallet({ isTrialing: false }) });
+
+    await missing.handle(PAYLOAD);
+    await paying.handle(PAYLOAD);
+
+    expect(missingProbe.probe).not.toHaveBeenCalled();
+    expect(payingProbe.probe).not.toHaveBeenCalled();
+    expect(probeJobService.scheduleNext).not.toHaveBeenCalled();
+  });
+
+  it("stops without rescheduling once the deployment has no live lease", async () => {
+    const { handler, probeJobService, detectionRepository } = setup({ report: createReport({ probeStatus: "no_live_lease" }) });
+
+    await handler.handle(PAYLOAD);
+
+    expect(probeJobService.scheduleNext).not.toHaveBeenCalled();
+    expect(detectionRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("reschedules a clean probe and records nothing", async () => {
+    const { handler, probeJobService, detectionRepository, instrumentation } = setup({ report: createReport({ verdict: "clean" }) });
+
+    await handler.handle(PAYLOAD);
+
+    expect(detectionRepository.create).not.toHaveBeenCalled();
+    expect(probeJobService.scheduleNext).toHaveBeenCalledWith(PAYLOAD);
+    expect(instrumentation.recordProbe).toHaveBeenCalledWith(expect.objectContaining({ verdict: "clean", probeStatus: "probed" }));
+  });
+
+  it("records a suspicious workload for review and keeps probing it", async () => {
+    const report = createReport({ verdict: "soft" });
+    const { handler, wallet, probeJobService, detectionRepository, logger } = setup({ report });
+
+    await handler.handle(PAYLOAD);
+
+    expect(detectionRepository.create).toHaveBeenCalledWith({
+      userId: wallet.userId,
+      walletId: wallet.id,
+      dseq: PAYLOAD.dseq,
+      provider: "akash1provider",
+      verdict: "soft",
+      probeStatus: "probed",
+      signals: report.signals,
+      evidenceExcerpt: report.excerpt
+    });
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_SUSPICIOUS", detectionId: "detection-1" }));
+    expect(probeJobService.scheduleNext).toHaveBeenCalledWith(PAYLOAD);
+  });
+
+  it("records confirmed mining and stops probing the deployment", async () => {
+    const { handler, probeJobService, detectionRepository, instrumentation, logger } = setup({ report: createReport({ verdict: "hard" }) });
+
+    await handler.handle(PAYLOAD);
+
+    expect(detectionRepository.create).toHaveBeenCalledWith(expect.objectContaining({ verdict: "hard" }));
+    expect(instrumentation.recordDetection).toHaveBeenCalledWith("hard");
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_ABUSE_DETECTED" }));
+    expect(probeJobService.scheduleNext).not.toHaveBeenCalled();
+  });
+
+  it("stops after the last allowed attempt", async () => {
+    const { handler, probeJobService } = setup({ report: createReport({ verdict: "clean" }), maxAttempts: 2 });
+
+    await handler.handle(PAYLOAD);
+
+    expect(probeJobService.scheduleNext).not.toHaveBeenCalled();
+  });
+
+  function createReport(overrides: Partial<ProbeReport>): ProbeReport {
+    return {
+      verdict: "clean",
+      signals: [{ bucket: "soft", category: "pool-port", source: "shell", service: "ssh", snippet: "pool:3333" }],
+      excerpt: "[soft/pool-port] shell:ssh: pool:3333",
+      probeStatus: "probed",
+      leases: [
+        {
+          provider: "akash1provider",
+          hostUri: "https://provider.example",
+          gseq: 1,
+          oseq: 1,
+          services: ["ssh"],
+          shellStatuses: ["completed"],
+          logStatus: "completed"
+        }
+      ],
+      ...overrides
+    };
+  }
+
+  function setup(input: { enabled?: boolean; wallet?: ReturnType<typeof createUserWallet> | null; report?: ProbeReport; maxAttempts?: number }) {
+    const wallet = input.wallet === undefined ? createUserWallet({ isTrialing: true }) : input.wallet;
+    const userWalletRepository = mock<UserWalletRepository>();
+    userWalletRepository.findById.mockResolvedValue(wallet ?? undefined);
+    const probeService = mock<TrialWorkloadProbeService>();
+    probeService.probe.mockResolvedValue(input.report ?? createReport({}));
+    const probeJobService = mock<TrialWorkloadProbeJobService>();
+    const detectionRepository = mock<WorkloadAbuseDetectionRepository>();
+    detectionRepository.create.mockResolvedValue(mock<WorkloadAbuseDetectionOutput>({ id: "detection-1" }));
+    const instrumentation = mock<WorkloadAbuseInstrumentationService>();
+    const config = mockConfigService<WorkloadAbuseConfigService>({
+      WORKLOAD_ABUSE_PROBE_ENABLED: input.enabled ?? true,
+      WORKLOAD_ABUSE_PROBE_MAX_PER_DEPLOYMENT: input.maxAttempts ?? 30
+    });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const handler = new ProbeTrialDeploymentHandler(
+      userWalletRepository,
+      probeService,
+      probeJobService,
+      detectionRepository,
+      instrumentation,
+      config,
+      createLogger
+    );
+
+    return { handler, wallet: wallet!, userWalletRepository, probeService, probeJobService, detectionRepository, instrumentation, logger };
+  }
+});

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
@@ -1,0 +1,116 @@
+import { inject, singleton } from "tsyringe";
+
+import { isWalletInitialized, UserWalletRepository } from "@src/billing/repositories";
+import { type CreateLogger, JOB_NAME, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
+import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { type ProbeReport, TrialWorkloadProbeService } from "@src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service";
+import { ProbeTrialDeployment, TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { WorkloadAbuseInstrumentationService } from "@src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service";
+
+/** Re-reads the wallet and the chain on every run, so a probe that waited an hour decides on what is true when it runs, not when it was queued. */
+@singleton()
+export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeployment> {
+  public readonly accepts = ProbeTrialDeployment;
+
+  public readonly concurrency = 2;
+
+  /** One job per state per deployment: the self re-enqueue is accepted while this run is active, and a concurrent sweep enqueue for the same key is dropped. */
+  public readonly policy = "stately";
+
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly probeService: TrialWorkloadProbeService,
+    private readonly probeJobService: TrialWorkloadProbeJobService,
+    private readonly detectionRepository: WorkloadAbuseDetectionRepository,
+    private readonly instrumentation: WorkloadAbuseInstrumentationService,
+    private readonly config: WorkloadAbuseConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: ProbeTrialDeploymentHandler.name });
+  }
+
+  async handle(payload: JobPayload<ProbeTrialDeployment>): Promise<void> {
+    const { walletId, dseq, attempt } = payload;
+    const context = { job: ProbeTrialDeployment[JOB_NAME], walletId, dseq, attempt };
+
+    if (!this.config.get("WORKLOAD_ABUSE_PROBE_ENABLED")) {
+      this.logger.debug({ event: "TRIAL_WORKLOAD_PROBE_SKIPPED", reason: "PROBING_DISABLED", ...context });
+      return;
+    }
+
+    const wallet = await this.userWalletRepository.findById(walletId);
+
+    if (!wallet || !isWalletInitialized(wallet)) {
+      this.logger.warn({ event: "TRIAL_WORKLOAD_PROBE_SKIPPED", reason: "WALLET_NOT_FOUND", ...context });
+      return;
+    }
+
+    if (!wallet.isTrialing) {
+      this.logger.debug({ event: "TRIAL_WORKLOAD_PROBE_SKIPPED", reason: "NOT_TRIALING", ...context, userId: wallet.userId });
+      return;
+    }
+
+    const report = await this.probeService.probe({ wallet, dseq });
+    this.instrumentation.recordProbe(report);
+
+    if (report.probeStatus === "no_live_lease") {
+      this.logger.info({ event: "TRIAL_WORKLOAD_PROBE_FINISHED", reason: "NO_LIVE_LEASE", ...context, userId: wallet.userId });
+      return;
+    }
+
+    if (report.verdict !== "clean") {
+      await this.#recordDetection(wallet, dseq, report);
+    }
+
+    this.logger.info({
+      event: "TRIAL_WORKLOAD_PROBED",
+      ...context,
+      userId: wallet.userId,
+      verdict: report.verdict,
+      probeStatus: report.probeStatus,
+      leases: report.leases.map(lease => ({
+        provider: lease.provider,
+        services: lease.services,
+        shellStatuses: lease.shellStatuses,
+        logStatus: lease.logStatus
+      }))
+    });
+
+    if (report.verdict === "hard") return;
+
+    if (attempt >= this.config.get("WORKLOAD_ABUSE_PROBE_MAX_PER_DEPLOYMENT")) {
+      this.logger.info({ event: "TRIAL_WORKLOAD_PROBE_FINISHED", reason: "MAX_ATTEMPTS", ...context, userId: wallet.userId });
+      return;
+    }
+
+    await this.probeJobService.scheduleNext(payload);
+  }
+
+  async #recordDetection(wallet: { id: number; userId: string; address: string }, dseq: string, report: ProbeReport): Promise<void> {
+    const detection = await this.detectionRepository.create({
+      userId: wallet.userId,
+      walletId: wallet.id,
+      dseq,
+      provider: report.leases.map(lease => lease.provider).join(","),
+      verdict: report.verdict as "hard" | "soft" | "proxy",
+      probeStatus: report.probeStatus,
+      signals: report.signals,
+      evidenceExcerpt: report.excerpt
+    });
+    this.instrumentation.recordDetection(report.verdict);
+
+    this.logger.warn({
+      event: report.verdict === "hard" ? "TRIAL_WORKLOAD_ABUSE_DETECTED" : "TRIAL_WORKLOAD_SUSPICIOUS",
+      detectionId: detection.id,
+      userId: wallet.userId,
+      walletId: wallet.id,
+      owner: wallet.address,
+      dseq,
+      verdict: report.verdict,
+      signals: report.signals.map(signal => ({ bucket: signal.bucket, category: signal.category, source: signal.source, service: signal.service }))
+    });
+  }
+}

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
@@ -53,6 +53,19 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
       return;
     }
 
+    const existingDetection = await this.detectionRepository.findOneBy({ walletId, dseq, verdict: "hard" });
+
+    if (existingDetection) {
+      this.logger.info({
+        event: "TRIAL_WORKLOAD_PROBE_FINISHED",
+        reason: "ALREADY_DETECTED",
+        ...context,
+        userId: wallet.userId,
+        detectionId: existingDetection.id
+      });
+      return;
+    }
+
     const report = await this.probeService.probe({ wallet, dseq });
     this.instrumentation.recordProbe(report);
 

--- a/apps/api/src/workload-abuse/services/provider-log-tail/provider-log-tail.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/provider-log-tail/provider-log-tail.service.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ProviderStreamResult, ProviderStreamService } from "@src/workload-abuse/services/provider-stream/provider-stream.service";
+import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { buildLogTailUrl, formatLogFrame, ProviderLogTailService } from "./provider-log-tail.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const TARGET = {
+  hostUri: "https://provider.example:8443",
+  providerAddress: "akash1provider",
+  token: "jwt",
+  dseq: "123",
+  gseq: 1,
+  oseq: 2,
+  services: ["web", "db"]
+};
+
+describe(ProviderLogTailService.name, () => {
+  describe("buildLogTailUrl", () => {
+    it("asks for a bounded, non-following tail of the named services", () => {
+      const url = new URL(buildLogTailUrl(TARGET, 300));
+
+      expect(url.origin + url.pathname).toBe("https://provider.example:8443/lease/123/1/2/logs");
+      expect(url.searchParams.get("follow")).toBe("false");
+      expect(url.searchParams.get("tail")).toBe("300");
+      expect(url.searchParams.get("service")).toBe("web,db");
+    });
+
+    it("omits the service filter when no services are named", () => {
+      expect(buildLogTailUrl({ ...TARGET, services: [] }, 10)).not.toContain("service=");
+    });
+  });
+
+  describe("formatLogFrame", () => {
+    it("renders a provider log entry as the service prefix and message", () => {
+      expect(formatLogFrame('{"name":"web-7d9f","message":"listening","service":"web"}')).toBe("[web]: listening");
+    });
+
+    it("keeps a frame that is not a log entry verbatim", () => {
+      expect(formatLogFrame("plain")).toBe("plain");
+      expect(formatLogFrame('{"other":true}')).toBe('{"other":true}');
+    });
+  });
+
+  describe("collect", () => {
+    it("formats every text frame into a line", async () => {
+      const { service } = setup({
+        status: "completed",
+        frames: [
+          { kind: "text", payload: '{"name":"web-1","message":"a"}' },
+          { kind: "text", payload: '{"name":"web-1","message":"b"}' }
+        ]
+      });
+
+      expect(await service.collect(TARGET)).toEqual({ status: "completed", lines: ["[web]: a", "[web]: b"] });
+    });
+  });
+
+  function setup(result: ProviderStreamResult) {
+    const providerStreamService = mock<ProviderStreamService>();
+    providerStreamService.collect.mockResolvedValue(result);
+    const config = mockConfigService<WorkloadAbuseConfigService>({
+      WORKLOAD_ABUSE_PROBE_LOG_TAIL: 300,
+      WORKLOAD_ABUSE_PROBE_IDLE_TIMEOUT_MS: 5_000,
+      WORKLOAD_ABUSE_PROBE_HARD_TIMEOUT_MS: 30_000,
+      WORKLOAD_ABUSE_PROBE_MAX_OUTPUT_BYTES: 65_536
+    });
+    const service = new ProviderLogTailService(providerStreamService, config);
+
+    return { service, providerStreamService };
+  }
+});

--- a/apps/api/src/workload-abuse/services/provider-log-tail/provider-log-tail.service.ts
+++ b/apps/api/src/workload-abuse/services/provider-log-tail/provider-log-tail.service.ts
@@ -1,0 +1,57 @@
+import { singleton } from "tsyringe";
+
+import { ProviderStreamService, type ProviderStreamStatus } from "@src/workload-abuse/services/provider-stream/provider-stream.service";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+
+export type LogTailTarget = {
+  hostUri: string;
+  providerAddress: string;
+  token: string;
+  dseq: string;
+  gseq: number;
+  oseq: number;
+  services: string[];
+};
+
+export type LogTailResult = { status: ProviderStreamStatus; lines: string[] };
+
+export function buildLogTailUrl(target: LogTailTarget, tail: number): string {
+  const services = target.services.length > 0 ? `&service=${encodeURIComponent(target.services.join(","))}` : "";
+
+  return `${target.hostUri}/lease/${target.dseq}/${target.gseq}/${target.oseq}/logs?follow=false&tail=${tail}${services}`;
+}
+
+/** Providers send one JSON log entry per text frame; anything else is kept verbatim rather than dropped. */
+export function formatLogFrame(payload: string): string {
+  try {
+    const entry = JSON.parse(payload) as { name?: unknown; message?: unknown };
+    if (typeof entry.message !== "string") return payload;
+
+    const service = typeof entry.name === "string" ? entry.name.split("-")[0] : "";
+
+    return `[${service}]: ${entry.message}`;
+  } catch {
+    return payload;
+  }
+}
+
+@singleton()
+export class ProviderLogTailService {
+  constructor(
+    private readonly providerStreamService: ProviderStreamService,
+    private readonly config: WorkloadAbuseConfigService
+  ) {}
+
+  async collect(target: LogTailTarget): Promise<LogTailResult> {
+    const result = await this.providerStreamService.collect({
+      url: buildLogTailUrl(target, this.config.get("WORKLOAD_ABUSE_PROBE_LOG_TAIL")),
+      providerAddress: target.providerAddress,
+      token: target.token,
+      idleTimeoutMs: this.config.get("WORKLOAD_ABUSE_PROBE_IDLE_TIMEOUT_MS"),
+      hardTimeoutMs: this.config.get("WORKLOAD_ABUSE_PROBE_HARD_TIMEOUT_MS"),
+      maxBytes: this.config.get("WORKLOAD_ABUSE_PROBE_MAX_OUTPUT_BYTES")
+    });
+
+    return { status: result.status, lines: result.frames.map(frame => formatLogFrame(frame.payload)) };
+  }
+}

--- a/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ProviderStreamResult, ProviderStreamService } from "@src/workload-abuse/services/provider-stream/provider-stream.service";
+import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { buildShellProbeUrl, ProviderShellProbeService, SHELL_PROBE_SCRIPT } from "./provider-shell-probe.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const TARGET = { hostUri: "https://provider.example:8443", providerAddress: "akash1provider", token: "jwt", dseq: "123", gseq: 1, oseq: 2, service: "ssh box" };
+
+describe(ProviderShellProbeService.name, () => {
+  describe("buildShellProbeUrl", () => {
+    it("runs the collector script through sh without stdin or a tty on the first pod of the service", () => {
+      const url = new URL(buildShellProbeUrl(TARGET));
+
+      expect(url.origin + url.pathname).toBe("https://provider.example:8443/lease/123/1/2/shell");
+      expect(url.searchParams.get("stdin")).toBe("0");
+      expect(url.searchParams.get("tty")).toBe("0");
+      expect(url.searchParams.get("podIndex")).toBe("0");
+      expect(url.searchParams.get("cmd0")).toBe("sh");
+      expect(url.searchParams.get("cmd1")).toBe("-c");
+      expect(url.searchParams.get("cmd2")).toBe(SHELL_PROBE_SCRIPT);
+      expect(url.searchParams.get("service")).toBe("ssh box");
+    });
+  });
+
+  describe("run", () => {
+    it("joins stdout and stderr into the output and keeps the stream status", async () => {
+      const { service } = setup({
+        status: "completed",
+        exitCode: 0,
+        frames: [
+          { kind: "shell", stream: "stdout", payload: "--loadavg\n1.00" },
+          { kind: "shell", stream: "stderr", payload: "\nwarn" },
+          { kind: "shell", stream: "result", payload: '{"exit_code":0}' }
+        ]
+      });
+
+      const result = await service.run(TARGET);
+
+      expect(result).toEqual({ status: "completed", output: "--loadavg\n1.00\nwarn", exitCode: 0 });
+    });
+
+    it("reports the shell as unavailable when the provider fails to exec or nothing comes back", async () => {
+      const { service: failing } = setup({ status: "completed", frames: [{ kind: "shell", stream: "failure", payload: "executable file not found" }] });
+      const { service: silent } = setup({ status: "completed", exitCode: 0, frames: [] });
+
+      expect((await failing.run(TARGET)).status).toBe("shell_unavailable");
+      expect((await silent.run(TARGET)).status).toBe("shell_unavailable");
+    });
+
+    it("passes a transport failure through untouched", async () => {
+      const { service } = setup({ status: "token_expired", frames: [], error: "tokenExpired" });
+
+      expect((await service.run(TARGET)).status).toBe("token_expired");
+    });
+  });
+
+  function setup(result: ProviderStreamResult) {
+    const providerStreamService = mock<ProviderStreamService>();
+    providerStreamService.collect.mockResolvedValue(result);
+    const config = mockConfigService<WorkloadAbuseConfigService>({
+      WORKLOAD_ABUSE_PROBE_IDLE_TIMEOUT_MS: 5_000,
+      WORKLOAD_ABUSE_PROBE_HARD_TIMEOUT_MS: 30_000,
+      WORKLOAD_ABUSE_PROBE_MAX_OUTPUT_BYTES: 65_536
+    });
+    const service = new ProviderShellProbeService(providerStreamService, config);
+
+    return { service, providerStreamService };
+  }
+});

--- a/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.ts
+++ b/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.ts
@@ -1,0 +1,65 @@
+import { singleton } from "tsyringe";
+
+import { ProviderStreamService, type ProviderStreamStatus } from "@src/workload-abuse/services/provider-stream/provider-stream.service";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+
+/** Collect-only: nothing here names what the scanner looks for, because argv is visible to the workload through /proc. */
+const SHELL_PROBE_COLLECTORS = [
+  "echo '--loadavg'; cat /proc/loadavg 2>/dev/null",
+  "echo '--nproc'; nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null",
+  'echo \'--procs\'; for p in /proc/[0-9]*; do c=$(tr \'\\0\' \' \' < "$p/cmdline" 2>/dev/null); [ -n "$c" ] || continue; echo "${p#/proc/} comm=$(cat "$p/comm" 2>/dev/null) exe=$(readlink "$p/exe" 2>/dev/null) cwd=$(readlink "$p/cwd" 2>/dev/null) cmd=$c"; done | head -150',
+  "echo '--net'; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | head -80",
+  "echo '--tmp'; ls -la /tmp /dev/shm 2>/dev/null | head -80",
+  'echo \'--files\'; for f in /tmp/*.json /tmp/*.conf /tmp/*.txt /tmp/*/*.json /tmp/*/*.conf; do [ -f "$f" ] && [ "$(wc -c < "$f")" -lt 16384 ] && echo "== $f" && cat "$f"; done 2>/dev/null | head -400',
+  "echo '--authorized-keys'; cat /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys 2>/dev/null | sort -u | head -10"
+];
+
+export const SHELL_PROBE_SCRIPT = SHELL_PROBE_COLLECTORS.join("; ");
+
+export type ShellProbeStatus = ProviderStreamStatus | "shell_unavailable";
+
+export type ShellProbeResult = { status: ShellProbeStatus; output: string; exitCode?: number };
+
+export type ShellProbeTarget = {
+  hostUri: string;
+  providerAddress: string;
+  token: string;
+  dseq: string;
+  gseq: number;
+  oseq: number;
+  service: string;
+};
+
+export function buildShellProbeUrl(target: ShellProbeTarget): string {
+  const command = ["sh", "-c", SHELL_PROBE_SCRIPT].map((part, index) => `cmd${index}=${encodeURIComponent(part)}`).join("&");
+
+  return `${target.hostUri}/lease/${target.dseq}/${target.gseq}/${target.oseq}/shell?stdin=0&tty=0&podIndex=0&${command}&service=${encodeURIComponent(target.service)}`;
+}
+
+@singleton()
+export class ProviderShellProbeService {
+  constructor(
+    private readonly providerStreamService: ProviderStreamService,
+    private readonly config: WorkloadAbuseConfigService
+  ) {}
+
+  async run(target: ShellProbeTarget): Promise<ShellProbeResult> {
+    const result = await this.providerStreamService.collect({
+      url: buildShellProbeUrl(target),
+      providerAddress: target.providerAddress,
+      token: target.token,
+      idleTimeoutMs: this.config.get("WORKLOAD_ABUSE_PROBE_IDLE_TIMEOUT_MS"),
+      hardTimeoutMs: this.config.get("WORKLOAD_ABUSE_PROBE_HARD_TIMEOUT_MS"),
+      maxBytes: this.config.get("WORKLOAD_ABUSE_PROBE_MAX_OUTPUT_BYTES")
+    });
+
+    const output = result.frames
+      .filter(frame => frame.kind === "shell" && (frame.stream === "stdout" || frame.stream === "stderr"))
+      .map(frame => frame.payload)
+      .join("");
+    const failed = result.frames.some(frame => frame.kind === "shell" && frame.stream === "failure");
+    const status: ShellProbeStatus = failed || (result.status === "completed" && output.length === 0) ? "shell_unavailable" : result.status;
+
+    return { status, output, exitCode: result.exitCode };
+  }
+}

--- a/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.spec.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ProviderProxySocket, ProviderProxySocketEvent } from "@src/workload-abuse/providers/provider-proxy-socket.provider";
+import { ProviderStreamService } from "./provider-stream.service";
+
+type Listener = (event: ProviderProxySocketEvent) => void;
+
+class FakeSocket implements ProviderProxySocket {
+  readonly sent: string[] = [];
+  closed = false;
+  readonly #listeners = new Map<string, Listener[]>();
+
+  addEventListener(type: string, listener: Listener): void {
+    this.#listeners.set(type, [...(this.#listeners.get(type) ?? []), listener]);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  emit(type: string, event: ProviderProxySocketEvent = {}): void {
+    for (const listener of this.#listeners.get(type) ?? []) listener(event);
+  }
+
+  emitProxyFrame(frame: Record<string, unknown>): void {
+    this.emit("message", { data: JSON.stringify({ type: "websocket", ...frame }) });
+  }
+
+  emitShellBytes(bytes: number[]): void {
+    this.emitProxyFrame({ message: { type: "Buffer", data: bytes } });
+  }
+}
+
+const INPUT = {
+  url: "https://provider.example:8443/lease/1/1/1/shell?stdin=0",
+  providerAddress: "akash1provider",
+  token: "jwt-token",
+  idleTimeoutMs: 5_000,
+  hardTimeoutMs: 30_000,
+  maxBytes: 1_000
+};
+
+describe(ProviderStreamService.name, () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens the provider stream with an auth message that carries no data", async () => {
+    const { service, socket } = setup();
+
+    const pending = service.collect(INPUT);
+    socket.emit("open");
+    socket.emitShellBytes([102, ...Buffer.from('{"exit_code":0}')]);
+    await pending;
+
+    expect(socket.sent).toEqual([
+      JSON.stringify({ type: "websocket", url: INPUT.url, providerAddress: INPUT.providerAddress, auth: { type: "jwt", token: INPUT.token }, isBase64: true })
+    ]);
+  });
+
+  it("collects frames until the result frame and reports its exit code", async () => {
+    const { service, socket } = setup();
+
+    const pending = service.collect(INPUT);
+    socket.emit("open");
+    socket.emitShellBytes([100, ...Buffer.from("out")]);
+    socket.emitShellBytes([101, ...Buffer.from("err")]);
+    socket.emitShellBytes([102, ...Buffer.from('{"exit_code":3}')]);
+    const result = await pending;
+
+    expect(result).toEqual({
+      status: "completed",
+      exitCode: 3,
+      frames: [
+        { kind: "shell", stream: "stdout", payload: "out" },
+        { kind: "shell", stream: "stderr", payload: "err" },
+        { kind: "shell", stream: "result", payload: '{"exit_code":3}' }
+      ]
+    });
+    expect(socket.closed).toBe(true);
+  });
+
+  it("treats the proxy closing the provider stream as completion", async () => {
+    const { service, socket } = setup();
+
+    const pending = service.collect(INPUT);
+    socket.emit("open");
+    socket.emitProxyFrame({ message: '{"name":"web-1","message":"line"}' });
+    socket.emitProxyFrame({ message: "", closed: true, code: 1000, reason: "" });
+    const result = await pending;
+
+    expect(result).toMatchObject({ status: "completed", closeCode: 1000, frames: [{ kind: "text", payload: '{"name":"web-1","message":"line"}' }] });
+  });
+
+  it("reports a rejected provider certificate and an expired token as distinct statuses", async () => {
+    const { service, socket } = setup();
+    const { service: otherService, socket: otherSocket } = setup();
+
+    const certificate = service.collect(INPUT);
+    socket.emit("open");
+    socket.emitProxyFrame({ message: "", closed: true, code: 1008, reason: "invalidCertificate.fingerprintMismatch" });
+    const token = otherService.collect(INPUT);
+    otherSocket.emit("open");
+    otherSocket.emitProxyFrame({ error: "tokenExpired" });
+
+    expect(await certificate).toMatchObject({ status: "invalid_certificate", closeReason: "invalidCertificate.fingerprintMismatch" });
+    expect(await token).toMatchObject({ status: "token_expired", error: "tokenExpired" });
+  });
+
+  it("gives up on a stream that goes silent", async () => {
+    vi.useFakeTimers();
+    const { service, socket } = setup();
+
+    const pending = service.collect(INPUT);
+    socket.emit("open");
+    socket.emitShellBytes([100, ...Buffer.from("partial")]);
+    await vi.advanceTimersByTimeAsync(INPUT.idleTimeoutMs + 1);
+    const result = await pending;
+
+    expect(result).toMatchObject({ status: "idle_timeout", frames: [{ stream: "stdout", payload: "partial" }] });
+    expect(socket.closed).toBe(true);
+  });
+
+  it("enforces the hard timeout even while frames keep arriving", async () => {
+    vi.useFakeTimers();
+    const { service, socket } = setup();
+
+    const pending = service.collect(INPUT);
+    socket.emit("open");
+    for (let elapsed = 0; elapsed < INPUT.hardTimeoutMs; elapsed += 1_000) {
+      socket.emitShellBytes([100, 65]);
+      await vi.advanceTimersByTimeAsync(1_000);
+    }
+    const result = await pending;
+
+    expect(result.status).toBe("hard_timeout");
+  });
+
+  it("stops collecting once the output cap is reached", async () => {
+    const { service, socket } = setup();
+
+    const pending = service.collect({ ...INPUT, maxBytes: 5 });
+    socket.emit("open");
+    socket.emitShellBytes([100, ...Buffer.from("123456")]);
+    socket.emitShellBytes([100, ...Buffer.from("ignored")]);
+    const result = await pending;
+
+    expect(result).toMatchObject({ status: "output_capped", frames: [{ payload: "123456" }] });
+  });
+
+  it("reports a connection error when the socket never opens", async () => {
+    const { service, socket } = setup();
+
+    const pending = service.collect(INPUT);
+    socket.emit("error");
+    socket.emit("close");
+
+    expect(await pending).toMatchObject({ status: "connection_error", frames: [] });
+  });
+
+  function setup() {
+    const socket = new FakeSocket();
+    const service = new ProviderStreamService(() => socket);
+
+    return { service, socket };
+  }
+});

--- a/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.ts
+++ b/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.ts
@@ -1,0 +1,133 @@
+import { inject, singleton } from "tsyringe";
+
+import { decodeProviderFrame, parseShellExit, type ProviderFrame } from "@src/workload-abuse/lib/provider-frame/provider-frame";
+import {
+  PROVIDER_PROXY_SOCKET_FACTORY,
+  type ProviderProxySocketEvent,
+  type ProviderProxySocketFactory
+} from "@src/workload-abuse/providers/provider-proxy-socket.provider";
+
+export type ProviderStreamStatus =
+  | "completed"
+  | "idle_timeout"
+  | "hard_timeout"
+  | "output_capped"
+  | "token_expired"
+  | "invalid_certificate"
+  | "proxy_error"
+  | "connection_error";
+
+export type CollectedFrame = Extract<ProviderFrame, { kind: "shell" | "text" }>;
+
+export type ProviderStreamResult = {
+  status: ProviderStreamStatus;
+  frames: CollectedFrame[];
+  exitCode?: number;
+  closeCode?: number;
+  closeReason?: string;
+  error?: string;
+};
+
+export type ProviderStreamInput = {
+  url: string;
+  providerAddress: string;
+  token: string;
+  idleTimeoutMs: number;
+  hardTimeoutMs: number;
+  maxBytes: number;
+};
+
+const INVALID_CERTIFICATE_REASON_PREFIX = "invalidCertificate";
+const TOKEN_EXPIRED_ERROR = "tokenExpired";
+
+/**
+ * Opens one provider stream through provider-proxy and collects it to completion. The proxy dials the provider on
+ * the first message, which must carry no `data`, and pins the provider certificate to the chain before forwarding.
+ */
+@singleton()
+export class ProviderStreamService {
+  constructor(@inject(PROVIDER_PROXY_SOCKET_FACTORY) private readonly createSocket: ProviderProxySocketFactory) {}
+
+  collect(input: ProviderStreamInput): Promise<ProviderStreamResult> {
+    return new Promise(resolve => {
+      const socket = this.createSocket();
+      const frames: CollectedFrame[] = [];
+      let collectedBytes = 0;
+      let exitCode: number | undefined;
+      let opened = false;
+      let settled = false;
+      let idleTimer: NodeJS.Timeout | undefined;
+
+      const finish = (status: ProviderStreamStatus, extra: Pick<ProviderStreamResult, "closeCode" | "closeReason" | "error"> = {}) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(idleTimer);
+        clearTimeout(hardTimer);
+        try {
+          socket.close();
+        } catch {
+          return resolve({ status, frames, exitCode, ...extra });
+        }
+        resolve({ status, frames, exitCode, ...extra });
+      };
+
+      const hardTimer = setTimeout(() => finish("hard_timeout"), input.hardTimeoutMs);
+      const armIdleTimer = () => {
+        clearTimeout(idleTimer);
+        idleTimer = setTimeout(() => finish("idle_timeout"), input.idleTimeoutMs);
+      };
+
+      socket.addEventListener("open", () => {
+        opened = true;
+        socket.send(
+          JSON.stringify({
+            type: "websocket",
+            url: input.url,
+            providerAddress: input.providerAddress,
+            auth: { type: "jwt", token: input.token },
+            isBase64: true
+          })
+        );
+        armIdleTimer();
+      });
+
+      socket.addEventListener("message", (event: ProviderProxySocketEvent) => {
+        if (settled) return;
+
+        const raw = toText(event.data);
+        if (raw === undefined) return;
+
+        const frame = decodeProviderFrame(raw);
+        if (frame.kind === "ignore") return;
+
+        armIdleTimer();
+
+        if (frame.kind === "error") return finish(frame.error === TOKEN_EXPIRED_ERROR ? "token_expired" : "proxy_error", { error: frame.error });
+        if (frame.kind === "closed") {
+          const status = frame.reason?.startsWith(INVALID_CERTIFICATE_REASON_PREFIX) ? "invalid_certificate" : "completed";
+          return finish(status, { closeCode: frame.code, closeReason: frame.reason });
+        }
+
+        frames.push(frame);
+        collectedBytes += frame.payload.length;
+
+        if (frame.kind === "shell" && frame.stream === "result") {
+          exitCode = parseShellExit(frame.payload)?.exitCode;
+          return finish("completed");
+        }
+
+        if (collectedBytes >= input.maxBytes) finish("output_capped");
+      });
+
+      socket.addEventListener("close", () => finish(opened ? "completed" : "connection_error"));
+      socket.addEventListener("error", () => finish("connection_error"));
+    });
+  }
+}
+
+function toText(data: unknown): string | undefined {
+  if (typeof data === "string") return data;
+  if (Buffer.isBuffer(data)) return data.toString("utf8");
+  if (data instanceof ArrayBuffer) return Buffer.from(data).toString("utf8");
+  return undefined;
+}

--- a/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.ts
+++ b/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.ts
@@ -40,10 +40,7 @@ export type ProviderStreamInput = {
 const INVALID_CERTIFICATE_REASON_PREFIX = "invalidCertificate";
 const TOKEN_EXPIRED_ERROR = "tokenExpired";
 
-/**
- * Opens one provider stream through provider-proxy and collects it to completion. The proxy dials the provider on
- * the first message, which must carry no `data`, and pins the provider certificate to the chain before forwarding.
- */
+/** Collects one provider stream to completion through provider-proxy, whose opening message must carry no `data` because the proxy dials the provider on it. */
 @singleton()
 export class ProviderStreamService {
   constructor(@inject(PROVIDER_PROXY_SOCKET_FACTORY) private readonly createSocket: ProviderProxySocketFactory) {}

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
@@ -1,9 +1,10 @@
-import { addMinutes } from "date-fns";
+import { addMinutes, subHours } from "date-fns";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { CreateLogger, JobQueueService } from "@src/core";
 import type { DeploymentSettingRepository, LiveTrialDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
 import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
 import { ProbeTrialDeployment, probeTrialDeploymentKeyFor, TrialWorkloadProbeJobService } from "./trial-workload-probe-job.service";
 
@@ -123,6 +124,20 @@ describe(TrialWorkloadProbeJobService.name, () => {
       );
     });
 
+    it("leaves a deployment that already carries a confirmed detection alone", async () => {
+      const { service, jobQueueService, detectionRepository, logger } = setup({ live, detected: [{ walletId: 1, dseq: "1" }], now: LEASE_CREATED_AT });
+
+      await service.reconcile({ dryRun: false });
+
+      expect(detectionRepository.findRecentHardTargets).toHaveBeenCalledWith({ since: subHours(LEASE_CREATED_AT, 26) });
+      expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
+      expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ walletId: 2, dseq: "2" }) }),
+        expect.anything()
+      );
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_RECONCILE_END", scheduled: 1, alreadyDetected: 1 }));
+    });
+
     it("skips the sweep while probing is disabled", async () => {
       const { service, deploymentSettingRepository } = setup({ enabled: false, live });
 
@@ -132,7 +147,13 @@ describe(TrialWorkloadProbeJobService.name, () => {
     });
   });
 
-  function setup(input: { enabled?: boolean; live?: LiveTrialDeployment[]; pendingKeys?: string[]; now?: Date }) {
+  function setup(input: {
+    enabled?: boolean;
+    live?: LiveTrialDeployment[];
+    pendingKeys?: string[];
+    detected?: Array<{ walletId: number; dseq: string }>;
+    now?: Date;
+  }) {
     if (input.now) vi.useFakeTimers({ now: input.now, toFake: ["Date"] });
     else vi.useRealTimers();
 
@@ -141,6 +162,8 @@ describe(TrialWorkloadProbeJobService.name, () => {
     jobQueueService.findPendingSingletonKeys.mockResolvedValue(new Set(input.pendingKeys ?? []));
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.findLiveTrialDeployments.mockResolvedValue(input.live ?? []);
+    const detectionRepository = mock<WorkloadAbuseDetectionRepository>();
+    detectionRepository.findRecentHardTargets.mockResolvedValue(input.detected ?? []);
     const config = mockConfigService<WorkloadAbuseConfigService>({
       WORKLOAD_ABUSE_PROBE_ENABLED: input.enabled ?? true,
       WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: [5, 20, 60],
@@ -151,8 +174,8 @@ describe(TrialWorkloadProbeJobService.name, () => {
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);
 
-    const service = new TrialWorkloadProbeJobService(jobQueueService, deploymentSettingRepository, config, createLogger);
+    const service = new TrialWorkloadProbeJobService(jobQueueService, deploymentSettingRepository, detectionRepository, config, createLogger);
 
-    return { service, jobQueueService, deploymentSettingRepository, logger };
+    return { service, jobQueueService, deploymentSettingRepository, detectionRepository, logger };
   }
 });

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
@@ -1,0 +1,158 @@
+import { addMinutes } from "date-fns";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger, JobQueueService } from "@src/core";
+import type { DeploymentSettingRepository, LiveTrialDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { ProbeTrialDeployment, probeTrialDeploymentKeyFor, TrialWorkloadProbeJobService } from "./trial-workload-probe-job.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const LEASE_CREATED_AT = new Date("2026-01-01T12:00:00.000Z");
+const TARGET = { walletId: 42, dseq: "1000001" };
+
+describe(TrialWorkloadProbeJobService.name, () => {
+  describe("scheduleInitial", () => {
+    it("enqueues nothing while probing is disabled", async () => {
+      const { service, jobQueueService } = setup({ enabled: false });
+
+      expect(await service.scheduleInitial({ ...TARGET, leaseCreatedAt: LEASE_CREATED_AT })).toBeNull();
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    });
+
+    it("enqueues the first attempt keyed by deployment at the first delay after the lease", async () => {
+      const { service, jobQueueService } = setup({ now: LEASE_CREATED_AT });
+
+      await service.scheduleInitial({ ...TARGET, leaseCreatedAt: LEASE_CREATED_AT });
+
+      expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+        new ProbeTrialDeployment({ ...TARGET, attempt: 1, leaseCreatedAt: LEASE_CREATED_AT.toISOString() }),
+        {
+          singletonKey: probeTrialDeploymentKeyFor(TARGET),
+          startAfter: addMinutes(LEASE_CREATED_AT, 5).toISOString()
+        }
+      );
+    });
+  });
+
+  describe("scheduleNext", () => {
+    it("enqueues the following attempt under the same key", async () => {
+      const { service, jobQueueService } = setup({ now: LEASE_CREATED_AT });
+
+      await service.scheduleNext({ ...TARGET, attempt: 1, leaseCreatedAt: LEASE_CREATED_AT.toISOString() });
+
+      expect(jobQueueService.enqueue).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ attempt: 2 }) }), {
+        singletonKey: probeTrialDeploymentKeyFor(TARGET),
+        startAfter: addMinutes(LEASE_CREATED_AT, 20).toISOString()
+      });
+    });
+  });
+
+  describe("startAfterFor", () => {
+    it("places the first attempts at fixed offsets from the lease", () => {
+      const { service } = setup({});
+      const data = { leaseCreatedAt: LEASE_CREATED_AT.toISOString() };
+
+      expect(service.startAfterFor({ ...data, attempt: 1 }, LEASE_CREATED_AT)).toEqual(addMinutes(LEASE_CREATED_AT, 5));
+      expect(service.startAfterFor({ ...data, attempt: 3 }, LEASE_CREATED_AT)).toEqual(addMinutes(LEASE_CREATED_AT, 60));
+    });
+
+    it("runs an overdue attempt now rather than in the past", () => {
+      const { service } = setup({});
+      const now = addMinutes(LEASE_CREATED_AT, 90);
+
+      expect(service.startAfterFor({ attempt: 1, leaseCreatedAt: LEASE_CREATED_AT.toISOString() }, now)).toEqual(now);
+    });
+
+    it("spreads later attempts around the interval with jitter", () => {
+      const { service } = setup({});
+      const now = new Date("2026-09-06T15:00:00.000Z");
+
+      const startAfter = service.startAfterFor({ attempt: 4, leaseCreatedAt: LEASE_CREATED_AT.toISOString() }, now);
+
+      expect(startAfter.getTime()).toBeGreaterThanOrEqual(addMinutes(now, 50).getTime());
+      expect(startAfter.getTime()).toBeLessThanOrEqual(addMinutes(now, 70).getTime());
+    });
+  });
+
+  describe("cancelForDeployment", () => {
+    it("cancels the pending probe under the deployment key", async () => {
+      const { service, jobQueueService } = setup({});
+
+      await service.cancelForDeployment(TARGET);
+
+      expect(jobQueueService.cancelCreatedBy).toHaveBeenCalledWith({ name: "ProbeTrialDeployment", singletonKey: probeTrialDeploymentKeyFor(TARGET) });
+    });
+  });
+
+  describe("reconcile", () => {
+    const live: LiveTrialDeployment[] = [
+      { userId: "u1", dseq: "1", walletId: 1, createdAt: LEASE_CREATED_AT },
+      { userId: "u2", dseq: "2", walletId: 2, createdAt: LEASE_CREATED_AT }
+    ];
+
+    it("enqueues nothing on a dry run", async () => {
+      const { service, jobQueueService } = setup({ live });
+
+      await service.reconcile({ dryRun: true });
+
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(jobQueueService.findPendingSingletonKeys).not.toHaveBeenCalled();
+    });
+
+    it("schedules an immediate first probe only for deployments with none pending", async () => {
+      const { service, jobQueueService, logger } = setup({
+        live,
+        pendingKeys: [probeTrialDeploymentKeyFor({ walletId: 1, dseq: "1" })],
+        now: LEASE_CREATED_AT
+      });
+
+      await service.reconcile({ dryRun: false });
+
+      expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
+      expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+        new ProbeTrialDeployment({ walletId: 2, dseq: "2", attempt: 1, leaseCreatedAt: LEASE_CREATED_AT.toISOString() }),
+        {
+          singletonKey: probeTrialDeploymentKeyFor({ walletId: 2, dseq: "2" }),
+          startAfter: LEASE_CREATED_AT.toISOString()
+        }
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_RECONCILE_END", found: 2, scheduled: 1, alreadyScheduled: 1, failed: 0 })
+      );
+    });
+
+    it("skips the sweep while probing is disabled", async () => {
+      const { service, deploymentSettingRepository } = setup({ enabled: false, live });
+
+      await service.reconcile({ dryRun: false });
+
+      expect(deploymentSettingRepository.findLiveTrialDeployments).not.toHaveBeenCalled();
+    });
+  });
+
+  function setup(input: { enabled?: boolean; live?: LiveTrialDeployment[]; pendingKeys?: string[]; now?: Date }) {
+    if (input.now) vi.useFakeTimers({ now: input.now, toFake: ["Date"] });
+    else vi.useRealTimers();
+
+    const jobQueueService = mock<JobQueueService>();
+    jobQueueService.enqueue.mockResolvedValue("job-id");
+    jobQueueService.findPendingSingletonKeys.mockResolvedValue(new Set(input.pendingKeys ?? []));
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.findLiveTrialDeployments.mockResolvedValue(input.live ?? []);
+    const config = mockConfigService<WorkloadAbuseConfigService>({
+      WORKLOAD_ABUSE_PROBE_ENABLED: input.enabled ?? true,
+      WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: [5, 20, 60],
+      WORKLOAD_ABUSE_PROBE_INTERVAL_MIN: 60,
+      WORKLOAD_ABUSE_PROBE_JITTER_MIN: 10,
+      WORKLOAD_ABUSE_RECONCILE_MAX_AGE_HOURS: 26
+    });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const service = new TrialWorkloadProbeJobService(jobQueueService, deploymentSettingRepository, config, createLogger);
+
+    return { service, jobQueueService, deploymentSettingRepository, logger };
+  }
+});

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
@@ -1,9 +1,10 @@
-import { addMinutes } from "date-fns";
+import { addMinutes, subHours } from "date-fns";
 import { inject, singleton } from "tsyringe";
 
 import { type CreateLogger, type Job, JOB_NAME, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import type { DryRunOptions } from "@src/core/types/console";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
 import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
 
 export class ProbeTrialDeployment implements Job {
@@ -38,6 +39,7 @@ export class TrialWorkloadProbeJobService {
   constructor(
     private readonly jobQueueService: JobQueueService,
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly detectionRepository: WorkloadAbuseDetectionRepository,
     private readonly config: WorkloadAbuseConfigService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
@@ -65,21 +67,30 @@ export class TrialWorkloadProbeJobService {
       return;
     }
 
-    const deployments = await this.deploymentSettingRepository.findLiveTrialDeployments({
-      maxAgeHours: this.config.get("WORKLOAD_ABUSE_RECONCILE_MAX_AGE_HOURS")
-    });
+    const maxAgeHours = this.config.get("WORKLOAD_ABUSE_RECONCILE_MAX_AGE_HOURS");
+    const deployments = await this.deploymentSettingRepository.findLiveTrialDeployments({ maxAgeHours });
     this.logger.info({ event: "TRIAL_WORKLOAD_PROBE_RECONCILE_START", count: deployments.length, dryRun });
 
     if (dryRun) return;
 
     const pendingKeys = await this.jobQueueService.findPendingSingletonKeys(ProbeTrialDeployment[JOB_NAME]);
+    const detectedTargets = await this.detectionRepository.findRecentHardTargets({ since: subHours(new Date(), maxAgeHours) });
+    const detectedKeys = new Set(detectedTargets.map(probeTrialDeploymentKeyFor));
     let scheduled = 0;
     let alreadyScheduled = 0;
+    let alreadyDetected = 0;
     let failed = 0;
 
     for (const deployment of deployments) {
-      if (pendingKeys.has(probeTrialDeploymentKeyFor(deployment))) {
+      const key = probeTrialDeploymentKeyFor(deployment);
+
+      if (pendingKeys.has(key)) {
         alreadyScheduled++;
+        continue;
+      }
+
+      if (detectedKeys.has(key)) {
+        alreadyDetected++;
         continue;
       }
 
@@ -96,7 +107,7 @@ export class TrialWorkloadProbeJobService {
       }
     }
 
-    this.logger.info({ event: "TRIAL_WORKLOAD_PROBE_RECONCILE_END", found: deployments.length, scheduled, alreadyScheduled, failed });
+    this.logger.info({ event: "TRIAL_WORKLOAD_PROBE_RECONCILE_END", found: deployments.length, scheduled, alreadyScheduled, alreadyDetected, failed });
   }
 
   /** `startAfter` never sits in the past, because pg-boss derives a job's retention from it and would archive an overdue job before a worker sees it. */

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
@@ -1,0 +1,123 @@
+import { addMinutes } from "date-fns";
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, type Job, JOB_NAME, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import type { DryRunOptions } from "@src/core/types/console";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+
+export class ProbeTrialDeployment implements Job {
+  static readonly [JOB_NAME] = "ProbeTrialDeployment";
+  readonly name = ProbeTrialDeployment[JOB_NAME];
+  readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      walletId: number;
+      dseq: string;
+      attempt: number;
+      leaseCreatedAt: string;
+    }
+  ) {}
+}
+
+export type ProbeTrialDeploymentTarget = { walletId: number; dseq: string };
+
+export function probeTrialDeploymentKeyFor({ walletId, dseq }: ProbeTrialDeploymentTarget): string {
+  return `probeTrialDeployment.${walletId}.${dseq}`;
+}
+
+/**
+ * Owns the probe schedule of a trial deployment: the first probes sit at fixed offsets from the lease, the rest repeat
+ * at a jittered interval so the workload cannot learn when the next look comes.
+ */
+@singleton()
+export class TrialWorkloadProbeJobService {
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly jobQueueService: JobQueueService,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly config: WorkloadAbuseConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: TrialWorkloadProbeJobService.name });
+  }
+
+  async scheduleInitial(target: ProbeTrialDeploymentTarget & { leaseCreatedAt: Date }): Promise<string | null> {
+    if (!this.config.get("WORKLOAD_ABUSE_PROBE_ENABLED")) return null;
+
+    return this.#schedule({ ...target, attempt: 1, leaseCreatedAt: target.leaseCreatedAt.toISOString() });
+  }
+
+  async scheduleNext(previous: ProbeTrialDeployment["data"]): Promise<string | null> {
+    return this.#schedule({ ...previous, attempt: previous.attempt + 1 });
+  }
+
+  async cancelForDeployment(target: ProbeTrialDeploymentTarget): Promise<void> {
+    await this.jobQueueService.cancelCreatedBy({ name: ProbeTrialDeployment[JOB_NAME], singletonKey: probeTrialDeploymentKeyFor(target) });
+  }
+
+  /** Backstops the lease-created hook: a live trial deployment with no pending probe gets one, whatever the reason it has none. */
+  async reconcile({ dryRun }: DryRunOptions): Promise<void> {
+    if (!this.config.get("WORKLOAD_ABUSE_PROBE_ENABLED")) {
+      this.logger.info({ event: "TRIAL_WORKLOAD_PROBE_RECONCILE_DISABLED" });
+      return;
+    }
+
+    const deployments = await this.deploymentSettingRepository.findLiveTrialDeployments({
+      maxAgeHours: this.config.get("WORKLOAD_ABUSE_RECONCILE_MAX_AGE_HOURS")
+    });
+    this.logger.info({ event: "TRIAL_WORKLOAD_PROBE_RECONCILE_START", count: deployments.length, dryRun });
+
+    if (dryRun) return;
+
+    const pendingKeys = await this.jobQueueService.findPendingSingletonKeys(ProbeTrialDeployment[JOB_NAME]);
+    let scheduled = 0;
+    let alreadyScheduled = 0;
+    let failed = 0;
+
+    for (const deployment of deployments) {
+      if (pendingKeys.has(probeTrialDeploymentKeyFor(deployment))) {
+        alreadyScheduled++;
+        continue;
+      }
+
+      try {
+        const jobId = await this.#schedule(
+          { walletId: deployment.walletId, dseq: deployment.dseq, attempt: 1, leaseCreatedAt: deployment.createdAt.toISOString() },
+          new Date()
+        );
+        if (jobId) scheduled++;
+        else alreadyScheduled++;
+      } catch (error) {
+        this.logger.error({ event: "TRIAL_WORKLOAD_PROBE_RECONCILE_FAILED", dseq: deployment.dseq, walletId: deployment.walletId, error });
+        failed++;
+      }
+    }
+
+    this.logger.info({ event: "TRIAL_WORKLOAD_PROBE_RECONCILE_END", found: deployments.length, scheduled, alreadyScheduled, failed });
+  }
+
+  /** `startAfter` never sits in the past, because pg-boss derives a job's retention from it and would archive an overdue job before a worker sees it. */
+  startAfterFor(data: Pick<ProbeTrialDeployment["data"], "attempt" | "leaseCreatedAt">, now = new Date()): Date {
+    const initialDelays = this.config.get("WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN");
+
+    if (data.attempt <= initialDelays.length) {
+      const scheduledAt = addMinutes(new Date(data.leaseCreatedAt), initialDelays[data.attempt - 1]);
+      return new Date(Math.max(scheduledAt.getTime(), now.getTime()));
+    }
+
+    const jitter = this.config.get("WORKLOAD_ABUSE_PROBE_JITTER_MIN");
+    const offset = (Math.random() * 2 - 1) * jitter;
+
+    return addMinutes(now, this.config.get("WORKLOAD_ABUSE_PROBE_INTERVAL_MIN") + offset);
+  }
+
+  async #schedule(data: ProbeTrialDeployment["data"], startAfter = this.startAfterFor(data)): Promise<string | null> {
+    return this.jobQueueService.enqueue(new ProbeTrialDeployment(data), {
+      singletonKey: probeTrialDeploymentKeyFor(data),
+      startAfter: startAfter.toISOString()
+    });
+  }
+}

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
@@ -70,6 +70,19 @@ describe(TrialWorkloadProbeService.name, () => {
     expect(logTailService.collect).toHaveBeenCalledWith(expect.objectContaining({ services: ["ssh"] }));
   });
 
+  it("probes at most eight services per lease however many the provider reports", async () => {
+    const { service, wallet, shellProbeService, logTailService, logger } = setup({
+      leases: [createRpcLease()],
+      services: Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`svc${index}`, 1]))
+    });
+
+    await service.probe({ wallet, dseq: DSEQ });
+
+    expect(shellProbeService.run).toHaveBeenCalledTimes(8);
+    expect(logTailService.collect.mock.calls[0][0].services).toHaveLength(8);
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_SERVICES_CAPPED", reported: 12, probed: 8 }));
+  });
+
   it("scans the shell output, the log tail and the stored SDL together", async () => {
     const { service, wallet } = setup({
       leases: [createRpcLease()],

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
@@ -83,6 +83,19 @@ describe(TrialWorkloadProbeService.name, () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_SERVICES_CAPPED", reported: 12, probed: 8 }));
   });
 
+  it("probes at most four leases per deployment however many the dseq has", async () => {
+    const { service, wallet, shellProbeService, logger } = setup({
+      leases: Array.from({ length: 7 }, (_, index) => createRpcLease({ gseq: index + 1 })),
+      services: { ssh: 1 }
+    });
+
+    const report = await service.probe({ wallet, dseq: DSEQ });
+
+    expect(report.leases).toHaveLength(4);
+    expect(shellProbeService.run).toHaveBeenCalledTimes(4);
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_LEASES_CAPPED", reported: 7, probed: 4 }));
+  });
+
   it("scans the shell output, the log tail and the stored SDL together", async () => {
     const { service, wallet } = setup({
       leases: [createRpcLease()],

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
@@ -96,6 +96,15 @@ describe(TrialWorkloadProbeService.name, () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_LEASES_CAPPED", reported: 7, probed: 4 }));
   });
 
+  it("logs no cap warning when the lease and service counts are within bounds", async () => {
+    const { service, wallet, logger } = setup({ leases: [createRpcLease()], services: { ssh: 1 } });
+
+    await service.probe({ wallet, dseq: DSEQ });
+
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_LEASES_CAPPED" }));
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_SERVICES_CAPPED" }));
+  });
+
   it("scans the shell output, the log tail and the stored SDL together", async () => {
     const { service, wallet } = setup({
       leases: [createRpcLease()],

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
@@ -1,0 +1,176 @@
+import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
+import type { LeaseHttpService, RpcLease } from "@akashnetwork/http-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core";
+import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
+import type { ProviderService } from "@src/provider/services/provider/provider.service";
+import type { CompiledSignature } from "@src/workload-abuse/config/env.config";
+import type { ProviderLogTailService } from "@src/workload-abuse/services/provider-log-tail/provider-log-tail.service";
+import type { ProviderShellProbeService, ShellProbeResult } from "@src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service";
+import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { TrialWorkloadProbeService } from "./trial-workload-probe.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+import { createLeaseStatus } from "@test/seeders/lease-status.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const SIGNATURES: CompiledSignature[] = [
+  { bucket: "hard", category: "stratum-url", pattern: /stratum\+tcp:\/\//i },
+  { bucket: "soft", category: "pool-port", pattern: /:3333\b/ }
+];
+const PROVIDER = "akash1provider";
+const HOST_URI = "https://provider.example:8443";
+const DSEQ = "1000001";
+
+describe(TrialWorkloadProbeService.name, () => {
+  it("reports no live lease without touching any provider", async () => {
+    const { service, wallet, providerService } = setup({ leases: [] });
+
+    const report = await service.probe({ wallet, dseq: DSEQ });
+
+    expect(report).toEqual({ verdict: "clean", signals: [], excerpt: "", probeStatus: "no_live_lease", leases: [] });
+    expect(providerService.toProviderAuth).not.toHaveBeenCalled();
+  });
+
+  it("reports an unknown provider when the lease points at one the indexer does not know", async () => {
+    const { service, wallet } = setup({ leases: [createRpcLease()], provider: null });
+
+    const report = await service.probe({ wallet, dseq: DSEQ });
+
+    expect(report.probeStatus).toBe("provider_unknown");
+  });
+
+  it("reports the lease status as unavailable when the provider does not answer it", async () => {
+    const { service, wallet, providerService } = setup({ leases: [createRpcLease()] });
+    providerService.getLeaseStatus.mockRejectedValue(new Error("504"));
+
+    const report = await service.probe({ wallet, dseq: DSEQ });
+
+    expect(report.probeStatus).toBe("status_unavailable");
+    expect(report.leases).toEqual([expect.objectContaining({ provider: PROVIDER, services: [] })]);
+  });
+
+  it("mints a read-only token and probes every running service through it", async () => {
+    const { service, wallet, providerService, shellProbeService, logTailService } = setup({
+      leases: [createRpcLease()],
+      services: { ssh: 1, idle: 0 },
+      shell: { status: "completed", output: "--loadavg\n18.21 18.41 18.65" }
+    });
+
+    await service.probe({ wallet, dseq: DSEQ });
+
+    expect(providerService.toProviderAuth).toHaveBeenCalledWith({ walletId: wallet.id, provider: PROVIDER }, ["status", "logs", "shell"], { ttl: 120 });
+    expect(shellProbeService.run).toHaveBeenCalledTimes(1);
+    expect(shellProbeService.run).toHaveBeenCalledWith(
+      expect.objectContaining({ hostUri: HOST_URI, providerAddress: PROVIDER, token: "jwt", dseq: DSEQ, gseq: 1, oseq: 1, service: "ssh" })
+    );
+    expect(logTailService.collect).toHaveBeenCalledWith(expect.objectContaining({ services: ["ssh"] }));
+  });
+
+  it("scans the shell output, the log tail and the stored SDL together", async () => {
+    const { service, wallet } = setup({
+      leases: [createRpcLease()],
+      services: { ssh: 1 },
+      sdl: "image: ubuntu\nenv:\n  - POOL=pool.example:3333",
+      shell: { status: "completed", output: "42 comm=worker cmd=/tmp/worker -o stratum+tcp://pool.example:3333" },
+      logs: ["[ssh]: Server listening on 0.0.0.0 port 22"]
+    });
+
+    const report = await service.probe({ wallet, dseq: DSEQ });
+
+    expect(report.verdict).toBe("hard");
+    expect(report.probeStatus).toBe("probed");
+    expect(report.signals).toEqual([
+      expect.objectContaining({ bucket: "soft", category: "pool-port", source: "sdl" }),
+      expect.objectContaining({ bucket: "hard", category: "stratum-url", source: "shell", service: "ssh" }),
+      expect.objectContaining({ bucket: "soft", category: "pool-port", source: "shell", service: "ssh" })
+    ]);
+    expect(report.excerpt).toContain("[hard/stratum-url] shell:ssh:");
+    expect(report.excerpt).toContain("--- shell ssh");
+  });
+
+  it("still scans what it has when the container has no shell", async () => {
+    const { service, wallet } = setup({
+      leases: [createRpcLease()],
+      services: { web: 1 },
+      shell: { status: "shell_unavailable", output: "" },
+      logs: ["[web]: connecting to stratum+tcp://pool.example:4444"]
+    });
+
+    const report = await service.probe({ wallet, dseq: DSEQ });
+
+    expect(report.probeStatus).toBe("shell_unavailable");
+    expect(report.verdict).toBe("hard");
+    expect(report.leases[0].shellStatuses).toEqual(["shell_unavailable"]);
+  });
+
+  it("reports a lease with nothing running as such", async () => {
+    const { service, wallet, shellProbeService } = setup({ leases: [createRpcLease()], services: { web: 0 } });
+
+    const report = await service.probe({ wallet, dseq: DSEQ });
+
+    expect(report.probeStatus).toBe("no_running_service");
+    expect(shellProbeService.run).not.toHaveBeenCalled();
+  });
+
+  function createRpcLease(overrides: Partial<RpcLease["lease"]["id"]> = {}): RpcLease {
+    return mock<RpcLease>({
+      lease: { id: { owner: "akash1owner", dseq: DSEQ, gseq: 1, oseq: 1, provider: PROVIDER, bseq: 1, ...overrides }, state: "active" }
+    });
+  }
+
+  function setup(input: {
+    leases: RpcLease[];
+    provider?: Provider | null;
+    services?: Record<string, number>;
+    sdl?: string | null;
+    shell?: ShellProbeResult;
+    logs?: string[];
+  }) {
+    const wallet = { ...createUserWallet({ isTrialing: true }), address: "akash1owner" };
+    const leaseHttpService = mock<LeaseHttpService>();
+    leaseHttpService.list.mockImplementation(async ({ state }) => ({
+      leases: state === "active" ? input.leases : [],
+      pagination: { next_key: null, total: "0" }
+    }));
+    const providerRepository = mock<ProviderRepository>();
+    providerRepository.findActiveByAddress.mockResolvedValue(
+      input.provider === undefined ? mock<Provider>({ owner: PROVIDER, hostUri: HOST_URI }) : input.provider
+    );
+    const providerService = mock<ProviderService>();
+    providerService.toProviderAuth.mockResolvedValue({ type: "jwt", token: "jwt" });
+    const leaseStatus = createLeaseStatus();
+    leaseStatus.services = Object.fromEntries(
+      Object.entries(input.services ?? {}).map(([name, available]) => [name, { ...leaseStatus.services.web, name, available, available_replicas: available }])
+    );
+    providerService.getLeaseStatus.mockResolvedValue(leaseStatus);
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.findOneBy.mockResolvedValue(mock<DeploymentSettingsOutput>({ sdl: input.sdl ?? null }));
+    const shellProbeService = mock<ProviderShellProbeService>();
+    shellProbeService.run.mockResolvedValue(input.shell ?? { status: "completed", output: "--loadavg\n0.10" });
+    const logTailService = mock<ProviderLogTailService>();
+    logTailService.collect.mockResolvedValue({ status: "completed", lines: input.logs ?? [] });
+    const config = mockConfigService<WorkloadAbuseConfigService>({
+      WORKLOAD_ABUSE_SIGNATURES: SIGNATURES,
+      WORKLOAD_ABUSE_PROVIDER_JWT_TTL_SECONDS: 120
+    });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const service = new TrialWorkloadProbeService(
+      leaseHttpService,
+      providerRepository,
+      providerService,
+      deploymentSettingRepository,
+      shellProbeService,
+      logTailService,
+      config,
+      createLogger
+    );
+
+    return { service, wallet, leaseHttpService, providerRepository, providerService, deploymentSettingRepository, shellProbeService, logTailService, logger };
+  }
+});

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.ts
@@ -39,6 +39,8 @@ export type ProbeReport = {
 };
 
 const PROVIDER_SCOPES = ["status", "logs", "shell"] as const;
+/** The probed provider reports its own service list, so a hostile one must not be able to stretch a run past this many shell sessions. */
+const MAX_PROBED_SERVICES_PER_LEASE = 8;
 /** Bounds the audit row; the full shell output stays in the job log, which has its own line cap. */
 const MAX_EXCERPT_LENGTH = 8_192;
 
@@ -116,14 +118,25 @@ export class TrialWorkloadProbeService {
     if (services.length === 0) return { status: "no_running_service", lease: probedLease };
 
     const target = { hostUri: provider.hostUri, providerAddress, token: auth.token, dseq, gseq, oseq };
+    const probedServices = services.slice(0, MAX_PROBED_SERVICES_PER_LEASE);
 
-    for (const service of services) {
+    if (probedServices.length < services.length) {
+      this.logger.warn({
+        event: "TRIAL_WORKLOAD_PROBE_SERVICES_CAPPED",
+        dseq,
+        provider: providerAddress,
+        reported: services.length,
+        probed: probedServices.length
+      });
+    }
+
+    for (const service of probedServices) {
       const shell = await this.shellProbeService.run({ ...target, service });
       probedLease.shellStatuses.push(shell.status);
       if (shell.output) sources.push({ kind: "shell", service, text: shell.output });
     }
 
-    const logs = await this.logTailService.collect({ ...target, services });
+    const logs = await this.logTailService.collect({ ...target, services: probedServices });
     probedLease.logStatus = logs.status;
     if (logs.lines.length > 0) sources.push({ kind: "logs", text: logs.lines.join("\n") });
 

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.ts
@@ -1,0 +1,160 @@
+import { LeaseHttpService, LIVE_LEASE_STATES, type RpcLease } from "@akashnetwork/http-sdk";
+import { inject, singleton } from "tsyringe";
+
+import type { WalletInitialized } from "@src/billing/repositories";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
+import { ProviderService } from "@src/provider/services/provider/provider.service";
+import type { ProviderAuth } from "@src/provider/services/provider/provider-proxy.service";
+import {
+  type DetectionSignal,
+  type EvidenceSource,
+  scanForSignals,
+  toVerdict,
+  type WorkloadVerdict
+} from "@src/workload-abuse/lib/evidence-scanner/evidence-scanner";
+import { ProviderLogTailService } from "@src/workload-abuse/services/provider-log-tail/provider-log-tail.service";
+import { ProviderShellProbeService, type ShellProbeStatus } from "@src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+
+export type ProbeStatus = "probed" | "no_live_lease" | "provider_unknown" | "status_unavailable" | "no_running_service" | "shell_unavailable" | "stream_failed";
+
+export type ProbedLease = {
+  provider: string;
+  hostUri: string;
+  gseq: number;
+  oseq: number;
+  services: string[];
+  shellStatuses: ShellProbeStatus[];
+  logStatus?: string;
+};
+
+export type ProbeReport = {
+  verdict: WorkloadVerdict;
+  signals: DetectionSignal[];
+  excerpt: string;
+  probeStatus: ProbeStatus;
+  leases: ProbedLease[];
+};
+
+const PROVIDER_SCOPES = ["status", "logs", "shell"] as const;
+/** Bounds the audit row; the full shell output stays in the job log, which has its own line cap. */
+const MAX_EXCERPT_LENGTH = 8_192;
+
+/** Probes one trial deployment: what its stored SDL declares, what the container is running, and what it logs. */
+@singleton()
+export class TrialWorkloadProbeService {
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly leaseHttpService: LeaseHttpService,
+    private readonly providerRepository: ProviderRepository,
+    private readonly providerService: ProviderService,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly shellProbeService: ProviderShellProbeService,
+    private readonly logTailService: ProviderLogTailService,
+    private readonly config: WorkloadAbuseConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: TrialWorkloadProbeService.name });
+  }
+
+  async probe(input: { wallet: WalletInitialized; dseq: string }): Promise<ProbeReport> {
+    const leases = await this.#findLiveLeases(input.wallet.address, input.dseq);
+
+    if (leases.length === 0) {
+      return { verdict: "clean", signals: [], excerpt: "", probeStatus: "no_live_lease", leases: [] };
+    }
+
+    const sources: EvidenceSource[] = [];
+    const setting = await this.deploymentSettingRepository.findOneBy({ userId: input.wallet.userId, dseq: input.dseq });
+    if (setting?.sdl) sources.push({ kind: "sdl", text: setting.sdl });
+
+    const probedLeases: ProbedLease[] = [];
+    const statuses: ProbeStatus[] = [];
+
+    for (const lease of leases) {
+      const probed = await this.#probeLease(input.wallet, lease, sources);
+      statuses.push(probed.status);
+      if (probed.lease) probedLeases.push(probed.lease);
+    }
+
+    const signals = scanForSignals(sources, this.config.get("WORKLOAD_ABUSE_SIGNATURES"));
+
+    return {
+      verdict: toVerdict(signals),
+      signals,
+      excerpt: buildExcerpt(sources, signals),
+      probeStatus: statuses.includes("probed") ? "probed" : statuses[0] ?? "stream_failed",
+      leases: probedLeases
+    };
+  }
+
+  async #findLiveLeases(owner: string, dseq: string): Promise<RpcLease[]> {
+    const responses = await Promise.all(LIVE_LEASE_STATES.map(state => this.leaseHttpService.list({ owner, dseq, state })));
+
+    return responses.flatMap(response => response.leases);
+  }
+
+  async #probeLease(wallet: WalletInitialized, lease: RpcLease, sources: EvidenceSource[]): Promise<{ status: ProbeStatus; lease?: ProbedLease }> {
+    const { provider: providerAddress, dseq, gseq, oseq } = lease.lease.id;
+    const provider = await this.providerRepository.findActiveByAddress(providerAddress);
+
+    if (!provider) {
+      this.logger.warn({ event: "TRIAL_WORKLOAD_PROBE_PROVIDER_UNKNOWN", dseq, provider: providerAddress });
+      return { status: "provider_unknown" };
+    }
+
+    const auth = await this.providerService.toProviderAuth({ walletId: wallet.id, provider: providerAddress }, [...PROVIDER_SCOPES], {
+      ttl: this.config.get("WORKLOAD_ABUSE_PROVIDER_JWT_TTL_SECONDS")
+    });
+    const services = await this.#findRunningServices(providerAddress, dseq, gseq, oseq, auth);
+    const probedLease: ProbedLease = { provider: providerAddress, hostUri: provider.hostUri, gseq, oseq, services: services ?? [], shellStatuses: [] };
+
+    if (!services) return { status: "status_unavailable", lease: probedLease };
+    if (services.length === 0) return { status: "no_running_service", lease: probedLease };
+
+    const target = { hostUri: provider.hostUri, providerAddress, token: auth.token, dseq, gseq, oseq };
+
+    for (const service of services) {
+      const shell = await this.shellProbeService.run({ ...target, service });
+      probedLease.shellStatuses.push(shell.status);
+      if (shell.output) sources.push({ kind: "shell", service, text: shell.output });
+    }
+
+    const logs = await this.logTailService.collect({ ...target, services });
+    probedLease.logStatus = logs.status;
+    if (logs.lines.length > 0) sources.push({ kind: "logs", text: logs.lines.join("\n") });
+
+    return { status: toLeaseProbeStatus(probedLease.shellStatuses), lease: probedLease };
+  }
+
+  async #findRunningServices(provider: string, dseq: string, gseq: number, oseq: number, auth: ProviderAuth): Promise<string[] | undefined> {
+    try {
+      const status = await this.providerService.getLeaseStatus(provider, dseq, gseq, oseq, auth);
+
+      return Object.entries(status.services ?? {})
+        .filter(([, service]) => (service?.available ?? 0) > 0)
+        .map(([name]) => name);
+    } catch (error) {
+      this.logger.warn({ event: "TRIAL_WORKLOAD_PROBE_STATUS_UNAVAILABLE", dseq, provider, error });
+      return undefined;
+    }
+  }
+}
+
+function toLeaseProbeStatus(shellStatuses: ShellProbeStatus[]): ProbeStatus {
+  if (shellStatuses.some(status => status === "completed" || status === "output_capped" || status === "idle_timeout")) return "probed";
+  if (shellStatuses.every(status => status === "shell_unavailable")) return "shell_unavailable";
+  return "stream_failed";
+}
+
+function buildExcerpt(sources: EvidenceSource[], signals: DetectionSignal[]): string {
+  const signalLines = signals.map(
+    signal => `[${signal.bucket}/${signal.category}] ${signal.source}${signal.service ? `:${signal.service}` : ""}: ${signal.snippet}`
+  );
+  const shellOutput = sources.filter(source => source.kind === "shell").map(source => `--- shell ${source.service ?? ""}\n${source.text}`);
+
+  return [...signalLines, ...shellOutput].join("\n").slice(0, MAX_EXCERPT_LENGTH);
+}

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.ts
@@ -41,6 +41,8 @@ export type ProbeReport = {
 const PROVIDER_SCOPES = ["status", "logs", "shell"] as const;
 /** The probed provider reports its own service list, so a hostile one must not be able to stretch a run past this many shell sessions. */
 const MAX_PROBED_SERVICES_PER_LEASE = 8;
+/** A deployment's own SDL decides how many groups it has, so a hostile one must not be able to stretch a run past this many leases. */
+const MAX_PROBED_LEASES_PER_DEPLOYMENT = 4;
 /** Bounds the audit row; the full shell output stays in the job log, which has its own line cap. */
 const MAX_EXCERPT_LENGTH = 8_192;
 
@@ -76,7 +78,18 @@ export class TrialWorkloadProbeService {
     const probedLeases: ProbedLease[] = [];
     const statuses: ProbeStatus[] = [];
 
-    for (const lease of leases) {
+    const leasesToProbe = leases.slice(0, MAX_PROBED_LEASES_PER_DEPLOYMENT);
+
+    if (leasesToProbe.length < leases.length) {
+      this.logger.warn({
+        event: "TRIAL_WORKLOAD_PROBE_LEASES_CAPPED",
+        dseq: input.dseq,
+        reported: leases.length,
+        probed: leasesToProbe.length
+      });
+    }
+
+    for (const lease of leasesToProbe) {
       const probed = await this.#probeLease(input.wallet, lease, sources);
       statuses.push(probed.status);
       if (probed.lease) probedLeases.push(probed.lease);

--- a/apps/api/src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service.ts
+++ b/apps/api/src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service.ts
@@ -1,0 +1,13 @@
+import { inject, singleton } from "tsyringe";
+
+import { ConfigService } from "@src/core/services/config/config.service";
+import { WORKLOAD_ABUSE_CONFIG } from "@src/workload-abuse/config/config.provider";
+import type { WorkloadAbuseConfig } from "@src/workload-abuse/config/env.config";
+import { envSchema } from "@src/workload-abuse/config/env.config";
+
+@singleton()
+export class WorkloadAbuseConfigService extends ConfigService<typeof envSchema> {
+  constructor(@inject(WORKLOAD_ABUSE_CONFIG) config: WorkloadAbuseConfig) {
+    super({ config });
+  }
+}

--- a/apps/api/src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service.ts
+++ b/apps/api/src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service.ts
@@ -1,0 +1,30 @@
+import type { Counter, Meter } from "@opentelemetry/api";
+import { singleton } from "tsyringe";
+
+import { MetricsService } from "@src/core/services/metrics/metrics.service";
+import type { WorkloadVerdict } from "@src/workload-abuse/lib/evidence-scanner/evidence-scanner";
+
+@singleton()
+export class WorkloadAbuseInstrumentationService {
+  private readonly meter: Meter;
+  private readonly probes: Counter;
+  private readonly detections: Counter;
+
+  constructor(metricsService: MetricsService) {
+    this.meter = metricsService.getMeter("workload-abuse", "1.0.0");
+    this.probes = metricsService.createCounter(this.meter, "workload_abuse_probes_total", {
+      description: "Trial workload probes by verdict and probe status"
+    });
+    this.detections = metricsService.createCounter(this.meter, "workload_abuse_detections_total", {
+      description: "Trial workload detections recorded, by verdict"
+    });
+  }
+
+  recordProbe(input: { verdict: WorkloadVerdict; probeStatus: string }): void {
+    this.probes.add(1, { verdict: input.verdict, probe_status: input.probeStatus });
+  }
+
+  recordDetection(verdict: WorkloadVerdict): void {
+    this.detections.add(1, { verdict });
+  }
+}


### PR DESCRIPTION
## Why

Fair Use Policy violations concentrate on free-trial deployments, and today the only way to see what a trial deployment is actually running is to look by hand. This adds an automated periodic check for trial wallets and records what it finds.

Second of three PRs. #3818 has landed, so this one now targets main. It only detects. Acting on findings is the next PR, so this can run in production for a while and be compared with manual review first.

## What

New `apps/api/src/workload-abuse` module.

- A pg-boss job is scheduled when a trial lease lands and re-runs periodically while the deployment stays live. A `probe-trial-deployments` CLI sweep (helm cron) backstops it for deployments created before rollout or with lost jobs.
- Each run inspects the live deployment through provider-proxy, so provider connections keep the proxy's certificate check, and evaluates what it sees against rules loaded from configuration. The rules themselves are not in the repository; the code ships the engine and an empty default.
- Findings are stored in a new `workload_abuse_detections` table (migration `0051`) with a bounded evidence excerpt, and every run increments `workload_abuse_probes_total`.
- Paying wallets are never inspected. Everything is off unless `WORKLOAD_ABUSE_PROBE_ENABLED=true`; the other knobs are listed in `env/.env.sample`.
- Small supporting changes: `ProviderService.toProviderAuth` takes an optional `ttl`, and `DeploymentSettingRepository.findLiveTrialDeployments` feeds the sweep.

### Verification

Full apps/api unit and functional suites green, plus the deployment-setting repository integration spec. `eslint --quiet` and `tsc --noEmit` clean on the touched files.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated monitoring for trial deployments to identify potentially abusive workloads.
  - Trial deployments are probed after lease creation and periodically while active.
  - Checks analyze deployment configuration, runtime activity, shell output, and service logs.
  - Findings are classified by severity, recorded with supporting evidence, and tracked through their resolution status.
  - Added safeguards to avoid duplicate checks and limit probing activity.
- **Bug Fixes**
  - Improved handling of unavailable providers, failed probes, timeouts, and incomplete responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->