### PR TITLE
refactor(sdl): apply a partial service definition to a stored sdl

### DIFF
--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -161,6 +161,23 @@ export const UpdateDeploymentRequestSchema = z.object({
   })
 });
 
+const PatchEnvSchema = z.record(z.string(), z.string().nullable()).openapi({
+  description: "Merged into the service's env. A null value removes the variable."
+});
+
+export const PatchServiceSchema = z
+  .object({
+    image: z.string(),
+    command: z.array(z.string()).nullable(),
+    args: z.array(z.string()).nullable(),
+    env: PatchEnvSchema,
+    credentials: z
+      .object({ host: z.string(), username: z.string(), password: z.string() })
+      .nullable()
+      .openapi({ description: "Private registry pull credentials. Null clears them." })
+  })
+  .partial();
+
 export const UpdateDeploymentResponseSchema = z.object({
   data: DeploymentResponseSchema
 });
@@ -313,6 +330,7 @@ export type CloseDeploymentResponse = z.infer<typeof CloseDeploymentResponseSche
 export type DepositDeploymentRequest = z.infer<typeof DepositDeploymentRequestSchema>;
 export type DepositDeploymentResponse = z.infer<typeof DepositDeploymentResponseSchema>;
 export type UpdateDeploymentRequest = z.infer<typeof UpdateDeploymentRequestSchema>;
+export type PatchService = z.infer<typeof PatchServiceSchema>;
 export type UpdateDeploymentResponse = z.infer<typeof UpdateDeploymentResponseSchema>;
 export type ListWithResourcesParams = z.infer<typeof ListWithResourcesParamsSchema>;
 export type ListWithResourcesQuery = z.infer<typeof ListWithResourcesQuerySchema>;

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -161,8 +161,11 @@ export const UpdateDeploymentRequestSchema = z.object({
   })
 });
 
