### PR TITLE
refactor(sdl): apply a partial service definition to expose and storage

### DIFF
--- a/apps/api/src/deployment/http-schemas/deployment.schema.spec.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.spec.ts
@@ -1,0 +1,51 @@
+import "@hono/zod-openapi";
+
+import { describe, expect, it } from "vitest";
+
+import { PatchServiceSchema } from "./deployment.schema";
+
+describe("PatchServiceSchema", () => {
+  describe("a patch that would write nothing", () => {
+    it("refuses a patch naming no field at all", () => {
+      expect(PatchServiceSchema.safeParse({}).success).toBe(false);
+    });
+
+    it("refuses an env record carrying no variable", () => {
+      expect(PatchServiceSchema.safeParse({ env: {} }).success).toBe(false);
+    });
+
+    it("refuses an expose record carrying no port", () => {
+      expect(PatchServiceSchema.safeParse({ expose: {} }).success).toBe(false);
+    });
+
+    it("refuses a storage record carrying no volume", () => {
+      expect(PatchServiceSchema.safeParse({ storage: {} }).success).toBe(false);
+    });
+
+    it("refuses every empty record at once rather than passing on the count of them", () => {
+      expect(PatchServiceSchema.safeParse({ env: {}, expose: {}, storage: {} }).success).toBe(false);
+    });
+  });
+
+  describe("a patch that would write something", () => {
+    it("accepts a field alongside an empty record", () => {
+      expect(PatchServiceSchema.safeParse({ image: "nginx:1.27", env: {} }).success).toBe(true);
+    });
+
+    it("accepts an empty command list, which clears the one the service declared", () => {
+      expect(PatchServiceSchema.safeParse({ command: [] }).success).toBe(true);
+    });
+
+    it("accepts cleared credentials", () => {
+      expect(PatchServiceSchema.safeParse({ credentials: null }).success).toBe(true);
+    });
+
+    it("leaves a named port to the writer, which knows whether the document declares it", () => {
+      expect(PatchServiceSchema.safeParse({ expose: { "80": { httpOptions: {} } } }).success).toBe(true);
+    });
+
+    it("leaves a named volume to the writer, which knows whether the profile declares it", () => {
+      expect(PatchServiceSchema.safeParse({ storage: { data: {} } }).success).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -204,7 +204,8 @@ export const PatchServiceSchema = z
       description: "Keyed by volume name. Mount point and read-only flag only — sizes are fixed at create."
     })
   })
-  .partial();
+  .partial()
+  .refine(patch => Object.keys(patch).length > 0, { message: "At least one field must be patched" });
 
 export const UpdateDeploymentResponseSchema = z.object({
   data: DeploymentResponseSchema

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -168,13 +168,14 @@ const PatchEnvSchema = z.record(z.string().regex(ENV_VARIABLE_NAME), z.string().
   description: "Merged into the service's env, keyed by environment variable name. A null value removes the variable."
 });
 
+/** `nonnegative` rather than `positive`: the grammar gives every one of these `minimum: 0`, and 0 is how a timeout is cleared. */
 const PatchHttpOptionsSchema = z
   .object({
-    maxBodySize: z.number().int().positive(),
-    readTimeout: z.number().int().positive(),
-    sendTimeout: z.number().int().positive(),
-    nextTries: z.number().int().positive(),
-    nextTimeout: z.number().int().positive(),
+    maxBodySize: z.number().int().nonnegative(),
+    readTimeout: z.number().int().nonnegative(),
+    sendTimeout: z.number().int().nonnegative(),
+    nextTries: z.number().int().nonnegative(),
+    nextTimeout: z.number().int().nonnegative(),
     nextCases: z.array(z.string())
   })
   .partial();

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -201,7 +201,7 @@ export const PatchServiceSchema = z
       description: "Keyed by container port. Only hosts and http options are patchable; endpoint kind and count are fixed at create."
     }),
     storage: z.record(z.string(), z.object({ mount: z.string(), readOnly: z.boolean() }).partial()).openapi({
-      description: "Keyed by volume name. Mount point only — sizes are fixed at create."
+      description: "Keyed by volume name. Mount point and read-only flag only — sizes are fixed at create."
     })
   })
   .partial();

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -187,6 +187,16 @@ const PatchExposeSchema = z
   })
   .partial();
 
+/** Naming a field is not patching one: `{ expose: {} }` reaches the writer with nothing to write, so an empty record has to be refused as firmly as an empty patch. */
+function assignsAField(patch: Record<string, unknown>): boolean {
+  return Object.values(patch).some(value => !isEmptyRecord(value));
+}
+
+/** An array is a value even when empty, because `command: []` clears the list the service declared. */
+function isEmptyRecord(value: unknown): boolean {
+  return !!value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0;
+}
+
 export const PatchServiceSchema = z
   .object({
     image: z.string(),
@@ -205,7 +215,7 @@ export const PatchServiceSchema = z
     })
   })
   .partial()
