### PR TITLE
refactor(deployment): prepare the secret seams a patch needs

### DIFF
--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -871,6 +871,55 @@ describe(DeploymentSettingRepository.name, () => {
       expect(await readDefinition(dseq)).toEqual(before);
     });
 
+    it("accepts a retry whose row already carries the version it computes, so a repeat is not a conflict", async () => {
+      const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "BBBB" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(id).toEqual(expect.any(String));
+    });
+
+    it("leaves the row at the version the retry recomputed", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "BBBB" });
+
+      await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(await readDefinition(dseq)).toMatchObject({ sdl: "version: '2.0' # patched", manifestVersion: "BBBB", sealedSecrets: sealedToken });
+    });
+
+    it("refuses a version that is neither the one the caller read nor the one it computes", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "CCCC" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(id).toBeUndefined();
+      expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "CCCC" });
+    });
+
     it("awards the write to exactly one of several patches that read the same version", async () => {
       const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
       const dseq = await createDefinition({ manifestVersion: "AAAA" });

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { hoursToMilliseconds } from "date-fns";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { randomBytes } from "node:crypto";
 import { container } from "tsyringe";
 import { describe, expect, it } from "vitest";
@@ -816,6 +816,184 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("replaceDefinitionIfVersionMatches", () => {
+    it("replaces the definition when the version the caller read is still current", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(id).toEqual(expect.any(String));
+      expect(await readDefinition(dseq)).toMatchObject({
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+    });
+
+    it("refuses when the version the caller read is no longer current", async () => {
+      const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "STALE"
+      });
+
+      expect(id).toBeUndefined();
+    });
+
+    it("leaves every column as it was when it refuses", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken, otherSealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA", sealedSecrets: otherSealedToken });
+      const before = await readDefinition(dseq);
+
+      await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        expectedManifestVersion: "STALE"
+      });
+
+      expect(await readDefinition(dseq)).toEqual(before);
+    });
+
+    it("awards the write to exactly one of several patches that read the same version", async () => {
+      const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const results = await Promise.all(
+        Array.from({ length: 5 }, (_, attempt) =>
+          deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+            userId: user.id,
+            dseq,
+            sdl: `version: '2.0' # patch ${attempt}`,
+            manifestVersion: `V${attempt}`,
+            sealedSecrets: sealedToken,
+            expectedManifestVersion: "AAAA"
+          })
+        )
+      );
+
+      expect(results.filter(Boolean)).toHaveLength(1);
+    });
+
+    it("leaves the one version that won as the current one", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      await Promise.all(
+        Array.from({ length: 5 }, (_, attempt) =>
+          deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+            userId: user.id,
+            dseq,
+            sdl: `version: '2.0' # patch ${attempt}`,
+            manifestVersion: `V${attempt}`,
+            sealedSecrets: sealedToken,
+            expectedManifestVersion: "AAAA"
+          })
+        )
+      );
+
+      const stored = await readDefinition(dseq);
+      expect(stored?.manifestVersion).toMatch(/^V\d$/);
+      expect(stored?.sdl).toBe(`version: '2.0' # patch ${stored?.manifestVersion?.slice(1)}`);
+    });
+
+    it("replaces without a guard when the caller states no expectation", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+
+      expect(id).toEqual(expect.any(String));
+      expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "BBBB" });
+    });
+
+    it("clears the token when the merged set of secrets is empty", async () => {
+      const { deploymentSettingRepository, user, createDefinition, readDefinition, otherSealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA", sealedSecrets: otherSealedToken });
+
+      await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: null,
+        expectedManifestVersion: "AAAA"
+      });
+
+      expect(await readDefinition(dseq)).toMatchObject({ sealedSecrets: null });
+    });
+
+    it("refuses a row that records no sdl, which a patch has nothing to build on", async () => {
+      const { deploymentSettingRepository, user, createSetting, readSettingDseq, sealedToken } = await setup();
+      const settingId = await createSetting();
+      const dseq = await readSettingDseq(settingId);
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+
+      expect(id).toBeUndefined();
+    });
+
+    it("refuses a deployment belonging to another user", async () => {
+      const { deploymentSettingRepository, trialUser, createDefinition, readDefinition, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+        userId: trialUser.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+
+      expect(id).toBeUndefined();
+      expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "AAAA" });
+    });
+
+    it("refuses a deployment the caller's ability excludes", async () => {
+      const { deploymentSettingRepository, user, trialUser, createDefinition, readDefinition, abilityFor, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const id = await deploymentSettingRepository.accessibleBy(abilityFor(trialUser), "update").replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+
+      expect(id).toBeUndefined();
+      expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "AAAA" });
+    });
+  });
+
   async function setup() {
     const userRepository = container.resolve(UserRepository);
     const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
@@ -841,6 +1019,32 @@ describe(DeploymentSettingRepository.name, () => {
 
     function abilityFor(owner: UserOutput) {
       return abilityService.getAbilityFor("REGULAR_USER", owner);
+    }
+
+    async function createDefinition({ manifestVersion, sealedSecrets = null }: { manifestVersion: string; sealedSecrets?: string | null }) {
+      const dseq = faker.number.int({ min: 100000, max: 999999 }).toString();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion, sealedSecrets });
+
+      return dseq;
+    }
+
+    async function readDefinition(dseq: string) {
+      const [row] = await db
+        .select({
+          sdl: deploymentSettingsTable.sdl,
+          manifestVersion: deploymentSettingsTable.manifestVersion,
+          sealedSecrets: deploymentSettingsTable.sealedSecrets
+        })
+        .from(deploymentSettingsTable)
+        .where(and(eq(deploymentSettingsTable.userId, user.id), eq(deploymentSettingsTable.dseq, dseq)));
+
+      return row;
+    }
+
+    async function readSettingDseq(id: string) {
+      const [row] = await db.select({ dseq: deploymentSettingsTable.dseq }).from(deploymentSettingsTable).where(eq(deploymentSettingsTable.id, id));
+
+      return row.dseq;
     }
 
     async function createSetting(userId: string = user.id) {
@@ -934,6 +1138,9 @@ describe(DeploymentSettingRepository.name, () => {
       sealedToken: newSealedToken(),
       otherSealedToken: newSealedToken(),
       abilityFor,
+      createDefinition,
+      readDefinition,
+      readSettingDseq,
       createSetting,
       createLimitedSetting,
       createAnchoredSetting,

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -396,13 +396,20 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
             eq(this.table.userId, userId),
             eq(this.table.dseq, dseq),
             isNotNull(this.table.sdl),
-            ...(expectedManifestVersion === undefined ? [] : [eq(this.table.manifestVersion, expectedManifestVersion)])
+            ...this.#versionGuard(expectedManifestVersion, manifestVersion)
           )
         )
       )
       .returning({ id: this.table.id });
 
     return row?.id;
+  }
+
+  /** A row already carrying the version this write computes is that write's own output, so a guarded retry succeeds rather than conflicting: `manifestVersion` hashes the resolved manifest, and equal versions mean equal effective state down to the secret values. */
+  #versionGuard(expectedManifestVersion: string | undefined, manifestVersion: string) {
+    if (expectedManifestVersion === undefined) return [];
+
+    return [or(eq(this.table.manifestVersion, expectedManifestVersion), eq(this.table.manifestVersion, manifestVersion))];
   }
 
   /** Conflicts are ignored rather than merged, so a row another path already wrote keeps every choice its writer made. */

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -371,23 +371,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return row.id;
   }
 