-const PatchEnvSchema = z.record(z.string(), z.string().nullable()).openapi({
-  description: "Merged into the service's env. A null value removes the variable."
+/** A key carrying `=` would be written as `NAME=REST=value` and read back as a different variable, silently overwriting it and leaving the supplied value unsealed. */
+const ENV_VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+const PatchEnvSchema = z.record(z.string().regex(ENV_VARIABLE_NAME), z.string().nullable()).openapi({
+  description: "Merged into the service's env, keyed by environment variable name. A null value removes the variable."
 });
 
 export const PatchServiceSchema = z

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
@@ -80,6 +80,15 @@ describe(SdlPatchService.name, () => {
       expect(document.services.web.env).toEqual(["A=ac-secret://s0_e0", "C=ac-secret://s0_e2", "B=replaced"]);
     });
 
+    it("leaves the stored list standing given an empty record", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two"] } } });
+      const stored = document.services.web.env;
+
+      service.apply(document, { web: { env: {} } });
+
+      expect(document.services.web.env).toBe(stored);
+    });
+
     it("appends a variable the service did not declare", () => {
       const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
 
@@ -373,6 +382,14 @@ describe(SdlPatchService.name, () => {
 
       expect(() => service.apply(document, { web: { env: { A: "two" } } })).toThrow();
       expect(document.services.worker.env).toEqual(["A=one"]);
+    });
+
+    it("allows a patch carrying an empty env record, which would not write to the shared list at all", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" }, worker: { image: "busybox" } }, shareEnv: ["A=one"] });
+
+      service.apply(document, { web: { image: "nginx:1.27", env: {} } });
+
+      expect(document.services.web.image).toBe("nginx:1.27");
     });
 
     it("refuses to patch credentials through a shared block", () => {

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
@@ -22,13 +22,29 @@ describe(SdlPatchService.name, () => {
     expect(document.services.web.args).toEqual(["-c", "new"]);
   });
 
-  it("clears command and args given null", () => {
+  it("removes command and args given null, rather than storing a null the user never wrote", () => {
     const { service, document } = setup({ services: { web: { image: "nginx", command: ["sh"], args: ["-c", "old"] } } });
 
     service.apply(document, { web: { command: null, args: null } });
 
-    expect(document.services.web.command).toBeNull();
-    expect(document.services.web.args).toBeNull();
+    expect("command" in document.services.web).toBe(false);
+    expect("args" in document.services.web).toBe(false);
+  });
+
+  it("leaves a command the patch does not name", () => {
+    const { service, document } = setup({ services: { web: { image: "nginx", command: ["sh"] } } });
+
+    service.apply(document, { web: { args: ["-c", "new"] } });
+
+    expect(document.services.web.command).toEqual(["sh"]);
+  });
+
+  it("clears a command on a service that never declared one without adding the key", () => {
+    const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+    service.apply(document, { web: { command: null } });
+
+    expect("command" in document.services.web).toBe(false);
   });
 
   it("leaves a field the patch does not name", () => {

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
@@ -145,6 +145,47 @@ describe(SdlPatchService.name, () => {
     });
   });
 
+  describe("an env key the stored document declares more than once", () => {
+    it("rewrites every occurrence, leaving no stale duplicate behind", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["FOO=one", "BAR=two", "FOO=three"] } } });
+
+      service.apply(document, { web: { env: { FOO: "replaced" } } });
+
+      expect(document.services.web.env).toEqual(["FOO=replaced", "BAR=two", "FOO=replaced"]);
+    });
+
+    it("removes every occurrence given null", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["FOO=one", "BAR=two", "FOO=three"] } } });
+
+      service.apply(document, { web: { env: { FOO: null } } });
+
+      expect(document.services.web.env).toEqual(["BAR=two"]);
+    });
+
+    it("reports every position it wrote, not only the first", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["FOO=one", "BAR=two", "FOO=three"] } } });
+
+      const written = service.apply(document, { web: { env: { FOO: "replaced" } } });
+
+      expect([...written].sort()).toEqual(["/services/web/env/0", "/services/web/env/2"]);
+    });
+  });
+
+  describe("a whole service definition two names share", () => {
+    it("refuses an image patch through the alias rather than rewriting both", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } }, aliasWebAs: "worker" });
+
+      expect(() => service.apply(document, { web: { image: "nginx:1.27" } })).toThrow(/share its definition with another part of the document/);
+    });
+
+    it("leaves the aliased service untouched", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } }, aliasWebAs: "worker" });
+
+      expect(() => service.apply(document, { web: { image: "nginx:1.27" } })).toThrow();
+      expect(document.services.worker.image).toBe("nginx");
+    });
+  });
+
   describe("credentials", () => {
     it("replaces the three fields it carries", () => {
       const { service, document } = setup({
@@ -291,6 +332,20 @@ describe(SdlPatchService.name, () => {
       expect(document.services.web.image).toBe("nginx");
     });
 
+    it("changes nothing when the unknown service is visited after a known one", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      expect(() => service.apply(document, { web: { image: "nginx:1.27" }, api: { image: "x" } })).toThrow();
+      expect(document.services.web.image).toBe("nginx");
+    });
+
+    it("writes no env either, when the unknown service is visited last", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
+
+      expect(() => service.apply(document, { web: { env: { A: "two" } }, api: { image: "x" } })).toThrow();
+      expect(document.services.web.env).toEqual(["A=one"]);
+    });
+
     it("bounds how much of an outsized service name it echoes", () => {
       const { service, document } = setup({ services: { web: { image: "nginx" } } });
       const outsized = "n".repeat(500);
@@ -305,7 +360,7 @@ describe(SdlPatchService.name, () => {
     it("refuses to patch env through a shared list", () => {
       const { service, document } = setup({ services: { web: { image: "nginx" }, worker: { image: "busybox" } }, shareEnv: ["A=one"] });
 
-      expect(() => service.apply(document, { web: { env: { A: "two" } } })).toThrow(/share its env with another service/);
+      expect(() => service.apply(document, { web: { env: { A: "two" } } })).toThrow(/share its env with another part of the document/);
     });
 
     it("leaves the shared list untouched when it refuses", () => {
@@ -322,7 +377,7 @@ describe(SdlPatchService.name, () => {
       });
 
       expect(() => service.apply(document, { web: { credentials: { host: "r.test", username: "u", password: "rotated" } } })).toThrow(
-        /share its credentials with another service/
+        /share its credentials with another part of the document/
       );
     });
 
@@ -348,6 +403,7 @@ describe(SdlPatchService.name, () => {
     services: Record<string, SDLInput["services"][string]>;
     shareEnv?: string[];
     shareCredentials?: NonNullable<SDLInput["services"][string]["credentials"]>;
+    aliasWebAs?: string;
   }) {
     const services = { ...input.services };
 
@@ -355,6 +411,8 @@ describe(SdlPatchService.name, () => {
       if (input.shareEnv) services[name] = { ...services[name], env: input.shareEnv };
       if (input.shareCredentials) services[name] = { ...services[name], credentials: input.shareCredentials };
     }
+
+    if (input.aliasWebAs) services[input.aliasWebAs] = services.web;
 
     const document: SDLInput = {
       version: "2.0",

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
@@ -64,12 +64,20 @@ describe(SdlPatchService.name, () => {
   });
 
   describe("env", () => {
-    it("rewrites a named variable at the index it already occupies", () => {
+    it("moves a patched variable to the end, since nothing downstream depends on where it sits", () => {
       const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two", "C=three"] } } });
 
       service.apply(document, { web: { env: { B: "replaced" } } });
 
-      expect(document.services.web.env).toEqual(["A=one", "B=replaced", "C=three"]);
+      expect(document.services.web.env).toEqual(["A=one", "C=three", "B=replaced"]);
+    });
+
+    it("leaves the variables it did not name carrying exactly the text they carried", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=ac-secret://s0_e0", "B=two", "C=ac-secret://s0_e2"] } } });
+
+      service.apply(document, { web: { env: { B: "replaced" } } });
+
+      expect(document.services.web.env).toEqual(["A=ac-secret://s0_e0", "C=ac-secret://s0_e2", "B=replaced"]);
     });
 
     it("appends a variable the service did not declare", () => {
@@ -136,6 +144,41 @@ describe(SdlPatchService.name, () => {
       expect(document.services.web.env).toEqual(["A=one", "B=supplied"]);
     });
 
+    it("leaves a non-string entry alone, since it is not ours to remove", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", 42 as unknown as string, "B=two"] } } });
+
+      service.apply(document, { web: { env: { B: "replaced" } } });
+
+      expect(document.services.web.env).toEqual(["A=one", 42, "B=replaced"]);
+    });
+
+    it("removes every occurrence of a cleared key and appends nothing", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["FOO=one", "BAR=two", "FOO=three"] } } });
+
+      service.apply(document, { web: { env: { FOO: null } } });
+
+      expect(document.services.web.env).toEqual(["BAR=two"]);
+    });
+
+    it("records the appended index when one call both removes and adds", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two", "C=three"] } } });
+
+      const written = service.apply(document, { web: { env: { A: null, B: "replaced" } } });
+
+      expect(document.services.web.env).toEqual(["C=three", "B=replaced"]);
+      expect([...written]).toEqual(["/services/web/env/1"]);
+    });
+
+    it("records an index that really addresses the appended entry", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two"] } } });
+
+      const written = service.apply(document, { web: { env: { A: "replaced" } } });
+
+      const [path] = [...written];
+      const index = Number(path.split("/").pop());
+      expect(document.services.web.env?.[index]).toBe("A=replaced");
+    });
+
     it("keeps a value carrying an equals sign intact", () => {
       const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
 
@@ -146,12 +189,12 @@ describe(SdlPatchService.name, () => {
   });
 
   describe("an env key the stored document declares more than once", () => {
-    it("rewrites every occurrence, leaving no stale duplicate behind", () => {
+    it("collapses a key the document declared twice into the single entry it appends", () => {
       const { service, document } = setup({ services: { web: { image: "nginx", env: ["FOO=one", "BAR=two", "FOO=three"] } } });
 
       service.apply(document, { web: { env: { FOO: "replaced" } } });
 
-      expect(document.services.web.env).toEqual(["FOO=replaced", "BAR=two", "FOO=replaced"]);
+      expect(document.services.web.env).toEqual(["BAR=two", "FOO=replaced"]);
     });
 
     it("removes every occurrence given null", () => {
@@ -162,12 +205,12 @@ describe(SdlPatchService.name, () => {
       expect(document.services.web.env).toEqual(["BAR=two"]);
     });
 
-    it("reports every position it wrote, not only the first", () => {
+    it("reports the one position the collapsed entry ended up at", () => {
       const { service, document } = setup({ services: { web: { image: "nginx", env: ["FOO=one", "BAR=two", "FOO=three"] } } });
 
       const written = service.apply(document, { web: { env: { FOO: "replaced" } } });
 
-      expect([...written].sort()).toEqual(["/services/web/env/0", "/services/web/env/2"]);
+      expect([...written]).toEqual(["/services/web/env/1"]);
     });
   });
 
@@ -227,28 +270,11 @@ describe(SdlPatchService.name, () => {
   });
 
   describe("the positions it reports having written", () => {
-    it("reports the env position it rewrote", () => {
-      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two"] } } });
-
-      const written = service.apply(document, { web: { env: { B: "replaced" } } });
-
-      expect([...written]).toEqual(["/services/web/env/1"]);
-    });
-
     it("reports the env position it appended", () => {
       const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
 
       const written = service.apply(document, { web: { env: { B: "two" } } });
 
-      expect([...written]).toEqual(["/services/web/env/1"]);
-    });
-
-    it("reports the shifted position of a variable it wrote beside one it removed", () => {
-      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two", "C=three"] } } });
-
-      const written = service.apply(document, { web: { env: { A: null, C: "rewritten" } } });
-
-      expect(document.services.web.env).toEqual(["B=two", "C=rewritten"]);
       expect([...written]).toEqual(["/services/web/env/1"]);
     });
 
@@ -323,27 +349,6 @@ describe(SdlPatchService.name, () => {
       const { service, document } = setup({ services: { web: { image: "nginx" } } });
 
       expect(() => service.apply(document, { constructor: { image: "nginx" } })).toThrow(/is not a service of this deployment/);
-    });
-
-    it("changes nothing when a later service in the same patch is unknown", () => {
-      const { service, document } = setup({ services: { web: { image: "nginx" } } });
-
-      expect(() => service.apply(document, { api: { image: "x" }, web: { image: "nginx:1.27" } })).toThrow();
-      expect(document.services.web.image).toBe("nginx");
-    });
-
-    it("changes nothing when the unknown service is visited after a known one", () => {
-      const { service, document } = setup({ services: { web: { image: "nginx" } } });
-
-      expect(() => service.apply(document, { web: { image: "nginx:1.27" }, api: { image: "x" } })).toThrow();
-      expect(document.services.web.image).toBe("nginx");
-    });
-
-    it("writes no env either, when the unknown service is visited last", () => {
-      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
-
-      expect(() => service.apply(document, { web: { env: { A: "two" } }, api: { image: "x" } })).toThrow();
-      expect(document.services.web.env).toEqual(["A=one"]);
     });
 
     it("bounds how much of an outsized service name it echoes", () => {

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
@@ -1,0 +1,352 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { describe, expect, it } from "vitest";
+
+import { MAX_ECHOED_REFERENCE_LENGTH, SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+import { SdlPatchService } from "./sdl-patch.service";
+
+describe(SdlPatchService.name, () => {
+  it("replaces the image of the named service", () => {
+    const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+    service.apply(document, { web: { image: "nginx:1.27" } });
+
+    expect(document.services.web.image).toBe("nginx:1.27");
+  });
+
+  it("replaces command and args", () => {
+    const { service, document } = setup({ services: { web: { image: "nginx", command: ["sh"], args: ["-c", "old"] } } });
+
+    service.apply(document, { web: { command: ["bash"], args: ["-c", "new"] } });
+
+    expect(document.services.web.command).toEqual(["bash"]);
+    expect(document.services.web.args).toEqual(["-c", "new"]);
+  });
+
+  it("clears command and args given null", () => {
+    const { service, document } = setup({ services: { web: { image: "nginx", command: ["sh"], args: ["-c", "old"] } } });
+
+    service.apply(document, { web: { command: null, args: null } });
+
+    expect(document.services.web.command).toBeNull();
+    expect(document.services.web.args).toBeNull();
+  });
+
+  it("leaves a field the patch does not name", () => {
+    const { service, document } = setup({ services: { web: { image: "nginx", command: ["sh"] } } });
+
+    service.apply(document, { web: { image: "nginx:1.27" } });
+
+    expect(document.services.web.command).toEqual(["sh"]);
+  });
+
+  it("leaves a service the patch does not name", () => {
+    const { service, document } = setup({ services: { web: { image: "nginx" }, worker: { image: "busybox" } } });
+
+    service.apply(document, { web: { image: "nginx:1.27" } });
+
+    expect(document.services.worker.image).toBe("busybox");
+  });
+
+  describe("env", () => {
+    it("rewrites a named variable at the index it already occupies", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two", "C=three"] } } });
+
+      service.apply(document, { web: { env: { B: "replaced" } } });
+
+      expect(document.services.web.env).toEqual(["A=one", "B=replaced", "C=three"]);
+    });
+
+    it("appends a variable the service did not declare", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
+
+      service.apply(document, { web: { env: { B: "two" } } });
+
+      expect(document.services.web.env).toEqual(["A=one", "B=two"]);
+    });
+
+    it("removes a variable given null", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two", "C=three"] } } });
+
+      service.apply(document, { web: { env: { B: null } } });
+
+      expect(document.services.web.env).toEqual(["A=one", "C=three"]);
+    });
+
+    it("ignores a removal of a variable the service never declared", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
+
+      service.apply(document, { web: { env: { NOPE: null } } });
+
+      expect(document.services.web.env).toEqual(["A=one"]);
+    });
+
+    it("drops the env key entirely once the last variable is removed", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
+
+      service.apply(document, { web: { env: { A: null } } });
+
+      expect("env" in document.services.web).toBe(false);
+    });
+
+    it("adds env to a service that declared none", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      service.apply(document, { web: { env: { A: "one" } } });
+
+      expect(document.services.web.env).toEqual(["A=one"]);
+    });
+
+    it("treats an entry with no assignment as its own name and gives it a value", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["INHERITED_FROM_HOST"] } } });
+
+      service.apply(document, { web: { env: { INHERITED_FROM_HOST: "explicit" } } });
+
+      expect(document.services.web.env).toEqual(["INHERITED_FROM_HOST=explicit"]);
+    });
+
+    it("keeps a reference standing at a variable the patch does not name", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=ac-secret://s0_e0", "B=two"] } } });
+
+      service.apply(document, { web: { env: { B: "replaced" } } });
+
+      expect(document.services.web.env).toEqual(["A=ac-secret://s0_e0", "B=replaced"]);
+    });
+
+    it("overwrites the reference standing at a variable the patch does name, at the same index", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=ac-secret://s0_e1"] } } });
+
+      service.apply(document, { web: { env: { B: "supplied" } } });
+
+      expect(document.services.web.env).toEqual(["A=one", "B=supplied"]);
+    });
+
+    it("keeps a value carrying an equals sign intact", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
+
+      service.apply(document, { web: { env: { A: "k=v=w" } } });
+
+      expect(document.services.web.env).toEqual(["A=k=v=w"]);
+    });
+  });
+
+  describe("credentials", () => {
+    it("replaces the three fields it carries", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", credentials: { host: "old.test", username: "old", password: "old" } } }
+      });
+
+      service.apply(document, { web: { credentials: { host: "new.test", username: "new", password: "rotated" } } });
+
+      expect(document.services.web.credentials).toEqual({ host: "new.test", username: "new", password: "rotated" });
+    });
+
+    it("keeps the email the patch schema has no field for", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", credentials: { host: "r.test", username: "old", password: "old", email: "keep@r.test" } } }
+      });
+
+      service.apply(document, { web: { credentials: { host: "r.test", username: "new", password: "rotated" } } });
+
+      expect(document.services.web.credentials?.email).toBe("keep@r.test");
+    });
+
+    it("clears the credentials given null", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", credentials: { host: "r.test", username: "u", password: "p" } } }
+      });
+
+      service.apply(document, { web: { credentials: null } });
+
+      expect("credentials" in document.services.web).toBe(false);
+    });
+
+    it("adds credentials to a service that declared none", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      service.apply(document, { web: { credentials: { host: "r.test", username: "u", password: "p" } } });
+
+      expect(document.services.web.credentials).toEqual({ host: "r.test", username: "u", password: "p" });
+    });
+  });
+
+  describe("the positions it reports having written", () => {
+    it("reports the env position it rewrote", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two"] } } });
+
+      const written = service.apply(document, { web: { env: { B: "replaced" } } });
+
+      expect([...written]).toEqual(["/services/web/env/1"]);
+    });
+
+    it("reports the env position it appended", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
+
+      const written = service.apply(document, { web: { env: { B: "two" } } });
+
+      expect([...written]).toEqual(["/services/web/env/1"]);
+    });
+
+    it("reports the shifted position of a variable it wrote beside one it removed", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one", "B=two", "C=three"] } } });
+
+      const written = service.apply(document, { web: { env: { A: null, C: "rewritten" } } });
+
+      expect(document.services.web.env).toEqual(["B=two", "C=rewritten"]);
+      expect([...written]).toEqual(["/services/web/env/1"]);
+    });
+
+    it("reports nothing for a variable it removed", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
+
+      const written = service.apply(document, { web: { env: { A: null } } });
+
+      expect([...written]).toEqual([]);
+    });
+
+    it("reports both halves of a credential it wrote, and not the host", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      const written = service.apply(document, { web: { credentials: { host: "r.test", username: "u", password: "p" } } });
+
+      expect([...written].sort()).toEqual(["/services/web/credentials/password", "/services/web/credentials/username"]);
+    });
+
+    it("reports nothing for credentials it cleared", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", credentials: { host: "r.test", username: "u", password: "p" } } }
+      });
+
+      const written = service.apply(document, { web: { credentials: null } });
+
+      expect([...written]).toEqual([]);
+    });
+
+    it("reports nothing for a patch that touches no value position", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
+
+      const written = service.apply(document, { web: { image: "nginx:1.27" } });
+
+      expect([...written]).toEqual([]);
+    });
+
+    it("reports only the service it was asked to patch", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", env: ["A=one"] }, worker: { image: "busybox", env: ["B=two"] } }
+      });
+
+      const written = service.apply(document, { web: { env: { A: "changed" } } });
+
+      expect([...written]).toEqual(["/services/web/env/0"]);
+    });
+
+    it("spells a position the way the sdl reference walk spells it", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] } } });
+
+      const written = service.apply(document, { web: { env: { A: "changed" } } });
+
+      const slots = new SdlReferenceService().slotsOf(document).map(slot => slot.instancePath);
+      expect(slots).toEqual(expect.arrayContaining([...written]));
+    });
+  });
+
+  describe("a key the deployment does not have", () => {
+    it("refuses a service the sdl does not declare, naming it", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      expect(() => service.apply(document, { api: { image: "nginx" } })).toThrow(/"api" is not a service of this deployment/);
+    });
+
+    it("refuses with a 400", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      expect(() => service.apply(document, { api: { image: "nginx" } })).toThrow(expect.objectContaining({ status: 400 }));
+    });
+
+    it("refuses a service name spelling an object prototype member rather than resolving one", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      expect(() => service.apply(document, { constructor: { image: "nginx" } })).toThrow(/is not a service of this deployment/);
+    });
+
+    it("changes nothing when a later service in the same patch is unknown", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      expect(() => service.apply(document, { api: { image: "x" }, web: { image: "nginx:1.27" } })).toThrow();
+      expect(document.services.web.image).toBe("nginx");
+    });
+
+    it("bounds how much of an outsized service name it echoes", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+      const outsized = "n".repeat(500);
+
+      expect(() => service.apply(document, { [outsized]: { image: "nginx" } })).toThrow(
+        `"${"n".repeat(MAX_ECHOED_REFERENCE_LENGTH)}" is not a service of this deployment`
+      );
+    });
+  });
+
+  describe("a node two services share through a yaml anchor", () => {
+    it("refuses to patch env through a shared list", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" }, worker: { image: "busybox" } }, shareEnv: ["A=one"] });
+
+      expect(() => service.apply(document, { web: { env: { A: "two" } } })).toThrow(/share its env with another service/);
+    });
+
+    it("leaves the shared list untouched when it refuses", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" }, worker: { image: "busybox" } }, shareEnv: ["A=one"] });
+
+      expect(() => service.apply(document, { web: { env: { A: "two" } } })).toThrow();
+      expect(document.services.worker.env).toEqual(["A=one"]);
+    });
+
+    it("refuses to patch credentials through a shared block", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx" }, worker: { image: "busybox" } },
+        shareCredentials: { host: "r.test", username: "u", password: "p" }
+      });
+
+      expect(() => service.apply(document, { web: { credentials: { host: "r.test", username: "u", password: "rotated" } } })).toThrow(
+        /share its credentials with another service/
+      );
+    });
+
+    it("still patches a field that does not reach the shared node", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" }, worker: { image: "busybox" } }, shareEnv: ["A=one"] });
+
+      service.apply(document, { web: { image: "nginx:1.27" } });
+
+      expect(document.services.web.image).toBe("nginx:1.27");
+    });
+
+    it("patches an env list only one service reaches", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", env: ["A=one"] }, worker: { image: "busybox", env: ["A=one"] } } });
+
+      service.apply(document, { web: { env: { A: "two" } } });
+
+      expect(document.services.web.env).toEqual(["A=two"]);
+      expect(document.services.worker.env).toEqual(["A=one"]);
+    });
+  });
+
+  function setup(input: {
+    services: Record<string, SDLInput["services"][string]>;
+    shareEnv?: string[];
+    shareCredentials?: NonNullable<SDLInput["services"][string]["credentials"]>;
+  }) {
+    const services = { ...input.services };
+
+    for (const name of Object.keys(services)) {
+      if (input.shareEnv) services[name] = { ...services[name], env: input.shareEnv };
+      if (input.shareCredentials) services[name] = { ...services[name], credentials: input.shareCredentials };
+    }
+
+    const document: SDLInput = {
+      version: "2.0",
+      services,
+      profiles: { compute: {}, placement: {} },
+      deployment: {}
+    };
+
+    return { service: new SdlPatchService(), document };
+  }
+});

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -68,8 +68,9 @@ export class SdlPatchService {
 
   #applyToService(service: SdlServiceNode, patch: PatchService, at: PatchTarget): void {
     if (patch.image !== undefined) service.image = patch.image;
-    if (patch.command !== undefined) service.command = patch.command;
-    if (patch.args !== undefined) service.args = patch.args;
+
+    this.#applyClearableList(service, "command", patch.command);
+    this.#applyClearableList(service, "args", patch.args);
 
     if (patch.env !== undefined) {
       this.#assertNotShared(service.env, { ...at, field: "env" });
@@ -80,6 +81,14 @@ export class SdlPatchService {
       this.#assertNotShared(service.credentials, { ...at, field: "credentials" });
       this.#applyCredentials(service, patch.credentials, at);
     }
+  }
+
+  /** A cleared list is removed rather than written as `null`, matching how a cleared `env` and cleared `credentials` behave, so a read never shows a field the user did not write. */
+  #applyClearableList(service: SdlServiceNode, field: "command" | "args", value: string[] | null | undefined): void {
+    if (value === undefined) return;
+
+    if (value === null) delete service[field];
+    else service[field] = value;
   }
 
   /** Rewrites a named variable where it already stands, so an `ac-secret://` reference keeps the position its stored name was minted from. */

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -1,0 +1,151 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import createError from "http-errors";
+import { singleton } from "tsyringe";
+
+import type { PatchService } from "@src/deployment/http-schemas/deployment.schema";
+import { MAX_ECHOED_REFERENCE_LENGTH, ownValue, readEnvDeclaration } from "@src/deployment/services/sdl-reference/sdl-reference.service";
+
+type SdlServiceNode = SDLInput["services"][string];
+
+/** Where a patch is being applied, plus the set it records each written value position into. */
+type PatchTarget = { serviceName: string; shared: Set<object>; written: Set<string> };
+
+/** Where an `env` entry with no `=` is its own name, because a bare entry asks for the variable to be inherited from the host. */
+function envKeyOf(entry: string): string {
+  return readEnvDeclaration(entry)?.key ?? entry;
+}
+
+/**
+ * The `env` lists and `credentials` blocks reachable from more than one service, which a YAML anchor
+ * makes possible: patching through such a node would silently rewrite a service the request never named.
+ */
+function sharedNodesOf(services: SDLInput["services"]): Set<object> {
+  const seen = new Set<object>();
+  const shared = new Set<object>();
+
+  for (const service of Object.values(services)) {
+    for (const node of [service?.env, service?.credentials]) {
+      if (!node || typeof node !== "object") continue;
+
+      if (seen.has(node)) shared.add(node);
+
+      seen.add(node);
+    }
+  }
+
+  return shared;
+}
+
+/**
+ * Applies a partial service definition to the SDL the console stored, mutating the document it is given.
+ * Every message it raises names only a key the caller itself sent, never a value, because those messages
+ * are echoed to the caller and logged.
+ */
+@singleton()
+export class SdlPatchService {
+  /**
+   * Returns the instance paths this patch wrote a value into, spelled the way the SDL Reference walk
+   * spells them, so a caller can seal exactly what the request supplied and leave every other value in
+   * the document as it found it.
+   */
+  apply(document: SDLInput, patches: Record<string, PatchService>): Set<string> {
+    const services = this.#servicesOf(document);
+    const shared = sharedNodesOf(services);
+    const written = new Set<string>();
+
+    for (const [serviceName, patch] of Object.entries(patches)) {
+      const service = ownValue(services, serviceName);
+
+      if (!service) {
+        throw this.#reject(`"${echo(serviceName)}" is not a service of this deployment`);
+      }
+
+      this.#applyToService(service, patch, { serviceName, shared, written });
+    }
+
+    return written;
+  }
+
+  #applyToService(service: SdlServiceNode, patch: PatchService, at: PatchTarget): void {
+    if (patch.image !== undefined) service.image = patch.image;
+    if (patch.command !== undefined) service.command = patch.command;
+    if (patch.args !== undefined) service.args = patch.args;
+
+    if (patch.env !== undefined) {
+      this.#assertNotShared(service.env, { ...at, field: "env" });
+      this.#applyEnv(service, patch.env, at);
+    }
+
+    if (patch.credentials !== undefined) {
+      this.#assertNotShared(service.credentials, { ...at, field: "credentials" });
+      this.#applyCredentials(service, patch.credentials, at);
+    }
+  }
+
+  /** Rewrites a named variable where it already stands, so an `ac-secret://` reference keeps the position its stored name was minted from. */
+  #applyEnv(service: SdlServiceNode, patch: NonNullable<PatchService["env"]>, target: PatchTarget): void {
+    const env: string[] = Array.isArray(service.env) ? service.env : [];
+
+    for (const [key, value] of Object.entries(patch)) {
+      const at = env.findIndex(entry => typeof entry === "string" && envKeyOf(entry) === key);
+
+      if (value === null) {
+        if (at !== -1) env.splice(at, 1);
+
+        continue;
+      }
+
+      const entry = `${key}=${value}`;
+
+      if (at === -1) env.push(entry);
+      else env[at] = entry;
+    }
+
+    if (env.length === 0) delete service.env;
+    else service.env = env;
+
+    /** Recorded after every write, because a removal shifts the entries below it and only the final array says where a value ended up. */
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === null) continue;
+
+      const index = env.findIndex(entry => typeof entry === "string" && envKeyOf(entry) === key);
+
+      if (index !== -1) target.written.add(`/services/${target.serviceName}/env/${index}`);
+    }
+  }
+
+  /** Merges rather than replaces, so the `email` the schema has no field for survives a credential rotation. */
+  #applyCredentials(service: SdlServiceNode, patch: NonNullable<PatchService["credentials"]> | null, target: PatchTarget): void {
+    if (patch === null) {
+      delete service.credentials;
+
+      return;
+    }
+
+    service.credentials = { ...service.credentials, ...patch };
+
+    for (const field of ["username", "password"] as const) {
+      if (patch[field] !== undefined) target.written.add(`/services/${target.serviceName}/credentials/${field}`);
+    }
+  }
+
+  #assertNotShared(node: unknown, at: { serviceName: string; shared: Set<object>; field: string }): void {
+    if (!node || typeof node !== "object" || !at.shared.has(node)) return;
+
+    throw this.#reject(`an SDL anchor makes service "${echo(at.serviceName)}" share its ${at.field} with another service, so patching it would change both`);
+  }
+
+  #servicesOf(document: SDLInput): SDLInput["services"] {
+    const services = document?.services;
+
+    return services && typeof services === "object" ? services : {};
+  }
+
+  #reject(message: string) {
+    return createError(400, message);
+  }
+}
+
+function echo(key: string): string {
+  return key.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+}

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -7,10 +7,7 @@ import { MAX_ECHOED_REFERENCE_LENGTH, ownValue, readEnvDeclaration } from "@src/
 
 type SdlServiceNode = SDLInput["services"][string];
 
