### PR TITLE
feat(deployment): enforce the fair use policy on trial deployments

### DIFF
--- a/apps/api/drizzle/0052_user_wallet_abuse_lock.sql
+++ b/apps/api/drizzle/0052_user_wallet_abuse_lock.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "user_wallets" ADD COLUMN "abuse_locked_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "user_wallets" ADD COLUMN "abuse_locked_reason" varchar(64);

--- a/apps/api/drizzle/meta/0052_snapshot.json
+++ b/apps/api/drizzle/meta/0052_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "3fe32cff-eec2-4c25-9330-a1dfe028de08",
-  "prevId": "1baab3b2-77e6-45fc-a1a0-070eea5ed256",
+  "id": "5bd1a611-9b71-43ba-9ac6-260581ff5218",
+  "prevId": "0f93730b-52a1-4661-8558-cfe5a66a4c39",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1574,7 +1574,7 @@
         },
         "provider": {
           "name": "provider",
-          "type": "varchar(255)",
+          "type": "text",
           "primaryKey": false,
           "notNull": true
         },

--- a/apps/api/drizzle/meta/0052_snapshot.json
+++ b/apps/api/drizzle/meta/0052_snapshot.json
@@ -1,0 +1,1750 @@
+{
+  "id": "3fe32cff-eec2-4c25-9330-a1dfe028de08",
+  "prevId": "1baab3b2-77e6-45fc-a1a0-070eea5ed256",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_sufficient_since": {
+          "name": "credits_sufficient_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_since": {
+          "name": "credits_low_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abuse_locked_at": {
+          "name": "abuse_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abuse_locked_reason": {
+          "name": "abuse_locked_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reload_failure_count": {
+          "name": "auto_reload_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_reload_paused_at": {
+          "name": "auto_reload_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fair_use_policy_accepted_at": {
+          "name": "fair_use_policy_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_secrets": {
+          "name": "sealed_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workload_abuse_detections": {
+      "name": "workload_abuse_detections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "workload_abuse_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probe_status": {
+          "name": "probe_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signals": {
+          "name": "signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_excerpt": {
+          "name": "evidence_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "workload_abuse_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "enforcement_error": {
+          "name": "enforcement_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workload_abuse_detections_user_id_idx": {
+          "name": "workload_abuse_detections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workload_abuse_detections_dseq_idx": {
+          "name": "workload_abuse_detections_dseq_idx",
+          "columns": [
+            {
+              "expression": "dseq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workload_abuse_detections_user_id_userSetting_id_fk": {
+          "name": "workload_abuse_detections_user_id_userSetting_id_fk",
+          "tableFrom": "workload_abuse_detections",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    },
+    "public.workload_abuse_action": {
+      "name": "workload_abuse_action",
+      "schema": "public",
+      "values": [
+        "detected",
+        "enforcing",
+        "enforced",
+        "enforcement_failed"
+      ]
+    },
+    "public.workload_abuse_verdict": {
+      "name": "workload_abuse_verdict",
+      "schema": "public",
+      "values": [
+        "hard",
+        "soft",
+        "proxy"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -369,7 +369,7 @@
     {
       "idx": 52,
       "version": "7",
-      "when": 1788717473603,
+      "when": 1788721409589,
       "tag": "0052_user_wallet_abuse_lock",
       "breakpoints": true
     }

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1788721188493,
       "tag": "0051_workload_abuse_detections",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1788717473603,
+      "tag": "0052_user_wallet_abuse_lock",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -10,6 +10,7 @@ import { DeleteUnbackedDeploymentSettingHandler } from "@src/deployment/services
 import { ReconcileManagedTxHandler } from "@src/deployment/services/reconcile-managed-tx/reconcile-managed-tx.handler";
 import { RecordDeploymentSettingHandler } from "@src/deployment/services/record-deployment-setting/record-deployment-setting.handler";
 import { NotificationHandler } from "@src/notifications/services/notification-handler/notification.handler";
+import { EnforceTrialAbuseHandler } from "@src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler";
 import { ProbeTrialDeploymentHandler } from "@src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler";
 import { AutoRechargeSucceededHandler } from "../services/auto-recharge-succeeded/auto-recharge-succeeded.handler";
 import { CloseExpiredDeploymentHandler } from "../services/close-expired-deployment/close-expired-deployment.handler";
@@ -44,7 +45,8 @@ export async function startJobQueues(): Promise<void> {
     container.resolve(DeleteUnbackedDeploymentSettingHandler),
     container.resolve(RecordDeploymentSettingHandler),
     container.resolve(ReconcileManagedTxHandler),
-    container.resolve(ProbeTrialDeploymentHandler)
+    container.resolve(ProbeTrialDeploymentHandler),
+    container.resolve(EnforceTrialAbuseHandler)
   ]);
 }
 

--- a/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
+++ b/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
@@ -17,6 +17,9 @@ export const UserWallets = pgTable("user_wallets", {
   creditsLowNotifiedAt: timestamp("credits_low_notified_at", { withTimezone: true }),
   creditsSufficientSince: timestamp("credits_sufficient_since", { withTimezone: true }),
   creditsLowSince: timestamp("credits_low_since", { withTimezone: true }),
+  /** Set when a wallet is wiped for workload abuse; a locked wallet is skipped by fee refills and probes but may still convert by paying. */
+  abuseLockedAt: timestamp("abuse_locked_at", { withTimezone: true }),
+  abuseLockedReason: varchar("abuse_locked_reason", { length: 64 }),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull()
 });

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
@@ -162,6 +162,35 @@ describe(UserWalletRepository.name, () => {
     });
   });
 
+  describe("lockForAbuse", () => {
+    it("zeroes both allowances, ends the trial and stamps the lock in one write", async () => {
+      const { userWalletRepository, wallet } = await setup();
+      await userWalletRepository.updateById(wallet.id, { deploymentAllowance: 1_000_000, feeAllowance: 500_000, isTrialing: true });
+
+      await userWalletRepository.lockForAbuse(wallet.id, "workload_abuse");
+
+      const locked = await userWalletRepository.findById(wallet.id);
+      expect(locked).toMatchObject({ deploymentAllowance: 0, feeAllowance: 0, isTrialing: false, abuseLockedReason: "workload_abuse" });
+      expect(locked?.abuseLockedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe("findDrainingWallets", () => {
+    it("leaves a wallet locked for abuse out of the fee refill", async () => {
+      const { userWalletRepository, wallet } = await setup();
+      const { wallet: lockedWallet } = await setup();
+      await userWalletRepository.updateById(wallet.id, { activatedAt: new Date(), feeAllowance: 0, isTrialing: false });
+      await userWalletRepository.updateById(lockedWallet.id, { activatedAt: new Date(), feeAllowance: 0, isTrialing: false });
+      await userWalletRepository.lockForAbuse(lockedWallet.id, "workload_abuse");
+
+      const draining = await userWalletRepository.findDrainingWallets({ fee: 1_000, trialExpirationDays: 30 });
+
+      const ids = draining.map(candidate => candidate.id);
+      expect(ids).toContain(wallet.id);
+      expect(ids).not.toContain(lockedWallet.id);
+    });
+  });
+
   async function setup(input: { creditsLowNotifiedAt?: Date; creditsSufficientSince?: Date; creditsLowSince?: Date } = {}) {
     const userRepository = container.resolve(UserRepository);
     const userWalletRepository = container.resolve(UserWalletRepository);

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
@@ -180,7 +180,7 @@ describe(UserWalletRepository.name, () => {
       const { userWalletRepository, wallet } = await setup();
       await userWalletRepository.lockForAbuse(wallet.id, "workload_abuse");
 
-      await userWalletRepository.clearAbuseLock(wallet.id);
+      await expect(userWalletRepository.clearAbuseLock(wallet.id)).resolves.toBe(true);
 
       expect(await userWalletRepository.findById(wallet.id)).toMatchObject({
         abuseLockedAt: null,
@@ -189,6 +189,12 @@ describe(UserWalletRepository.name, () => {
         feeAllowance: 0,
         isTrialing: false
       });
+    });
+
+    it("reports no clear for a wallet that holds no lock", async () => {
+      const { userWalletRepository, wallet } = await setup();
+
+      await expect(userWalletRepository.clearAbuseLock(wallet.id)).resolves.toBe(false);
     });
   });
 

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
@@ -175,6 +175,23 @@ describe(UserWalletRepository.name, () => {
     });
   });
 
+  describe("clearAbuseLock", () => {
+    it("removes the lock and its reason without touching the allowances", async () => {
+      const { userWalletRepository, wallet } = await setup();
+      await userWalletRepository.lockForAbuse(wallet.id, "workload_abuse");
+
+      await userWalletRepository.clearAbuseLock(wallet.id);
+
+      expect(await userWalletRepository.findById(wallet.id)).toMatchObject({
+        abuseLockedAt: null,
+        abuseLockedReason: null,
+        deploymentAllowance: 0,
+        feeAllowance: 0,
+        isTrialing: false
+      });
+    });
+  });
+
   describe("findDrainingWallets", () => {
     it("leaves a wallet locked for abuse out of the fee refill", async () => {
       const { userWalletRepository, wallet } = await setup();

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -153,12 +153,18 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
         where: this.whereAccessibleBy(
           and(
             isNotNull(this.table.activatedAt),
+            isNull(this.table.abuseLockedAt),
             lte(this.table.feeAllowance, thresholds.fee.toString()),
             or(and(eq(this.table.isTrialing, true), gt(this.table.activatedAt, trialWindowStart)), eq(this.table.isTrialing, false))
           )
         )
       })
     );
+  }
+
+  /** One write, so a wallet is never left with zeroed allowances but no lock or the other way round. */
+  async lockForAbuse(id: UserWalletOutput["id"], reason: string): Promise<void> {
+    await this.updateById(id, { deploymentAllowance: 0, feeAllowance: 0, isTrialing: false, abuseLockedAt: new Date(), abuseLockedReason: reason });
   }
 
   @Trace()

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -167,8 +167,15 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     await this.updateById(id, { deploymentAllowance: 0, feeAllowance: 0, isTrialing: false, abuseLockedAt: new Date(), abuseLockedReason: reason });
   }
 
-  async clearAbuseLock(id: UserWalletOutput["id"]): Promise<void> {
-    await this.updateById(id, { abuseLockedAt: null, abuseLockedReason: null });
+  /** Re-checks the lock in SQL so a lock applied after the payer read the wallet is still cleared by that payment. */
+  async clearAbuseLock(id: UserWalletOutput["id"]): Promise<boolean> {
+    const [cleared] = await this.cursor
+      .update(this.table)
+      .set({ abuseLockedAt: null, abuseLockedReason: null })
+      .where(this.whereAccessibleBy(and(eq(this.table.id, id), isNotNull(this.table.abuseLockedAt))))
+      .returning({ id: this.table.id });
+
+    return !!cleared;
   }
 
   @Trace()

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -167,6 +167,10 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     await this.updateById(id, { deploymentAllowance: 0, feeAllowance: 0, isTrialing: false, abuseLockedAt: new Date(), abuseLockedReason: reason });
   }
 
+  async clearAbuseLock(id: UserWalletOutput["id"]): Promise<void> {
+    await this.updateById(id, { abuseLockedAt: null, abuseLockedReason: null });
+  }
+
   @Trace()
   async findOneByUserId(userId: UserWalletOutput["userId"]) {
     if (!userId) return undefined;

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -51,6 +51,19 @@ describe(RefillService.name, () => {
       expect(userWalletRepository.clearAbuseLock).toHaveBeenCalledWith(unlockedWallet.id);
     });
 
+    it("settles the payment even when clearing the abuse lock fails", async () => {
+      const { service, userWalletRepository, walletInitializerService, balancesService, analyticsService } = setup();
+      const wallet = createInitializedUserWallet({ userId });
+      walletInitializerService.ensureWallet.mockResolvedValue(wallet);
+      userWalletRepository.claimActivation.mockResolvedValue(undefined);
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+      userWalletRepository.clearAbuseLock.mockRejectedValue(new Error("deadlock detected"));
+
+      await expect(service.topUpWallet(amountUsd, userId)).resolves.toEqual({ walletId: wallet.id, address: wallet.address });
+
+      expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up", expect.objectContaining({ amount_cents: amountUsd }));
+    });
+
     it("attaches payment context to the balance_top_up analytics event", async () => {
       const { service, userWalletRepository, managedUserWalletService, balancesService, analyticsService, walletInitializerService } = setup();
       const existingWallet = createInitializedUserWallet({ userId });

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -38,6 +38,21 @@ describe(RefillService.name, () => {
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up", expect.objectContaining({ amount_cents: amountUsd, amount_usd: 1 }));
     });
 
+    it("clears the abuse lock of a wallet that pays and leaves an unlocked wallet alone", async () => {
+      const { service, userWalletRepository, walletInitializerService, balancesService } = setup();
+      const lockedWallet = createInitializedUserWallet({ userId, abuseLockedAt: new Date(), abuseLockedReason: "workload_abuse" });
+      walletInitializerService.ensureWallet.mockResolvedValue(lockedWallet);
+      userWalletRepository.claimActivation.mockResolvedValue(undefined);
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+
+      await service.topUpWallet(amountUsd, userId);
+      walletInitializerService.ensureWallet.mockResolvedValue(createInitializedUserWallet({ userId }));
+      await service.topUpWallet(amountUsd, userId);
+
+      expect(userWalletRepository.clearAbuseLock).toHaveBeenCalledTimes(1);
+      expect(userWalletRepository.clearAbuseLock).toHaveBeenCalledWith(lockedWallet.id);
+    });
+
     it("attaches payment context to the balance_top_up analytics event", async () => {
       const { service, userWalletRepository, managedUserWalletService, balancesService, analyticsService, walletInitializerService } = setup();
       const existingWallet = createInitializedUserWallet({ userId });

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfig } from "@src/billing/providers";
@@ -7,6 +7,7 @@ import type { ManagedSignerService, ManagedUserWalletService } from "@src/billin
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import type { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
 
 import { createInitializedUserWallet, createUserWallet } from "@test/seeders/user-wallet.seeder";
@@ -39,7 +40,7 @@ describe(RefillService.name, () => {
     });
 
     it("asks to clear the abuse lock on every payment, so a lock applied after the wallet was read is still cleared", async () => {
-      const { service, userWalletRepository, walletInitializerService, balancesService } = setup();
+      const { service, userWalletRepository, walletInitializerService, balancesService, logger } = setup();
       const unlockedWallet = createInitializedUserWallet({ userId, abuseLockedAt: null, abuseLockedReason: null });
       walletInitializerService.ensureWallet.mockResolvedValue(unlockedWallet);
       userWalletRepository.claimActivation.mockResolvedValue(undefined);
@@ -49,19 +50,34 @@ describe(RefillService.name, () => {
       await service.topUpWallet(amountUsd, userId);
 
       expect(userWalletRepository.clearAbuseLock).toHaveBeenCalledWith(unlockedWallet.id);
+      expect(logger.info).toHaveBeenCalledWith({ event: "WALLET_ABUSE_LOCK_CLEARED", walletId: unlockedWallet.id, userId: unlockedWallet.userId });
+    });
+
+    it("does not report a cleared lock when the wallet held none", async () => {
+      const { service, userWalletRepository, walletInitializerService, balancesService, logger } = setup();
+      walletInitializerService.ensureWallet.mockResolvedValue(createInitializedUserWallet({ userId }));
+      userWalletRepository.claimActivation.mockResolvedValue(undefined);
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+      userWalletRepository.clearAbuseLock.mockResolvedValue(false);
+
+      await service.topUpWallet(amountUsd, userId);
+
+      expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "WALLET_ABUSE_LOCK_CLEARED" }));
     });
 
     it("settles the payment even when clearing the abuse lock fails", async () => {
-      const { service, userWalletRepository, walletInitializerService, balancesService, analyticsService } = setup();
+      const { service, userWalletRepository, walletInitializerService, balancesService, analyticsService, logger } = setup();
       const wallet = createInitializedUserWallet({ userId });
       walletInitializerService.ensureWallet.mockResolvedValue(wallet);
       userWalletRepository.claimActivation.mockResolvedValue(undefined);
       balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
-      userWalletRepository.clearAbuseLock.mockRejectedValue(new Error("deadlock detected"));
+      const error = new Error("deadlock detected");
+      userWalletRepository.clearAbuseLock.mockRejectedValue(error);
 
       await expect(service.topUpWallet(amountUsd, userId)).resolves.toEqual({ walletId: wallet.id, address: wallet.address });
 
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up", expect.objectContaining({ amount_cents: amountUsd }));
+      expect(logger.error).toHaveBeenCalledWith({ event: "WALLET_ABUSE_LOCK_CLEAR_FAILED", walletId: wallet.id, userId: wallet.userId, error });
     });
 
     it("attaches payment context to the balance_top_up analytics event", async () => {
@@ -155,6 +171,8 @@ describe(RefillService.name, () => {
       const balancesService = mock<BalancesService>();
       const walletInitializerService = mock<WalletInitializerService>();
       const analyticsService = mock<AnalyticsService>();
+      const logger = mock<ReturnType<CreateLogger>>();
+      const createLogger = vi.fn<CreateLogger>(() => logger);
 
       billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT = 1000;
 
@@ -165,7 +183,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        createLogger
       );
 
       return {
@@ -176,7 +195,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        logger
       };
     }
   });
@@ -277,6 +297,8 @@ describe(RefillService.name, () => {
       const balancesService = mock<BalancesService>();
       const walletInitializerService = mock<WalletInitializerService>();
       const analyticsService = mock<AnalyticsService>();
+      const logger = mock<ReturnType<CreateLogger>>();
+      const createLogger = vi.fn<CreateLogger>(() => logger);
 
       billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT = 1000;
 
@@ -287,7 +309,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        createLogger
       );
 
       return {
@@ -298,7 +321,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        logger
       };
     }
   });

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -38,19 +38,17 @@ describe(RefillService.name, () => {
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up", expect.objectContaining({ amount_cents: amountUsd, amount_usd: 1 }));
     });
 
-    it("clears the abuse lock of a wallet that pays and leaves an unlocked wallet alone", async () => {
+    it("asks to clear the abuse lock on every payment, so a lock applied after the wallet was read is still cleared", async () => {
       const { service, userWalletRepository, walletInitializerService, balancesService } = setup();
-      const lockedWallet = createInitializedUserWallet({ userId, abuseLockedAt: new Date(), abuseLockedReason: "workload_abuse" });
-      walletInitializerService.ensureWallet.mockResolvedValue(lockedWallet);
+      const unlockedWallet = createInitializedUserWallet({ userId, abuseLockedAt: null, abuseLockedReason: null });
+      walletInitializerService.ensureWallet.mockResolvedValue(unlockedWallet);
       userWalletRepository.claimActivation.mockResolvedValue(undefined);
       balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+      userWalletRepository.clearAbuseLock.mockResolvedValue(true);
 
       await service.topUpWallet(amountUsd, userId);
-      walletInitializerService.ensureWallet.mockResolvedValue(createInitializedUserWallet({ userId }));
-      await service.topUpWallet(amountUsd, userId);
 
-      expect(userWalletRepository.clearAbuseLock).toHaveBeenCalledTimes(1);
-      expect(userWalletRepository.clearAbuseLock).toHaveBeenCalledWith(lockedWallet.id);
+      expect(userWalletRepository.clearAbuseLock).toHaveBeenCalledWith(unlockedWallet.id);
     });
 
     it("attaches payment context to the balance_top_up analytics event", async () => {

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -1,6 +1,5 @@
-import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { PromisePool } from "@supercharge/promise-pool";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { type StripeTransactionType, type UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
@@ -8,6 +7,7 @@ import { BalancesService } from "@src/billing/services/balances/balances.service
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
 import { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
 
 export interface PaymentAnalyticsContext {
@@ -28,7 +28,7 @@ export interface ToppedUpWallet {
 
 @singleton()
 export class RefillService {
-  private readonly logger = createOtelLogger({ context: RefillService.name });
+  private readonly logger: ReturnType<CreateLogger>;
 
   constructor(
     @InjectBillingConfig() private readonly config: BillingConfig,
@@ -37,8 +37,11 @@ export class RefillService {
     private readonly managedSignerService: ManagedSignerService,
     private readonly balancesService: BalancesService,
     private readonly walletInitializerService: WalletInitializerService,
-    private readonly analyticsService: AnalyticsService
-  ) {}
+    private readonly analyticsService: AnalyticsService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: RefillService.name });
+  }
 
   async refillAllFees() {
     const wallets = await this.userWalletRepository.findDrainingWallets({

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -138,11 +138,15 @@ export class RefillService {
     this.logger.info({ event: "WALLET_BALANCE_REDUCED", userId, amountUsd, previousLimit: currentLimit, nextLimit });
   }
 
-  /** A wallet locked as an abusive trial becomes an ordinary paying wallet the moment it pays, so fee refills and credit alerts resume for it. */
+  /** A failed clear is logged instead of thrown: authorizeSpending has already raised the on-chain allowance, so rolling the settlement back would let a webhook retry credit the same charge twice. */
   private async clearAbuseLockOnPayment(userWallet: UserWalletOutput) {
-    if (!(await this.userWalletRepository.clearAbuseLock(userWallet.id))) return;
+    try {
+      if (!(await this.userWalletRepository.clearAbuseLock(userWallet.id))) return;
 
-    this.logger.info({ event: "WALLET_ABUSE_LOCK_CLEARED", walletId: userWallet.id, userId: userWallet.userId });
+      this.logger.info({ event: "WALLET_ABUSE_LOCK_CLEARED", walletId: userWallet.id, userId: userWallet.userId });
+    } catch (error) {
+      this.logger.error({ event: "WALLET_ABUSE_LOCK_CLEAR_FAILED", walletId: userWallet.id, userId: userWallet.userId, error });
+    }
   }
 
   /**

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -85,6 +85,7 @@ export class RefillService {
     });
 
     await this.balancesService.refreshUserWalletLimits(userWallet, { endTrial: options.endTrial ?? true });
+    await this.clearAbuseLockOnPayment(userWallet);
 
     this.analyticsService.track(userId, "balance_top_up", {
       amount_cents: amountUsd,
@@ -142,6 +143,14 @@ export class RefillService {
    * funding with real money must activate a wallet even when the user never started a trial.
    * The activation claim no-ops for already-activated wallets.
    */
+  /** A wallet locked as an abusive trial becomes an ordinary paying wallet the moment it pays, so fee refills and credit alerts resume for it. */
+  private async clearAbuseLockOnPayment(userWallet: UserWalletOutput) {
+    if (!userWallet.abuseLockedAt) return;
+
+    await this.userWalletRepository.clearAbuseLock(userWallet.id);
+    this.logger.info({ event: "WALLET_ABUSE_LOCK_CLEARED", walletId: userWallet.id, userId: userWallet.userId, reason: userWallet.abuseLockedReason });
+  }
+
   private async ensureActivatedWallet(userId: UserWalletOutput["userId"]) {
     const userWallet = await this.walletInitializerService.ensureWallet(userId);
 

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -138,19 +138,18 @@ export class RefillService {
     this.logger.info({ event: "WALLET_BALANCE_REDUCED", userId, amountUsd, previousLimit: currentLimit, nextLimit });
   }
 
+  /** A wallet locked as an abusive trial becomes an ordinary paying wallet the moment it pays, so fee refills and credit alerts resume for it. */
+  private async clearAbuseLockOnPayment(userWallet: UserWalletOutput) {
+    if (!(await this.userWalletRepository.clearAbuseLock(userWallet.id))) return;
+
+    this.logger.info({ event: "WALLET_ABUSE_LOCK_CLEARED", walletId: userWallet.id, userId: userWallet.userId });
+  }
+
   /**
    * Returns the user's wallet, creating and activating it as needed —
    * funding with real money must activate a wallet even when the user never started a trial.
    * The activation claim no-ops for already-activated wallets.
    */
-  /** A wallet locked as an abusive trial becomes an ordinary paying wallet the moment it pays, so fee refills and credit alerts resume for it. */
-  private async clearAbuseLockOnPayment(userWallet: UserWalletOutput) {
-    if (!userWallet.abuseLockedAt) return;
-
-    await this.userWalletRepository.clearAbuseLock(userWallet.id);
-    this.logger.info({ event: "WALLET_ABUSE_LOCK_CLEARED", walletId: userWallet.id, userId: userWallet.userId, reason: userWallet.abuseLockedReason });
-  }
-
   private async ensureActivatedWallet(userId: UserWalletOutput["userId"]) {
     const userWallet = await this.walletInitializerService.ensureWallet(userId);
 

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -88,6 +88,15 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(notificationService.createNotification).toHaveBeenCalled();
   });
 
+  it("does not send when the wallet has been locked for abuse", async () => {
+    const { handler, notificationService, logger, job } = setup({ abuseLockedAt: new Date("2026-09-06T14:00:00.000Z") });
+
+    await handler.handle(job);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_CHECK_SKIPPED", reason: "abuse_locked" }));
+  });
+
   it("does not send when the wallet is trialing", async () => {
     const { handler, notificationService, userWalletRepository, logger, job } = setup({
       isTrialing: true
@@ -402,6 +411,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     autoReloadPausedAt?: Date;
     walletSettingNotFound?: boolean;
     isTrialing?: boolean;
+    abuseLockedAt?: Date | null;
     creditsLowNotifiedAt?: Date | null;
     creditsSufficientSince?: Date | null;
     creditsLowSince?: Date | null;
@@ -418,6 +428,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     const wallet = createUserWallet({
       userId: user.id,
       isTrialing: input?.isTrialing ?? false,
+      abuseLockedAt: input?.abuseLockedAt ?? null,
       creditsLowNotifiedAt: input?.creditsLowNotifiedAt ?? null,
       creditsSufficientSince: input?.creditsSufficientSince ?? null,
       creditsLowSince: input?.creditsLowSince === undefined ? new Date("2026-01-01T00:00:00.000Z") : input.creditsLowSince

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -11,7 +11,16 @@ import { NotificationService } from "@src/notifications/services/notification/no
 import { creditsRunningLowNotification } from "@src/notifications/services/notification-templates/credits-running-low-notification";
 import { type UserOutput, UserRepository } from "@src/user/repositories";
 
-type SkipReason = "auto_reload_enabled" | "no_wallet" | "trialing" | "no_email" | "zero_cost" | "sufficient_balance" | "already_notified" | "low_unconfirmed";
+type SkipReason =
+  | "auto_reload_enabled"
+  | "no_wallet"
+  | "trialing"
+  | "abuse_locked"
+  | "no_email"
+  | "zero_cost"
+  | "sufficient_balance"
+  | "already_notified"
+  | "low_unconfirmed";
 
 type NotLowReason = Extract<SkipReason, "zero_cost" | "sufficient_balance">;
 
@@ -144,6 +153,11 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
 
     if (wallet.isTrialing) {
       this.#skip("trialing", userId);
+      return;
+    }
+
+    if (wallet.abuseLockedAt) {
+      this.#skip("abuse_locked", userId);
       return;
     }
 

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -814,6 +814,18 @@ describe(DeploymentSettingRepository.name, () => {
       expect(ofTrialUser).toEqual([{ userId: trialUser.id, dseq: liveDseq, walletId: trialWallet.walletId, createdAt: expect.any(Date) }]);
       expect(deployments.some(deployment => deployment.userId !== trialUser.id && deployment.walletId === undefined)).toBe(false);
     });
+
+    it("leaves the deployments of a wallet locked for abuse out of the sweep", async () => {
+      const { deploymentSettingRepository, trialUser, trialWallet, db, deploymentSettingsTable, userWalletsTable } = await setup();
+      await db
+        .insert(deploymentSettingsTable)
+        .values({ userId: trialUser.id, dseq: faker.number.int({ min: 100000, max: 999999 }).toString(), autoTopUpEnabled: true });
+      await db.update(userWalletsTable).set({ abuseLockedAt: new Date() }).where(eq(userWalletsTable.id, trialWallet.walletId));
+
+      const deployments = await deploymentSettingRepository.findLiveTrialDeployments({ maxAgeHours: 26 });
+
+      expect(deployments.some(deployment => deployment.userId === trialUser.id)).toBe(false);
+    });
   });
 
   describe("replaceDefinitionIfVersionMatches", () => {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -202,6 +202,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
           eq(this.table.closed, false),
           eq(UserWallets.isTrialing, true),
           isNotNull(UserWallets.address),
+          isNull(UserWallets.abuseLockedAt),
           gt(this.table.createdAt, sql`(now() at time zone 'utc') - make_interval(hours => ${sql.raw(String(hours))})`)
         )
       )

--- a/apps/api/src/workload-abuse/config/env.config.ts
+++ b/apps/api/src/workload-abuse/config/env.config.ts
@@ -69,6 +69,8 @@ export const envSchema = z.object({
     .default("false")
     .transform(value => value === "true"),
   WORKLOAD_ABUSE_SIGNATURES: z.string().default("{}").transform(compileSignatures),
+  /** `detect` records hard verdicts without acting on them, so a rollout can be compared against manual review first. */
+  WORKLOAD_ABUSE_ENFORCEMENT_MODE: z.enum(["detect", "enforce"]).default("detect"),
   WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: z.string().default("5,20,60").transform(parseMinutesList),
   WORKLOAD_ABUSE_PROBE_INTERVAL_MIN: z.number({ coerce: true }).int().positive().default(60),
   WORKLOAD_ABUSE_PROBE_JITTER_MIN: z.number({ coerce: true }).int().nonnegative().default(10),

--- a/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.integration.ts
+++ b/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.integration.ts
@@ -21,13 +21,35 @@ describe(WorkloadAbuseDetectionRepository.name, () => {
     });
   });
 
+  describe("markWalletEnforced", () => {
+    it("settles every confirmed detection of the wallet and leaves the rest alone", async () => {
+      const { repository, walletId, createDetection } = await setup();
+      const { walletId: otherWalletId, createDetection: createOtherDetection } = await setup();
+      const detected = await createDetection({ dseq: "1", verdict: "hard" });
+      const failed = await createDetection({ dseq: "2", verdict: "hard", action: "enforcement_failed" });
+      const soft = await createDetection({ dseq: "3", verdict: "soft" });
+      const other = await createOtherDetection({ dseq: "4", verdict: "hard" });
+
+      await repository.markWalletEnforced(walletId);
+
+      const actions = await Promise.all([detected, failed, soft, other].map(async detection => (await repository.findById(detection.id))?.action));
+      expect(actions).toEqual(["enforced", "enforced", "detected", "detected"]);
+      expect(otherWalletId).not.toBe(walletId);
+    });
+  });
+
   async function setup() {
     const userRepository = container.resolve(UserRepository);
     const repository = container.resolve(WorkloadAbuseDetectionRepository);
     const user = await userRepository.create({ userId: faker.string.uuid() });
     const walletId = faker.number.int({ min: 1, max: 1_000_000_000 });
 
-    async function createDetection(input: { dseq: string; verdict: "hard" | "soft" | "proxy"; createdAt?: Date }) {
+    async function createDetection(input: {
+      dseq: string;
+      verdict: "hard" | "soft" | "proxy";
+      action?: "detected" | "enforcing" | "enforced" | "enforcement_failed";
+      createdAt?: Date;
+    }) {
       return repository.create({
         userId: user.id,
         walletId,
@@ -37,6 +59,7 @@ describe(WorkloadAbuseDetectionRepository.name, () => {
         probeStatus: "probed",
         signals: [],
         evidenceExcerpt: "",
+        action: input.action,
         createdAt: input.createdAt
       });
     }

--- a/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.ts
+++ b/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt } from "drizzle-orm";
+import { and, eq, gt, ne } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -28,5 +28,13 @@ export class WorkloadAbuseDetectionRepository extends BaseRepository<Table, Work
       .selectDistinct({ walletId: this.table.walletId, dseq: this.table.dseq })
       .from(this.table)
       .where(and(eq(this.table.verdict, "hard"), gt(this.table.createdAt, since)));
+  }
+
+  /** A locked wallet settles every confirmed detection it has, including the ones whose own enforcement job never ran or failed. */
+  async markWalletEnforced(walletId: number): Promise<void> {
+    await this.cursor
+      .update(this.table)
+      .set({ action: "enforced", enforcementError: null, updatedAt: new Date() })
+      .where(and(eq(this.table.walletId, walletId), eq(this.table.verdict, "hard"), ne(this.table.action, "enforced")));
   }
 }

--- a/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.integration.ts
+++ b/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.integration.ts
@@ -1,0 +1,157 @@
+import { AuthzHttpService, LeaseHttpService, type RpcLease } from "@akashnetwork/http-sdk";
+import { addHours } from "date-fns";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
+import { JOB_NAME } from "@src/core";
+import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { ProbeTrialDeploymentHandler } from "@src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler";
+import { ABUSE_LOCK_REASON } from "@src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service";
+import { ProbeTrialDeployment, probeTrialDeploymentKeyFor } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
+import { EnforceTrialAbuse, EnforceTrialAbuseHandler, enforceTrialAbuseKeyFor } from "./enforce-trial-abuse.handler";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(EnforceTrialAbuseHandler), container.resolve(ProbeTrialDeploymentHandler)]);
+
+describe(EnforceTrialAbuseHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("wipes a trial wallet the way a worker runs it: revokes both grants, closes its deployments, locks the wallet and cancels its probes", async () => {
+    const { wallet, detection, close, executeFundingTx, enqueueEnforcement, startWorkers, findWallet, findDetection, findProbeJob } = await setup({
+      liveDseqs: ["11"]
+    });
+
+    await enqueueEnforcement(detection.id);
+    await startWorkers();
+
+    await expectJobCompleted(EnforceTrialAbuse[JOB_NAME], { singletonKey: enforceTrialAbuseKeyFor(wallet.id) });
+    expect(await findWallet()).toMatchObject({ deploymentAllowance: 0, feeAllowance: 0, isTrialing: false, abuseLockedReason: ABUSE_LOCK_REASON });
+    expect((await findWallet())?.abuseLockedAt).toBeInstanceOf(Date);
+    expect((await findDetection(detection.id))?.action).toBe("enforced");
+    expect((await findProbeJob("11"))?.state).toBe("cancelled");
+    expect(close).toHaveBeenCalledWith(expect.objectContaining({ id: wallet.id }), "11");
+    expect(executeFundingTx).toHaveBeenCalledTimes(2);
+  });
+
+  it("settles every confirmed detection of the wallet, not only the one that triggered the wipe", async () => {
+    const { handler, wallet, detection, createDetection, findDetection } = await setup({ liveDseqs: ["11", "22"] });
+    const otherDetection = await createDetection("22");
+
+    await handler.handle({ walletId: wallet.id, detectionId: detection.id, version: 1 });
+
+    expect((await findDetection(detection.id))?.action).toBe("enforced");
+    expect((await findDetection(otherDetection.id))?.action).toBe("enforced");
+  });
+
+  it("settles the detection without touching the chain when the wallet is already locked", async () => {
+    const { handler, wallet, detection, close, executeFundingTx, findWallet, findDetection } = await setup({ abuseLockedAt: new Date() });
+
+    await handler.handle({ walletId: wallet.id, detectionId: detection.id, version: 1 });
+
+    expect((await findDetection(detection.id))?.action).toBe("enforced");
+    expect((await findWallet())?.deploymentAllowance).toBe(10_000_000);
+    expect(close).not.toHaveBeenCalled();
+    expect(executeFundingTx).not.toHaveBeenCalled();
+  });
+
+  it("leaves a wallet that has since paid alone", async () => {
+    const { handler, wallet, detection, close, executeFundingTx, findWallet, findDetection } = await setup({ isTrialing: false });
+
+    await handler.handle({ walletId: wallet.id, detectionId: detection.id, version: 1 });
+
+    expect((await findDetection(detection.id))?.action).toBe("detected");
+    expect(await findWallet()).toMatchObject({ abuseLockedAt: null, deploymentAllowance: 10_000_000, isTrialing: false });
+    expect(close).not.toHaveBeenCalled();
+    expect(executeFundingTx).not.toHaveBeenCalled();
+  });
+
+  it("records the failure on the detection and keeps the wallet unlocked and monitored when a revoke fails", async () => {
+    const { handler, wallet, detection, findWallet, findDetection, findProbeJob } = await setup({
+      liveDseqs: ["11"],
+      revokeError: new Error("account sequence mismatch")
+    });
+
+    await expect(handler.handle({ walletId: wallet.id, detectionId: detection.id, version: 1 })).rejects.toThrow("account sequence mismatch");
+
+    expect(await findDetection(detection.id)).toMatchObject({ action: "enforcement_failed", enforcementError: "account sequence mismatch" });
+    expect(await findWallet()).toMatchObject({ abuseLockedAt: null, isTrialing: true });
+    expect((await findProbeJob("11"))?.state).toBe("created");
+  });
+
+  async function setup(input: { isTrialing?: boolean; abuseLockedAt?: Date; liveDseqs?: string[]; revokeError?: Error } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const userWalletRepository = container.resolve(UserWalletRepository);
+    const detectionRepository = container.resolve(WorkloadAbuseDetectionRepository);
+    const liveDseqs = input.liveDseqs ?? [];
+
+    const { user, wallet } = await seedUserWithWallet({
+      isTrialing: input.isTrialing ?? true,
+      abuseLockedAt: input.abuseLockedAt ?? null,
+      abuseLockedReason: input.abuseLockedAt ? ABUSE_LOCK_REASON : null
+    });
+
+    async function createDetection(dseq: string) {
+      return await detectionRepository.create({
+        userId: user.id,
+        walletId: wallet.id,
+        dseq,
+        provider: createAkashAddress(),
+        verdict: "hard",
+        probeStatus: "probed",
+        signals: [],
+        evidenceExcerpt: "",
+        action: "detected"
+      });
+    }
+
+    const detection = await createDetection(liveDseqs[0] ?? "11");
+
+    for (const dseq of liveDseqs) {
+      await enqueue(new ProbeTrialDeployment({ walletId: wallet.id, dseq, attempt: 1, leaseCreatedAt: new Date().toISOString() }), {
+        singletonKey: probeTrialDeploymentKeyFor({ walletId: wallet.id, dseq }),
+        startAfter: addHours(new Date(), 1)
+      });
+    }
+
+    vi.spyOn(container.resolve(TxManagerService), "getFundingWalletAddress").mockResolvedValue(createAkashAddress());
+    vi.spyOn(container.resolve(AuthzHttpService), "hasDepositDeploymentGrant").mockResolvedValue(true);
+    vi.spyOn(container.resolve(AuthzHttpService), "hasFeeAllowance").mockResolvedValue(true);
+    vi.spyOn(container.resolve(LeaseHttpService), "list").mockImplementation(async ({ state }) => ({
+      leases: state === "active" ? liveDseqs.map(dseq => mock<RpcLease>({ lease: { id: { dseq } } })) : [],
+      pagination: { next_key: null, total: "0" }
+    }));
+    const executeFundingTx = vi.spyOn(container.resolve(ManagedSignerService), "executeFundingTx");
+    if (input.revokeError) executeFundingTx.mockRejectedValue(input.revokeError);
+    else executeFundingTx.mockResolvedValue(mock<Awaited<ReturnType<ManagedSignerService["executeFundingTx"]>>>());
+    const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(true);
+
+    return {
+      handler: container.resolve(EnforceTrialAbuseHandler),
+      wallet,
+      detection,
+      close,
+      executeFundingTx,
+      createDetection,
+      startWorkers,
+      enqueueEnforcement: (detectionId: string) =>
+        enqueue(new EnforceTrialAbuse({ walletId: wallet.id, detectionId }), { singletonKey: enforceTrialAbuseKeyFor(wallet.id) }),
+      findWallet: () => userWalletRepository.findById(wallet.id),
+      findDetection: (id: string) => detectionRepository.findById(id),
+      findProbeJob: async (dseq: string) => {
+        const [row] = await findJobRows(ProbeTrialDeployment[JOB_NAME], { singletonKey: probeTrialDeploymentKeyFor({ walletId: wallet.id, dseq }) });
+
+        return row;
+      }
+    };
+  }
+});

--- a/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.spec.ts
+++ b/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { CreateLogger } from "@src/core";
+import type { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import type { TrialAbuseEnforcementService } from "@src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service";
+import type { WorkloadAbuseInstrumentationService } from "@src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service";
+import { EnforceTrialAbuseHandler, enforceTrialAbuseKeyFor } from "./enforce-trial-abuse.handler";
+
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const PAYLOAD = { walletId: 42, detectionId: "detection-1", version: 1 as const };
+
+describe(EnforceTrialAbuseHandler.name, () => {
+  it("keys the wipe by wallet", () => {
+    expect(enforceTrialAbuseKeyFor(7)).toBe("enforceTrialAbuse.7");
+  });
+
+  it("wipes a trial wallet that is not locked yet", async () => {
+    const { handler, wallet, enforcementService } = setup({ wallet: createUserWallet({ isTrialing: true }) });
+
+    await handler.handle(PAYLOAD);
+
+    expect(enforcementService.enforce).toHaveBeenCalledWith({ wallet, detectionId: PAYLOAD.detectionId });
+  });
+
+  it("marks the detection enforced without acting again when the wallet is already locked", async () => {
+    const { handler, enforcementService, detectionRepository, instrumentation } = setup({
+      wallet: createUserWallet({ isTrialing: false, abuseLockedAt: new Date() })
+    });
+
+    await handler.handle(PAYLOAD);
+
+    expect(enforcementService.enforce).not.toHaveBeenCalled();
+    expect(detectionRepository.updateById).toHaveBeenCalledWith(PAYLOAD.detectionId, { action: "enforced", updatedAt: expect.any(Date) });
+    expect(instrumentation.recordEnforcement).toHaveBeenCalledWith("skipped");
+  });
+
+  it("leaves a wallet that has since paid alone", async () => {
+    const { handler, enforcementService, logger } = setup({ wallet: createUserWallet({ isTrialing: false }) });
+
+    await handler.handle(PAYLOAD);
+
+    expect(enforcementService.enforce).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_SKIPPED", reason: "NOT_TRIALING" }));
+  });
+
+  it("skips a wallet it cannot find", async () => {
+    const { handler, enforcementService, logger } = setup({ wallet: null });
+
+    await handler.handle(PAYLOAD);
+
+    expect(enforcementService.enforce).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ reason: "WALLET_NOT_FOUND" }));
+  });
+
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup({ wallet: null });
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
+  function setup(input: { wallet: ReturnType<typeof createUserWallet> | null }) {
+    const userWalletRepository = mock<UserWalletRepository>();
+    userWalletRepository.findById.mockResolvedValue(input.wallet ?? undefined);
+    const detectionRepository = mock<WorkloadAbuseDetectionRepository>();
+    const enforcementService = mock<TrialAbuseEnforcementService>();
+    const instrumentation = mock<WorkloadAbuseInstrumentationService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const handler = new EnforceTrialAbuseHandler(userWalletRepository, detectionRepository, enforcementService, instrumentation, createLogger);
+
+    return { handler, wallet: input.wallet!, userWalletRepository, detectionRepository, enforcementService, instrumentation, logger };
+  }
+});

--- a/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.spec.ts
+++ b/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.spec.ts
@@ -25,7 +25,7 @@ describe(EnforceTrialAbuseHandler.name, () => {
     expect(enforcementService.enforce).toHaveBeenCalledWith({ wallet, detectionId: PAYLOAD.detectionId });
   });
 
-  it("marks the detection enforced without acting again when the wallet is already locked", async () => {
+  it("settles the wallet's detections without acting again when the wallet is already locked", async () => {
     const { handler, enforcementService, detectionRepository, instrumentation } = setup({
       wallet: createUserWallet({ isTrialing: false, abuseLockedAt: new Date() })
     });
@@ -33,7 +33,7 @@ describe(EnforceTrialAbuseHandler.name, () => {
     await handler.handle(PAYLOAD);
 
     expect(enforcementService.enforce).not.toHaveBeenCalled();
-    expect(detectionRepository.updateById).toHaveBeenCalledWith(PAYLOAD.detectionId, { action: "enforced", updatedAt: expect.any(Date) });
+    expect(detectionRepository.markWalletEnforced).toHaveBeenCalledWith(PAYLOAD.walletId);
     expect(instrumentation.recordEnforcement).toHaveBeenCalledWith("skipped");
   });
 

--- a/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.ts
+++ b/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.ts
@@ -1,0 +1,78 @@
+import { inject, singleton } from "tsyringe";
+
+import { isWalletInitialized, UserWalletRepository } from "@src/billing/repositories";
+import { type CreateLogger, type Job, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, LOGGER_FACTORY } from "@src/core";
+import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { TrialAbuseEnforcementService } from "@src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service";
+import { WorkloadAbuseInstrumentationService } from "@src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service";
+
+export class EnforceTrialAbuse implements Job {
+  static readonly [JOB_NAME] = "EnforceTrialAbuse";
+  readonly name = EnforceTrialAbuse[JOB_NAME];
+  readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      walletId: number;
+      detectionId: string;
+    }
+  ) {}
+}
+
+/** Keyed by wallet, because the wipe covers every deployment the wallet owns whichever detection triggered it. */
+export function enforceTrialAbuseKeyFor(walletId: number): string {
+  return `enforceTrialAbuse.${walletId}`;
+}
+
+/** Re-reads the wallet so a wipe that already landed, or a user who paid in the meantime, is not wiped twice or at all. */
+@singleton()
+export class EnforceTrialAbuseHandler implements JobHandler<EnforceTrialAbuse> {
+  public readonly accepts = EnforceTrialAbuse;
+
+  public readonly concurrency = 1;
+
+  public readonly policy = "stately";
+
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly detectionRepository: WorkloadAbuseDetectionRepository,
+    private readonly enforcementService: TrialAbuseEnforcementService,
+    private readonly instrumentation: WorkloadAbuseInstrumentationService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: EnforceTrialAbuseHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
+  }
+
+  async handle(payload: JobPayload<EnforceTrialAbuse>): Promise<void> {
+    const { walletId, detectionId } = payload;
+    const context = { job: EnforceTrialAbuse[JOB_NAME], walletId, detectionId };
+    const wallet = await this.userWalletRepository.findById(walletId);
+
+    if (!wallet || !isWalletInitialized(wallet)) {
+      this.logger.warn({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_SKIPPED", reason: "WALLET_NOT_FOUND", ...context });
+      this.instrumentation.recordEnforcement("skipped");
+      return;
+    }
+
+    if (wallet.abuseLockedAt) {
+      this.logger.info({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_SKIPPED", reason: "ALREADY_LOCKED", ...context, userId: wallet.userId });
+      await this.detectionRepository.updateById(detectionId, { action: "enforced", updatedAt: new Date() });
+      this.instrumentation.recordEnforcement("skipped");
+      return;
+    }
+
+    if (!wallet.isTrialing) {
+      this.logger.info({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_SKIPPED", reason: "NOT_TRIALING", ...context, userId: wallet.userId });
+      this.instrumentation.recordEnforcement("skipped");
+      return;
+    }
+
+    await this.enforcementService.enforce({ wallet, detectionId });
+  }
+}

--- a/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.ts
+++ b/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.ts
@@ -62,7 +62,7 @@ export class EnforceTrialAbuseHandler implements JobHandler<EnforceTrialAbuse> {
 
     if (wallet.abuseLockedAt) {
       this.logger.info({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_SKIPPED", reason: "ALREADY_LOCKED", ...context, userId: wallet.userId });
-      await this.detectionRepository.updateById(detectionId, { action: "enforced", updatedAt: new Date() });
+      await this.detectionRepository.markWalletEnforced(walletId);
       this.instrumentation.recordEnforcement("skipped");
       return;
     }

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
@@ -165,6 +165,17 @@ describe(ProbeTrialDeploymentHandler.name, () => {
     expect(handler.requiresPermission()).toEqual([]);
   });
 
+  it("re-queues the wipe for an already confirmed deployment instead of probing it again", async () => {
+    const { handler, wallet, probeService, jobQueueService } = setup({ existingDetection: true, enforcementMode: "enforce" });
+
+    await handler.handle(PAYLOAD);
+
+    expect(probeService.probe).not.toHaveBeenCalled();
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(new EnforceTrialAbuse({ walletId: wallet.id, detectionId: "detection-0" }), {
+      singletonKey: `enforceTrialAbuse.${wallet.id}`
+    });
+  });
+
   function setup(input: {
     enabled?: boolean;
     wallet?: ReturnType<typeof createUserWallet> | null;

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
@@ -2,11 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
-import type { CreateLogger } from "@src/core";
+import type { CreateLogger, JobQueueService } from "@src/core";
 import type {
   WorkloadAbuseDetectionOutput,
   WorkloadAbuseDetectionRepository
 } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { EnforceTrialAbuse } from "@src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler";
 import type { ProbeReport, TrialWorkloadProbeService } from "@src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service";
 import type { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
 import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
@@ -90,6 +91,33 @@ describe(ProbeTrialDeploymentHandler.name, () => {
     expect(probeJobService.scheduleNext).not.toHaveBeenCalled();
   });
 
+  it("skips a wallet that has already been locked for abuse", async () => {
+    const { handler, probeService } = setup({ wallet: createUserWallet({ isTrialing: true, abuseLockedAt: new Date() }) });
+
+    await handler.handle(PAYLOAD);
+
+    expect(probeService.probe).not.toHaveBeenCalled();
+  });
+
+  it("only records confirmed mining while enforcement is in detect mode", async () => {
+    const { handler, jobQueueService, logger } = setup({ report: createReport({ verdict: "hard" }), enforcementMode: "detect" });
+
+    await handler.handle(PAYLOAD);
+
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_DEFERRED", detectionId: "detection-1" }));
+  });
+
+  it("queues the wallet wipe for confirmed mining in enforce mode", async () => {
+    const { handler, wallet, jobQueueService } = setup({ report: createReport({ verdict: "hard" }), enforcementMode: "enforce" });
+
+    await handler.handle(PAYLOAD);
+
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(new EnforceTrialAbuse({ walletId: wallet.id, detectionId: "detection-1" }), {
+      singletonKey: `enforceTrialAbuse.${wallet.id}`
+    });
+  });
+
   it("stops after the last allowed attempt", async () => {
     const { handler, probeJobService } = setup({ report: createReport({ verdict: "clean" }), maxAttempts: 2 });
 
@@ -143,6 +171,7 @@ describe(ProbeTrialDeploymentHandler.name, () => {
     report?: ProbeReport;
     maxAttempts?: number;
     existingDetection?: boolean;
+    enforcementMode?: "detect" | "enforce";
   }) {
     const wallet = input.wallet === undefined ? createUserWallet({ isTrialing: true }) : input.wallet;
     const userWalletRepository = mock<UserWalletRepository>();
@@ -156,8 +185,10 @@ describe(ProbeTrialDeploymentHandler.name, () => {
     const instrumentation = mock<WorkloadAbuseInstrumentationService>();
     const config = mockConfigService<WorkloadAbuseConfigService>({
       WORKLOAD_ABUSE_PROBE_ENABLED: input.enabled ?? true,
-      WORKLOAD_ABUSE_PROBE_MAX_PER_DEPLOYMENT: input.maxAttempts ?? 30
+      WORKLOAD_ABUSE_PROBE_MAX_PER_DEPLOYMENT: input.maxAttempts ?? 30,
+      WORKLOAD_ABUSE_ENFORCEMENT_MODE: input.enforcementMode ?? "detect"
     });
+    const jobQueueService = mock<JobQueueService>();
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);
 
@@ -168,9 +199,10 @@ describe(ProbeTrialDeploymentHandler.name, () => {
       detectionRepository,
       instrumentation,
       config,
+      jobQueueService,
       createLogger
     );
 
-    return { handler, wallet: wallet!, userWalletRepository, probeService, probeJobService, detectionRepository, instrumentation, logger };
+    return { handler, wallet: wallet!, userWalletRepository, probeService, probeJobService, detectionRepository, instrumentation, jobQueueService, logger };
   }
 });

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
@@ -1,8 +1,9 @@
 import { inject, singleton } from "tsyringe";
 
 import { isWalletInitialized, UserWalletRepository } from "@src/billing/repositories";
-import { type CreateLogger, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { EnforceTrialAbuse, enforceTrialAbuseKeyFor } from "@src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler";
 import { type ProbeReport, TrialWorkloadProbeService } from "@src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service";
 import { ProbeTrialDeployment, TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
 import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
@@ -27,6 +28,7 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
     private readonly detectionRepository: WorkloadAbuseDetectionRepository,
     private readonly instrumentation: WorkloadAbuseInstrumentationService,
     private readonly config: WorkloadAbuseConfigService,
+    private readonly jobQueueService: JobQueueService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: ProbeTrialDeploymentHandler.name });
@@ -57,6 +59,11 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
       return;
     }
 
+    if (wallet.abuseLockedAt) {
+      this.logger.debug({ event: "TRIAL_WORKLOAD_PROBE_SKIPPED", reason: "ABUSE_LOCKED", ...context, userId: wallet.userId });
+      return;
+    }
+
     const existingDetection = await this.detectionRepository.findOneBy({ walletId, dseq, verdict: "hard" });
 
     if (existingDetection) {
@@ -67,6 +74,7 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
         userId: wallet.userId,
         detectionId: existingDetection.id
       });
+      await this.#enforce(wallet, existingDetection.id, context);
       return;
     }
 
@@ -78,9 +86,7 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
       return;
     }
 
-    if (report.verdict !== "clean") {
-      await this.#recordDetection(wallet, dseq, report);
-    }
+    const detectionId = report.verdict === "clean" ? undefined : await this.#recordDetection(wallet, dseq, report);
 
     this.logger.info({
       event: "TRIAL_WORKLOAD_PROBED",
@@ -96,7 +102,10 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
       }))
     });
 
-    if (report.verdict === "hard") return;
+    if (report.verdict === "hard") {
+      if (detectionId) await this.#enforce(wallet, detectionId, context);
+      return;
+    }
 
     if (attempt >= this.config.get("WORKLOAD_ABUSE_PROBE_MAX_PER_DEPLOYMENT")) {
       this.logger.info({ event: "TRIAL_WORKLOAD_PROBE_FINISHED", reason: "MAX_ATTEMPTS", ...context, userId: wallet.userId });
@@ -106,7 +115,7 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
     await this.probeJobService.scheduleNext(payload);
   }
 
-  async #recordDetection(wallet: { id: number; userId: string; address: string }, dseq: string, report: ProbeReport): Promise<void> {
+  async #recordDetection(wallet: { id: number; userId: string; address: string }, dseq: string, report: ProbeReport): Promise<string> {
     const detection = await this.detectionRepository.create({
       userId: wallet.userId,
       walletId: wallet.id,
@@ -129,5 +138,17 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
       verdict: report.verdict,
       signals: report.signals.map(signal => ({ bucket: signal.bucket, category: signal.category, source: signal.source, service: signal.service }))
     });
+
+    return detection.id;
+  }
+
+  /** Detect mode records the verdict and stops there, so a rollout can be compared against manual review before anything is wiped. */
+  async #enforce(wallet: { id: number; userId: string }, detectionId: string, context: Record<string, unknown>): Promise<void> {
+    if (this.config.get("WORKLOAD_ABUSE_ENFORCEMENT_MODE") !== "enforce") {
+      this.logger.info({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_DEFERRED", reason: "DETECT_MODE", ...context, userId: wallet.userId, detectionId });
+      return;
+    }
+
+    await this.jobQueueService.enqueue(new EnforceTrialAbuse({ walletId: wallet.id, detectionId }), { singletonKey: enforceTrialAbuseKeyFor(wallet.id) });
   }
 }

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
@@ -22,12 +22,12 @@ const REVOKE_DEPOSIT = mock<ReturnType<RpcMessageService["getRevokeDepositDeploy
 const REVOKE_FEE = mock<ReturnType<RpcMessageService["getRevokeAllowanceMsg"]>>({ typeUrl: "/cosmos.feegrant.v1beta1.MsgRevokeAllowance" });
 
 describe(TrialAbuseEnforcementService.name, () => {
-  it("revokes the deposit grant, closes every live deployment, revokes the fee grant, then locks the wallet, in that order", async () => {
+  it("revokes the deposit grant, closes every live deployment, revokes the fee grant, locks the wallet, then cancels its probes, in that order", async () => {
     const { service, wallet, calls, userWalletRepository, detectionRepository, instrumentation } = setup({ liveDseqs: ["11", "22"] });
 
     const outcome = await service.enforce({ wallet, detectionId: DETECTION_ID });
 
-    expect(calls).toEqual(["cancelProbes", "revoke:deposit", "close:11", "close:22", "revoke:fee", "lock"]);
+    expect(calls).toEqual(["revoke:deposit", "close:11", "close:22", "revoke:fee", "lock", "cancelProbes"]);
     expect(userWalletRepository.lockForAbuse).toHaveBeenCalledWith(wallet.id, ABUSE_LOCK_REASON);
     expect(outcome).toEqual({ depositGrantRevoked: true, feeGrantRevoked: true, closedDseqs: ["11", "22"] });
     expect(detectionRepository.updateById).toHaveBeenNthCalledWith(1, DETECTION_ID, {
@@ -58,7 +58,7 @@ describe(TrialAbuseEnforcementService.name, () => {
 
     expect(signerService.executeFundingTx).toHaveBeenCalledTimes(1);
     expect(signerService.executeFundingTx).toHaveBeenCalledWith([REVOKE_FEE]);
-    expect(calls).toEqual(["cancelProbes", "lock"]);
+    expect(calls).toEqual(["lock", "cancelProbes"]);
     expect(outcome).toEqual({ depositGrantRevoked: false, feeGrantRevoked: true, closedDseqs: [] });
   });
 
@@ -93,14 +93,15 @@ describe(TrialAbuseEnforcementService.name, () => {
     expect(instrumentation.recordEnforcement).toHaveBeenCalledWith("failed");
   });
 
-  it("leaves the wallet untouched and rethrows when a revoke fails for another reason", async () => {
-    const { service, wallet, signerService, userWalletRepository, deploymentWriterService } = setup({ liveDseqs: ["11"] });
+  it("leaves the wallet untouched and keeps its probes scheduled when a revoke fails for another reason", async () => {
+    const { service, wallet, signerService, userWalletRepository, deploymentWriterService, probeJobService } = setup({ liveDseqs: ["11"] });
     signerService.executeFundingTx.mockRejectedValueOnce(new Error("account sequence mismatch"));
 
     await expect(service.enforce({ wallet, detectionId: DETECTION_ID })).rejects.toThrow("account sequence mismatch");
 
     expect(deploymentWriterService.close).not.toHaveBeenCalled();
     expect(userWalletRepository.lockForAbuse).not.toHaveBeenCalled();
+    expect(probeJobService.cancelForWallet).not.toHaveBeenCalled();
   });
 
   function setup(input: { liveDseqs: string[]; hasDepositGrant?: boolean; hasFeeGrant?: boolean }) {
@@ -170,6 +171,7 @@ describe(TrialAbuseEnforcementService.name, () => {
       chainErrorService,
       userWalletRepository,
       detectionRepository,
+      probeJobService,
       instrumentation,
       logger
     };

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
@@ -35,8 +35,19 @@ describe(TrialAbuseEnforcementService.name, () => {
       enforcementError: null,
       updatedAt: expect.any(Date)
     });
-    expect(detectionRepository.updateById).toHaveBeenLastCalledWith(DETECTION_ID, { action: "enforced", updatedAt: expect.any(Date) });
+    expect(detectionRepository.markWalletEnforced).toHaveBeenCalledWith(wallet.id);
     expect(instrumentation.recordEnforcement).toHaveBeenCalledWith("enforced");
+  });
+
+  it("does not count a wipe that landed as failed when the bookkeeping after the lock throws", async () => {
+    const { service, wallet, calls, detectionRepository, instrumentation } = setup({ liveDseqs: [] });
+    detectionRepository.markWalletEnforced.mockRejectedValue(new Error("db down"));
+
+    await expect(service.enforce({ wallet, detectionId: DETECTION_ID })).rejects.toThrow("db down");
+
+    expect(calls).toContain("lock");
+    expect(detectionRepository.updateById).not.toHaveBeenCalledWith(DETECTION_ID, expect.objectContaining({ action: "enforcement_failed" }));
+    expect(instrumentation.recordEnforcement).not.toHaveBeenCalledWith("failed");
   });
 
   it("skips a revoke the chain no longer holds and tolerates one it reports as already gone", async () => {

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
@@ -1,0 +1,166 @@
+import type { AuthzHttpService, LeaseHttpService, RpcLease } from "@akashnetwork/http-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
+import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import type { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
+import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
+import type { CreateLogger } from "@src/core";
+import type { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import type { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import type { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
+import type { WorkloadAbuseInstrumentationService } from "@src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service";
+import { ABUSE_LOCK_REASON, TrialAbuseEnforcementService } from "./trial-abuse-enforcement.service";
+
+import { createInitializedUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const GRANTER = "akash1funding";
+const DETECTION_ID = "detection-1";
+const REVOKE_DEPOSIT = mock<ReturnType<RpcMessageService["getRevokeDepositDeploymentGrantMsg"]>>({ typeUrl: "/cosmos.authz.v1beta1.MsgRevoke" });
+const REVOKE_FEE = mock<ReturnType<RpcMessageService["getRevokeAllowanceMsg"]>>({ typeUrl: "/cosmos.feegrant.v1beta1.MsgRevokeAllowance" });
+
+describe(TrialAbuseEnforcementService.name, () => {
+  it("revokes the deposit grant, closes every live deployment, revokes the fee grant, then locks the wallet, in that order", async () => {
+    const { service, wallet, calls, userWalletRepository, detectionRepository, instrumentation } = setup({ liveDseqs: ["11", "22"] });
+
+    const outcome = await service.enforce({ wallet, detectionId: DETECTION_ID });
+
+    expect(calls).toEqual(["cancelProbes", "revoke:deposit", "close:11", "close:22", "revoke:fee", "lock"]);
+    expect(userWalletRepository.lockForAbuse).toHaveBeenCalledWith(wallet.id, ABUSE_LOCK_REASON);
+    expect(outcome).toEqual({ depositGrantRevoked: true, feeGrantRevoked: true, closedDseqs: ["11", "22"] });
+    expect(detectionRepository.updateById).toHaveBeenNthCalledWith(1, DETECTION_ID, {
+      action: "enforcing",
+      enforcementError: null,
+      updatedAt: expect.any(Date)
+    });
+    expect(detectionRepository.updateById).toHaveBeenLastCalledWith(DETECTION_ID, { action: "enforced", updatedAt: expect.any(Date) });
+    expect(instrumentation.recordEnforcement).toHaveBeenCalledWith("enforced");
+  });
+
+  it("skips a revoke the chain no longer holds and tolerates one it reports as already gone", async () => {
+    const { service, wallet, signerService, calls } = setup({ liveDseqs: [], hasDepositGrant: false, hasFeeGrant: true });
+    signerService.executeFundingTx.mockRejectedValueOnce(new Error("failed to execute message; message index: 0: authorization not found"));
+
+    const outcome = await service.enforce({ wallet, detectionId: DETECTION_ID });
+
+    expect(signerService.executeFundingTx).toHaveBeenCalledTimes(1);
+    expect(signerService.executeFundingTx).toHaveBeenCalledWith([REVOKE_FEE]);
+    expect(calls).toEqual(["cancelProbes", "lock"]);
+    expect(outcome).toEqual({ depositGrantRevoked: false, feeGrantRevoked: true, closedDseqs: [] });
+  });
+
+  it("closes each live deployment once even when several leases share it", async () => {
+    const { service, wallet, deploymentWriterService } = setup({ liveDseqs: ["11", "11"] });
+
+    await service.enforce({ wallet, detectionId: DETECTION_ID });
+
+    expect(deploymentWriterService.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the other deployments, then fails the run when an escrow cannot settle yet, so the queue retries", async () => {
+    const { service, wallet, deploymentWriterService, chainErrorService, userWalletRepository, detectionRepository, instrumentation } = setup({
+      liveDseqs: ["11", "22"]
+    });
+    const unsettleable = new Error("escrow settlement underflow");
+    deploymentWriterService.close.mockImplementation(async (_wallet, dseq) => {
+      if (dseq === "11") throw unsettleable;
+      return true;
+    });
+    chainErrorService.isUnsettleableDeploymentError.mockImplementation(error => error === unsettleable);
+
+    await expect(service.enforce({ wallet, detectionId: DETECTION_ID })).rejects.toThrow(/11 cannot be closed/);
+
+    expect(deploymentWriterService.close).toHaveBeenCalledWith(wallet, "22");
+    expect(userWalletRepository.lockForAbuse).not.toHaveBeenCalled();
+    expect(detectionRepository.updateById).toHaveBeenLastCalledWith(DETECTION_ID, {
+      action: "enforcement_failed",
+      enforcementError: expect.stringContaining("11 cannot be closed"),
+      updatedAt: expect.any(Date)
+    });
+    expect(instrumentation.recordEnforcement).toHaveBeenCalledWith("failed");
+  });
+
+  it("leaves the wallet untouched and rethrows when a revoke fails for another reason", async () => {
+    const { service, wallet, signerService, userWalletRepository, deploymentWriterService } = setup({ liveDseqs: ["11"] });
+    signerService.executeFundingTx.mockRejectedValueOnce(new Error("account sequence mismatch"));
+
+    await expect(service.enforce({ wallet, detectionId: DETECTION_ID })).rejects.toThrow("account sequence mismatch");
+
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+    expect(userWalletRepository.lockForAbuse).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { liveDseqs: string[]; hasDepositGrant?: boolean; hasFeeGrant?: boolean }) {
+    const wallet = createInitializedUserWallet({ isTrialing: true });
+    const calls: string[] = [];
+
+    const txManagerService = mock<TxManagerService>();
+    txManagerService.getFundingWalletAddress.mockResolvedValue(GRANTER);
+    const authzHttpService = mock<AuthzHttpService>();
+    authzHttpService.hasDepositDeploymentGrant.mockResolvedValue(input.hasDepositGrant ?? true);
+    authzHttpService.hasFeeAllowance.mockResolvedValue(input.hasFeeGrant ?? true);
+    const rpcMessageService = mock<RpcMessageService>();
+    rpcMessageService.getRevokeDepositDeploymentGrantMsg.mockReturnValue(REVOKE_DEPOSIT);
+    rpcMessageService.getRevokeAllowanceMsg.mockReturnValue(REVOKE_FEE);
+    const signerService = mock<ManagedSignerService>();
+    signerService.executeFundingTx.mockImplementation(async messages => {
+      calls.push(messages[0] === REVOKE_DEPOSIT ? "revoke:deposit" : "revoke:fee");
+      return mock<Awaited<ReturnType<ManagedSignerService["executeFundingTx"]>>>();
+    });
+    const leaseHttpService = mock<LeaseHttpService>();
+    leaseHttpService.list.mockImplementation(async ({ state }) => ({
+      leases: state === "active" ? input.liveDseqs.map(dseq => mock<RpcLease>({ lease: { id: { dseq } } })) : [],
+      pagination: { next_key: null, total: "0" }
+    }));
+    const deploymentWriterService = mock<DeploymentWriterService>();
+    deploymentWriterService.close.mockImplementation(async (_wallet, dseq) => {
+      calls.push(`close:${dseq}`);
+      return true;
+    });
+    const chainErrorService = mock<ChainErrorService>();
+    chainErrorService.isUnsettleableDeploymentError.mockReturnValue(false);
+    const userWalletRepository = mock<UserWalletRepository>();
+    userWalletRepository.lockForAbuse.mockImplementation(async () => {
+      calls.push("lock");
+    });
+    const detectionRepository = mock<WorkloadAbuseDetectionRepository>();
+    const probeJobService = mock<TrialWorkloadProbeJobService>();
+    probeJobService.cancelForWallet.mockImplementation(async () => {
+      calls.push("cancelProbes");
+      return 0;
+    });
+    const instrumentation = mock<WorkloadAbuseInstrumentationService>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const service = new TrialAbuseEnforcementService(
+      txManagerService,
+      authzHttpService,
+      rpcMessageService,
+      signerService,
+      leaseHttpService,
+      deploymentWriterService,
+      chainErrorService,
+      userWalletRepository,
+      detectionRepository,
+      probeJobService,
+      instrumentation,
+      createLogger
+    );
+
+    return {
+      service,
+      wallet,
+      calls,
+      signerService,
+      deploymentWriterService,
+      chainErrorService,
+      userWalletRepository,
+      detectionRepository,
+      instrumentation,
+      logger
+    };
+  }
+});

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
@@ -79,14 +79,14 @@ export class TrialAbuseEnforcementService {
     return outcome;
   }
 
-  /** The lock is the last step, so anything that fails before it leaves the wallet unlocked for the retry and anything after it cannot undo an enforcement that landed. */
+  /** The lock commits before the probes are cancelled, so a wipe that fails partway leaves the wallet unlocked and still monitored for the retry. */
   async #wipe(wallet: WalletInitialized): Promise<EnforcementOutcome> {
-    await this.probeJobService.cancelForWallet(wallet.id);
     const granter = await this.txManagerService.getFundingWalletAddress();
     const depositGrantRevoked = await this.#revokeDepositGrant(granter, wallet.address);
     const closedDseqs = await this.#closeLiveDeployments(wallet);
     const feeGrantRevoked = await this.#revokeFeeGrant(granter, wallet.address);
     await this.userWalletRepository.lockForAbuse(wallet.id, ABUSE_LOCK_REASON);
+    await this.probeJobService.cancelForWallet(wallet.id);
 
     return { depositGrantRevoked, feeGrantRevoked, closedDseqs };
   }

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
@@ -1,0 +1,153 @@
+import { AuthzHttpService, LeaseHttpService, LIVE_LEASE_STATES } from "@akashnetwork/http-sdk";
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import { inject, singleton } from "tsyringe";
+
+import { UserWalletRepository, type WalletInitialized } from "@src/billing/repositories";
+import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
+import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
+import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
+import { WorkloadAbuseInstrumentationService } from "@src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service";
+
+export const ABUSE_LOCK_REASON = "workload_abuse";
+
+export type EnforcementOutcome = {
+  depositGrantRevoked: boolean;
+  feeGrantRevoked: boolean;
+  closedDseqs: string[];
+};
+
+/** The chain reports a revoke of a grant that no longer exists this way, which an earlier attempt of the same wipe can have caused. */
+const GRANT_MISSING_PATTERN = /not found/i;
+
+/**
+ * Wipes a trial wallet caught mining: the deposit grant goes first so nothing new can be created, the live deployments
+ * are closed while the fee grant still pays for the closes, then the fee grant goes and the wallet is zeroed and
+ * locked in one write. Every step re-reads chain state, so a retry after a partial failure resumes where it stopped.
+ */
+@singleton()
+export class TrialAbuseEnforcementService {
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly txManagerService: TxManagerService,
+    private readonly authzHttpService: AuthzHttpService,
+    private readonly rpcMessageService: RpcMessageService,
+    private readonly signerService: ManagedSignerService,
+    private readonly leaseHttpService: LeaseHttpService,
+    private readonly deploymentWriterService: DeploymentWriterService,
+    private readonly chainErrorService: ChainErrorService,
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly detectionRepository: WorkloadAbuseDetectionRepository,
+    private readonly probeJobService: TrialWorkloadProbeJobService,
+    private readonly instrumentation: WorkloadAbuseInstrumentationService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: TrialAbuseEnforcementService.name });
+  }
+
+  async enforce(input: { wallet: WalletInitialized; detectionId: string }): Promise<EnforcementOutcome> {
+    const { wallet, detectionId } = input;
+    await this.detectionRepository.updateById(detectionId, { action: "enforcing", enforcementError: null, updatedAt: new Date() });
+
+    try {
+      await this.probeJobService.cancelForWallet(wallet.id);
+      const granter = await this.txManagerService.getFundingWalletAddress();
+      const depositGrantRevoked = await this.#revokeDepositGrant(granter, wallet.address);
+      const closedDseqs = await this.#closeLiveDeployments(wallet);
+      const feeGrantRevoked = await this.#revokeFeeGrant(granter, wallet.address);
+      await this.userWalletRepository.lockForAbuse(wallet.id, ABUSE_LOCK_REASON);
+      await this.detectionRepository.updateById(detectionId, { action: "enforced", updatedAt: new Date() });
+      this.instrumentation.recordEnforcement("enforced");
+
+      const outcome = { depositGrantRevoked, feeGrantRevoked, closedDseqs };
+      this.logger.warn({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCED", detectionId, walletId: wallet.id, userId: wallet.userId, owner: wallet.address, ...outcome });
+
+      return outcome;
+    } catch (error) {
+      await this.detectionRepository.updateById(detectionId, { action: "enforcement_failed", enforcementError: toErrorMessage(error), updatedAt: new Date() });
+      this.instrumentation.recordEnforcement("failed");
+      this.logger.error({
+        event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_FAILED",
+        detectionId,
+        walletId: wallet.id,
+        userId: wallet.userId,
+        owner: wallet.address,
+        error
+      });
+      throw error;
+    }
+  }
+
+  async #revokeDepositGrant(granter: string, grantee: string): Promise<boolean> {
+    if (!(await this.authzHttpService.hasDepositDeploymentGrant(granter, grantee))) return false;
+
+    await this.#executeRevoke(this.rpcMessageService.getRevokeDepositDeploymentGrantMsg({ granter, grantee }));
+    return true;
+  }
+
+  async #revokeFeeGrant(granter: string, grantee: string): Promise<boolean> {
+    if (!(await this.authzHttpService.hasFeeAllowance(granter, grantee))) return false;
+
+    await this.#executeRevoke(this.rpcMessageService.getRevokeAllowanceMsg({ granter, grantee }));
+    return true;
+  }
+
+  async #executeRevoke(message: EncodeObject): Promise<void> {
+    try {
+      await this.signerService.executeFundingTx([message]);
+    } catch (error) {
+      if (isGrantMissingError(error)) return;
+      throw error;
+    }
+  }
+
+  /** An unsettleable escrow is skipped for this pass and fails the run at the end, so the queue retries the close later without blocking the other deployments. */
+  async #closeLiveDeployments(wallet: WalletInitialized): Promise<string[]> {
+    const dseqs = await this.#findLiveDseqs(wallet.address);
+    const closed: string[] = [];
+    const unsettleable: string[] = [];
+
+    for (const dseq of dseqs) {
+      try {
+        await this.deploymentWriterService.close(wallet, dseq);
+        closed.push(dseq);
+      } catch (error) {
+        if (error instanceof Error && this.chainErrorService.isUnsettleableDeploymentError(error)) {
+          unsettleable.push(dseq);
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    if (unsettleable.length > 0) {
+      throw new Error(`Deployments ${unsettleable.join(", ")} cannot be closed until their escrow settles`);
+    }
+
+    return closed;
+  }
+
+  async #findLiveDseqs(owner: string): Promise<string[]> {
+    const responses = await Promise.all(LIVE_LEASE_STATES.map(state => this.leaseHttpService.list({ owner, state })));
+
+    return [...new Set(responses.flatMap(response => response.leases.map(lease => lease.lease.id.dseq)))];
+  }
+}
+
+function isGrantMissingError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const originalError = (error as { originalError?: unknown }).originalError;
+  const messages = [error.message, originalError instanceof Error ? originalError.message : undefined];
+
+  return messages.some(message => message && GRANT_MISSING_PATTERN.test(message));
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
@@ -54,20 +54,10 @@ export class TrialAbuseEnforcementService {
     const { wallet, detectionId } = input;
     await this.detectionRepository.updateById(detectionId, { action: "enforcing", enforcementError: null, updatedAt: new Date() });
 
+    let outcome: EnforcementOutcome;
+
     try {
-      await this.probeJobService.cancelForWallet(wallet.id);
-      const granter = await this.txManagerService.getFundingWalletAddress();
-      const depositGrantRevoked = await this.#revokeDepositGrant(granter, wallet.address);
-      const closedDseqs = await this.#closeLiveDeployments(wallet);
-      const feeGrantRevoked = await this.#revokeFeeGrant(granter, wallet.address);
-      await this.userWalletRepository.lockForAbuse(wallet.id, ABUSE_LOCK_REASON);
-      await this.detectionRepository.updateById(detectionId, { action: "enforced", updatedAt: new Date() });
-      this.instrumentation.recordEnforcement("enforced");
-
-      const outcome = { depositGrantRevoked, feeGrantRevoked, closedDseqs };
-      this.logger.warn({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCED", detectionId, walletId: wallet.id, userId: wallet.userId, owner: wallet.address, ...outcome });
-
-      return outcome;
+      outcome = await this.#wipe(wallet);
     } catch (error) {
       await this.detectionRepository.updateById(detectionId, { action: "enforcement_failed", enforcementError: toErrorMessage(error), updatedAt: new Date() });
       this.instrumentation.recordEnforcement("failed");
@@ -81,6 +71,24 @@ export class TrialAbuseEnforcementService {
       });
       throw error;
     }
+
+    await this.detectionRepository.markWalletEnforced(wallet.id);
+    this.instrumentation.recordEnforcement("enforced");
+    this.logger.warn({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCED", detectionId, walletId: wallet.id, userId: wallet.userId, owner: wallet.address, ...outcome });
+
+    return outcome;
+  }
+
+  /** The lock is the last step, so anything that fails before it leaves the wallet unlocked for the retry and anything after it cannot undo an enforcement that landed. */
+  async #wipe(wallet: WalletInitialized): Promise<EnforcementOutcome> {
+    await this.probeJobService.cancelForWallet(wallet.id);
+    const granter = await this.txManagerService.getFundingWalletAddress();
+    const depositGrantRevoked = await this.#revokeDepositGrant(granter, wallet.address);
+    const closedDseqs = await this.#closeLiveDeployments(wallet);
+    const feeGrantRevoked = await this.#revokeFeeGrant(granter, wallet.address);
+    await this.userWalletRepository.lockForAbuse(wallet.id, ABUSE_LOCK_REASON);
+
+    return { depositGrantRevoked, feeGrantRevoked, closedDseqs };
   }
 
   async #revokeDepositGrant(granter: string, grantee: string): Promise<boolean> {

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
@@ -87,6 +87,19 @@ describe(TrialWorkloadProbeJobService.name, () => {
     });
   });
 
+  describe("cancelForWallet", () => {
+    it("cancels every pending probe of the wallet and none of another wallet", async () => {
+      const { service, jobQueueService } = setup({ pendingKeys: ["probeTrialDeployment.7.1", "probeTrialDeployment.7.2", "probeTrialDeployment.70.3"] });
+
+      const cancelled = await service.cancelForWallet(7);
+
+      expect(cancelled).toBe(2);
+      expect(jobQueueService.cancelCreatedBy).toHaveBeenCalledTimes(2);
+      expect(jobQueueService.cancelCreatedBy).toHaveBeenCalledWith({ name: "ProbeTrialDeployment", singletonKey: "probeTrialDeployment.7.1" });
+      expect(jobQueueService.cancelCreatedBy).toHaveBeenCalledWith({ name: "ProbeTrialDeployment", singletonKey: "probeTrialDeployment.7.2" });
+    });
+  });
+
   describe("reconcile", () => {
     const live: LiveTrialDeployment[] = [
       { userId: "u1", dseq: "1", walletId: 1, createdAt: LEASE_CREATED_AT },

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
@@ -60,6 +60,17 @@ export class TrialWorkloadProbeJobService {
     await this.jobQueueService.cancelCreatedBy({ name: ProbeTrialDeployment[JOB_NAME], singletonKey: probeTrialDeploymentKeyFor(target) });
   }
 
+  async cancelForWallet(walletId: number): Promise<number> {
+    const prefix = `probeTrialDeployment.${walletId}.`;
+    const pendingKeys = [...(await this.jobQueueService.findPendingSingletonKeys(ProbeTrialDeployment[JOB_NAME]))].filter(key => key.startsWith(prefix));
+
+    for (const singletonKey of pendingKeys) {
+      await this.jobQueueService.cancelCreatedBy({ name: ProbeTrialDeployment[JOB_NAME], singletonKey });
+    }
+
+    return pendingKeys.length;
+  }
+
   /** Backstops the lease-created hook: a live trial deployment with no pending probe gets one, whatever the reason it has none. */
   async reconcile({ dryRun }: DryRunOptions): Promise<void> {
     if (!this.config.get("WORKLOAD_ABUSE_PROBE_ENABLED")) {

--- a/apps/api/src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service.ts
+++ b/apps/api/src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service.ts
@@ -9,6 +9,7 @@ export class WorkloadAbuseInstrumentationService {
   private readonly meter: Meter;
   private readonly probes: Counter;
   private readonly detections: Counter;
+  private readonly enforcements: Counter;
 
   constructor(metricsService: MetricsService) {
     this.meter = metricsService.getMeter("workload-abuse", "1.0.0");
@@ -18,6 +19,9 @@ export class WorkloadAbuseInstrumentationService {
     this.detections = metricsService.createCounter(this.meter, "workload_abuse_detections_total", {
       description: "Trial workload detections recorded, by verdict"
     });
+    this.enforcements = metricsService.createCounter(this.meter, "workload_abuse_enforcements_total", {
+      description: "Trial abuse enforcement runs, by result"
+    });
   }
 
   recordProbe(input: { verdict: WorkloadVerdict; probeStatus: string }): void {
@@ -26,5 +30,9 @@ export class WorkloadAbuseInstrumentationService {
 
   recordDetection(verdict: WorkloadVerdict): void {
     this.detections.add(1, { verdict });
+  }
+
+  recordEnforcement(result: "enforced" | "failed" | "skipped"): void {
+    this.enforcements.add(1, { result });
   }
 }

--- a/apps/api/test/seeders/user-wallet.seeder.ts
+++ b/apps/api/test/seeders/user-wallet.seeder.ts
@@ -15,7 +15,9 @@ export function createUserWallet({
   activatedAt = createdAt,
   creditsLowNotifiedAt = null,
   creditsSufficientSince = null,
-  creditsLowSince = null
+  creditsLowSince = null,
+  abuseLockedAt = null,
+  abuseLockedReason = null
 }: Partial<UserWalletOutput> = {}): UserWalletOutput {
   return {
     id,
@@ -30,7 +32,9 @@ export function createUserWallet({
     activatedAt,
     creditsLowNotifiedAt,
     creditsSufficientSince,
-    creditsLowSince
+    creditsLowSince,
+    abuseLockedAt,
+    abuseLockedReason
   };
 }
 


### PR DESCRIPTION
## Why

#3819 records Fair Use Policy violations on trial deployments. This PR acts on them, so a confirmed violation on a trial wallet no longer needs someone to run a script by hand. Paying wallets are never touched.

Third of three stacked PRs, on top of #3819.

## What

- **`EnforceTrialAbuse` job**, one per wallet, queued on a confirmed finding when `WORKLOAD_ABUSE_ENFORCEMENT_MODE=enforce`. The default `detect` only logs, so nothing changes until the mode is flipped.
- **`TrialAbuseEnforcementService`** closes the wallet's live deployments, revokes its trial grants and ends the trial. Every step re-reads chain state first, so a pg-boss retry is safe, and the detection row moves `detected → enforcing → enforced | enforcement_failed` with the error text.
- **Wallet lock**: `user_wallets.abuse_locked_at` and `abuse_locked_reason` (migration `0052`, nullable columns). Without it `findDrainingWallets` would treat the wallet as an ordinary non-trial wallet with a low fee allowance and the hourly refill would undo the enforcement. Locked wallets are skipped by fee refills, monitoring and credits-low emails. They can still add funds and become regular paying customers.
- New counter `workload_abuse_enforcements_total{result}`.

Rollout: once #3819 has run in `detect` mode for a few days, set `WORKLOAD_ABUSE_ENFORCEMENT_MODE=enforce` and alert on `result="failed"`.

### Verification

Full apps/api unit and functional suites green, plus the user-wallet and deployment-setting repository integration specs. `eslint --quiet` and `tsc --noEmit` clean on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workload-abuse enforcement for trial wallets, including revoking grants, closing deployments, cancelling related checks, and locking affected wallets.
  * Added configurable detection modes: detect-only or enforce.
  * Added abuse-lock tracking with timestamps and reasons.
* **Bug Fixes**
  * Abuse-locked wallets are excluded from trial deployments, credit alerts, and automatic fee refills.
  * Making a payment clears the abuse lock without restoring previously removed allowances.
* **Monitoring**
  * Added enforcement outcome tracking for successful, failed, and skipped actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->