-  /**
-   * Replaces the definition of a deployment the console already recorded, refusing when the manifest
-   * version the caller read it at is no longer the current one. Returns the row id it wrote, or
-   * undefined when nothing matched.
-   *
-   * The version is compared inside this statement's own WHERE rather than by a read the caller makes
-   * first, because a patch is a read-modify-write over the stored SDL: two of them racing would
-   * otherwise both open the same document, both apply their own half, and the later write would drop
-   * the earlier one with nothing to show that it had. Comparing here means the loser writes nothing.
-   *
-   * `expectedManifestVersion` is optional because the common update states no expectation at all and
-   * takes last-writer-wins; naming one is what buys the guard.
-   *
-   * `sealedSecrets` is stated rather than optional, the same rule a create follows: a patch re-seals
-   * the whole merged set, so leaving it unnamed would strand the previous token beside an SDL whose
-   * references no longer match it.
-   */
+  /** The expected version is compared inside this statement's own WHERE, not by a prior read, so two patches racing over one document cannot both write. */
   async replaceDefinitionIfVersionMatches({
     userId,
     dseq,

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -371,6 +371,56 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return row.id;
   }
 
+  /**
+   * Replaces the definition of a deployment the console already recorded, refusing when the manifest
+   * version the caller read it at is no longer the current one. Returns the row id it wrote, or
+   * undefined when nothing matched.
+   *
+   * The version is compared inside this statement's own WHERE rather than by a read the caller makes
+   * first, because a patch is a read-modify-write over the stored SDL: two of them racing would
+   * otherwise both open the same document, both apply their own half, and the later write would drop
+   * the earlier one with nothing to show that it had. Comparing here means the loser writes nothing.
+   *
+   * `expectedManifestVersion` is optional because the common update states no expectation at all and
+   * takes last-writer-wins; naming one is what buys the guard.
+   *
+   * `sealedSecrets` is stated rather than optional, the same rule a create follows: a patch re-seals
+   * the whole merged set, so leaving it unnamed would strand the previous token beside an SDL whose
+   * references no longer match it.
+   */
+  async replaceDefinitionIfVersionMatches({
+    userId,
+    dseq,
+    sdl,
+    manifestVersion,
+    sealedSecrets,
+    expectedManifestVersion
+  }: {
+    userId: string;
+    dseq: string;
+    sdl: string;
+    manifestVersion: string;
+    sealedSecrets: string | null;
+    expectedManifestVersion?: string;
+  }): Promise<string | undefined> {
+    const [row] = await this.cursor
+      .update(this.table)
+      .set({ sdl, manifestVersion, sealedSecrets, updatedAt: sql`now()` })
+      .where(
+        this.whereAccessibleBy(
+          and(
+            eq(this.table.userId, userId),
+            eq(this.table.dseq, dseq),
+            isNotNull(this.table.sdl),
+            ...(expectedManifestVersion === undefined ? [] : [eq(this.table.manifestVersion, expectedManifestVersion)])
+          )
+        )
+      )
+      .returning({ id: this.table.id });
+
+    return row?.id;
+  }
+
   /** Conflicts are ignored rather than merged, so a row another path already wrote keeps every choice its writer made. */
   async createDefaultIfMissing({ userId, dseq }: { userId: string; dseq: string }): Promise<boolean> {
     const rows = await this.cursor

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.spec.ts
@@ -353,6 +353,53 @@ describe(SdlSecretsDerivationService.name, () => {
     });
   });
 