-type PatchTarget = { serviceName: string; written: Set<string> };
-
-/** One service resolved and cleared for mutation, so nothing is written until every service in the patch has passed. */
-type ResolvedPatch = { serviceName: string; service: SdlServiceNode; patch: PatchService };
+type PatchTarget = { serviceName: string; shared: Set<object>; written: Set<string> };
 
 /** A bare `env` entry is its own name, because it asks for the variable to be inherited from the host. */
 function envKeyOf(entry: string): string {
@@ -46,47 +43,42 @@ function echo(key: string): string {
 /** Applies a partial service definition to the stored SDL, naming only keys the caller sent and never a value, because its messages are echoed back and logged. */
 @singleton()
 export class SdlPatchService {
-  /** Returns the instance paths it wrote a value into, spelled as the SDL Reference walk spells them, so a caller can seal exactly what the request supplied. */
+  /** Returns the instance paths it wrote a value into, spelled as the SDL Reference walk spells them, so a caller can seal exactly what the request supplied and nothing else. */
   apply(document: SDLInput, patches: Record<string, PatchService>): Set<string> {
     const services = this.#servicesOf(document);
     const shared = sharedNodesOf(services);
-    const resolved = this.#resolveAll(services, patches, shared);
     const written = new Set<string>();
 
-    for (const { serviceName, service, patch } of resolved) {
-      this.#applyToService(service, patch, { serviceName, written });
-    }
-
-    return written;
-  }
-
-  /** Every service and every node it would write through is checked before the first mutation, so a patch rejected on its last key leaves the document as it found it. */
-  #resolveAll(services: SDLInput["services"], patches: Record<string, PatchService>, shared: Set<object>): ResolvedPatch[] {
-    return Object.entries(patches).map(([serviceName, patch]) => {
+    for (const [serviceName, patch] of Object.entries(patches)) {
       const service = ownValue(services, serviceName);
 
       if (!service) {
         throw this.#reject(`"${echo(serviceName)}" is not a service of this deployment`);
       }
 
-      this.#assertNotShared(service, { serviceName, shared, field: "definition" });
+      this.#applyToService(service, patch, { serviceName, shared, written });
+    }
 
-      if (patch.env !== undefined) this.#assertNotShared(service.env, { serviceName, shared, field: "env" });
-      if (patch.credentials !== undefined) this.#assertNotShared(service.credentials, { serviceName, shared, field: "credentials" });
-
-      return { serviceName, service, patch };
-    });
+    return written;
   }
 
   #applyToService(service: SdlServiceNode, patch: PatchService, at: PatchTarget): void {
+    this.#assertNotShared(service, { ...at, field: "definition" });
+
     if (patch.image !== undefined) service.image = patch.image;
 
     this.#applyClearableList(service, "command", patch.command);
     this.#applyClearableList(service, "args", patch.args);
 
-    if (patch.env !== undefined) this.#applyEnv(service, patch.env, at);
+    if (patch.env !== undefined) {
+      this.#assertNotShared(service.env, { ...at, field: "env" });
+      this.#applyEnv(service, patch.env, at);
+    }
 
-    if (patch.credentials !== undefined) this.#applyCredentials(service, patch.credentials, at);
+    if (patch.credentials !== undefined) {
+      this.#assertNotShared(service.credentials, { ...at, field: "credentials" });
+      this.#applyCredentials(service, patch.credentials, at);
+    }
   }
 
   /** A cleared list is removed rather than written as `null`, so a read never shows a field the user did not write. */
@@ -97,38 +89,27 @@ export class SdlPatchService {
     else service[field] = value;
   }
 
-  /** Rewrites a named variable at every index it already occupies, so an `ac-secret://` reference keeps the position its stored name was minted from and no stale duplicate survives. */
+  /**
+   * A patched variable is dropped wherever it stood and appended, so it moves position and any
+   * duplicate of it collapses into one entry; nothing downstream depends on where a value sits. The
+   * recorded path is the appended index, which is what scopes derivation to the values this patch
+   * supplied rather than every plaintext in the document.
+   */
   #applyEnv(service: SdlServiceNode, patch: NonNullable<PatchService["env"]>, target: PatchTarget): void {
-    const env: string[] = Array.isArray(service.env) ? service.env : [];
+    const source: string[] = Array.isArray(service.env) ? service.env : [];
+    const patched = new Set(Object.keys(patch));
+    /** A non-string entry is not ours to remove, whatever the user put there. */
+    const env = source.filter(entry => typeof entry !== "string" || !patched.has(envKeyOf(entry)));
 
     for (const [key, value] of Object.entries(patch)) {
-      const at = indicesOfEnvKey(env, key);
+      if (value === null) continue;
 
-      if (value === null) {
-        for (const index of [...at].reverse()) env.splice(index, 1);
-
-        continue;
-      }
-
-      if (at.length === 0) env.push(`${key}=${value}`);
-      else for (const index of at) env[index] = `${key}=${value}`;
+      target.written.add(`/services/${target.serviceName}/env/${env.length}`);
+      env.push(`${key}=${value}`);
     }
 
     if (env.length === 0) delete service.env;
     else service.env = env;
-
-    this.#recordWrittenEnv(env, patch, target);
-  }
-
-  /** Read after every write, because a removal shifts the entries below it and only the final array says where a value ended up. */
-  #recordWrittenEnv(env: string[], patch: NonNullable<PatchService["env"]>, target: PatchTarget): void {
-    for (const [key, value] of Object.entries(patch)) {
-      if (value === null) continue;
-
-      for (const index of indicesOfEnvKey(env, key)) {
-        target.written.add(`/services/${target.serviceName}/env/${index}`);
-      }
-    }
   }
 
   /** Merges rather than replaces, so the `email` the schema has no field for survives a credential rotation. */
