### PR TITLE
refactor(deployment): guard a definition write on the version it was read at

### DIFF
--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -871,6 +871,55 @@ describe(DeploymentSettingRepository.name, () => {
       expect(await readDefinition(dseq)).toEqual(before);
     });
 
+    it("accepts a retry whose row already carries the version it computes, so a repeat is not a conflict", async () => {
+      const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "BBBB" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(id).toEqual(expect.any(String));
+    });
+
+    it("leaves the row at the version the retry recomputed", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "BBBB" });
+
+      await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(await readDefinition(dseq)).toMatchObject({ sdl: "version: '2.0' # patched", manifestVersion: "BBBB", sealedSecrets: sealedToken });
+    });
+
+    it("refuses a version that is neither the one the caller read nor the one it computes", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "CCCC" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(id).toBeUndefined();
+      expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "CCCC" });
+    });
+
     it("awards the write to exactly one of several patches that read the same version", async () => {
       const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
       const dseq = await createDefinition({ manifestVersion: "AAAA" });

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { hoursToMilliseconds } from "date-fns";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { randomBytes } from "node:crypto";
 import { container } from "tsyringe";
 import { describe, expect, it } from "vitest";
@@ -816,6 +816,184 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("replaceDefinitionIfVersionMatches", () => {
+    it("replaces the definition when the version the caller read is still current", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(id).toEqual(expect.any(String));
+      expect(await readDefinition(dseq)).toMatchObject({
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+    });
+
+    it("refuses when the version the caller read is no longer current", async () => {
+      const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "STALE"
+      });
+
+      expect(id).toBeUndefined();
+    });
+
+    it("leaves every column as it was when it refuses", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken, otherSealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA", sealedSecrets: otherSealedToken });
+      const before = await readDefinition(dseq);
+
+      await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "STALE"
+      });
+
+      expect(await readDefinition(dseq)).toEqual(before);
+    });
+
+    it("awards the write to exactly one of several patches that read the same version", async () => {
+      const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const results = await Promise.all(
+        Array.from({ length: 5 }, (_, attempt) =>
+          deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+            userId: user.id,
+            dseq,
+            sdl: `version: '2.0' # patch ${attempt}`,
+            manifestVersion: `V${attempt}`,
+            sealedSecrets: sealedToken,
+            expectedManifestVersion: "AAAA"
+          })
+        )
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+    });
+
+    it("leaves the one version that won as the current one", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      await Promise.all(
+        Array.from({ length: 5 }, (_, attempt) =>
+          deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+            userId: user.id,
+            dseq,
+            sdl: `version: '2.0' # patch ${attempt}`,
+            manifestVersion: `V${attempt}`,
+            sealedSecrets: sealedToken,
+            expectedManifestVersion: "AAAA"
+          })
+        )
+      );
+
+      const stored = await readDefinition(dseq);
+      expect(stored?.manifestVersion).toMatch(/^V\d$/);
+      expect(stored?.sdl).toBe(`version: '2.0' # patch ${stored?.manifestVersion?.slice(1)}`);
+    });
+
+    it("replaces without a guard when the caller states no expectation", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+
+      expect(id).toEqual(expect.any(String));
+      expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "BBBB" });
+    });
+
+    it("clears the token when the merged set of secrets is empty", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, otherSealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA", sealedSecrets: otherSealedToken });
+
+      await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: null,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(await readDefinition(dseq)).toMatchObject({ sealedSecrets: null });
+    });
+
+    it("refuses a row that records no sdl, which a patch has nothing to build on", async () => {
+      const { deploymentSettingRepository, user, createSetting, readSettingDseq, sealedToken } = await setup();
+      const settingId = await createSetting();
+      const dseq = await readSettingDseq(settingId);
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+
+      expect(id).toBeUndefined();
+    });
+
+    it("refuses a deployment belonging to another user", async () => {
+      const { deploymentSettingRepository, trialUser, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: trialUser.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+
+      expect(id).toBeUndefined();
+      expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "AAAA" });
+    });
+
+    it("refuses a deployment the caller's ability excludes", async () => {
+      const { deploymentSettingRepository, user, trialUser, createDefinition, readDefinition, abilityFor, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.accessibleBy(abilityFor(trialUser), "update").replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+
+      expect(id).toBeUndefined();
+      expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "AAAA" });
+    });
+  });
+
   async function setup() {
     const userRepository = container.resolve(UserRepository);
     const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
@@ -841,6 +1019,32 @@ describe(DeploymentSettingRepository.name, () => {
 
     function abilityFor(owner: UserOutput) {
       return abilityService.getAbilityFor("REGULAR_USER", owner);
+    }
+
+    async function createDefinition({ manifestVersion, sealedSecrets = null }: { manifestVersion: string; sealedSecrets?: string | null }) {
+      const dseq = faker.number.int({ min: 100000, max: 999999 }).toString();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion, sealedSecrets });
+
+      return dseq;
+    }
+
+    async function readDefinition(dseq: string) {
+      const [row] = await db
+        .select({
+          sdl: deploymentSettingsTable.sdl,
+          manifestVersion: deploymentSettingsTable.manifestVersion,
+          sealedSecrets: deploymentSettingsTable.sealedSecrets
+        })
+        .from(deploymentSettingsTable)
+        .where(and(eq(deploymentSettingsTable.userId, user.id), eq(deploymentSettingsTable.dseq, dseq)));
+
+      return row;
+    }
+
+    async function readSettingDseq(id: string) {
+      const [row] = await db.select({ dseq: deploymentSettingsTable.dseq }).from(deploymentSettingsTable).where(eq(deploymentSettingsTable.id, id));
+
+      return row.dseq;
     }
 
     async function createSetting(userId: string = user.id) {
@@ -934,6 +1138,9 @@ describe(DeploymentSettingRepository.name, () => {
       sealedToken: newSealedToken(),
       otherSealedToken: newSealedToken(),
       abilityFor,
+      createDefinition,
+      readDefinition,
+      readSettingDseq,
       createSetting,
       createLimitedSetting,
       createAnchoredSetting,

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -396,13 +396,20 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
             eq(this.table.userId, userId),
             eq(this.table.dseq, dseq),
             isNotNull(this.table.sdl),
-            ...(expectedManifestVersion === undefined ? [] : [eq(this.table.manifestVersion, expectedManifestVersion)])
+            ...this.#versionGuard(expectedManifestVersion, manifestVersion)
           )
         )
       )
       .returning({ id: this.table.id });
 
     return row?.id;
+  }
+
+  /** A row already carrying the version this write computes is that write's own output, so a guarded retry succeeds rather than conflicting: `manifestVersion` hashes the resolved manifest, and equal versions mean equal effective state down to the secret values. */
+  #versionGuard(expectedManifestVersion: string | undefined, manifestVersion: string) {
+    if (expectedManifestVersion === undefined) return [];
+
+    return [or(eq(this.table.manifestVersion, expectedManifestVersion), eq(this.table.manifestVersion, manifestVersion))];
   }
 
   /** Conflicts are ignored rather than merged, so a row another path already wrote keeps every choice its writer made. */

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -371,23 +371,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return row.id;
   }
 