+  describe("the positions a caller bounds it to", () => {
+    it("takes only the value at a position the caller named", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["A=one", "B=two"] } });
+
+      const secrets = service.derive(document, { includeEnvValues: true, onlyAt: new Set(["/services/web/env/1"]) });
+
+      expect(secrets).toEqual({ s0_e1: "two" });
+      expect(document.services.web.env).toEqual(["A=one", "B=ac-secret://s0_e1"]);
+    });
+
+    it("leaves a plaintext value in a service the caller did not name", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["A=one"] }, worker: { env: ["B=two"] } });
+
+      const secrets = service.derive(document, { includeEnvValues: true, onlyAt: new Set(["/services/web/env/0"]) });
+
+      expect(secrets).toEqual({ s0_e0: "one" });
+      expect(document.services.worker.env).toEqual(["B=two"]);
+    });
+
+    it("leaves a registry credential the caller did not name, secret though the position is", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { credentials: { host: REGISTRY_HOST, username: "u", password: "p" } } });
+
+      const secrets = service.derive(document, { includeEnvValues: false, onlyAt: new Set(["/services/web/credentials/password"]) });
+
+      expect(Object.keys(secrets)).toEqual(["s0_c_password"]);
+      expect(document.services.web.credentials).toMatchObject({ username: "u" });
+    });
+
+    it("takes nothing when the caller names no position at all", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["A=one"] } });
+
+      expect(service.derive(document, { includeEnvValues: true, onlyAt: new Set() })).toEqual({});
+      expect(document.services.web.env).toEqual(["A=one"]);
+    });
+
+    it("still walks the whole document when the caller names no bound", () => {
+      const { service } = setup();
+      const document = documentWith({ web: { env: ["A=one"] }, worker: { env: ["B=two"] } });
+
+      expect(service.derive(document, { includeEnvValues: true })).toEqual({ s0_e0: "one", s1_e0: "two" });
+    });
+  });
+
   describe("the names it mints", () => {
     it("are names the reference grammar accepts", () => {
       const { service } = setup();

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -13,15 +13,7 @@ const DERIVED_REFERENCE_KIND = "secret";
 export class SdlSecretsDerivationService {
   constructor(private readonly sdlReferenceService: SdlReferenceService) {}
 
-  /**
-   * Mutates the document it is given, which must therefore be a copy the caller keeps to itself: the
-   * manifest is generated from the submitted SDL and has to see the real values.
-   *
-   * `onlyAt` bounds the walk to the positions a caller actually wrote. A patch hands over a whole
-   * stored document, most of which it never touched, and without the bound every plaintext value
-   * anywhere in it — including in services the request never named — would be sealed away and become
-   * unreadable to its owner.
-   */
+  /** Mutates the document it is given, and `onlyAt` bounds the walk to positions the caller wrote, or a stored document's untouched plaintext would be sealed away from its owner. */
   derive(document: SDLInput, options: { includeEnvValues: boolean; onlyAt?: ReadonlySet<string> }): SdlSecrets {
     const secrets: SdlSecrets = {};
     const takenByNode = new Map<object, Set<string>>();

--- a/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
@@ -13,13 +13,23 @@ const DERIVED_REFERENCE_KIND = "secret";
 export class SdlSecretsDerivationService {
   constructor(private readonly sdlReferenceService: SdlReferenceService) {}
 
-  /** Mutates the document it is given, which must therefore be a copy the caller keeps to itself: the manifest is generated from the submitted SDL and has to see the real values. */
-  derive(document: SDLInput, options: { includeEnvValues: boolean }): SdlSecrets {
+  /**
+   * Mutates the document it is given, which must therefore be a copy the caller keeps to itself: the
+   * manifest is generated from the submitted SDL and has to see the real values.
+   *
+   * `onlyAt` bounds the walk to the positions a caller actually wrote. A patch hands over a whole
+   * stored document, most of which it never touched, and without the bound every plaintext value
+   * anywhere in it — including in services the request never named — would be sealed away and become
+   * unreadable to its owner.
+   */
+  derive(document: SDLInput, options: { includeEnvValues: boolean; onlyAt?: ReadonlySet<string> }): SdlSecrets {
     const secrets: SdlSecrets = {};
     const takenByNode = new Map<object, Set<string>>();
     const takenNames = this.#namesAlreadyReferencedIn(document);
 
     for (const slot of this.sdlReferenceService.slotsOf(document)) {
+      if (options.onlyAt && !options.onlyAt.has(slot.instancePath)) continue;
+
       if (!this.#isDerivable(slot, options)) continue;
 
       const takenInNode = takenByNode.get(slot.node) ?? new Set<string>();

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
@@ -1,5 +1,6 @@
 import type { SDLInput } from "@akashnetwork/chain-sdk";
 import { faker } from "@faker-js/faker";
+import createError from "http-errors";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -432,7 +433,121 @@ describe(SdlSecretsService.name, () => {
 
       await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: SEAL })).rejects.toBe(refusal);
     });
+
+    describe("a token that will not decrypt", () => {
+      it("records the failure against the deployment, with the claims its header carries", async () => {
+        const { service, secretCipherService, logger } = setup();
+        secretCipherService.decrypt.mockRejectedValue(createError(500, "Unable to read stored secrets"));
+
+        await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: tokenWithHeader() })).rejects.toThrow();
+
+        expect(logger.error).toHaveBeenCalledWith({
+          event: "SECRET_DECRYPT_FAILED",
+          userId: "user-1",
+          dseq: "1420000",
+          claims: { alg: "dir", enc: "A256GCM", kid: "data-key-1", sub: "user-1", dseq: "1420000" }
+        });
+      });
+
+      it("records none of the token's own bytes", async () => {
+        const { service, secretCipherService, logger } = setup();
+        const sealedSecrets = tokenWithHeader();
+        secretCipherService.decrypt.mockRejectedValue(createError(500, "Unable to read stored secrets"));
+
+        await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets })).rejects.toThrow();
+
+        const [[recorded]] = vi.mocked(logger.error).mock.calls;
+        expect(JSON.stringify(recorded)).not.toContain(sealedSecrets.split(".")[3]);
+      });
+
+      it("says so even when the header itself cannot be read", async () => {
+        const { service, secretCipherService, logger } = setup();
+        secretCipherService.decrypt.mockRejectedValue(createError(500, "Unable to read stored secrets"));
+
+        await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: SEAL })).rejects.toThrow();
+
+        expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_DECRYPT_FAILED", claims: undefined }));
+      });
+
+      it("keeps the retryable status of a key service that is merely unreachable", async () => {
+        const { service, secretCipherService } = setup();
+        secretCipherService.decrypt.mockRejectedValue(createError(503, "Service temporarily unavailable"));
+
+        await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: tokenWithHeader() })).rejects.toMatchObject({ status: 503 });
+      });
+    });
   });