-  .refine(patch => Object.keys(patch).length > 0, { message: "At least one field must be patched" });
+  .refine(assignsAField, { message: "At least one field must be patched" });
 
 export const UpdateDeploymentResponseSchema = z.object({
   data: DeploymentResponseSchema

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -168,6 +168,24 @@ const PatchEnvSchema = z.record(z.string().regex(ENV_VARIABLE_NAME), z.string().
   description: "Merged into the service's env, keyed by environment variable name. A null value removes the variable."
 });
 
+const PatchHttpOptionsSchema = z
+  .object({
+    maxBodySize: z.number().int().positive(),
+    readTimeout: z.number().int().positive(),
+    sendTimeout: z.number().int().positive(),
+    nextTries: z.number().int().positive(),
+    nextTimeout: z.number().int().positive(),
+    nextCases: z.array(z.string())
+  })
+  .partial();
+
+const PatchExposeSchema = z
+  .object({
+    accept: z.array(z.string()).openapi({ description: "Custom domains. Replaces the existing list." }),
+    httpOptions: PatchHttpOptionsSchema
+  })
+  .partial();
+
 export const PatchServiceSchema = z
   .object({
     image: z.string(),
@@ -177,7 +195,13 @@ export const PatchServiceSchema = z
     credentials: z
       .object({ host: z.string(), username: z.string(), password: z.string() })
       .nullable()
-      .openapi({ description: "Private registry pull credentials. Null clears them." })
+      .openapi({ description: "Private registry pull credentials. Null clears them." }),
+    expose: z.record(z.string(), PatchExposeSchema).openapi({
+      description: "Keyed by container port. Only hosts and http options are patchable; endpoint kind and count are fixed at create."
+    }),
+    storage: z.record(z.string(), z.object({ mount: z.string(), readOnly: z.boolean() }).partial()).openapi({
+      description: "Keyed by volume name. Mount point only — sizes are fixed at create."
+    })
   })
   .partial();
 

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import { MAX_ECHOED_REFERENCE_LENGTH, SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlPatchService } from "./sdl-patch.service";
 
+type SdlExposeEntry = NonNullable<SDLInput["services"][string]["expose"]>[number];
+
 describe(SdlPatchService.name, () => {
   it("replaces the image of the named service", () => {
     const { service, document } = setup({ services: { web: { image: "nginx" } } });
@@ -459,6 +461,27 @@ describe(SdlPatchService.name, () => {
       expect(() => service.apply(document, { web: { expose: { "8080": { accept: ["x.test"] } } } })).toThrow();
       expect(document.services.web.expose?.[0].accept).toEqual(["old.test"]);
     });
+
+    it('refuses a port spelled "undefined" rather than matching an endpoint that declares none', () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", expose: [{ accept: ["old.test"] } as SdlExposeEntry] } } });
+
+      expect(() => service.apply(document, { web: { expose: { undefined: { accept: ["x.test"] } } } })).toThrow(/exposes no port "undefined"/);
+      expect(document.services.web.expose?.[0].accept).toEqual(["old.test"]);
+    });
+
+    it("still refuses an unknown port carrying a sub-patch that assigns nothing", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", expose: [{ port: 80 }] } } });
+
+      expect(() => service.apply(document, { web: { expose: { "8080": {} } } })).toThrow(/exposes no port "8080"/);
+    });
+
+    it("writes no http options node for a sub-patch that assigns nothing", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", expose: [{ port: 80 }] } } });
+
+      service.apply(document, { web: { expose: { "80": {} } } });
+
+      expect(document.services.web.expose?.[0]).toEqual({ port: 80 });
+    });
   });
 
   describe("storage", () => {
@@ -600,6 +623,39 @@ describe(SdlPatchService.name, () => {
       });
 
       expect(() => service.apply(document, { web: { storage: { data: { mount: "/srv" } } } })).toThrow(/share its storage volume data/);
+    });
+
+    it("accepts an expose sub-patch that assigns nothing, rather than refusing a write it would never make", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx" }, worker: { image: "busybox" } },
+        shareExpose: [{ port: 80, accept: ["a.test"] }]
+      });
+
+      service.apply(document, { web: { expose: { "80": {} } } });
+
+      expect(document.services.worker.expose?.[0].accept).toEqual(["a.test"]);
+    });
+
+    it("accepts an http options sub-patch that assigns nothing on a shared options block", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx" }, worker: { image: "busybox" } },
+        shareHttpOptions: { max_body_size: 1024 }
+      });
+
+      service.apply(document, { web: { expose: { "80": { httpOptions: {} } } } });
+
+      expect(document.services.worker.expose?.[0].http_options).toEqual({ max_body_size: 1024 });
+    });
+
+    it("accepts a storage sub-patch that assigns nothing, rather than refusing a write it would never make", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx" }, worker: { image: "busybox" } },
+        shareStorage: { data: { mount: "/data" } }
+      });
+
+      service.apply(document, { web: { storage: { data: {} } } });
+
+      expect(document.services.worker.params?.storage?.data).toEqual({ mount: "/data" });
     });
   });
 

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
@@ -232,6 +232,18 @@ describe(SdlPatchService.name, () => {
       expect(() => service.apply(document, { web: { image: "nginx:1.27" } })).toThrow(/share its definition with another part of the document/);
     });
 