-  /**
-   * Replaces the definition of a deployment the console already recorded, refusing when the manifest
-   * version the caller read it at is no longer the current one. Returns the row id it wrote, or
-   * undefined when nothing matched.
-   *
-   * The version is compared inside this statement's own WHERE rather than by a read the caller makes
-   * first, because a patch is a read-modify-write over the stored SDL: two of them racing would
-   * otherwise both open the same document, both apply their own half, and the later write would drop
-   * the earlier one with nothing to show that it had. Comparing here means the loser writes nothing.
-   *
-   * `expectedManifestVersion` is optional because the common update states no expectation at all and
-   * takes last-writer-wins; naming one is what buys the guard.
-   *
-   * `sealedSecrets` is stated rather than optional, the same rule a create follows: a patch re-seals
-   * the whole merged set, so leaving it unnamed would strand the previous token beside an SDL whose
-   * references no longer match it.
-   */
+  /** The expected version is compared inside this statement's own WHERE, not by a prior read, so two patches racing over one document cannot both write. */
   async replaceDefinitionIfVersionMatches({
     userId,
     dseq,

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -371,6 +371,56 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return row.id;
   }
 
+  /**
+   * Replaces the definition of a deployment the console already recorded, refusing when the manifest
+   * version the caller read it at is no longer the current one. Returns the row id it wrote, or
+   * undefined when nothing matched.
+   *
+   * The version is compared inside this statement's own WHERE rather than by a read the caller makes
+   * first, because a patch is a read-modify-write over the stored SDL: two of them racing would
+   * otherwise both open the same document, both apply their own half, and the later write would drop
+   * the earlier one with nothing to show that it had. Comparing here means the loser writes nothing.
+   *
+   * `expectedManifestVersion` is optional because the common update states no expectation at all and
+   * takes last-writer-wins; naming one is what buys the guard.
+   *
+   * `sealedSecrets` is stated rather than optional, the same rule a create follows: a patch re-seals
+   * the whole merged set, so leaving it unnamed would strand the previous token beside an SDL whose
+   * references no longer match it.
+   */
+  async replaceDefinitionIfVersionMatches({
+    userId,
+    dseq,
+    sdl,
+    manifestVersion,
+    sealedSecrets,
+    expectedManifestVersion
+  }: {
+    userId: string;
+    dseq: string;
+    sdl: string;
+    manifestVersion: string;
+    sealedSecrets: string | null;
+    expectedManifestVersion?: string;
+  }): Promise<string | undefined> {
+    const [row] = await this.cursor
+      .update(this.table)
+      .set({ sdl, manifestVersion, sealedSecrets, updatedAt: sql`now()` })
+      .where(
+        this.whereAccessibleBy(
+          and(
+            eq(this.table.userId, userId),
+            eq(this.table.dseq, dseq),
+            isNotNull(this.table.sdl),
+            ...(expectedManifestVersion === undefined ? [] : [eq(this.table.manifestVersion, expectedManifestVersion)])
+          )
+        )
+      )
+      .returning({ id: this.table.id });
+
+    return row?.id;
+  }
+
   /** Conflicts are ignored rather than merged, so a row another path already wrote keeps every choice its writer made. */
   async createDefaultIfMissing({ userId, dseq }: { userId: string; dseq: string }): Promise<boolean> {
     const rows = await this.cursor


### PR DESCRIPTION
## Why

Part of CON-864.

A patch is a read-modify-write over the stored SDL: it opens the recorded document, applies its own half and writes the result back. Two of them racing would both open the same document and the later write would drop the earlier one with nothing to show it had.

## What

`replaceDefinitionIfVersionMatches` compares the expected manifest version **inside the UPDATE's own WHERE clause** rather than by a read the caller makes first, so the loser writes nothing instead of losing a check-then-write window. Modelled on the existing `applyRuntimeLimit`.

Dropping that one condition and rerunning the spec fails three tests, including the one that fires five concurrent patches at a single row and expects exactly one to win.

Stating no expectation keeps last-writer-wins, which is what the common update wants; naming one is what buys the guard.

`sealedSecrets` is required rather than optional, the rule a create already follows: a patch re-seals the whole merged set, so leaving it unnamed would strand the previous token beside an SDL whose references no longer match it.

Ten integration tests against a real database, covering the guard, the five-writer race, ability scoping, another user's deployment, a row with no recorded SDL, and clearing the token when the merged set is empty.

Observable behaviour of the endpoint is demonstrated in the PATCH exposure PR.

Measured: 259 non-excluded changed lines. `apps/api` tsc 42 against a 42 baseline, lint 0, deployment-setting integration 91/91, functional 405/405.

### Review round 5 — the guarded write is now idempotent

The guard as first written delivered convergence but not retriability: a client that got a 5xx and retried its patch with the `ifManifestVersion` it originally read was answered **409**, because the CAS had already advanced the row past the version it was guarding on. The thing the client actually experiences was left broken.

The predicate now matches **either** the expected version **or** the version this write is about to record:

```ts
or(eq(this.table.manifestVersion, expectedManifestVersion), eq(this.table.manifestVersion, manifestVersion))
```

so a retry of the same patch, whose row already sits at the version it computes, is a success — and then falls through to the chain transaction and the provider push, which is exactly the repair path.

Two things worth being explicit about:

- **The unguarded path is unchanged.** With `ifManifestVersion` absent there is still no version predicate at all, and `#versionGuard` returns an empty clause list before it reaches the `or`.
- **The OR means a client guarding on `V_old` also succeeds when the row sits at `V_new`.** That is the intended idempotency, and it is safe because `manifestVersion` hashes the *resolved* manifest: equal versions mean equal effective state, secret values included. The reasoning sits on `#versionGuard`'s declaration, where the predicate lives.

The row still gets `sdl`, `sealedSecrets` and `updatedAt` rewritten on the idempotent path. That is harmless — same plaintext, fresh AES-GCM ciphertext — rather than a no-op.

Three integration tests cover it; the two that pin the new behaviour fail when the `or` is reverted to a plain `eq`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for finding recent, open trial deployments associated with funded wallets.
  - Deployment definitions can be replaced conditionally based on their manifest version.
  - Updates are applied atomically, preventing stale or conflicting changes from overwriting newer definitions.
  - Replacement supports sealed-secret clearing and enforces deployment access and authorization requirements.
- **Bug Fixes**
  - Invalid updates are rejected when the deployment is unavailable, lacks a valid definition, or fails ownership and authorization checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->