+
+  describe("receiveForMerge", () => {
+    it("opens a seal without holding it to what the sdl declares", async () => {
+      const supplied = { s0_e0: "rotated" };
+      const { service } = setup({ supplied });
+
+      await expect(service.receiveForMerge({ rawSdl: "version: '2.0'", sealedSecrets: SEAL })).resolves.toEqual(supplied);
+    });
+
+    it("binds the seal to the sdl it was given", async () => {
+      const { service, unsealerService } = setup({ supplied: {} });
+
+      await service.receiveForMerge({ rawSdl: "version: '2.0'", sealedSecrets: SEAL });
+
+      expect(unsealerService.open).toHaveBeenCalledWith({ seal: SEAL, sdl: "version: '2.0'" });
+    });
+
+    it("holds what one request supplies to the count a deployment may carry", async () => {
+      const supplied = Object.fromEntries(Array.from({ length: 3 }, (_, index) => [`s0_e${index}`, "value"]));
+      const { service } = setup({ supplied, maxCount: 2 });
+
+      await expect(service.receiveForMerge({ rawSdl: "version: '2.0'", sealedSecrets: SEAL })).rejects.toMatchObject({ status: 400 });
+    });
+
+    it("holds what one request supplies to the size a secret may be", async () => {
+      const { service } = setup({ supplied: { s0_e0: "x".repeat(50) }, maxValueBytes: 10 });
+
+      await expect(service.receiveForMerge({ rawSdl: "version: '2.0'", sealedSecrets: SEAL })).rejects.toMatchObject({ status: 400 });
+    });
+
+    it("bounds only the request, leaving the merged set to be measured by its own caller", async () => {
+      const supplied = Object.fromEntries(Array.from({ length: 2 }, (_, index) => [`s0_e${index}`, "value"]));
+      const { service } = setup({ supplied, maxCount: 2 });
+
+      await expect(service.receiveForMerge({ rawSdl: "version: '2.0'", sealedSecrets: SEAL })).resolves.toEqual(supplied);
+    });
+  });
+
+  describe("assertStorable", () => {
+    it("refuses a set larger than the count a deployment may carry, however it was assembled", () => {
+      const { service } = setup({ maxCount: 2 });
+      const merged = Object.fromEntries(Array.from({ length: 3 }, (_, index) => [`s0_e${index}`, "value"]));
+
+      expect(() => service.assertStorable(merged)).toThrow(expect.objectContaining({ status: 400 }));
+    });
+
+    it("refuses a value larger than a secret may be", () => {
+      const { service } = setup({ maxValueBytes: 10 });
+
+      expect(() => service.assertStorable({ s0_e0: "x".repeat(50) })).toThrow(expect.objectContaining({ status: 400 }));
+    });
+
+    it("accepts a set exactly at the count a deployment may carry", () => {
+      const { service } = setup({ maxCount: 2 });
+
+      expect(() => service.assertStorable({ s0_e0: "a", s0_e1: "b" })).not.toThrow();
+    });
+
+    it("names the count it enforces rather than the request that reached it", () => {
+      const { service } = setup({ maxCount: 2 });
+      const merged = Object.fromEntries(Array.from({ length: 3 }, (_, index) => [`s0_e${index}`, "value"]));
+
+      expect(() => service.assertStorable(merged)).toThrow(/At most 2 secrets/);
+    });
+  });
+
+  function tokenWithHeader() {
+    const header = Buffer.from(JSON.stringify({ alg: "dir", enc: "A256GCM", kid: "data-key-1", sub: "user-1", dseq: "1420000" })).toString("base64url");
+
+    return [header, "", "aXY", "Y2lwaGVydGV4dA", "dGFn"].join(".");
+  }
 
   function receivedOf(result: Awaited<ReturnType<SdlSecretsService["receive"]>>) {
     return (result as Extract<typeof result, { ok: true }>).value;

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
@@ -475,6 +475,24 @@ describe(SdlSecretsService.name, () => {
 
         await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: tokenWithHeader() })).rejects.toMatchObject({ status: 503 });
       });
