### PR TITLE
chore(ci): report a security scan on the commit its pull request points at

### DIFF
--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   create-check-run:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     outputs:
       run_scan: ${{ steps.decide.outputs.run_scan }}
       event: ${{ env.PARENT_WORKFLOW_EVENT }}
@@ -107,64 +107,37 @@ jobs:
       - name: Resolve commit to report on
         id: report_target
         if: ${{ steps.decide.outputs.report_check == 'true' }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.associated_pr.outputs.number }}
-        with:
-          script: | # js
-            const scannedSha = process.env.PARENT_WORKFLOW_HEAD_SHA;
+          PR_HEAD: ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}
+        run: | # shell
+          report_on() {
+            echo "sha=$1" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
 
-            const findPullRequest = async () => {
-              const number = Number(process.env.PR_NUMBER);
-              if (number) {
-                const { data } = await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: number
-                });
-                return data;
-              }
+          tree_of() {
+            gh api "repos/$GITHUB_REPOSITORY/commits/$1" --jq .commit.tree.sha
+          }
 
-              const parentRun = context.payload.workflow_run;
-              if (!parentRun || !parentRun.head_branch) return null;
+          [[ "$PARENT_WORKFLOW_EVENT" == "pull_request" ]] || report_on "$PARENT_WORKFLOW_HEAD_SHA"
 
-              const { data } = await github.rest.pulls.list({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                state: "open",
-                head: `${parentRun.head_repository?.owner?.login || context.repo.owner}:${parentRun.head_branch}`
-              });
-              return data[0] || null;
-            };
+          pr="$PR_NUMBER"
+          if [[ -z "$pr" ]]; then
+            pr=$(gh api "repos/$GITHUB_REPOSITORY/pulls" -f state=open -f head="$PR_HEAD" --jq '.[0].number // ""') || pr=""
+          fi
+          [[ -n "$pr" ]] || report_on "$PARENT_WORKFLOW_HEAD_SHA"
 
-            const holdsScannedContent = async sha => {
-              const { data } = await github.rest.repos.compareCommitsWithBasehead({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                basehead: `${scannedSha}...${sha}`
-              });
-              return !data.files || data.files.length === 0;
-            };
+          head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr" --jq .head.sha) || report_on "$PARENT_WORKFLOW_HEAD_SHA"
+          [[ "$head_sha" != "$PARENT_WORKFLOW_HEAD_SHA" ]] || report_on "$PARENT_WORKFLOW_HEAD_SHA"
 
-            const resolveShaToReportOn = async () => {
-              if (process.env.PARENT_WORKFLOW_EVENT !== "pull_request") return scannedSha;
+          scanned_tree=$(tree_of "$PARENT_WORKFLOW_HEAD_SHA") || report_on "$PARENT_WORKFLOW_HEAD_SHA"
+          head_tree=$(tree_of "$head_sha") || report_on "$PARENT_WORKFLOW_HEAD_SHA"
+          [[ "$scanned_tree" == "$head_tree" ]] || report_on "$PARENT_WORKFLOW_HEAD_SHA"
 
-              const pull = await findPullRequest();
-              if (!pull || pull.head.sha === scannedSha) return scannedSha;
-
-              if (!(await holdsScannedContent(pull.head.sha))) {
-                core.info(`#${pull.number} moved to ${pull.head.sha}, which changes content and gets its own scan`);
-                return scannedSha;
-              }
-
-              core.info(`Reporting on ${pull.head.sha}: #${pull.number} moved off ${scannedSha} without changing content`);
-              return pull.head.sha;
-            };
-
-            core.setOutput("sha", await resolveShaToReportOn().catch(error => {
-              core.warning(`Reporting on ${scannedSha}: resolving the pull request head failed with ${error.message}`);
-              return scannedSha;
-            }));
+          echo "Reporting on $head_sha: #$pr moved off $PARENT_WORKFLOW_HEAD_SHA without changing content"
+          report_on "$head_sha"
 
       - name: Create check run
         id: create_check

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -38,6 +38,7 @@ jobs:
       run_scan: ${{ steps.decide.outputs.run_scan }}
       event: ${{ env.PARENT_WORKFLOW_EVENT }}
       check_run_id: ${{ steps.create_check.outputs.check_run_id }}
+      check_run_sha: ${{ steps.report_target.outputs.sha }}
       skip_reason: ${{ steps.decide.outputs.skip_reason }}
     steps:
       - name: Checkout repository
@@ -100,13 +101,80 @@ jobs:
         run: | # shell
           echo "No \`security-scan\` check reported for ${PARENT_WORKFLOW_HEAD_SHA}: ${SKIP_REASON}" >> "$GITHUB_STEP_SUMMARY"
 
