### PR TITLE
fix(deployment): mark the whole-sdl update endpoint deprecated

### DIFF
--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -164,8 +164,11 @@ deploymentsRouter.openapi(depositRoute, async function routeDepositDeployment(c)
 const updateRoute = createRoute({
   method: "put",
   path: "/v1/deployments/{dseq}",
-  summary: "Update a deployment",
+  summary: "Update a deployment (deprecated)",
+  description:
+    "Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. This endpoint will be removed in a future release.",
   operationId: "updateDeployment",
+  deprecated: true,
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
   request: {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -303,6 +303,8 @@ export class DeploymentWriterService {
    * reference with no value spends no key-service call.
    */
   public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<DeploymentResponse> {
+    this.logger.warn({ event: "DEPRECATED_UPDATE_DEPLOYMENT_ENDPOINT_USED", userId, dseq });
+
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
     const { sdl, derived } = this.#storedSdlOf(input.sdl, "every-value-sealed", dseq);
 

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4381,8 +4381,10 @@
         }
       },
       "put": {
-        "summary": "Update a deployment",
+        "summary": "Update a deployment (deprecated)",
+        "description": "Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. This endpoint will be removed in a future release.",
         "operationId": "updateDeployment",
+        "deprecated": true,
         "tags": [
           "Deployments"
         ],

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7522,6 +7522,8 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
       "put": {
+        "deprecated": true,
+        "description": "Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. This endpoint will be removed in a future release.",
         "operationId": "updateDeployment",
         "parameters": [
           {
@@ -7943,7 +7945,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "ApiKeyAuth": [],
           },
         ],
-        "summary": "Update a deployment",
+        "summary": "Update a deployment (deprecated)",
         "tags": [
           "Deployments",
         ],

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -1142,6 +1142,16 @@ describe("Deployments API", () => {
   });
 
   describe("PUT /v1/deployments/{dseq}", () => {
+    it("announces itself as deprecated in the document callers read", async () => {
+      const response = await app.request("/v1/doc?scope=console");
+      const document = (await response.json()) as { paths: Record<string, Record<string, { deprecated?: boolean; description?: string }>> };
+
+      expect(response.status).toBe(200);
+      const put = document.paths["/v1/deployments/{dseq}"].put;
+      expect(put.deprecated).toBe(true);
+      expect(put.description).toContain("re-supplying every other value");
+    });
+
     it("should update a deployment successfully", async () => {
       const { userApiKeySecret, wallets } = await mockPersistedUser();
       const dseq = "1234";

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -2097,7 +2097,11 @@ export interface paths {
     };
     /** Get a deployment */
     get: operations["getDeployment"];
-    /** Update a deployment */
+    /**
+     * Update a deployment (deprecated)
+     * @deprecated
+     * @description Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. This endpoint will be removed in a future release.
+     */
     put: operations["updateDeployment"];
     post?: never;
     /** Close a deployment */


### PR DESCRIPTION
## Why

Part of CON-864.

`PUT /v1/deployments/{dseq}` resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries — and since no endpoint returns a stored secret value, a caller cannot assemble that set at all. It is superseded by the partial-update endpoint later in this stack.

## What

Marks the route `deprecated: true` with a summary and description saying why, and logs `DEPRECATED_UPDATE_DEPLOYMENT_ENDPOINT_USED` on each use so the remaining callers are visible.

No replacement is named yet: the endpoint that supersedes it lands later in this stack, and a description pointing at a route that does not exist would be wrong at every merge point before then. The pointer is added in that PR.

### The weakest test in this stack

The Spec requires that the API "must not imply otherwise" about a replaced value taking effect when the deployment is next updated on chain rather than in the already-running workload. That is satisfied by **description text plus a document assertion** — it checks prose, not behaviour. Stating that plainly rather than presenting it as behavioural coverage: it is the weakest check in the stack, and no assertion available here is stronger.

`deploy-web` still calls this endpoint; deprecation does not break it, and migrating the frontend is out of scope.

Observable behaviour of the replacement is demonstrated in the PATCH exposure PR.

Measured: 21 non-excluded changed lines. `apps/api` tsc 42 against a 42 baseline, lint 0, functional 405/405.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Marked the deployment update endpoint as deprecated.
  - Clarified that updates require resubmitting the complete SDL and all document values when rotating secrets.
  - Noted that stored values cannot be returned for resubmission and that the endpoint will be removed in a future release.
  - Clarified date-range inclusivity, default end-date behavior, and validation errors.
- **New Features**
  - Added an API endpoint for accepting the fair-use policy.
  - Added fair-use acceptance and reclaim-notification timestamps to API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->