+    it("refuses an env patch through the alias, naming the definition it would rewrite", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } }, aliasWebAs: "worker" });
+
+      expect(() => service.apply(document, { web: { env: { A: "two" } } })).toThrow(/share its definition with another part of the document/);
+    });
+
+    it("allows a patch whose only field is an empty env record, which assigns nothing", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } }, aliasWebAs: "worker" });
+
+      expect(() => service.apply(document, { web: { env: {} } })).not.toThrow();
+    });
+
     it("leaves the aliased service untouched", () => {
       const { service, document } = setup({ services: { web: { image: "nginx" } }, aliasWebAs: "worker" });
 

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
@@ -238,6 +238,30 @@ describe(SdlPatchService.name, () => {
       expect(() => service.apply(document, { web: { image: "nginx:1.27" } })).toThrow();
       expect(document.services.worker.image).toBe("nginx");
     });
+
+    it("accepts a patch naming no field, rather than refusing a write it would never make", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } }, aliasWebAs: "worker" });
+
+      service.apply(document, { web: {} });
+
+      expect(document.services.worker.image).toBe("nginx");
+    });
+
+    it("accepts a patch whose only sub-patch assigns nothing", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", expose: [{ port: 80, accept: ["a.test"] }] } }, aliasWebAs: "worker" });
+
+      service.apply(document, { web: { expose: { "80": {} } } });
+
+      expect(document.services.worker.expose?.[0].accept).toEqual(["a.test"]);
+    });
+
+    it("still refuses a sub-patch that does assign through the alias", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", expose: [{ port: 80, accept: ["a.test"] }] } }, aliasWebAs: "worker" });
+
+      expect(() => service.apply(document, { web: { expose: { "80": { accept: ["b.test"] } } } })).toThrow(
+        /share its definition with another part of the document/
+      );
+    });
   });
 
   describe("credentials", () => {

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.spec.ts
@@ -370,6 +370,151 @@ describe(SdlPatchService.name, () => {
     });
   });
 