+      # A pull request in a stack is rewritten whenever a branch below it moves, and an empty retrigger commit
+      # does the same by hand, leaving CI's commit off the pull request: the verdict belongs on the commit the
+      # merge box reads, as long as that commit holds the content this run scanned.
+      - name: Resolve commit to report on
+        id: report_target
+        if: ${{ steps.decide.outputs.report_check == 'true' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.associated_pr.outputs.number }}
+        with:
+          script: | # js
+            const scannedSha = process.env.PARENT_WORKFLOW_HEAD_SHA;
+
+            const findPullRequest = async () => {
+              const number = Number(process.env.PR_NUMBER);
+              if (number) {
+                const { data } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: number
+                });
+                return data;
+              }
+
+              const parentRun = context.payload.workflow_run;
+              if (!parentRun || !parentRun.head_branch) return null;
+
+              const { data } = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                head: `${parentRun.head_repository?.owner?.login || context.repo.owner}:${parentRun.head_branch}`
+              });
+              return data[0] || null;
+            };
+
+            const holdsScannedContent = async sha => {
+              const { data } = await github.rest.repos.compareCommitsWithBasehead({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                basehead: `${scannedSha}...${sha}`
+              });
+              return !data.files || data.files.length === 0;
+            };
+
+            const resolveShaToReportOn = async () => {
+              if (process.env.PARENT_WORKFLOW_EVENT !== "pull_request") return scannedSha;
+
+              const pull = await findPullRequest();
+              if (!pull || pull.head.sha === scannedSha) return scannedSha;
+
+              if (!(await holdsScannedContent(pull.head.sha))) {
+                core.info(`#${pull.number} moved to ${pull.head.sha}, which changes content and gets its own scan`);
+                return scannedSha;
+              }
+
+              core.info(`Reporting on ${pull.head.sha}: #${pull.number} moved off ${scannedSha} without changing content`);
+              return pull.head.sha;
+            };
+
+            core.setOutput("sha", await resolveShaToReportOn().catch(error => {
+              core.warning(`Reporting on ${scannedSha}: resolving the pull request head failed with ${error.message}`);
+              return scannedSha;
+            }));
+
       - name: Create check run
         id: create_check
         if: ${{ steps.decide.outputs.report_check == 'true' }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REPORT_SHA: ${{ steps.report_target.outputs.sha }}
         with:
           script: | # js
-            const sha = process.env.PARENT_WORKFLOW_HEAD_SHA;
+            const sha = process.env.REPORT_SHA;
             const workflowRunUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const res = await github.rest.checks.create({
               name: "security-scan",
@@ -345,11 +413,12 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CHECK_RUN_ID: ${{ needs.create-check-run.outputs.check_run_id }}
+          CHECK_RUN_SHA: ${{ needs.create-check-run.outputs.check_run_sha }}
           CONCLUSION: ${{ steps.final.outputs.conclusion }}
           SUMMARY: ${{ steps.final.outputs.summary }}
         with:
           script: | # js
-            const sha = process.env.PARENT_WORKFLOW_HEAD_SHA;
+            const sha = process.env.CHECK_RUN_SHA;
             const checkRunId = Number(process.env.CHECK_RUN_ID);
             const workflowRunUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -125,7 +125,7 @@ jobs:
 
           pr="$PR_NUMBER"
           if [[ -z "$pr" ]]; then
-            pr=$(gh api "repos/$GITHUB_REPOSITORY/pulls" -f state=open -f head="$PR_HEAD" --jq '.[0].number // ""') || pr=""
+            pr=$(gh api -X GET "repos/$GITHUB_REPOSITORY/pulls" -f state=open -f head="$PR_HEAD" --jq '.[0].number // ""') || pr=""
           fi
           [[ -n "$pr" ]] || report_on "$PARENT_WORKFLOW_HEAD_SHA"
 


### PR DESCRIPTION
## Why

`security-scan` is a required check, and it is created on the commit the CI run that triggered the scan ran
against. That commit stops being the one the merge box reads as soon as the pull request moves: a stacked
pull request is rewritten whenever a branch below it moves, and an empty retrigger commit does the same by
hand. The verdict then lands on a commit no longer attached to the pull request, the head is left without the
required check, and merging stays blocked with `security-scan` never reported — #3799 sat that way this
morning until it was retriggered by hand.

## What

The scan now resolves the commit it reports on before creating the check run:

- the pull request is found from the scanned commit as before, falling back to the head branch of the
  triggering run so a rewritten pull request is still found once its old commit is orphaned;
- the check is created on that pull request's current head, but only when that head's tree matches the tree
  of the scanned commit, so a verdict is never attached to content this run did not scan;
- anything else — a push build, no pull request, a head that moved on to different content, any failing API
  call — reports on the scanned commit exactly as today.

`finalize` completes the same check run, so it now reads the resolved commit as well.

`create-check-run` moves from the `akash` self-hosted runners to `ubuntu-latest`: the step is plain bash over
`gh api`, and no self-hosted job in this repo uses the `gh` CLI today, so its presence there is not
established.

Known gap left for a follow-up: the head is resolved when the check is created, so a rewrite that happens
during the scan itself still lands the verdict on the commit that was current when the scan started.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security check reporting for pull requests by associating results with the appropriate commit when content is unchanged.
  * Added fallback handling for lookup, comparison, and non-pull-request scenarios, ensuring checks continue to report against the scanned commit when needed.
  * Improved the reliability of check creation and completion across supported workflow events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->