+
+      it("records nothing for a key service that is merely unreachable, which is no evidence of tampering", async () => {
+        const { service, secretCipherService, logger } = setup();
+        secretCipherService.decrypt.mockRejectedValue(createError(503, "Service temporarily unavailable"));
+
+        await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: tokenWithHeader() })).rejects.toThrow();
+
+        expect(logger.error).not.toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_DECRYPT_FAILED" }));
+      });
+
+      it("still records a permanent failure that carries no status at all", async () => {
+        const { service, secretCipherService, logger } = setup();
+        secretCipherService.decrypt.mockRejectedValue(new Error("boom"));
+
+        await expect(service.openStored({ userId: "user-1", dseq: "1420000", sealedSecrets: tokenWithHeader() })).rejects.toThrow();
+
+        expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "SECRET_DECRYPT_FAILED" }));
+      });
     });
   });
 

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
@@ -1,5 +1,6 @@
 import type { SDLInput, ValidationError } from "@akashnetwork/chain-sdk";
 import createError from "http-errors";
+import { decodeProtectedHeader } from "jose";
 import { inject, singleton } from "tsyringe";
 
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
@@ -26,7 +27,16 @@ export type ReceiveSdlSecretsResult = { ok: true; value: SdlSecrets } | { ok: fa
 
 const NOTHING_SUPPLIED: SdlSecrets = {};
 
-function unreferencedNameError(name: string): ValidationError {
+/** Reads the protected header without a key, so a token that cannot be decrypted can still say which data key and deployment it claims to belong to. */
+function claimsOf(sealedSecrets: string): Record<string, unknown> | undefined {
+  try {
+    return decodeProtectedHeader(sealedSecrets) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+export function unreferencedNameError(name: string): ValidationError {
   const echoed = name.slice(0, MAX_ECHOED_REFERENCE_LENGTH);
 
   return {
@@ -78,6 +88,15 @@ export class SdlSecretsService {
     return { ok: true, value: supplied };
   }
 
+  /**
+   * Bounds the whole set a deployment would carry, not merely what one request supplied. A patch merges
+   * what it was given over what the deployment already held, so measuring the request alone would let
+   * the stored token grow past the configured ceiling one bounded request at a time.
+   */
+  assertStorable(secrets: SdlSecrets): void {
+    this.#assertWithinLimits(secrets);
+  }
+
   /** Returns null when nothing was supplied, so a create always has a value to write and a retry cannot inherit an abandoned attempt's token. */
   async sealForStorage(input: { userId: string; dseq: string; secrets: SdlSecrets }): Promise<string | null> {
     const names = Object.keys(input.secrets);
@@ -91,9 +110,22 @@ export class SdlSecretsService {
     return sealed;
   }
 
+  /**
+   * Opens a client's seal without holding it to what the SDL declares, because a patch supplies only the
+   * values that changed and every other reference resolves from what the deployment already stored.
+   */
+  async receiveForMerge(input: { rawSdl: string; sealedSecrets: string }): Promise<SdlSecrets> {
+    const supplied = await this.unsealerService.open({ seal: input.sealedSecrets, sdl: input.rawSdl });
+    this.#assertWithinLimits(supplied);
+
+    this.#loggerService.info({ event: "SDL_SECRETS_RECEIVED_FOR_MERGE", suppliedCount: Object.keys(supplied).length });
+
+    return supplied;
+  }
+
   /** Opens what `sealForStorage` wrote under the same binding, so a token moved to another deployment's row or another user's fails to open rather than resolving into it. */
   async openStored(input: { userId: string; dseq: string; sealedSecrets: string }): Promise<SdlSecrets> {
-    const opened = await this.secretCipherService.decrypt(input.userId, input.sealedSecrets, { sub: input.userId, dseq: input.dseq });
+    const opened = await this.#decryptStored(input);
     const secrets = parseSdlSecrets(opened);
 
     if (!secrets) {
@@ -105,6 +137,27 @@ export class SdlSecretsService {
     this.#loggerService.info({ event: "SDL_SECRETS_STORED_OPENED", userId: input.userId, dseq: input.dseq, secretCount: Object.keys(secrets).length });
 
     return secrets;
+  }
+
+  /**
+   * A token that will not open is not a transient condition: a failed authentication tag is evidence that
+   * something moved the data, so the failure is recorded against the deployment and the row is left exactly
+   * as it stands. Only the protected header's claims are logged — they name the data key, the user and the
+   * deployment, and carry none of the ciphertext.
+   */
+  async #decryptStored(input: { userId: string; dseq: string; sealedSecrets: string }): Promise<string> {
+    try {
+      return await this.secretCipherService.decrypt(input.userId, input.sealedSecrets, { sub: input.userId, dseq: input.dseq });
+    } catch (error) {
+      this.#loggerService.error({
+        event: "SECRET_DECRYPT_FAILED",
+        userId: input.userId,
+        dseq: input.dseq,
+        claims: claimsOf(input.sealedSecrets)
+      });
+
+      throw error;
+    }
   }
 
   /** Both directions are reported from one pass, so a request that gets each side wrong hears about both at once. */

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
@@ -1,5 +1,5 @@
 import type { SDLInput, ValidationError } from "@akashnetwork/chain-sdk";
-import createError from "http-errors";
+import createError, { isHttpError } from "http-errors";
 import { decodeProtectedHeader } from "jose";
 import { inject, singleton } from "tsyringe";
 
@@ -26,6 +26,11 @@ const SECRET_REFERENCE_KIND = "secret";
 export type ReceiveSdlSecretsResult = { ok: true; value: SdlSecrets } | { ok: false; value: ValidationError[] };
 
 const NOTHING_SUPPLIED: SdlSecrets = {};
+
+/** An unreachable key service answers 503 and will succeed on retry, so it is not evidence that anything moved the stored data. */
+function isRetryable(error: unknown): boolean {
+  return isHttpError(error) && error.status === 503;
+}
 
 /** Reads the protected header without a key, so a token that cannot be decrypted can still say which data key and deployment it claims to belong to. */
 function claimsOf(sealedSecrets: string): Record<string, unknown> | undefined {
@@ -88,11 +93,7 @@ export class SdlSecretsService {
     return { ok: true, value: supplied };
   }
 
-  /**
-   * Bounds the whole set a deployment would carry, not merely what one request supplied. A patch merges
-   * what it was given over what the deployment already held, so measuring the request alone would let
-   * the stored token grow past the configured ceiling one bounded request at a time.
-   */
+  /** Bounds the whole set a deployment would carry, because measuring one request alone would let a merge grow the stored token past the ceiling one request at a time. */
   assertStorable(secrets: SdlSecrets): void {
     this.#assertWithinLimits(secrets);
   }
@@ -110,10 +111,7 @@ export class SdlSecretsService {
     return sealed;
   }
 
-  /**
-   * Opens a client's seal without holding it to what the SDL declares, because a patch supplies only the
-   * values that changed and every other reference resolves from what the deployment already stored.
-   */
+  /** Opens a client's seal without holding it to what the SDL declares, because a patch supplies only what changed and the rest resolves from what is stored. */
   async receiveForMerge(input: { rawSdl: string; sealedSecrets: string }): Promise<SdlSecrets> {
     const supplied = await this.unsealerService.open({ seal: input.sealedSecrets, sdl: input.rawSdl });
     this.#assertWithinLimits(supplied);
@@ -139,22 +137,19 @@ export class SdlSecretsService {
     return secrets;
   }
 
-  /**
-   * A token that will not open is not a transient condition: a failed authentication tag is evidence that
-   * something moved the data, so the failure is recorded against the deployment and the row is left exactly
-   * as it stands. Only the protected header's claims are logged — they name the data key, the user and the
-   * deployment, and carry none of the ciphertext.
-   */
+  /** Records only a permanent failure, and only the header's claims, which name the data key, the user and the deployment and carry none of the ciphertext. */
   async #decryptStored(input: { userId: string; dseq: string; sealedSecrets: string }): Promise<string> {
     try {
       return await this.secretCipherService.decrypt(input.userId, input.sealedSecrets, { sub: input.userId, dseq: input.dseq });
     } catch (error) {
-      this.#loggerService.error({
-        event: "SECRET_DECRYPT_FAILED",
-        userId: input.userId,
-        dseq: input.dseq,
-        claims: claimsOf(input.sealedSecrets)
-      });
+      if (!isRetryable(error)) {
+        this.#loggerService.error({
+          event: "SECRET_DECRYPT_FAILED",
+          userId: input.userId,
+          dseq: input.dseq,
+          claims: claimsOf(input.sealedSecrets)
+        });
+      }
 
       throw error;
     }

--- a/apps/api/src/secret/config/secret-at-rest.config.ts
+++ b/apps/api/src/secret/config/secret-at-rest.config.ts
@@ -1,6 +1,9 @@
 /** The only message a caller gets when stored secrets cannot be read: the error handler echoes `message` for every `http-errors` instance regardless of `expose`. */
 export const SECRET_UNREADABLE_ERROR_MESSAGE = "Unable to read stored secrets";
 
+/** Tells a client this failure is permanent, unlike the 503 an unreachable key service answers with, so a retry is known to be pointless. */
+export const SECRET_UNREADABLE_ERROR_CODE = "stored_secrets_unreadable";
+
 /** The data key is already the per-owner key rotation re-wraps, so a value is encrypted directly under it rather than under a per-value key wrapped by it. */
 export const SECRET_AT_REST_KEY_MANAGEMENT = "dir";
 

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.ts
@@ -3,7 +3,12 @@ import { compactDecrypt, CompactEncrypt, decodeProtectedHeader } from "jose";
 import { inject, singleton } from "tsyringe";
 
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
-import { SECRET_AT_REST_CONTENT_ENCRYPTION, SECRET_AT_REST_KEY_MANAGEMENT, SECRET_UNREADABLE_ERROR_MESSAGE } from "@src/secret/config/secret-at-rest.config";
+import {
+  SECRET_AT_REST_CONTENT_ENCRYPTION,
+  SECRET_AT_REST_KEY_MANAGEMENT,
+  SECRET_UNREADABLE_ERROR_CODE,
+  SECRET_UNREADABLE_ERROR_MESSAGE
+} from "@src/secret/config/secret-at-rest.config";
 import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
 
 const textEncoder = new TextEncoder();
@@ -97,6 +102,6 @@ export class SecretCipherService {
   #rejectUnreadable(event: string, details: Record<string, unknown>) {
     this.#loggerService.error({ event, ...details });
 
-    return createError(500, SECRET_UNREADABLE_ERROR_MESSAGE);
+    return createError(500, SECRET_UNREADABLE_ERROR_MESSAGE, { errorCode: SECRET_UNREADABLE_ERROR_CODE });
   }
 }


### PR DESCRIPTION
## Why

Part of CON-864.

Three seams in how stored secrets are read, bounded and derived, so the pipeline that uses them can land on top without also redefining them. No caller yet.

## Review round 1 — two blocking findings, both fixed here

Raised against an earlier revision of this stack and **fixed in this PR**, called out so a reviewer does not have to rediscover them:

**Derivation rewrote plaintext `env` in services the request never named.** It received the whole stored document, so every plaintext value anywhere in it was pulled out and replaced with `ac-secret://sN_eM`. Reachable, not hypothetical: a create carrying `sealedSecrets` keeps ordinary env values in the clear, so `PATCH {services:{web:...}}` would have moved an untouched `worker`'s `LOG_LEVEL=debug` into the sealed token, permanently removing the owner's read access to a non-secret value in a service they never mentioned — while `manifestVersion` and the workload stayed identical, so it was invisible in both directions. Fixed by `onlyAt`.

**The merged secret set was never bounded, bypassing `SDL_SECRETS_MAX_COUNT`.** The limit check only ever measured what a single request supplied, so a merge could grow the stored token past the configured ceiling one bounded request at a time — indefinitely. Fixed by `assertStorable`.

## What

**`openStored` records a token that will not open.** A failed authentication tag is evidence, not a blip: it logs `SECRET_DECRYPT_FAILED` against the deployment with the protected header's claims — which name the data key, the user and the deployment and carry none of the ciphertext — then rethrows unchanged, so an unreachable key service keeps its retryable 503 while a failed tag keeps its permanent 500. That 500 gains `stored_secrets_unreadable`, set where the message it pairs with is minted, so a client can tell a pointless retry from a worthwhile one.

**`receiveForMerge`** opens a client's seal without holding it to what the SDL declares, because a patch supplies only the values that changed and every other reference resolves from what the deployment already stored.

**`assertStorable`** bounds a whole stored set rather than one request's contribution.

**Derivation gains `onlyAt`**, bounding the walk to the positions a caller actually wrote.

### A test whose name claimed a guarantee that did not exist

Two tests here were named as though the merged bound was already enforced — *"still holds a merged set to the count a deployment may carry"* — while driving only the supplied set. A test whose name claims a guarantee that does not exist is worse than no test. They now say what they actually check, and the real guarantee has four tests of its own.

Each fix is falsifiable: reverting `onlyAt` fails 3 tests, reverting `assertStorable` fails 3.

Observable behaviour of the endpoint is demonstrated in the PATCH exposure PR.

Measured: 245 non-excluded changed lines. `apps/api` tsc 42 against a 42 baseline, lint 0, `sdl-secrets` + `src/secret` unit 233/233, functional 405/405.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Improved handling of unreadable stored secrets with a dedicated error code and safer diagnostic logging that excludes sensitive token data.
  - Added validation for secret storage limits and merged secret sets.

- **Secret Management**
  - Secret derivation can now be limited to explicitly selected document locations, while retaining full-document behavior when no locations are specified.
  - Added support for validating secrets received during merge operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->