@@ -163,8 +144,4 @@ export class SdlPatchService {
   #reject(message: string) {
     return createError(400, message);
   }
-}
-
-function indicesOfEnvKey(env: string[], key: string): number[] {
-  return env.flatMap((entry, index) => (typeof entry === "string" && envKeyOf(entry) === key ? [index] : []));
 }

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -14,6 +14,10 @@ function envKeyOf(entry: string): string {
   return readEnvDeclaration(entry)?.key ?? entry;
 }
 
+function declaresPatchedVariable(entry: unknown, patchedKeys: Set<string>): boolean {
+  return typeof entry === "string" && patchedKeys.has(envKeyOf(entry));
+}
+
 function isNode(value: unknown): value is object {
   return !!value && typeof value === "object";
 }
@@ -97,9 +101,8 @@ export class SdlPatchService {
    */
   #applyEnv(service: SdlServiceNode, patch: NonNullable<PatchService["env"]>, target: PatchTarget): void {
     const source: string[] = Array.isArray(service.env) ? service.env : [];
-    const patched = new Set(Object.keys(patch));
-    /** A non-string entry is not ours to remove, whatever the user put there. */
-    const env = source.filter(entry => typeof entry !== "string" || !patched.has(envKeyOf(entry)));
+    const patchedKeys = new Set(Object.keys(patch));
+    const env = source.filter(entry => !declaresPatchedVariable(entry, patchedKeys));
 
     for (const [key, value] of Object.entries(patch)) {
       if (value === null) continue;

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -7,25 +7,28 @@ import { MAX_ECHOED_REFERENCE_LENGTH, ownValue, readEnvDeclaration } from "@src/
 
 type SdlServiceNode = SDLInput["services"][string];
 
-/** Where a patch is being applied, plus the set it records each written value position into. */
-type PatchTarget = { serviceName: string; shared: Set<object>; written: Set<string> };
+type PatchTarget = { serviceName: string; written: Set<string> };
 
-/** Where an `env` entry with no `=` is its own name, because a bare entry asks for the variable to be inherited from the host. */
+/** One service resolved and cleared for mutation, so nothing is written until every service in the patch has passed. */
+type ResolvedPatch = { serviceName: string; service: SdlServiceNode; patch: PatchService };
+
+/** A bare `env` entry is its own name, because it asks for the variable to be inherited from the host. */
 function envKeyOf(entry: string): string {
   return readEnvDeclaration(entry)?.key ?? entry;
 }
 
-/**
- * The `env` lists and `credentials` blocks reachable from more than one service, which a YAML anchor
- * makes possible: patching through such a node would silently rewrite a service the request never named.
- */
+function isNode(value: unknown): value is object {
+  return !!value && typeof value === "object";
+}
+
+/** A node reachable twice is one a write would change in a place the request did not name, whether the second reacher is another service or another part of the same one. */
 function sharedNodesOf(services: SDLInput["services"]): Set<object> {
   const seen = new Set<object>();
   const shared = new Set<object>();
 
   for (const service of Object.values(services)) {
-    for (const node of [service?.env, service?.credentials]) {
-      if (!node || typeof node !== "object") continue;
+    for (const node of [service, service?.env, service?.credentials]) {
+      if (!isNode(node)) continue;
 
       if (seen.has(node)) shared.add(node);
 
@@ -36,34 +39,43 @@ function sharedNodesOf(services: SDLInput["services"]): Set<object> {
   return shared;
 }
 
-/**
- * Applies a partial service definition to the SDL the console stored, mutating the document it is given.
- * Every message it raises names only a key the caller itself sent, never a value, because those messages
- * are echoed to the caller and logged.
- */
+function echo(key: string): string {
+  return key.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+}
+
+/** Applies a partial service definition to the stored SDL, naming only keys the caller sent and never a value, because its messages are echoed back and logged. */
 @singleton()
 export class SdlPatchService {
-  /**
-   * Returns the instance paths this patch wrote a value into, spelled the way the SDL Reference walk
-   * spells them, so a caller can seal exactly what the request supplied and leave every other value in
-   * the document as it found it.
-   */
+  /** Returns the instance paths it wrote a value into, spelled as the SDL Reference walk spells them, so a caller can seal exactly what the request supplied. */
   apply(document: SDLInput, patches: Record<string, PatchService>): Set<string> {
     const services = this.#servicesOf(document);
     const shared = sharedNodesOf(services);
+    const resolved = this.#resolveAll(services, patches, shared);
     const written = new Set<string>();
 
-    for (const [serviceName, patch] of Object.entries(patches)) {
+    for (const { serviceName, service, patch } of resolved) {
+      this.#applyToService(service, patch, { serviceName, written });
+    }
+
+    return written;
+  }
+
+  /** Every service and every node it would write through is checked before the first mutation, so a patch rejected on its last key leaves the document as it found it. */
+  #resolveAll(services: SDLInput["services"], patches: Record<string, PatchService>, shared: Set<object>): ResolvedPatch[] {
+    return Object.entries(patches).map(([serviceName, patch]) => {
       const service = ownValue(services, serviceName);
 
       if (!service) {
         throw this.#reject(`"${echo(serviceName)}" is not a service of this deployment`);
       }
 
-      this.#applyToService(service, patch, { serviceName, shared, written });
-    }
+      this.#assertNotShared(service, { serviceName, shared, field: "definition" });
 
-    return written;
+      if (patch.env !== undefined) this.#assertNotShared(service.env, { serviceName, shared, field: "env" });
+      if (patch.credentials !== undefined) this.#assertNotShared(service.credentials, { serviceName, shared, field: "credentials" });
+
+      return { serviceName, service, patch };
+    });
   }
 
   #applyToService(service: SdlServiceNode, patch: PatchService, at: PatchTarget): void {
@@ -72,18 +84,12 @@ export class SdlPatchService {
     this.#applyClearableList(service, "command", patch.command);
     this.#applyClearableList(service, "args", patch.args);
 
-    if (patch.env !== undefined) {
-      this.#assertNotShared(service.env, { ...at, field: "env" });
-      this.#applyEnv(service, patch.env, at);
-    }
+    if (patch.env !== undefined) this.#applyEnv(service, patch.env, at);
 
-    if (patch.credentials !== undefined) {
-      this.#assertNotShared(service.credentials, { ...at, field: "credentials" });
-      this.#applyCredentials(service, patch.credentials, at);
-    }
+    if (patch.credentials !== undefined) this.#applyCredentials(service, patch.credentials, at);
   }
 
-  /** A cleared list is removed rather than written as `null`, matching how a cleared `env` and cleared `credentials` behave, so a read never shows a field the user did not write. */
+  /** A cleared list is removed rather than written as `null`, so a read never shows a field the user did not write. */
   #applyClearableList(service: SdlServiceNode, field: "command" | "args", value: string[] | null | undefined): void {
     if (value === undefined) return;
 
@@ -91,35 +97,37 @@ export class SdlPatchService {
     else service[field] = value;
   }
 
-  /** Rewrites a named variable where it already stands, so an `ac-secret://` reference keeps the position its stored name was minted from. */
+  /** Rewrites a named variable at every index it already occupies, so an `ac-secret://` reference keeps the position its stored name was minted from and no stale duplicate survives. */
   #applyEnv(service: SdlServiceNode, patch: NonNullable<PatchService["env"]>, target: PatchTarget): void {
     const env: string[] = Array.isArray(service.env) ? service.env : [];
 
     for (const [key, value] of Object.entries(patch)) {
-      const at = env.findIndex(entry => typeof entry === "string" && envKeyOf(entry) === key);
+      const at = indicesOfEnvKey(env, key);
 
       if (value === null) {
-        if (at !== -1) env.splice(at, 1);
+        for (const index of [...at].reverse()) env.splice(index, 1);
 
         continue;
       }
 
-      const entry = `${key}=${value}`;
-
-      if (at === -1) env.push(entry);
-      else env[at] = entry;
+      if (at.length === 0) env.push(`${key}=${value}`);
+      else for (const index of at) env[index] = `${key}=${value}`;
     }
 
     if (env.length === 0) delete service.env;
     else service.env = env;
 
-    /** Recorded after every write, because a removal shifts the entries below it and only the final array says where a value ended up. */
+    this.#recordWrittenEnv(env, patch, target);
+  }
+
+  /** Read after every write, because a removal shifts the entries below it and only the final array says where a value ended up. */
+  #recordWrittenEnv(env: string[], patch: NonNullable<PatchService["env"]>, target: PatchTarget): void {
     for (const [key, value] of Object.entries(patch)) {
       if (value === null) continue;
 
-      const index = env.findIndex(entry => typeof entry === "string" && envKeyOf(entry) === key);
-
-      if (index !== -1) target.written.add(`/services/${target.serviceName}/env/${index}`);
+      for (const index of indicesOfEnvKey(env, key)) {
+        target.written.add(`/services/${target.serviceName}/env/${index}`);
+      }
     }
   }
 
@@ -139,9 +147,11 @@ export class SdlPatchService {
   }
 
   #assertNotShared(node: unknown, at: { serviceName: string; shared: Set<object>; field: string }): void {
-    if (!node || typeof node !== "object" || !at.shared.has(node)) return;
+    if (!isNode(node) || !at.shared.has(node)) return;
 
-    throw this.#reject(`an SDL anchor makes service "${echo(at.serviceName)}" share its ${at.field} with another service, so patching it would change both`);
+    throw this.#reject(
+      `an SDL anchor makes service "${echo(at.serviceName)}" share its ${at.field} with another part of the document, so patching it would change both`
+    );
   }
 
   #servicesOf(document: SDLInput): SDLInput["services"] {
@@ -155,6 +165,6 @@ export class SdlPatchService {
   }
 }
 
-function echo(key: string): string {
-  return key.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+function indicesOfEnvKey(env: string[], key: string): number[] {
+  return env.flatMap((entry, index) => (typeof entry === "string" && envKeyOf(entry) === key ? [index] : []));
 }

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -22,6 +22,11 @@ function isNode(value: unknown): value is object {
   return !!value && typeof value === "object";
 }
 
+/** An empty record names no variable, so it neither writes nor deserves the refusal an anchored env node would otherwise earn it. */
+function assignsEnv(patch: PatchService["env"]): patch is NonNullable<PatchService["env"]> {
+  return patch !== undefined && Object.keys(patch).length > 0;
+}
+
 /** A node reachable twice is one a write would change in a place the request did not name, whether the second reacher is another service or another part of the same one. */
 function sharedNodesOf(services: SDLInput["services"]): Set<object> {
   const seen = new Set<object>();
@@ -74,7 +79,7 @@ export class SdlPatchService {
     this.#applyClearableList(service, "command", patch.command);
     this.#applyClearableList(service, "args", patch.args);
 
-    if (patch.env !== undefined) {
+    if (assignsEnv(patch.env)) {
       this.#assertNotShared(service.env, { ...at, field: "env" });
       this.#applyEnv(service, patch.env, at);
     }

--- a/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
+++ b/apps/api/src/deployment/services/sdl-reference/sdl-reference.service.ts
@@ -37,7 +37,8 @@ function readSdlReference(value: string): SdlReferenceRead {
   return { type: "reference", kind: reference[1], name: reference[2] };
 }
 
-function readEnvDeclaration(entry: string): { key: string; value: string } | null {
+/** Shared with the patcher, so one place decides where an `env` entry's name ends and its value begins. */
+export function readEnvDeclaration(entry: string): { key: string; value: string } | null {
   const valueStart = entry.indexOf("=");
 
   return valueStart === -1 ? null : { key: entry.slice(0, valueStart), value: entry.slice(valueStart + 1) };


### PR DESCRIPTION
## Why

Part of CON-864.

The first half of the SDL patcher the new endpoint needs: image, command, args, env and registry credentials. No caller yet — the pipeline that uses it lands later in this stack.

## What

`SdlPatchService.apply` mutates the parsed document the console stored, so the SDL stays the source of truth for which names exist, and returns the instance paths it wrote a value into.

Three choices are load-bearing rather than incidental:

**An `env` variable the patch names is dropped wherever it stood and appended.** Positional `sN_eM` naming is a console-internal fallback for a create that supplied no sealed secrets; the name only has to be unique, and a client that cares about names chooses them in its own seal. References therefore do not need to survive an update, which removes the only consumer of position stability. `#applyEnv` is one filter plus one append loop: a duplicate key collapses into a single entry for free, a cleared key appends nothing, and an updated variable gets a fresh derived name while the old name falls out of the token through the existing prune.

The filter keeps non-string entries — one is not ours to remove whatever the user put there, and inverting that predicate would silently drop malformed entries. There is a test that fails when it is inverted.

**Consequence, accepted:** `env` reordering is visible in `GET`'s `consoleSettings.sdl` after a patch. Nothing hides it; the route and field descriptions say so.

**`apply` reports the positions it wrote.** The caller seals exactly what the request supplied and leaves every other value in the document as it found it. Without that report a patch would have to seal every plaintext value in a stored document — including in services the request never named — which would move a non-secret config value into the sealed token and out of its owner's reach. Nine tests cover the reported set, including the shifted position of a variable written beside one that was removed.

**A patch is refused when a YAML anchor makes the service, its `env` list or its `credentials` block reachable from a second place**, because writing through that node would silently rewrite a service the request never named. Anchored env is rare and a clear refusal beats a surprise.

Service names are read with `ownValue`, so a service called `constructor` is reported as absent instead of resolving to a function. Every message names only a key the caller sent, bounded to the same echo length the reference errors use — never a value.

### Review rounds

`command: null` and `args: null` were written through literally while a cleared `env` and cleared `credentials` were removed, so a read showed a `command: null` the user never wrote. All three now remove the key.

An `env` patch key was unconstrained. `{"A=B": "c"}` was written as `A=B=c`, which `envKeyOf` reads back as variable `A` with value `B=c` — it silently overwrote a different variable, and because the written-position lookup then found nothing, **the supplied value stayed in the stored SDL in the clear**. Keys must now be environment variable names.

`#resolveAll` and its `ResolvedPatch` type are gone. A reviewer asked for the patcher to be all-or-nothing, and I built a validate-then-apply pre-pass for it; the pipeline re-parses the stored SDL from its string per request, so a throw leaves the partially-mutated object unreachable and nothing is persisted. That pre-pass guarded a state nothing can observe. Its checks are kept, run inline in the single pass, and the tests asserting the unobservable property are removed rather than left passing for the wrong reason.

`indicesOfEnvKey` and `#recordWrittenEnv` are gone with the rewrite. The first existed only to locate removals and write targets, which the `Set` predicate now does — and a `Set` also sidesteps the prototype-key hazard of probing a record built from user input. The second existed because removals shifted indices so only the final array knew where a value landed; with append-only writes `env.length` at push time *is* the final index, so recording inline is strictly more correct as well as shorter. Its purpose is unchanged and load-bearing: without the recorded paths, derivation sweeps the whole document and re-seals plaintext env in services the patch never named.

Observable behaviour of the endpoint is demonstrated in the PATCH exposure PR.

Measured: 549 non-excluded changed lines. `apps/api` tsc 42 against a 42 baseline, lint 0, `sdl-patch` unit 40/40, functional 406/406.

### Review round 4 — one clean-code fix

The `#applyEnv` filter carried its reasoning in a JSDoc block sitting **inside** the function body, which `clean-code-over-comments.md` does not allow — a JSDoc block belongs on a declaration. The point is lifted into the name instead: the filter now reads `source.filter(entry => !declaresPatchedVariable(entry, patchedKeys))`, and a non-string entry declares no patched variable, so it survives without needing to be told so.


### Review round 5 — an empty env record, and the sweep for the rest of its family

**`env: {}` refused a patch it would never have written.** `PatchEnvSchema` is a `z.record`, so `{ image: "nginx:1.27", env: {} }` is a valid request that names env without asking for a variable. `#applyToService` gated the env branch on `patch.env !== undefined`, so it ran `#assertNotShared` on the env list anyway and answered **400** whenever that service's env happened to be YAML-anchor-shared — for a request that never asked to change env.

The 400 was not the whole cost. In the *unanchored* case the same gate let `env: {}` reach `#applyEnv`, which rebuilds the list into a fresh array (`service.env = env`) even having filtered and appended nothing. Same content, new object identity — a no-op patch quietly replacing the very node the anchor detection exists to protect. The regression test asserts identity rather than equality, so it covers that half too.

The gate is now `assignsEnv(patch.env)`, a type predicate so `patch.env` still narrows for `#applyEnv`.

**This was the third instance of one family, so the service was swept rather than patched in place.** The first was an empty `httpOptions` synthesising an `http_options: {}` node the user never wrote; the second was an empty service patch asserting on the definition; this is the third. Every place a sub-patch's *presence*, rather than its *content*, gated either a shared-node assertion or a write was re-examined:

| field | gate | verdict |
| --- | --- | --- |
| `env` | `patch.env !== undefined` | **fixed here** — a `z.record` accepts `{}` |
| `credentials` | `patch.credentials !== undefined` | sound — `host`, `username` and `password` are all required, so presence *is* content, and `null` is a real write (it clears them) |
| `image` | `patch.image !== undefined` | sound — a leaf |
| `command`, `args` | `value === undefined` early return | sound — leaves, and `command: []` is a real write that clears the list |
| `assignsService` | reads `env` by presence | same defect one level up; fixed on #3825, which owns that function |
| `expose`, `storage` | already content-gated | sound — `assignsExpose` and `assignsStorage` |

#3825 carries the other two halves: `assignsService` asking `assignsEnv`, and the schema's completeness check deepened so `{ env: {} }` is refused before it reaches the writer at all.

Both new tests were verified to fail when the gate is reverted to `patch.env !== undefined`.

Re-measured on the re-stacked head: `apps/api` tsc **41 against a re-measured 41 baseline** (main moved since the figure above), lint **0** on the changed files. The functional suite does not run on this machine — the local `console-db-1` has only the `postgres` role after an unrelated experiment — so its result comes from CI rather than from a local pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selectively updating deployed service settings, including images, commands, arguments, environment variables, and credentials.
  - Service updates now support clearing credential fields and removing environment variables with null values.
  - Environment variable updates handle duplicate entries and preserve the intended configuration order.

- **Bug Fixes**
  - Invalid environment-variable names are now rejected with clear validation errors.
  - Shared or ambiguous service configuration entries are protected from unsafe updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