+  describe("expose", () => {
+    it("replaces the accepted hosts of the named port", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", expose: [{ port: 80, accept: ["old.test"] }] } } });
+
+      service.apply(document, { web: { expose: { "80": { accept: ["new.test", "www.new.test"] } } } });
+
+      expect(document.services.web.expose?.[0].accept).toEqual(["new.test", "www.new.test"]);
+    });
+
+    it("matches the port the endpoint declares rather than its position", () => {
+      const { service, document } = setup({
+        services: {
+          web: {
+            image: "nginx",
+            expose: [
+              { port: 80, accept: ["a.test"] },
+              { port: 8080, accept: ["b.test"] }
+            ]
+          }
+        }
+      });
+
+      service.apply(document, { web: { expose: { "8080": { accept: ["patched.test"] } } } });
+
+      expect(document.services.web.expose?.[0].accept).toEqual(["a.test"]);
+      expect(document.services.web.expose?.[1].accept).toEqual(["patched.test"]);
+    });
+
+    it("translates every camelCase http option onto the snake_case key the sdl names", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", expose: [{ port: 80 }] } } });
+
+      service.apply(document, {
+        web: {
+          expose: {
+            "80": {
+              httpOptions: { maxBodySize: 2048, readTimeout: 1000, sendTimeout: 2000, nextTries: 3, nextTimeout: 4000, nextCases: ["500", "timeout"] }
+            }
+          }
+        }
+      });
+
+      expect(document.services.web.expose?.[0].http_options).toEqual({
+        max_body_size: 2048,
+        read_timeout: 1000,
+        send_timeout: 2000,
+        next_tries: 3,
+        next_timeout: 4000,
+        next_cases: ["500", "timeout"]
+      });
+    });
+
+    it("merges http options over the ones already declared", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", expose: [{ port: 80, http_options: { max_body_size: 1024, read_timeout: 5000 } }] } }
+      });
+
+      service.apply(document, { web: { expose: { "80": { httpOptions: { readTimeout: 9000 } } } } });
+
+      expect(document.services.web.expose?.[0].http_options).toEqual({ max_body_size: 1024, read_timeout: 9000 });
+    });
+
+    it("leaves the endpoint kind and count alone while patching its hosts", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", expose: [{ port: 80, as: 80, proto: "TCP", to: [{ global: true }], accept: ["old.test"] }] } }
+      });
+
+      service.apply(document, { web: { expose: { "80": { accept: ["new.test"] } } } });
+
+      expect(document.services.web.expose?.[0]).toMatchObject({ port: 80, as: 80, proto: "TCP", to: [{ global: true }] });
+    });
+
+    it("refuses a port the service does not expose, naming it", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", expose: [{ port: 80 }] } } });
+
+      expect(() => service.apply(document, { web: { expose: { "8080": { accept: ["x.test"] } } } })).toThrow(/service "web" exposes no port "8080"/);
+    });
+
+    it("refuses a port on a service exposing nothing at all", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      expect(() => service.apply(document, { web: { expose: { "80": { accept: ["x.test"] } } } })).toThrow(/exposes no port "80"/);
+    });
+
+    it("changes nothing when a later port in the same patch is unknown", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx", expose: [{ port: 80, accept: ["old.test"] }] } } });
+
+      expect(() => service.apply(document, { web: { expose: { "8080": { accept: ["x.test"] } } } })).toThrow();
+      expect(document.services.web.expose?.[0].accept).toEqual(["old.test"]);
+    });
+  });
+
+  describe("storage", () => {
+    it("moves the mount point of the named volume", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", params: { storage: { data: { mount: "/old", readOnly: false } } } } }
+      });
+
+      service.apply(document, { web: { storage: { data: { mount: "/srv/data" } } } });
+
+      expect(document.services.web.params?.storage?.data).toEqual({ mount: "/srv/data", readOnly: false });
+    });
+
+    it("sets the read-only flag of the named volume", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", params: { storage: { data: { mount: "/srv/data", readOnly: false } } } } }
+      });
+
+      service.apply(document, { web: { storage: { data: { readOnly: true } } } });
+
+      expect(document.services.web.params?.storage?.data.readOnly).toBe(true);
+    });
+
+    it("leaves a volume the patch does not name", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", params: { storage: { data: { mount: "/data" }, cache: { mount: "/cache" } } } } }
+      });
+
+      service.apply(document, { web: { storage: { data: { mount: "/srv/data" } } } });
+
+      expect(document.services.web.params?.storage?.cache).toEqual({ mount: "/cache" });
+    });
+
+    it("refuses a volume the service does not declare, naming it", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", params: { storage: { data: { mount: "/data" } } } } }
+      });
+
+      expect(() => service.apply(document, { web: { storage: { nope: { mount: "/nope" } } } })).toThrow(/service "web" declares no storage volume "nope"/);
+    });
+
+    it("refuses a volume on a service declaring no storage at all", () => {
+      const { service, document } = setup({ services: { web: { image: "nginx" } } });
+
+      expect(() => service.apply(document, { web: { storage: { data: { mount: "/data" } } } })).toThrow(/declares no storage volume "data"/);
+    });
+
+    it("refuses a volume name spelling an object prototype member rather than resolving one", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx", params: { storage: { data: { mount: "/data" } } } } }
+      });
+
+      expect(() => service.apply(document, { web: { storage: { constructor: { mount: "/x" } } } })).toThrow(/declares no storage volume/);
+    });
+  });
+
   describe("a node two services share through a yaml anchor", () => {
     it("refuses to patch env through a shared list", () => {
       const { service, document } = setup({ services: { web: { image: "nginx" }, worker: { image: "busybox" } }, shareEnv: ["A=one"] });
@@ -419,12 +564,52 @@ describe(SdlPatchService.name, () => {
       expect(document.services.web.env).toEqual(["A=two"]);
       expect(document.services.worker.env).toEqual(["A=one"]);
     });
+
+    it("refuses to patch expose through a shared endpoint", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx" }, worker: { image: "busybox" } },
+        shareExpose: [{ port: 80, accept: ["a.test"] }]
+      });
+
+      expect(() => service.apply(document, { web: { expose: { "80": { accept: ["b.test"] } } } })).toThrow(/share its expose on port 80/);
+    });
+
+    it("refuses to patch http options through a shared options block", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx" }, worker: { image: "busybox" } },
+        shareHttpOptions: { max_body_size: 1024 }
+      });
+
+      expect(() => service.apply(document, { web: { expose: { "80": { httpOptions: { readTimeout: 9000 } } } } })).toThrow(/share its http options on port 80/);
+    });
+
+    it("leaves the shared options block untouched when it refuses", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx" }, worker: { image: "busybox" } },
+        shareHttpOptions: { max_body_size: 1024 }
+      });
+
+      expect(() => service.apply(document, { web: { expose: { "80": { httpOptions: { readTimeout: 9000 } } } } })).toThrow();
+      expect(document.services.worker.expose?.[0].http_options).toEqual({ max_body_size: 1024 });
+    });
+
+    it("refuses to patch storage through a shared volume", () => {
+      const { service, document } = setup({
+        services: { web: { image: "nginx" }, worker: { image: "busybox" } },
+        shareStorage: { data: { mount: "/data" } }
+      });
+
+      expect(() => service.apply(document, { web: { storage: { data: { mount: "/srv" } } } })).toThrow(/share its storage volume data/);
+    });
   });
 
   function setup(input: {
     services: Record<string, SDLInput["services"][string]>;
     shareEnv?: string[];
     shareCredentials?: NonNullable<SDLInput["services"][string]["credentials"]>;
+    shareExpose?: NonNullable<SDLInput["services"][string]["expose"]>;
+    shareStorage?: NonNullable<NonNullable<SDLInput["services"][string]["params"]>["storage"]>;
+    shareHttpOptions?: NonNullable<NonNullable<SDLInput["services"][string]["expose"]>[number]["http_options"]>;
     aliasWebAs?: string;
   }) {
     const services = { ...input.services };
@@ -432,6 +617,9 @@ describe(SdlPatchService.name, () => {
     for (const name of Object.keys(services)) {
       if (input.shareEnv) services[name] = { ...services[name], env: input.shareEnv };
       if (input.shareCredentials) services[name] = { ...services[name], credentials: input.shareCredentials };
+      if (input.shareExpose) services[name] = { ...services[name], expose: input.shareExpose };
+      if (input.shareStorage) services[name] = { ...services[name], params: { storage: input.shareStorage } };
+      if (input.shareHttpOptions) services[name] = { ...services[name], expose: [{ port: 80, http_options: input.shareHttpOptions }] };
     }
 
     if (input.aliasWebAs) services[input.aliasWebAs] = services.web;

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -6,6 +6,10 @@ import type { PatchService } from "@src/deployment/http-schemas/deployment.schem
 import { MAX_ECHOED_REFERENCE_LENGTH, ownValue, readEnvDeclaration } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 
 type SdlServiceNode = SDLInput["services"][string];
+type SdlExposeNode = NonNullable<SdlServiceNode["expose"]>[number];
+type SdlHttpOptionsNode = NonNullable<SdlExposeNode["http_options"]>;
+type SdlStorageNode = NonNullable<NonNullable<SdlServiceNode["params"]>["storage"]>[string];
+type PatchExpose = NonNullable<PatchService["expose"]>[string];
 
 type PatchTarget = { serviceName: string; shared: Set<object>; written: Set<string> };
 
@@ -27,15 +31,41 @@ function assignsEnv(patch: PatchService["env"]): patch is NonNullable<PatchServi
   return patch !== undefined && Object.keys(patch).length > 0;
 }
 
+function echo(key: string): string {
+  return key.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
+}
+
+/** An empty options object assigns nothing, and synthesising the node for it would leave a read showing an `http_options: {}` the user never wrote. */
+function assignsHttpOptions(patch: PatchExpose): boolean {
+  return patch.httpOptions !== undefined && Object.values(patch.httpOptions).some(value => value !== undefined);
+}
+
+/** Every node a patch could write through, so sharing is judged against the object that would actually be mutated. */
+function writableNodesOf(service: SdlServiceNode): object[] {
+  const nodes: unknown[] = [service, service.env, service.credentials, service.expose, service.params, service.params?.storage];
+
+  if (Array.isArray(service.expose)) {
+    for (const entry of service.expose) nodes.push(entry, entry?.http_options);
+  }
+
+  const storage = service.params?.storage;
+
+  if (isNode(storage)) {
+    for (const volume of Object.values(storage)) nodes.push(volume);
+  }
+
+  return nodes.filter(isNode);
+}
+
 /** A node reachable twice is one a write would change in a place the request did not name, whether the second reacher is another service or another part of the same one. */
 function sharedNodesOf(services: SDLInput["services"]): Set<object> {
   const seen = new Set<object>();
   const shared = new Set<object>();
 
   for (const service of Object.values(services)) {
-    for (const node of [service, service?.env, service?.credentials]) {
-      if (!isNode(node)) continue;
+    if (!isNode(service)) continue;
 
+    for (const node of writableNodesOf(service)) {
       if (seen.has(node)) shared.add(node);
 
       seen.add(node);
@@ -43,10 +73,6 @@ function sharedNodesOf(services: SDLInput["services"]): Set<object> {
   }
 
   return shared;
-}
-
-function echo(key: string): string {
-  return key.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
 }
 
 /** Applies a partial service definition to the stored SDL, naming only keys the caller sent and never a value, because its messages are echoed back and logged. */
@@ -88,6 +114,10 @@ export class SdlPatchService {
       this.#assertNotShared(service.credentials, { ...at, field: "credentials" });
       this.#applyCredentials(service, patch.credentials, at);
     }
+
+    if (patch.expose !== undefined) this.#applyExpose(service, patch.expose, at);
+
+    if (patch.storage !== undefined) this.#applyStorage(service, patch.storage, at);
   }
 
   /** A cleared list is removed rather than written as `null`, so a read never shows a field the user did not write. */
@@ -132,6 +162,70 @@ export class SdlPatchService {
 
     for (const field of ["username", "password"] as const) {
       if (patch[field] !== undefined) target.written.add(`/services/${target.serviceName}/credentials/${field}`);
+    }
+  }
+
+  /**
+   * Matched on the container port the endpoint declares, because an endpoint's kind and count are fixed
+   * at create; the grammar allows two endpoints to share one port and differ only by `proto` or `as`, so
+   * an address matching more than one is refused rather than resolved to the first.
+   */
+  #applyExpose(service: SdlServiceNode, patch: NonNullable<PatchService["expose"]>, at: PatchTarget): void {
+    const exposed = Array.isArray(service.expose) ? service.expose : [];
+
+    for (const [port, entryPatch] of Object.entries(patch)) {
+      const matches = exposed.filter(candidate => String(candidate?.port) === port);
+
+      if (matches.length === 0) {
+        throw this.#reject(`service "${echo(at.serviceName)}" exposes no port "${echo(port)}"`);
+      }
+
+      if (matches.length > 1) {
+        throw this.#reject(
+          `service "${echo(at.serviceName)}" exposes port "${echo(port)}" ${matches.length} times, so this patch cannot say which endpoint it means`
+        );
+      }
+
+      this.#assertNotShared(matches[0], { ...at, field: `expose on port ${echo(port)}` });
+      this.#applyExposeEntry(matches[0], entryPatch, at, port);
+    }
+  }
+
+  #applyExposeEntry(entry: SdlExposeNode, patch: PatchExpose, at: PatchTarget, port: string): void {
+    if (patch.accept !== undefined) entry.accept = patch.accept;
+
+    if (!assignsHttpOptions(patch)) return;
+
+    this.#assertNotShared(entry.http_options, { ...at, field: `http options on port ${echo(port)}` });
+    entry.http_options ??= {};
+    this.#applyHttpOptions(entry.http_options, patch.httpOptions!);
+  }
+
+  /** Spelled out one key at a time so the compiler checks the SDL key each camelCase field lands on; `nextCases` is cast because the request accepts any string where the SDL names a closed set. */
+  #applyHttpOptions(target: SdlHttpOptionsNode, patch: NonNullable<PatchExpose["httpOptions"]>): void {
+    if (patch.maxBodySize !== undefined) target.max_body_size = patch.maxBodySize;
+    if (patch.readTimeout !== undefined) target.read_timeout = patch.readTimeout;
+    if (patch.sendTimeout !== undefined) target.send_timeout = patch.sendTimeout;
+    if (patch.nextTries !== undefined) target.next_tries = patch.nextTries;
+    if (patch.nextTimeout !== undefined) target.next_timeout = patch.nextTimeout;
+    if (patch.nextCases !== undefined) target.next_cases = patch.nextCases as SdlHttpOptionsNode["next_cases"];
+  }
+
+  /** Volume sizes are fixed at create, so only the mount point moves and a volume the profile does not declare is refused rather than added. */
+  #applyStorage(service: SdlServiceNode, patch: NonNullable<PatchService["storage"]>, at: PatchTarget): void {
+    const declared = service.params?.storage;
+
+    for (const [volumeName, volumePatch] of Object.entries(patch)) {
+      const volume: SdlStorageNode | undefined = declared ? ownValue(declared, volumeName) : undefined;
+
+      if (!volume) {
+        throw this.#reject(`service "${echo(at.serviceName)}" declares no storage volume "${echo(volumeName)}"`);
+      }
+
+      this.#assertNotShared(volume, { ...at, field: `storage volume ${echo(volumeName)}` });
+
+      if (volumePatch.mount !== undefined) volume.mount = volumePatch.mount;
+      if (volumePatch.readOnly !== undefined) volume.readOnly = volumePatch.readOnly;
     }
   }
 

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -10,6 +10,7 @@ type SdlExposeNode = NonNullable<SdlServiceNode["expose"]>[number];
 type SdlHttpOptionsNode = NonNullable<SdlExposeNode["http_options"]>;
 type SdlStorageNode = NonNullable<NonNullable<SdlServiceNode["params"]>["storage"]>[string];
 type PatchExpose = NonNullable<PatchService["expose"]>[string];
