### PR TITLE
fix(sdl): mint a derived secret name no other slot is already standing on

### DIFF
--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -272,14 +272,39 @@ describe(SdlSecretsDerivationService.name, () => {
       expect(document.services.web.env).toEqual(["B=ac-secret://s0_e1", "C=ac-secret://s0_e1_2"]);
     });
 
-    it("reuses the name a slot's own position spells when nothing else is standing on it", () => {
-      const { service } = setup();
+    it("mints a name unique in the document, whatever it happens to spell", () => {
+      const { service, sdlReferenceService } = setup();
       const document = documentWith({ web: { env: ["A=ac-secret://s0_e0", "B=resupplied"] } });
 
       const secrets = service.derive(document, { includeEnvValues: true });
 
-      expect(secrets).toEqual({ s0_e1: "resupplied" });
-      expect(document.services.web.env).toEqual(["A=ac-secret://s0_e0", "B=ac-secret://s0_e1"]);
+      expect(Object.keys(secrets)).toHaveLength(1);
+      expect(Object.keys(secrets)[0]).not.toBe("s0_e0");
+      expect(sdlReferenceService.validate(document)).toEqual([]);
+    });
+
+    it("mints a fresh name for a credential even when a seal supplied the env values", () => {
+      const { service } = setup();
+      const document = documentWith({
+        web: { env: ["A=ac-secret://MY_TOKEN"], credentials: { host: REGISTRY_HOST, username: "u", password: "p" } }
+      });
+
+      const secrets = service.derive(document, { includeEnvValues: false });
+
+      expect(Object.keys(secrets).sort()).toEqual(["s0_c_password", "s0_c_username"]);
+      expect(document.services.web.env).toEqual(["A=ac-secret://MY_TOKEN"]);
+    });
+
+    it("avoids a client-chosen seal name a credential position would otherwise mint onto", () => {
+      const { service } = setup();
+      const document = documentWith({
+        web: { env: ["A=ac-secret://s0_c_username"], credentials: { host: REGISTRY_HOST, username: "u", password: "p" } }
+      });
+
+      const secrets = service.derive(document, { includeEnvValues: false });
+
+      expect(Object.keys(secrets)).not.toContain("s0_c_username");
+      expect(document.services.web.env).toEqual(["A=ac-secret://s0_c_username"]);
     });
 
     it("gives every colliding slot a name of its own rather than one they share", () => {

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -242,6 +242,82 @@ describe(SdlSecretsDerivationService.name, () => {
     });
   });
 
+  describe("a name another slot in the same document is already standing on", () => {
+    it("does not mint the name a reference elsewhere already holds", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["A=plain", "B=ac-secret://s0_e0"] } });
+
+      const secrets = service.derive(document, { includeEnvValues: true });
+
+      expect(Object.keys(secrets)).not.toContain("s0_e0");
+    });
+
+    it("leaves that reference resolving to its own stored value rather than to the derived one", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["A=plain", "B=ac-secret://s0_e0"] } });
+
+      const secrets = service.derive(document, { includeEnvValues: true });
+
+      expect(document.services.web.env).toEqual(["A=ac-secret://s0_e0_2", "B=ac-secret://s0_e0"]);
+      expect(secrets).toEqual({ s0_e0_2: "plain" });
+    });
+
+    it("keeps one name per slot when positions have shifted under the references", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["B=ac-secret://s0_e1", "C=plain"] } });
+
+      const secrets = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e1_2: "plain" });
+      expect(document.services.web.env).toEqual(["B=ac-secret://s0_e1", "C=ac-secret://s0_e1_2"]);
+    });
+
+    it("reuses the name a slot's own position spells when nothing else is standing on it", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["A=ac-secret://s0_e0", "B=resupplied"] } });
+
+      const secrets = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e1: "resupplied" });
+      expect(document.services.web.env).toEqual(["A=ac-secret://s0_e0", "B=ac-secret://s0_e1"]);
+    });
+
+    it("gives every colliding slot a name of its own rather than one they share", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["A=first", "B=second", "C=ac-secret://s0_e0", "D=ac-secret://s0_e1"] } });
+
+      const secrets = service.derive(document, { includeEnvValues: true });
+
+      expect(Object.keys(secrets)).toHaveLength(2);
+      expect(new Set(Object.values(secrets))).toEqual(new Set(["first", "second"]));
+    });
+
+    it("avoids a name a registry credential reference is standing on", () => {
+      const { service } = setup();
+      const document = documentWith({
+        web: { credentials: { host: REGISTRY_HOST, username: "ac-secret://s0_c_password", password: "plain" } }
+      });
+
+      const secrets = service.derive(document, { includeEnvValues: false });
+
+      expect(Object.keys(secrets)).toEqual(["s0_c_password_2"]);
+      expect(document.services.web.credentials).toMatchObject({
+        username: "ac-secret://s0_c_password",
+        password: "ac-secret://s0_c_password_2"
+      });
+    });
+
+    it("mints names the reference grammar still accepts after avoiding a collision", () => {
+      const { service, sdlReferenceService } = setup();
+      const document = documentWith({ web: { env: ["A=plain", "B=ac-secret://s0_e0"] } });
+
+      const secrets = service.derive(document, { includeEnvValues: true });
+
+      expect(sdlReferenceService.validate(document)).toEqual([]);
+      expect(Object.keys(secrets).every(name => name.length <= MAX_SDL_REFERENCE_NAME_LENGTH)).toBe(true);
+    });
+  });
+
   describe("the names it mints", () => {
     it("are names the reference grammar accepts", () => {
       const { service } = setup();

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -262,6 +262,16 @@ describe(SdlSecretsDerivationService.name, () => {
       expect(secrets).toEqual({ s0_e0_2: "plain" });
     });
 
+    it("walks the suffix upward when the spelling it falls back to is taken as well", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["A=plain", "B=ac-secret://s0_e0", "C=ac-secret://s0_e0_2"] } });
+
+      const secrets = service.derive(document, { includeEnvValues: true });
+
+      expect(secrets).toEqual({ s0_e0_3: "plain" });
+      expect(document.services.web.env).toEqual(["A=ac-secret://s0_e0_3", "B=ac-secret://s0_e0", "C=ac-secret://s0_e0_2"]);
+    });
+
     it("keeps one name per slot when positions have shifted under the references", () => {
       const { service } = setup();
       const document = documentWith({ web: { env: ["B=ac-secret://s0_e1", "C=plain"] } });

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -29,7 +29,6 @@ export class SdlSecretsDerivationService {
 
       const name = mintName(`s${slot.serviceIndex}_${slot.position}`, takenNames);
       takenInNode.add(slot.position);
-      takenNames.add(name);
       secrets[name] = slot.value;
       slot.replace(`ac-${DERIVED_REFERENCE_KIND}://${name}`);
     }
@@ -49,7 +48,7 @@ export class SdlSecretsDerivationService {
   }
 }
 
-/** A minted name need only be unique: it must not be one any reference in the document already stands on, or that one value would resolve into two places. */
+/** Only names the document already stands on are avoided: no two slots prefer the same name, because a position spells `e0` or `c_password`, never `e0_2`. */
 function mintName(preferred: string, taken: Set<string>): string {
   let candidate = preferred;
   let suffix = 2;

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -37,11 +37,7 @@ export class SdlSecretsDerivationService {
     return secrets;
   }
 
-  /**
-   * Read before anything is written, because a document that already carries references — every
-   * document the console stored — would otherwise have a name minted onto a position whose spelling
-   * another slot is still standing on, and one value would then resolve into two places.
-   */
+  /** Read before anything is written, or a name could be minted onto a spelling another slot is still standing on and one value would resolve into two places. */
   #namesAlreadyReferencedIn(document: SDLInput): Set<string> {
     return new Set(this.sdlReferenceService.declarationsOf(document, DERIVED_REFERENCE_KIND).map(declaration => declaration.name));
   }
@@ -53,11 +49,7 @@ export class SdlSecretsDerivationService {
   }
 }
 
