### PR TITLE
chore(ci): exclude the generated api artifacts from the pr size label

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -61,9 +61,14 @@ jobs:
               "yarn.lock",
               "bun.lockb",
             ]);
+            const generatedApiArtifacts = new Set([
+              "apps/api/swagger/openapi.json",
+              "packages/console-api-types/src/schema.d.ts",
+            ]);
             const totalChangedLines = files.reduce((total, file) => {
               const path = file.filename ?? "";
               const isIgnoredFile = excludedLockfiles.has(path) ||
+                generatedApiArtifacts.has(path) ||
                 (path.includes("/drizzle/meta/") && path.endsWith('.json')) || path.endsWith('.md') ||
                 path.endsWith(".gen.ts") ||
                 path.includes("/generated/");


### PR DESCRIPTION
## Why

Part of CON-864.

`apps/api/swagger/openapi.json` and `packages/console-api-types/src/schema.d.ts` are regenerated from the route definitions. A PR that adds one hand-written route handler can add hundreds of generated lines that nobody reviews line by line, and the size label counts them, so the label stops describing the review effort.

Concretely: the PATCH endpoint later in this stack is **~130 hand-written lines** but its raw diff is **873**. With this change it measures **84**.

## What

Extends the existing `isIgnoredFile` predicate in `.github/workflows/labeler.yml` with the two generated API artifacts, enumerated explicitly rather than matched by a glob so no hand-written file can fall into the exclusion.

Verified by extracting the `github-script` block and running the real predicate over sample paths:

| path | counted? |
|---|---|
| `apps/api/swagger/openapi.json` | excluded |
| `packages/console-api-types/src/schema.d.ts` | excluded |
| `packages/console-api-types/src/index.ts` | **counted** |
| a bare `src/schema.d.ts` elsewhere | **counted** |
| `apps/api/swagger/openapi.json.bak` | **counted** |

`*.snap` snapshots are deliberately **not** excluded: a snapshot diff *is* the assertion, so hiding it would hide real test changes.

Base of a 10-PR stack. Observable behaviour of the endpoint this stack builds is demonstrated in the PATCH exposure PR.

Measured: 5 non-excluded changed lines. `apps/api` tsc 42 against a 42 baseline on `main`, lint 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request size calculations to exclude generated API artifacts from changed-line totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->