+type PatchStorage = NonNullable<PatchService["storage"]>[string];
 
 type PatchTarget = { serviceName: string; shared: Set<object>; written: Set<string> };
 
@@ -38,6 +39,19 @@ function echo(key: string): string {
 /** An empty options object assigns nothing, and synthesising the node for it would leave a read showing an `http_options: {}` the user never wrote. */
 function assignsHttpOptions(patch: PatchExpose): boolean {
   return patch.httpOptions !== undefined && Object.values(patch.httpOptions).some(value => value !== undefined);
+}
+
+/** A port has to be declared before it is compared, because `String(undefined)` is `"undefined"` and a patch key spelled that way would otherwise match an entry declaring no port at all. */
+function declaresPort(entry: SdlExposeNode | undefined, port: string): boolean {
+  return entry?.port !== undefined && String(entry.port) === port;
+}
+
+function assignsExpose(patch: PatchExpose): boolean {
+  return patch.accept !== undefined || assignsHttpOptions(patch);
+}
+
+function assignsStorage(patch: PatchStorage): boolean {
+  return patch.mount !== undefined || patch.readOnly !== undefined;
 }
 
 /** Every node a patch could write through, so sharing is judged against the object that would actually be mutated. */
@@ -174,7 +188,7 @@ export class SdlPatchService {
     const exposed = Array.isArray(service.expose) ? service.expose : [];
 
     for (const [port, entryPatch] of Object.entries(patch)) {
-      const matches = exposed.filter(candidate => String(candidate?.port) === port);
+      const matches = exposed.filter(candidate => declaresPort(candidate, port));
 
       if (matches.length === 0) {
         throw this.#reject(`service "${echo(at.serviceName)}" exposes no port "${echo(port)}"`);
@@ -185,6 +199,8 @@ export class SdlPatchService {
           `service "${echo(at.serviceName)}" exposes port "${echo(port)}" ${matches.length} times, so this patch cannot say which endpoint it means`
         );
       }
+
+      if (!assignsExpose(entryPatch)) continue;
 
       this.#assertNotShared(matches[0], { ...at, field: `expose on port ${echo(port)}` });
       this.#applyExposeEntry(matches[0], entryPatch, at, port);
@@ -221,6 +237,8 @@ export class SdlPatchService {
       if (!volume) {
         throw this.#reject(`service "${echo(at.serviceName)}" declares no storage volume "${echo(volumeName)}"`);
       }
+
+      if (!assignsStorage(volumePatch)) continue;
 
       this.#assertNotShared(volume, { ...at, field: `storage volume ${echo(volumeName)}` });
 

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -54,6 +54,17 @@ function assignsStorage(patch: PatchStorage): boolean {
   return patch.mount !== undefined || patch.readOnly !== undefined;
 }
 
+/** Naming a field a patch leaves untouched is not a write, so an anchored service is only refused once the patch would actually change it. */
+function assignsService(patch: PatchService): boolean {
+  const { expose, storage, ...fields } = patch;
+
+  return (
+    Object.values(fields).some(value => value !== undefined) ||
+    Object.values(expose ?? {}).some(assignsExpose) ||
+    Object.values(storage ?? {}).some(assignsStorage)
+  );
+}
+
 /** Every node a patch could write through, so sharing is judged against the object that would actually be mutated. */
 function writableNodesOf(service: SdlServiceNode): object[] {
   const nodes: unknown[] = [service, service.env, service.credentials, service.expose, service.params, service.params?.storage];
@@ -112,7 +123,7 @@ export class SdlPatchService {
   }
 
   #applyToService(service: SdlServiceNode, patch: PatchService, at: PatchTarget): void {
-    this.#assertNotShared(service, { ...at, field: "definition" });
+    if (assignsService(patch)) this.#assertNotShared(service, { ...at, field: "definition" });
 
     if (patch.image !== undefined) service.image = patch.image;
 

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -56,10 +56,11 @@ function assignsStorage(patch: PatchStorage): boolean {
 
 /** Naming a field a patch leaves untouched is not a write, so an anchored service is only refused once the patch would actually change it. */
 function assignsService(patch: PatchService): boolean {
-  const { expose, storage, ...fields } = patch;
+  const { expose, storage, env, ...fields } = patch;
 
   return (
     Object.values(fields).some(value => value !== undefined) ||
+    assignsEnv(env) ||
     Object.values(expose ?? {}).some(assignsExpose) ||
     Object.values(storage ?? {}).some(assignsStorage)
   );


### PR DESCRIPTION
## Why

Part of CON-864.

The second half of the SDL patcher: custom domains and http options per exposed port, and mount points per storage volume.

## What

Both are keyed by something the SDL already declares — the container port, the volume name — and a key the document does not have is **refused rather than created**. An endpoint's kind and count and a volume's size are fixed at create, so there is no correct way to invent one from a patch.

The camelCase request fields are translated onto the snake_case keys the SDL grammar uses (`maxBodySize` → `max_body_size`, and so on). That translation is spelled out one assignment at a time rather than driven by a lookup table, so the compiler checks the SDL key each field lands on instead of a `Record` cast hiding a typo.

### Two Spec corrections a reviewer will otherwise flag as drift

**`accept` is a plain `string[]`, and the Spec was right — I was wrong.** My earlier reading had it mapping to `accept.items`, taken from the `@deprecated` `v2Accept = { items?: string[] }` type. The authoritative `interface SDLInput` says `accept?: string[]`; the `items` in `sdl-schema.yaml` is the JSON-Schema keyword, not a document key. So the Spec's `accept: z.array(z.string())` maps straight across with no translation. Correcting my own earlier finding.

**`nextCases` is typed wider on the wire than in the SDL.** The Spec has `z.array(z.string())` where the SDL names a closed `HttpErrorCode` union. Left as the Spec wrote it: an unknown case is refused by the manifest generator rather than by the schema, still before any write. One narrow cast, with the reason on the declaration.

### Review round 3 — three defects in this half

**The container port is not a unique key.** The grammar puts no uniqueness constraint on `port`, so two endpoints may legitimately share one and differ only by `proto` or by the external `as` — one container port published on two external ports is the ordinary case. Matching with `.find()` took the first and left the second unaddressable: patching the second endpoint on port 80 answered **200**, left that endpoint untouched, and rewrote a different one. Answering 200 while changing something the caller did not name is worse than refusing, so an ambiguous address is now refused, naming the port and how many endpoints carry it. A compound key stays possible later; since the Spec fixes endpoint kind and count at create and makes only hosts and http options patchable, refusing is the conservative reading rather than a permanent limit.

**`.positive()` made a legitimate value unreachable.** Every numeric http option carries `minimum: 0` in the grammar, and 0 is how a timeout is cleared, so a value settable at create was rejected through PATCH. Now `.nonnegative()`, and the published document says `minimum: 0` rather than `exclusiveMinimum: 0`. **This is a fourth correction to the Spec's snippet**, alongside `accept`, the `.min(1)` the Spec put on a `z.record` (carried out as a `.refine`, because this zod version has no `.min` there) and `nextCases`.

**An empty `httpOptions` permanently altered the stored document.** `entry.http_options ??= {}` synthesised the node even when nothing was assigned, so a no-op patch made a read show an `http_options: {}` the user never wrote. The node is now created only when a field is actually assigned.

Each has a test verified to fail when its fix is reverted.

### The widened YAML-anchor guard, and why it is in scope

Shared-node detection now covers every node a patch can write through: an expose entry, its http options, a storage volume, and a whole service definition two names reach through one anchor. This is in scope rather than scope creep because **patching through an alias rewrites a service the request never named** — the same data-corruption class as the reference-name collision fixed later in this stack. Each guarded site has a test that fails when its guard line is deleted, including the `http_options` site.

Observable behaviour of the endpoint is demonstrated in the PATCH exposure PR.

Measured: 449 non-excluded changed lines. `apps/api` tsc 42 against a 42 baseline, lint 0, `sdl-patch` unit 67/67, functional 406/406.

### Review round 4 — two defects and a fifth Spec correction

**A patch key spelled `"undefined"` rewrote an endpoint that declares no port.** `String(candidate?.port)` yields the string `"undefined"` for an entry with no `port`, and `expose` is a `z.record(z.string(), …)`, so the key `"undefined"` is accepted and matched such an entry. Matching now goes through `declaresPort`, which requires a declared port before comparing. The SDL type makes `port` required, so the test constructs that entry through one narrow cast — real YAML is what can be missing it.

**An empty sub-patch refused an aliased node it would never have written to.** `.partial()` accepts `expose: {"80": {}}` and `storage: {"data": {}}`, and both `#applyExpose` and `#applyStorage` called `#assertNotShared` unconditionally, so a no-op sub-patch on a YAML-aliased entry answered **400**. Both now check that the sub-patch actually assigns something before the shared-node check and the write — `assignsExpose` and `assignsStorage`, mirroring the existing `assignsHttpOptions` guard. The unknown-port and unknown-volume refusals still fire for an empty sub-patch, since the caller named something the document does not declare; a test pins that ordering.

**A fifth correction to the Spec's description text.** The `storage` field's published description said "Mount point only — sizes are fixed at create", but the schema accepts and the service applies `readOnly` as well. It now reads "Keyed by volume name. Mount point and read-only flag only — sizes are fixed at create." This joins `accept`, the `z.record` `.min(1)`, `nextCases` and the `minimum: 0` bound above. The generated artifacts that publish it only exist from the PATCH exposure PR onwards, so their regeneration lands there.

Each defect has a test verified to fail when its fix is reverted.

### Review round 5 — a skin-deep completeness check, and a correction this body misdescribed

**`{ expose: {} }` passed the completeness check.** `.refine(patch => Object.keys(patch).length > 0)` counted top-level keys, so a patch whose every field was an empty record satisfied it, reached the writer with nothing to write, and answered **200** over a stored definition that was then rewritten unchanged. A field now counts only when it is not an empty record, so `{}`, `{ env: {} }`, `{ expose: {} }` and `{ storage: {} }` are refused alike.

A record that *has* an entry still passes. `{ expose: { "80": {} } }` names a port the writer has to look for in the document, and refusing it here would answer "at least one field must be patched" to a request that named one — the unknown-port and unknown-volume refusals stay the writer's to give. An array stays a value however short, because `command: []` clears the list the service declared. A new `deployment.schema.spec.ts` pins both halves; its four new-behaviour cases were verified to fail against the old refine, and its six existing-behaviour cases to pass against both.

**The mechanism the review suggested does not exist.** The suggestion was `.min(1)` on the two `z.record(...)` schemas. `z.record()` has no `.min` in zod 3.24.4 — `typeof z.record(z.string(), z.string()).min` is `undefined` — which is the same reason the Spec's own `z.record(...).min(1)` could never be applied literally. It is a `.refine` on key count, as the sibling check on `services` already is.

**And this body said otherwise.** Two lines above listed `z.record(...).min(1)` among the corrections *applied* here, which reads as a claim that the schema carries `.min(1)`. It never did and cannot. Both mentions now name the correction for what it is: a `.min(1)` the Spec asked for that this zod version does not offer, carried out as a `.refine`.

**An empty env record refused an anchored service definition.** `assignsService` is this slice's second reader of a service patch, and it counted `env` as assigned whenever the key was present — so an aliased definition was refused for a patch whose only field was an empty env record, the same defect #3824 fixes one level down in the write path. Both now ask `assignsEnv`.

That makes three instances of one family in this stack: the empty `httpOptions` synthesising a node, the empty service patch asserting on the definition, and now the empty env record. So the whole service patch was swept for sub-patches gated on presence rather than content, rather than fixing only the reported one. What is left is sound: `credentials` is the only other object-valued field and its three keys are all required, so presence is content; `image`, `command` and `args` are leaves; `expose` and `storage` already went through `assignsExpose` and `assignsStorage`.

Measured on the re-stacked head: `apps/api` tsc **41 against a re-measured 41 baseline**, lint **0** on the changed files, unit **2967/2967**. The functional suite does not run on this machine — the local `console-db-1` has only the `postgres` role — so its result comes from CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for partially updating service images, commands, arguments, credentials, environment variables, exposed ports, HTTP options, and storage settings.
  * Added support for updating exposed-port domains, HTTP options, storage mount points, and read-only settings.
  * Improved environment variable patching while preserving supported values and removing duplicates.

* **Bug Fixes**
  * Added validation for invalid or ambiguous ports, undeclared storage volumes, shared configuration, and HTTP option values.
  * Preserved unrelated service settings and maintained rollback handling when updates fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