-/**
- * Prefers the name the slot's own position spells, so re-supplying a value lands back on the name the
- * deployment already stored it under and the token is replaced rather than grown. Terminates because
- * the taken set is finite and every candidate it tries is distinct.
- */
+/** Prefers the name the slot's own position spells, so re-supplying a value replaces the stored name rather than growing the token. */
 function mintName(preferred: string, taken: Set<string>): string {
   let candidate = preferred;
   let suffix = 2;

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -49,7 +49,7 @@ export class SdlSecretsDerivationService {
   }
 }
 
-/** Prefers the name the slot's own position spells, so re-supplying a value replaces the stored name rather than growing the token. */
+/** A minted name need only be unique: it must not be one any reference in the document already stands on, or that one value would resolve into two places. */
 function mintName(preferred: string, taken: Set<string>): string {
   let candidate = preferred;
   let suffix = 2;

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -17,6 +17,7 @@ export class SdlSecretsDerivationService {
   derive(document: SDLInput, options: { includeEnvValues: boolean }): SdlSecrets {
     const secrets: SdlSecrets = {};
     const takenByNode = new Map<object, Set<string>>();
+    const takenNames = this.#namesAlreadyReferencedIn(document);
 
     for (const slot of this.sdlReferenceService.slotsOf(document)) {
       if (!this.#isDerivable(slot, options)) continue;
@@ -26,8 +27,9 @@ export class SdlSecretsDerivationService {
 
       if (takenInNode.has(slot.position)) continue;
 
-      const name = `s${slot.serviceIndex}_${slot.position}`;
+      const name = mintName(`s${slot.serviceIndex}_${slot.position}`, takenNames);
       takenInNode.add(slot.position);
+      takenNames.add(name);
       secrets[name] = slot.value;
       slot.replace(`ac-${DERIVED_REFERENCE_KIND}://${name}`);
     }
@@ -35,9 +37,35 @@ export class SdlSecretsDerivationService {
     return secrets;
   }
 
+  /**
+   * Read before anything is written, because a document that already carries references — every
+   * document the console stored — would otherwise have a name minted onto a position whose spelling
+   * another slot is still standing on, and one value would then resolve into two places.
+   */
+  #namesAlreadyReferencedIn(document: SDLInput): Set<string> {
+    return new Set(this.sdlReferenceService.declarationsOf(document, DERIVED_REFERENCE_KIND).map(declaration => declaration.name));
+  }
+
   #isDerivable(slot: SdlReferenceSlot, options: { includeEnvValues: boolean }): boolean {
     if (isSdlReference(slot.value)) return false;
 
     return slot.valueIsAlwaysSecret || options.includeEnvValues;
   }
+}
+
+/**
+ * Prefers the name the slot's own position spells, so re-supplying a value lands back on the name the
+ * deployment already stored it under and the token is replaced rather than grown. Terminates because
+ * the taken set is finite and every candidate it tries is distinct.
+ */
+function mintName(preferred: string, taken: Set<string>): string {
+  let candidate = preferred;
+  let suffix = 2;
+
+  while (taken.has(candidate)) {
+    candidate = `${preferred}_${suffix}`;
+    suffix++;
+  }
+
+  return candidate;
 }


### PR DESCRIPTION
## Why

Part of CON-864.

Derivation named a secret from its slot's position alone: an env value at index 0 of the first service became `s0_e0`. **Nothing checked whether some other slot in the same document was already referencing that exact name.** When one was, both positions ended up spelling `ac-secret://s0_e0`, so a single stored value silently resolved into two places, with no error anywhere.

## What

A minted name need only be **unique**: it must not be one any reference in the document already stands on. A suffix is added when the name a slot's position spells is occupied.

The positional *preference* that first shipped with this — "re-supplying a value lands back on the name it was already stored under" — has been removed as a rationale. Positional `sN_eM` naming is a console-internal fallback for a create that supplied no sealed secrets, and a client that cares about names chooses them in its own seal, so references do not need to survive an update. That is a design ruling, not a defect: the *guard* below was never about the preference.

### Minting is not confined to a create with no seal

The fallback framing understates where this runs. `credentials.username` and `credentials.password` are `valueIsAlwaysSecret`, so they derive **even when a seal is supplied**. The mint path is live in both cases, and both are tested — including one where a client's chosen seal name is exactly what a credential position would otherwise have minted.

### The evidence

Reverting this file and rerunning its spec:

```
Tests  4 failed | 41 passed (45)

× does not mint the name a reference elsewhere already holds
× leaves that reference resolving to its own stored value rather than to the derived one
× keeps one name per slot when positions have shifted under the references
× avoids a name a registry credential reference is standing on
```

The failure that matters:

```
- Expected
+ Received

  [
-   "A=ac-secret://s0_e0_2",
+   "A=ac-secret://s0_e0",
    "B=ac-secret://s0_e0",
```

**36 of the 40 tests already in that spec pass either way.** That sentence is the point: nothing already in the repo could have caught this, which is why it survived.

### The guard is still required, and still falsifiable

Removing `mintName` reddens five tests. A client-supplied seal can name anything, so a collision with a derived name remains reachable regardless of how positions are chosen.

### It removes a latent collision from the existing create path too, not only the new one

Unreachable from create and update **as they stand**, because both derive from a *submitted* document: with no seal, intake refuses a document carrying references at all, and with a seal, env values are not derived. Both conditions are properties of those callers, not of the derivation — so this is a latent collision in the create path that this fix removes, and it becomes reachable rather than latent the moment anything derives from a *stored* document, which is exactly what the patch pipeline later in this stack does.

Observable behaviour of the endpoint is demonstrated in the PATCH exposure PR.

Measured: 106 non-excluded changed lines. `apps/api` tsc 42 against a 42 baseline, lint 0, derivation unit 45/45, functional 405/405.

### The two mutants the gate kept alive here

This PR scored 77.78% on two survivors, both in this collision path — and the reviewer was right that two survivors meant the tests were not pinning the mechanism.

**`suffix++ -> suffix--` survived, and it mattered.** One collision reaches `_2` whether the counter goes up or down, because the suffix is read before it moves — so every existing test held for a mint that walked *backwards* into spellings below the one it started from. A document standing on both `s0_e0` and `s0_e0_2` separates them: the real mint reaches `s0_e0_3`, the mutant reaches `s0_e0_1`. The new test pins the walk, not the arithmetic. Verified to fail when the increment is reverted.

**`takenNames.add(name)` survived because nothing can reach it.** Recording each minted name kept the set current, but no later mint ever asks: a slot prefers `s{i}_e{n}` or `s{i}_c_{field}`, and a mint that collides spells `{preferred}_{k}`, so a minted name can never be a later preferred one. The two grammars are disjoint, so the set never needs to grow.

That is an equivalent mutant, not a coverage gap, and no test can kill it. Rather than reach for an ignore label, the line is removed, and the constraint that makes its absence safe now sits on `mintName` where an editor changing how a position spells itself will read it.

Checked rather than argued: enumerating 5487 documents — every arrangement of three env slots over two services drawn from a pool of deliberately colliding reference names, with and without credentials, in both derivation modes — gives byte-identical output with the line and without it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented derived secret names from conflicting with existing environment and registry credential references.
  * Added unique numeric suffixes when preferred secret names are already in use.
  * Preserved existing references while maintaining valid SDL naming and length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->