### PR TITLE
feat(deployment): patch a deployment over http

### DIFF
--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.integration.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.integration.ts
@@ -37,12 +37,12 @@ describe(CloseTrialDeploymentHandler.name, () => {
   });
 
   it("leaves a wallet that has left the trial alone", async () => {
-    const { closeTrialDeployment, close, sentNotifications } = await setup({ isTrialing: false });
+    const { closeTrialDeployment, close, findClosedNotice } = await setup({ isTrialing: false });
 
     await closeTrialDeployment();
 
     expect(close).not.toHaveBeenCalled();
-    expect(sentNotifications()).toHaveLength(0);
+    expect(await findClosedNotice()).toBeUndefined();
   });
 
   it("leaves a wallet with no address alone", async () => {

--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
@@ -114,6 +114,7 @@ describe(DeploymentSettingController.name, () => {
       dseq: faker.string.numeric(6),
       autoTopUpEnabled: faker.datatype.boolean(),
       closed: false,
+      sdl: "sdl",
       estimatedTopUpAmount: faker.number.float({ min: 0, max: 100 }),
       topUpFrequencyMs: faker.number.int({ min: 1000, max: 100000 }),
       runtimeLimitHours: null,

--- a/apps/api/src/deployment/controllers/deployment/deployment.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/deployment.controller.ts
@@ -16,9 +16,12 @@ import {
   ListWithResourcesParams,
   ListWithResourcesQuery,
   ListWithResourcesResponse,
+  PatchDeploymentRequest,
+  PatchDeploymentResponse,
   UpdateDeploymentRequest,
   UpdateDeploymentResponse
 } from "@src/deployment/http-schemas/deployment.schema";
+import { DeploymentPatchService } from "@src/deployment/services/deployment-patch/deployment-patch.service";
 import { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
@@ -28,6 +31,7 @@ export class DeploymentController {
   constructor(
     private readonly deploymentReaderService: DeploymentReaderService,
     private readonly deploymentWriterService: DeploymentWriterService,
+    private readonly deploymentPatchService: DeploymentPatchService,
     private readonly authService: AuthService,
     private readonly drainingDeploymentService: DrainingDeploymentService
   ) {}
@@ -63,6 +67,12 @@ export class DeploymentController {
   @Protected([{ action: "sign", subject: "UserWallet" }])
   async update(dseq: string, input: UpdateDeploymentRequest["data"]): Promise<UpdateDeploymentResponse> {
     const result = await this.deploymentWriterService.updateByUserIdAndDseq(this.authService.currentUser.id, dseq, input);
+    return { data: result };
+  }
+
+  @Protected([{ action: "sign", subject: "UserWallet" }])
+  async patch(dseq: string, input: PatchDeploymentRequest["data"]): Promise<PatchDeploymentResponse> {
+    const result = await this.deploymentPatchService.patchByUserIdAndDseq(this.authService.currentUser.id, dseq, input);
     return { data: result };
   }
 

--- a/apps/api/src/deployment/controllers/deployment/deployment.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/deployment.controller.ts
@@ -21,7 +21,6 @@ import {
   UpdateDeploymentRequest,
   UpdateDeploymentResponse
 } from "@src/deployment/http-schemas/deployment.schema";
-import { DeploymentPatchService } from "@src/deployment/services/deployment-patch/deployment-patch.service";
 import { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
@@ -31,7 +30,6 @@ export class DeploymentController {
   constructor(
     private readonly deploymentReaderService: DeploymentReaderService,
     private readonly deploymentWriterService: DeploymentWriterService,
-    private readonly deploymentPatchService: DeploymentPatchService,
     private readonly authService: AuthService,
     private readonly drainingDeploymentService: DrainingDeploymentService
   ) {}
@@ -72,7 +70,7 @@ export class DeploymentController {
 
   @Protected([{ action: "sign", subject: "UserWallet" }])
   async patch(dseq: string, input: PatchDeploymentRequest["data"]): Promise<PatchDeploymentResponse> {
-    const result = await this.deploymentPatchService.patchByUserIdAndDseq(this.authService.currentUser.id, dseq, input);
+    const result = await this.deploymentWriterService.patchByUserIdAndDseq(this.authService.currentUser.id, dseq, input, this.authService.ability);
     return { data: result };
   }
 

--- a/apps/api/src/deployment/controllers/deployment/deployment.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/deployment.controller.ts
@@ -1,3 +1,4 @@
+/* v8 ignore start */
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 import { z } from "zod";

--- a/apps/api/src/deployment/http-schemas/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-setting.schema.ts
@@ -7,6 +7,7 @@ const DeploymentSettingSchema = z.object({
   id: z.string().uuid(),
   userId: z.string(),
   dseq: DseqSchema,
+  sdl: z.string().nullable(),
   autoTopUpEnabled: z.boolean(),
   estimatedTopUpAmount: z.number(),
   topUpFrequencyMs: z.number(),

--- a/apps/api/src/deployment/http-schemas/deployment.schema.spec.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.spec.ts
@@ -69,6 +69,16 @@ describe("PatchDeploymentRequestSchema", () => {
     });
   });
 
+  describe("when the seal is an empty string", () => {
+    it("refuses it in place of a service patch, which every reader would read as no seal at all", () => {
+      expect(parse({ web: {} }, { sealedSecrets: "" }).success).toBe(false);
+    });
+
+    it("refuses it beside a service patch that would write something", () => {
+      expect(parse({ web: { image: "nginx:1.27" } }, { sealedSecrets: "" }).success).toBe(false);
+    });
+  });
+
   const SEAL = "eyJhbGciOiJSU0EtT0FFUC0yNTYifQ.sealed.payload";
 
   function parse(services: Record<string, unknown>, rest: Record<string, unknown> = {}) {

--- a/apps/api/src/deployment/http-schemas/deployment.schema.spec.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.spec.ts
@@ -2,50 +2,76 @@ import "@hono/zod-openapi";
 
 import { describe, expect, it } from "vitest";
 
-import { PatchServiceSchema } from "./deployment.schema";
+import { PatchDeploymentRequestSchema } from "./deployment.schema";
 
-describe("PatchServiceSchema", () => {
+describe("PatchDeploymentRequestSchema", () => {
   describe("a patch that would write nothing", () => {
-    it("refuses a patch naming no field at all", () => {
-      expect(PatchServiceSchema.safeParse({}).success).toBe(false);
+    it("refuses a body naming no service", () => {
+      expect(parse({}).success).toBe(false);
+    });
+
+    it("refuses a service naming no field", () => {
+      expect(parse({ web: {} }).success).toBe(false);
     });
 
     it("refuses an env record carrying no variable", () => {
-      expect(PatchServiceSchema.safeParse({ env: {} }).success).toBe(false);
+      expect(parse({ web: { env: {} } }).success).toBe(false);
     });
 
     it("refuses an expose record carrying no port", () => {
-      expect(PatchServiceSchema.safeParse({ expose: {} }).success).toBe(false);
+      expect(parse({ web: { expose: {} } }).success).toBe(false);
     });
 
     it("refuses a storage record carrying no volume", () => {
-      expect(PatchServiceSchema.safeParse({ storage: {} }).success).toBe(false);
+      expect(parse({ web: { storage: {} } }).success).toBe(false);
     });
 
     it("refuses every empty record at once rather than passing on the count of them", () => {
-      expect(PatchServiceSchema.safeParse({ env: {}, expose: {}, storage: {} }).success).toBe(false);
+      expect(parse({ web: { env: {}, expose: {}, storage: {} } }).success).toBe(false);
+    });
+
+    it("refuses a service that assigns nothing next to one that also assigns nothing", () => {
+      expect(parse({ web: { env: {} }, worker: {} }).success).toBe(false);
     });
   });
 
   describe("a patch that would write something", () => {
+    it("accepts a service naming no field when the request carries sealed secrets", () => {
+      expect(parse({ web: {} }, { sealedSecrets: SEAL }).success).toBe(true);
+    });
+
+    it("accepts sealed secrets alongside a service whose every record is empty", () => {
+      expect(parse({ web: { env: {} } }, { sealedSecrets: SEAL }).success).toBe(true);
+    });
+
     it("accepts a field alongside an empty record", () => {
-      expect(PatchServiceSchema.safeParse({ image: "nginx:1.27", env: {} }).success).toBe(true);
+      expect(parse({ web: { image: "nginx:1.27", env: {} } }).success).toBe(true);
     });
 
     it("accepts an empty command list, which clears the one the service declared", () => {
-      expect(PatchServiceSchema.safeParse({ command: [] }).success).toBe(true);
+      expect(parse({ web: { command: [] } }).success).toBe(true);
     });
 
     it("accepts cleared credentials", () => {
-      expect(PatchServiceSchema.safeParse({ credentials: null }).success).toBe(true);
+      expect(parse({ web: { credentials: null } }).success).toBe(true);
+    });
+
+    it("accepts one assigning service beside one that assigns nothing", () => {
+      expect(parse({ web: {}, worker: { image: "busybox:1.37" } }).success).toBe(true);
     });
 
     it("leaves a named port to the writer, which knows whether the document declares it", () => {
-      expect(PatchServiceSchema.safeParse({ expose: { "80": { httpOptions: {} } } }).success).toBe(true);
+      expect(parse({ web: { expose: { "80": { httpOptions: {} } } } }).success).toBe(true);
     });
 
     it("leaves a named volume to the writer, which knows whether the profile declares it", () => {
-      expect(PatchServiceSchema.safeParse({ storage: { data: {} } }).success).toBe(true);
+      expect(parse({ web: { storage: { data: {} } } }).success).toBe(true);
     });
   });
+
+  const SEAL = "eyJhbGciOiJSU0EtT0FFUC0yNTYifQ.sealed.payload";
+
+  function parse(services: Record<string, unknown>, rest: Record<string, unknown> = {}) {
+    return PatchDeploymentRequestSchema.safeParse({ data: { services, ...rest } });
+  }
 });

--- a/apps/api/src/deployment/http-schemas/deployment.schema.spec.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.spec.ts
@@ -79,9 +79,77 @@ describe("PatchDeploymentRequestSchema", () => {
     });
   });
 
+  describe("http options the provider would read as something else", () => {
+    it("refuses a zero body size, which the provider reads as a workload carrying no http options at all", () => {
+      expect(parseHttpOptions({ maxBodySize: 0 }).success).toBe(false);
+    });
+
+    it("refuses a zero body size even beside the options it would take the rest of the block down with", () => {
+      expect(parseHttpOptions({ maxBodySize: 0, readTimeout: 5000, nextTries: 1 }).success).toBe(false);
+    });
+
+    it("accepts the smallest body size the provider reads as a body size", () => {
+      expect(parseHttpOptions({ maxBodySize: 1 }).success).toBe(true);
+    });
+
+    it("accepts the largest body size the grammar allows", () => {
+      expect(parseHttpOptions({ maxBodySize: 104857600 }).success).toBe(true);
+    });
+
+    it("refuses a body size above what the grammar allows", () => {
+      expect(parseHttpOptions({ maxBodySize: 104857601 }).success).toBe(false);
+    });
+
+    it("refuses a zero read timeout, which means nginx's own default on one provider and none at all on another", () => {
+      expect(parseHttpOptions({ readTimeout: 0 }).success).toBe(false);
+    });
+
+    it("refuses a zero send timeout for the same reason", () => {
+      expect(parseHttpOptions({ sendTimeout: 0 }).success).toBe(false);
+    });
+
+    it("accepts timeouts a provider reads the same way whichever proxy it runs", () => {
+      expect(parseHttpOptions({ readTimeout: 5000, sendTimeout: 5000 }).success).toBe(true);
+    });
+
+    it("accepts a zero retry count and retry timeout, which every provider reads as unlimited", () => {
+      expect(parseHttpOptions({ nextTries: 0, nextTimeout: 0 }).success).toBe(true);
+    });
+
+    it("refuses a value above what the manifest can carry", () => {
+      expect(parseHttpOptions({ readTimeout: 4294967296 }).success).toBe(false);
+    });
+  });
+
+  describe("the cases a proxy retries on", () => {
+    it("accepts the cases the grammar names", () => {
+      expect(parseHttpOptions({ nextCases: ["error", "timeout", "503"] }).success).toBe(true);
+    });
+
+    it("refuses a case the grammar does not name", () => {
+      expect(parseHttpOptions({ nextCases: ["http_503"] }).success).toBe(false);
+    });
+
+    it("refuses an empty list, which would leave the provider rendering a retry rule naming nothing", () => {
+      expect(parseHttpOptions({ nextCases: [] }).success).toBe(false);
+    });
+
+    it("accepts retrying turned off", () => {
+      expect(parseHttpOptions({ nextCases: ["off"] }).success).toBe(true);
+    });
+
+    it("refuses retrying turned off beside a case to retry on", () => {
+      expect(parseHttpOptions({ nextCases: ["off", "error"] }).success).toBe(false);
+    });
+  });
+
   const SEAL = "eyJhbGciOiJSU0EtT0FFUC0yNTYifQ.sealed.payload";
 
   function parse(services: Record<string, unknown>, rest: Record<string, unknown> = {}) {
     return PatchDeploymentRequestSchema.safeParse({ data: { services, ...rest } });
+  }
+
+  function parseHttpOptions(httpOptions: Record<string, unknown>) {
+    return parse({ web: { expose: { "80": { httpOptions } } } });
   }
 });

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -105,11 +105,14 @@ export const GetDeploymentParamsSchema = z.object({
   dseq: DseqSchema.describe("Deployment sequence number")
 });
 
+/** Every reader treats an empty seal as no seal, so accepting one would take a request the caller meant as a secret write and silently do nothing. */
+const SealedSecretsSchema = z.string().min(1);
+
 export const CreateDeploymentRequestSchema = z.object({
   data: z.object({
     sdl: z.string().max(MAX_SUBMITTED_SDL_LENGTH),
     /** Accepted and validated but withheld from every generated document by the route's `undocumentedRequestFields`, so the capability works before it is announced. */
-    sealedSecrets: z.string().optional(),
+    sealedSecrets: SealedSecretsSchema.optional(),
     deposit: z.number().optional().openapi({
       deprecated: true,
       description: "Deprecated and ignored. The platform funds every deployment automatically from your account credits."
@@ -227,7 +230,7 @@ export const PatchDeploymentParamsSchema = z.object({
 
 /** A seal is a write no service patch can describe, so naming a service and changing none of its fields is how a caller asks for a rotation and nothing else. */
 function patchesSomething(data: { services: Record<string, Record<string, unknown>>; sealedSecrets?: string }): boolean {
-  return data.sealedSecrets !== undefined || Object.values(data.services).some(assignsAField);
+  return !!data.sealedSecrets || Object.values(data.services).some(assignsAField);
 }
 
 /** `.refine` rather than a length rule on the record itself, which this zod version does not offer. */
@@ -240,7 +243,7 @@ export const PatchDeploymentRequestSchema = z.object({
         .openapi({
           description: "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
         }),
-      sealedSecrets: z.string().optional(),
+      sealedSecrets: SealedSecretsSchema.optional(),
       ifManifestVersion: z.string().max(MAX_MANIFEST_VERSION_LENGTH).optional().openapi({
         description:
           "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -1,3 +1,4 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
 import { DeploymentInfoSchema } from "@akashnetwork/http-sdk";
 import { z } from "zod";
 
@@ -164,6 +165,9 @@ export const UpdateDeploymentRequestSchema = z.object({
   })
 });
 
+type SdlExposeNode = NonNullable<SDLInput["services"][string]["expose"]>[number];
+type SdlNextCase = NonNullable<NonNullable<SdlExposeNode["http_options"]>["next_cases"]>[number];
+
 /** A key carrying `=` would be written as `NAME=REST=value` and read back as a different variable, silently overwriting it and leaving the supplied value unsealed. */
 const ENV_VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
@@ -172,21 +176,46 @@ const PatchEnvSchema = z.record(z.string().regex(ENV_VARIABLE_NAME), z.string().
     "Merged into the service's env, keyed by environment variable name. A null value removes the variable. A patched variable is re-appended, so the order of the stored env list may change."
 });
 
-/** `nonnegative` rather than `positive`: the grammar gives every one of these `minimum: 0`, and 0 is how a timeout is cleared. */
+/** Every one of these is a uint32 by the time it reaches the provider. */
+const UINT32_MAX = 4294967295;
+
+/** The SDL grammar's own ceiling, refused here so the message names the field rather than the whole document. */
+const MAX_BODY_SIZE_BYTES = 104857600;
+
+/** A zero body size is the sentinel the provider's hostname operator reads as "this workload predates http options", on which it drops the rest of the block for its own defaults. */
+const MIN_BODY_SIZE_BYTES = 1;
+
+/** Providers disagree on what a zero timeout means, nginx's own default under the Gateway API against none at all under ingress, so the ambiguous spelling is refused rather than resolved. */
+const MIN_TIMEOUT_MS = 1;
+
+const HTTP_NEXT_CASES = ["error", "timeout", "500", "502", "503", "504", "403", "404", "429", "off"] as const satisfies readonly SdlNextCase[];
+
+/** `off` turns retrying off outright, so naming a case to retry on beside it is a contradiction. */
+function retriesOffAlone(cases: readonly SdlNextCase[]): boolean {
+  return cases.length === 1 || !cases.includes("off");
+}
+
 const PatchHttpOptionsSchema = z
   .object({
-    maxBodySize: z.number().int().nonnegative(),
-    readTimeout: z.number().int().nonnegative(),
-    sendTimeout: z.number().int().nonnegative(),
-    nextTries: z.number().int().nonnegative(),
-    nextTimeout: z.number().int().nonnegative(),
-    nextCases: z.array(z.string())
+    maxBodySize: z.number().int().min(MIN_BODY_SIZE_BYTES).max(MAX_BODY_SIZE_BYTES),
+    readTimeout: z.number().int().min(MIN_TIMEOUT_MS).max(UINT32_MAX),
+    sendTimeout: z.number().int().min(MIN_TIMEOUT_MS).max(UINT32_MAX),
+    nextTries: z.number().int().nonnegative().max(UINT32_MAX),
+    nextTimeout: z.number().int().nonnegative().max(UINT32_MAX),
+    nextCases: z
+      .array(z.enum(HTTP_NEXT_CASES))
+      .nonempty()
+      .refine(retriesOffAlone, { message: '"off" cannot be combined with other cases' })
+      .openapi({ description: 'Conditions the proxy retries on. Replaces the existing list; "off" disables retrying and stands alone.' })
   })
   .partial();
 
 const PatchExposeSchema = z
   .object({
-    accept: z.array(z.string()).openapi({ description: "Custom domains. Replaces the existing list." }),
+    accept: z.array(z.string()).openapi({
+      description:
+        "Custom domains. Replaces the existing list. Emptying it is rejected by providers that do not generate a hostname of their own, which leaves the patch recorded but undeployed."
+    }),
     httpOptions: PatchHttpOptionsSchema
   })
   .partial();

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -221,6 +221,10 @@ export const UpdateDeploymentResponseSchema = z.object({
   data: DeploymentResponseSchema
 });
 
+export const PatchDeploymentParamsSchema = z.object({
+  dseq: DseqSchema.describe("Deployment sequence number")
+});
+
 /** `.refine` rather than a length rule on the record itself, which this zod version does not offer. */
 export const PatchDeploymentRequestSchema = z.object({
   data: z.object({

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -273,7 +273,7 @@ export const PatchDeploymentRequestSchema = z.object({
           description: "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
         }),
       sealedSecrets: SealedSecretsSchema.optional(),
-      ifManifestVersion: z.string().max(MAX_MANIFEST_VERSION_LENGTH).optional().openapi({
+      ifManifestVersion: z.string().min(1).max(MAX_MANIFEST_VERSION_LENGTH).optional().openapi({
         description:
           "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."
       })

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -238,7 +238,7 @@ export const PatchDeploymentRequestSchema = z.object({
     sealedSecrets: z.string().optional(),
     ifManifestVersion: z.string().max(MAX_MANIFEST_VERSION_LENGTH).optional().openapi({
       description:
-        "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed."
+        "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."
     })
   })
 });

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -188,7 +188,7 @@ const PatchExposeSchema = z
   })
   .partial();
 
-/** Naming a field is not patching one: `{ expose: {} }` reaches the writer with nothing to write, so an empty record has to be refused as firmly as an empty patch. */
+/** Naming a field is not patching one: `{ expose: {} }` reaches the writer with nothing to write, so an empty record has to count for as little as an empty patch. */
 function assignsAField(patch: Record<string, unknown>): boolean {
   return Object.values(patch).some(value => !isEmptyRecord(value));
 }
@@ -215,8 +215,7 @@ export const PatchServiceSchema = z
       description: "Keyed by volume name. Mount point and read-only flag only — sizes are fixed at create."
     })
   })
-  .partial()
-  .refine(assignsAField, { message: "At least one field must be patched" });
+  .partial();
 
 export const UpdateDeploymentResponseSchema = z.object({
   data: DeploymentResponseSchema
@@ -226,21 +225,28 @@ export const PatchDeploymentParamsSchema = z.object({
   dseq: DseqSchema.describe("Deployment sequence number")
 });
 
+/** A seal is a write no service patch can describe, so naming a service and changing none of its fields is how a caller asks for a rotation and nothing else. */
+function patchesSomething(data: { services: Record<string, Record<string, unknown>>; sealedSecrets?: string }): boolean {
+  return data.sealedSecrets !== undefined || Object.values(data.services).some(assignsAField);
+}
+
 /** `.refine` rather than a length rule on the record itself, which this zod version does not offer. */
 export const PatchDeploymentRequestSchema = z.object({
-  data: z.object({
-    services: z
-      .record(z.string(), PatchServiceSchema)
-      .refine(services => Object.keys(services).length > 0, { message: "At least one service must be patched" })
-      .openapi({
-        description: "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
-      }),
-    sealedSecrets: z.string().optional(),
-    ifManifestVersion: z.string().max(MAX_MANIFEST_VERSION_LENGTH).optional().openapi({
-      description:
-        "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."
+  data: z
+    .object({
+      services: z
+        .record(z.string(), PatchServiceSchema)
+        .refine(services => Object.keys(services).length > 0, { message: "At least one service must be patched" })
+        .openapi({
+          description: "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
+        }),
+      sealedSecrets: z.string().optional(),
+      ifManifestVersion: z.string().max(MAX_MANIFEST_VERSION_LENGTH).optional().openapi({
+        description:
+          "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."
+      })
     })
-  })
+    .refine(patchesSomething, { message: "At least one field must be patched, or sealed secrets supplied" })
 });
 
 export const PatchDeploymentResponseSchema = z.object({

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -237,7 +237,8 @@ export const PatchDeploymentRequestSchema = z.object({
       }),
     sealedSecrets: z.string().optional(),
     ifManifestVersion: z.string().max(MAX_MANIFEST_VERSION_LENGTH).optional().openapi({
-      description: "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on."
+      description:
+        "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed."
     })
   })
 });

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -165,7 +165,8 @@ export const UpdateDeploymentRequestSchema = z.object({
 const ENV_VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 const PatchEnvSchema = z.record(z.string().regex(ENV_VARIABLE_NAME), z.string().nullable()).openapi({
-  description: "Merged into the service's env, keyed by environment variable name. A null value removes the variable."
+  description:
+    "Merged into the service's env, keyed by environment variable name. A null value removes the variable. A patched variable is re-appended, so the order of the stored env list may change."
 });
 
 /** `nonnegative` rather than `positive`: the grammar gives every one of these `minimum: 0`, and 0 is how a timeout is cleared. */

--- a/apps/api/src/deployment/routes/deployment-setting/deployment-setting.router.ts
+++ b/apps/api/src/deployment/routes/deployment-setting/deployment-setting.router.ts
@@ -155,6 +155,7 @@ const getRouteV2 = createRoute({
   path: "/v2/deployment-settings/{dseq}",
   summary: "Get deployment settings by dseq",
   tags: ["Deployment Settings"],
+  operationId: "getDeploymentSetting",
   security: SECURITY_BEARER_OR_API_KEY,
   request: {
     params: FindDeploymentSettingV2ParamsSchema,

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -262,7 +262,7 @@ const patchRoute = createRoute({
     },
     409: {
       description:
-        "The deployment definition changed since the manifest version this patch expected. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds",
+        "The deployment definition changed between this patch reading it and writing it. A patch naming no `ifManifestVersion` is guarded on the version it read, so a concurrent patch produces this too. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds",
       content: {
         "application/json": {
           schema: ErrorResponseSchema

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -203,6 +203,14 @@ deploymentsRouter.openapi(updateRoute, async function routeUpdateDeployment(c) {
   return c.json(result, 200);
 });
 
+/** What `HonoErrorHandlerService` actually returns for a refused request, rather than the `message` alone the first draft of this route declared. */
+const ErrorResponseSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+  code: z.string(),
+  type: z.string()
+});
+
 const patchRoute = createRoute({
   method: "patch",
   path: "/v1/deployments/{dseq}",
@@ -240,7 +248,7 @@ const patchRoute = createRoute({
         "The patch names a service, port or volume the stored SDL does not declare, supplies a secret name it does not reference, or leaves a reference with no value",
       content: {
         "application/json": {
-          schema: z.object({ message: z.string() })
+          schema: ErrorResponseSchema
         }
       }
     },
@@ -248,7 +256,7 @@ const patchRoute = createRoute({
       description: "No SDL is recorded for this deployment, so there is nothing to patch",
       content: {
         "application/json": {
-          schema: z.object({ message: z.string() })
+          schema: ErrorResponseSchema
         }
       }
     },
@@ -256,16 +264,24 @@ const patchRoute = createRoute({
       description: "The deployment definition changed since the manifest version this patch expected",
       content: {
         "application/json": {
-          schema: z.object({ message: z.string() })
+          schema: ErrorResponseSchema
         }
       }
     },
     500: {
       description:
-        "The stored secrets could not be read. Permanent rather than transient: `code` is `stored_secrets_unreadable` and the stored token is left untouched, so a retry cannot help",
+        "The deployment's stored state could not be read. Permanent rather than transient, so a retry cannot help, and the stored token is left untouched: `code` is `stored_secrets_unreadable` when the sealed secrets would not open and `stored_sdl_unreadable` when the recorded SDL would not parse",
       content: {
         "application/json": {
-          schema: z.object({ message: z.string(), code: z.string() })
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    503: {
+      description: "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 500 above",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
         }
       }
     }

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -216,7 +216,7 @@ const patchRoute = createRoute({
   path: "/v1/deployments/{dseq}",
   summary: "Patch a deployment",
   description:
-    "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
+    "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.",
   operationId: "patchDeployment",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
@@ -261,7 +261,8 @@ const patchRoute = createRoute({
       }
     },
     409: {
-      description: "The deployment definition changed since the manifest version this patch expected",
+      description:
+        "The deployment definition changed since the manifest version this patch expected. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds",
       content: {
         "application/json": {
           schema: ErrorResponseSchema

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -1,3 +1,4 @@
+import { z } from "@hono/zod-openapi";
 import { container } from "tsyringe";
 
 import { createRoute } from "@src/core/lib/create-route/create-route";
@@ -22,6 +23,9 @@ import {
   ListWithResourcesParamsSchema,
   ListWithResourcesQuerySchema,
   ListWithResourcesResponseSchema,
+  PatchDeploymentParamsSchema,
+  PatchDeploymentRequestSchema,
+  PatchDeploymentResponseSchema,
   UpdateDeploymentRequestSchema,
   UpdateDeploymentResponseSchema
 } from "@src/deployment/http-schemas/deployment.schema";
@@ -166,7 +170,7 @@ const updateRoute = createRoute({
   path: "/v1/deployments/{dseq}",
   summary: "Update a deployment (deprecated)",
   description:
-    "Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. This endpoint will be removed in a future release.",
+    "Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. Use PATCH /v1/deployments/{dseq} instead. This endpoint will be removed in a future release.",
   operationId: "updateDeployment",
   deprecated: true,
   tags: ["Deployments"],
@@ -196,6 +200,81 @@ deploymentsRouter.openapi(updateRoute, async function routeUpdateDeployment(c) {
   const { dseq } = c.req.valid("param");
   const { data } = c.req.valid("json");
   const result = await container.resolve(DeploymentController).update(dseq, data);
+  return c.json(result, 200);
+});
+
+const patchRoute = createRoute({
+  method: "patch",
+  path: "/v1/deployments/{dseq}",
+  summary: "Patch a deployment",
+  description:
+    "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
+  operationId: "patchDeployment",
+  tags: ["Deployments"],
+  security: SECURITY_BEARER_OR_API_KEY,
+  /** Sized like the create route, because a patch may carry a seal and the default allowance would shadow the stated secret limits. */
+  bodyLimit: { maxSize: CREATE_DEPLOYMENT_BODY_LIMIT_BYTES },
+  /** Accepted and validated in full; unpublished because sealed secrets are not announced yet, matching the create route. */
+  undocumentedRequestFields: ["sealedSecrets"],
+  request: {
+    params: PatchDeploymentParamsSchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: PatchDeploymentRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Deployment patched successfully",
+      content: {
+        "application/json": {
+          schema: PatchDeploymentResponseSchema
+        }
+      }
+    },
+    400: {
+      description:
+        "The patch names a service, port or volume the stored SDL does not declare, supplies a secret name it does not reference, or leaves a reference with no value",
+      content: {
+        "application/json": {
+          schema: z.object({ message: z.string() })
+        }
+      }
+    },
+    404: {
+      description: "No SDL is recorded for this deployment, so there is nothing to patch",
+      content: {
+        "application/json": {
+          schema: z.object({ message: z.string() })
+        }
+      }
+    },
+    409: {
+      description: "The deployment definition changed since the manifest version this patch expected",
+      content: {
+        "application/json": {
+          schema: z.object({ message: z.string() })
+        }
+      }
+    },
+    500: {
+      description:
+        "The stored secrets could not be read. Permanent rather than transient: `code` is `stored_secrets_unreadable` and the stored token is left untouched, so a retry cannot help",
+      content: {
+        "application/json": {
+          schema: z.object({ message: z.string(), code: z.string() })
+        }
+      }
+    }
+  }
+});
+deploymentsRouter.openapi(patchRoute, async function routePatchDeployment(c) {
+  const { dseq } = c.req.valid("param");
+  const { data } = c.req.valid("json");
+  const result = await container.resolve(DeploymentController).patch(dseq, data);
   return c.json(result, 200);
 });
 

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -270,7 +270,7 @@ const patchRoute = createRoute({
     },
     500: {
       description:
-        "The deployment's stored state could not be read. Permanent rather than transient, so a retry cannot help, and the stored token is left untouched: `code` is `stored_secrets_unreadable` when the sealed secrets would not open and `stored_sdl_unreadable` when the recorded SDL would not parse",
+        "The deployment's stored state could not be read: `code` is `stored_secrets_unreadable` when the sealed secrets would not open and `stored_sdl_unreadable` when the recorded SDL would not parse. Both are permanent rather than transient, so a retry cannot help, and both leave the stored token untouched. A 500 carrying any other `code` is an unexpected failure and promises neither of those things",
       content: {
         "application/json": {
           schema: ErrorResponseSchema

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -216,7 +216,7 @@ const patchRoute = createRoute({
   path: "/v1/deployments/{dseq}",
   summary: "Patch a deployment",
   description:
-    "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
+    "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
   operationId: "patchDeployment",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -26,7 +26,7 @@ type DeploymentSettingChange = Pick<DeploymentSettingsInput, "runtimeLimitHours"
 
 type DeploymentSettingWithEstimatedTopUpAmount = Omit<
   DeploymentSettingsOutput,
-  "lastFundedAt" | "runtimeEndingNotifiedFor" | "providerUnreachableNotifiedFor" | "sdl" | "sealedSecrets" | "manifestVersion" | "runtimeEndsAt"
+  "lastFundedAt" | "runtimeEndingNotifiedFor" | "providerUnreachableNotifiedFor" | "sealedSecrets" | "manifestVersion" | "runtimeEndsAt"
 > & {
   estimatedTopUpAmount: number;
   topUpFrequencyMs: number;
@@ -347,7 +347,7 @@ export class DeploymentSettingService {
     const setting = { ...rest, runtimeEndsAt: runtimeEndsAt?.toISOString() ?? null };
 
     if (!setting.autoTopUpEnabled) {
-      return { ...setting, estimatedTopUpAmount: 0, topUpFrequencyMs: this.topUpFrequencyMs };
+      return { ...setting, estimatedTopUpAmount: 0, topUpFrequencyMs: this.topUpFrequencyMs, sdl };
     }
 
     const estimatedTopUpAmount = await this.drainingDeploymentService.calculateTopUpAmountForDseqAndUserId(setting.dseq, setting.userId);
@@ -360,6 +360,6 @@ export class DeploymentSettingService {
       });
     }
 
-    return { ...setting, estimatedTopUpAmount, topUpFrequencyMs: this.topUpFrequencyMs };
+    return { ...setting, sdl, estimatedTopUpAmount, topUpFrequencyMs: this.topUpFrequencyMs };
   }
 }

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1207,6 +1207,7 @@ describe(DeploymentWriterService.name, () => {
 
   describe("patchByUserIdAndDseq", () => {
     const STORED_VERSION = "U1RPUkVEVkVSU0lPTg==";
+    const STORED_TOKEN = "stored.token.aaa.bbb.ccc";
     const STORED_SDL = [
       'version: "2.0"',
       "services:",
@@ -1468,6 +1469,22 @@ describe(DeploymentWriterService.name, () => {
       await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { env: { DATABASE_URL: null } } } }, ability);
 
       expect(sealedFor()).toEqual({ s0_e0: "token" });
+    });
+
+    it("opens the stored token under the very deployment and user the row belongs to", async () => {
+      const { service, ability, sdlSecretsService } = setup({ held: { s0_e0: "token" } });
+
+      await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { image: "nginx:1.27" } } }, ability);
+
+      expect(sdlSecretsService.openStored).toHaveBeenCalledWith({ userId: "user-1", dseq: "1234", sealedSecrets: STORED_TOKEN });
+    });
+
+    it("opens the client's seal against the sdl the console stored, which is what it was sealed to", async () => {
+      const { service, ability, sdlSecretsService } = setup({ supplied: { s0_e0: "rotated" } });
+
+      await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: {} }, sealedSecrets: CLIENT_SEAL }, ability);
+
+      expect(sdlSecretsService.receiveForMerge).toHaveBeenCalledWith({ rawSdl: STORED_SDL, sealedSecrets: CLIENT_SEAL });
     });
 
     it("opens the stored token exactly once however many secrets change", async () => {
@@ -1742,7 +1759,7 @@ describe(DeploymentWriterService.name, () => {
       isTrialing?: boolean;
     }) {
       const manifestVersion = new Uint8Array([1, 2, 3]);
-      const storedToken = input?.storedToken === undefined ? "stored.token.aaa.bbb.ccc" : input.storedToken;
+      const storedToken = input?.storedToken === undefined ? STORED_TOKEN : input.storedToken;
       const hasSetting = !("setting" in (input ?? {})) || input?.setting !== undefined;
 
       const walletReaderService = mock<WalletReaderService>();

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -355,8 +355,7 @@ export class DeploymentWriterService {
     input: PatchDeploymentRequest["data"],
     ability: AnyAbility
   ): Promise<PatchDeploymentResponse["data"]> {
-    const wallet = await this.walletReaderService.getWalletByUserId(userId);
-    const stored = await this.#findStoredDefinition({ userId, dseq }, ability);
+    const [wallet, stored] = await Promise.all([this.walletReaderService.getWalletByUserId(userId), this.#findStoredDefinition({ userId, dseq }, ability)]);
     const parsed = this.#parseStored(stored.sdl, { userId, dseq });
     const document = parsed.document;
 
@@ -364,8 +363,10 @@ export class DeploymentWriterService {
     const derived = this.sdlSecretsDerivationService.derive(document, { includeEnvValues: true, onlyAt: written });
     const patchedSdl = this.#serialize(parsed, { userId, dseq });
 
-    const supplied = input.sealedSecrets ? await this.sdlSecretsService.receiveForMerge({ rawSdl: stored.sdl, sealedSecrets: input.sealedSecrets }) : {};
-    const held = stored.sealedSecrets ? await this.sdlSecretsService.openStored({ userId, dseq, sealedSecrets: stored.sealedSecrets }) : {};
+    const [supplied, held] = await Promise.all([
+      input.sealedSecrets ? await this.sdlSecretsService.receiveForMerge({ rawSdl: stored.sdl, sealedSecrets: input.sealedSecrets }) : {},
+      stored.sealedSecrets ? await this.sdlSecretsService.openStored({ userId, dseq, sealedSecrets: stored.sealedSecrets }) : {}
+    ]);
     const merged = this.#mergeAndPrune({ held, supplied, derived }, document);
 
     const { manifestVersion, manifest } = await this.#resolveSdl(patchedSdl, { secrets: merged, isTrialing: !!wallet.isTrialing });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -364,8 +364,8 @@ export class DeploymentWriterService {
     const patchedSdl = this.#serialize(parsed, { userId, dseq });
 
     const [supplied, held] = await Promise.all([
-      input.sealedSecrets ? await this.sdlSecretsService.receiveForMerge({ rawSdl: stored.sdl, sealedSecrets: input.sealedSecrets }) : {},
-      stored.sealedSecrets ? await this.sdlSecretsService.openStored({ userId, dseq, sealedSecrets: stored.sealedSecrets }) : {}
+      input.sealedSecrets ? this.sdlSecretsService.receiveForMerge({ rawSdl: stored.sdl, sealedSecrets: input.sealedSecrets }) : {},
+      stored.sealedSecrets ? this.sdlSecretsService.openStored({ userId, dseq, sealedSecrets: stored.sealedSecrets }) : {}
     ]);
     const merged = this.#mergeAndPrune({ held, supplied, derived }, document);
 

--- a/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
+++ b/apps/api/src/deployment/services/sdl-patch/sdl-patch.service.ts
@@ -229,14 +229,14 @@ export class SdlPatchService {
     this.#applyHttpOptions(entry.http_options, patch.httpOptions!);
   }
 
-  /** Spelled out one key at a time so the compiler checks the SDL key each camelCase field lands on; `nextCases` is cast because the request accepts any string where the SDL names a closed set. */
+  /** Spelled out one key at a time so the compiler checks the SDL key each camelCase field lands on. */
   #applyHttpOptions(target: SdlHttpOptionsNode, patch: NonNullable<PatchExpose["httpOptions"]>): void {
     if (patch.maxBodySize !== undefined) target.max_body_size = patch.maxBodySize;
     if (patch.readTimeout !== undefined) target.read_timeout = patch.readTimeout;
     if (patch.sendTimeout !== undefined) target.send_timeout = patch.sendTimeout;
     if (patch.nextTries !== undefined) target.next_tries = patch.nextTries;
     if (patch.nextTimeout !== undefined) target.next_timeout = patch.nextTimeout;
-    if (patch.nextCases !== undefined) target.next_cases = patch.nextCases as SdlHttpOptionsNode["next_cases"];
+    if (patch.nextCases !== undefined) target.next_cases = patch.nextCases;
   }
 
   /** Volume sizes are fixed at create, so only the mount point moves and a volume the profile does not declare is refused rather than added. */

--- a/apps/api/src/utils/schema.ts
+++ b/apps/api/src/utils/schema.ts
@@ -1,11 +1,13 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { isValidBech32Address } from "./addresses";
 
 export const AkashAddressSchema = z.string().refine(val => isValidBech32Address(val, "akash"), { message: "Invalid address" });
 export const AkashValidatorAddressSchema = z.string().refine(val => isValidBech32Address(val, "akashvaloper"), { message: "Invalid address" });
 
+/** zod-to-openapi derives `^d+$` for bigint from an unescaped template literal, so the digit pattern is declared here instead. */
 export const DseqSchema = z
   .bigint({ coerce: true })
   .positive()
-  .transform(val => val.toString());
+  .transform(val => val.toString())
+  .openapi({ pattern: "^\\d+$" });

--- a/apps/api/src/utils/schema.ts
+++ b/apps/api/src/utils/schema.ts
@@ -5,9 +5,9 @@ import { isValidBech32Address } from "./addresses";
 export const AkashAddressSchema = z.string().refine(val => isValidBech32Address(val, "akash"), { message: "Invalid address" });
 export const AkashValidatorAddressSchema = z.string().refine(val => isValidBech32Address(val, "akashvaloper"), { message: "Invalid address" });
 
-/** zod-to-openapi derives `^d+$` for bigint from an unescaped template literal, so the digit pattern is declared here instead. */
+/** zod-to-openapi derives `^d+$` for bigint from an unescaped template literal, so the pattern is declared here, and it excludes the zero `.positive()` rejects. */
 export const DseqSchema = z
   .bigint({ coerce: true })
   .positive()
   .transform(val => val.toString())
-  .openapi({ pattern: "^\\d+$" });
+  .openapi({ pattern: "^0*[1-9]\\d*$" });

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4966,7 +4966,7 @@
                       "ifManifestVersion": {
                         "type": "string",
                         "maxLength": 64,
-                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed."
+                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."
                       }
                     },
                     "required": [
@@ -5420,7 +5420,7 @@
             }
           },
           "409": {
-            "description": "The deployment definition changed since the manifest version this patch expected. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds",
+            "description": "The deployment definition changed between this patch reading it and writing it. A patch naming no `ifManifestVersion` is guarded on the version it read, so a concurrent patch produces this too. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4811,7 +4811,7 @@
       },
       "patch": {
         "summary": "Patch a deployment",
-        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
+        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
         "operationId": "patchDeployment",
         "tags": [
           "Deployments"
@@ -4874,7 +4874,7 @@
                                 "type": "string",
                                 "nullable": true
                               },
-                              "description": "Merged into the service's env, keyed by environment variable name. A null value removes the variable."
+                              "description": "Merged into the service's env, keyed by environment variable name. A null value removes the variable. A patched variable is re-appended, so the order of the stored env list may change."
                             },
                             "credentials": {
                               "type": "object",

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -3082,6 +3082,10 @@
                           "type": "string",
                           "pattern": "^0*[1-9]\\d*$"
                         },
+                        "sdl": {
+                          "type": "string",
+                          "nullable": true
+                        },
                         "autoTopUpEnabled": {
                           "type": "boolean"
                         },
@@ -3115,6 +3119,7 @@
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -3234,6 +3239,10 @@
                           "type": "string",
                           "pattern": "^0*[1-9]\\d*$"
                         },
+                        "sdl": {
+                          "type": "string",
+                          "nullable": true
+                        },
                         "autoTopUpEnabled": {
                           "type": "boolean"
                         },
@@ -3267,6 +3276,7 @@
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -3409,6 +3419,10 @@
                           "type": "string",
                           "pattern": "^0*[1-9]\\d*$"
                         },
+                        "sdl": {
+                          "type": "string",
+                          "nullable": true
+                        },
                         "autoTopUpEnabled": {
                           "type": "boolean"
                         },
@@ -3442,6 +3456,7 @@
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -3468,6 +3483,7 @@
         "tags": [
           "Deployment Settings"
         ],
+        "operationId": "getDeploymentSetting",
         "security": [
           {
             "BearerAuth": []
@@ -3520,6 +3536,10 @@
                           "type": "string",
                           "pattern": "^0*[1-9]\\d*$"
                         },
+                        "sdl": {
+                          "type": "string",
+                          "nullable": true
+                        },
                         "autoTopUpEnabled": {
                           "type": "boolean"
                         },
@@ -3553,6 +3573,7 @@
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -3673,6 +3694,10 @@
                           "type": "string",
                           "pattern": "^0*[1-9]\\d*$"
                         },
+                        "sdl": {
+                          "type": "string",
+                          "nullable": true
+                        },
                         "autoTopUpEnabled": {
                           "type": "boolean"
                         },
@@ -3706,6 +3731,7 @@
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -3848,6 +3874,10 @@
                           "type": "string",
                           "pattern": "^0*[1-9]\\d*$"
                         },
+                        "sdl": {
+                          "type": "string",
+                          "nullable": true
+                        },
                         "autoTopUpEnabled": {
                           "type": "boolean"
                         },
@@ -3881,6 +3911,7 @@
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4957,7 +4957,7 @@
                                   }
                                 }
                               },
-                              "description": "Keyed by volume name. Mount point only — sizes are fixed at create."
+                              "description": "Keyed by volume name. Mount point and read-only flag only — sizes are fixed at create."
                             }
                           }
                         },
@@ -5450,7 +5450,7 @@
             }
           },
           "500": {
-            "description": "The deployment's stored state could not be read. Permanent rather than transient, so a retry cannot help, and the stored token is left untouched: `code` is `stored_secrets_unreadable` when the sealed secrets would not open and `stored_sdl_unreadable` when the recorded SDL would not parse",
+            "description": "The deployment's stored state could not be read: `code` is `stored_secrets_unreadable` when the sealed secrets would not open and `stored_sdl_unreadable` when the recorded SDL would not parse. Both are permanent rather than transient, so a retry cannot help, and both leave the stored token untouched. A 500 carrying any other `code` is an unexpected failure and promises neither of those things",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -3052,7 +3052,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3080,7 +3080,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^\\d+$"
+                          "pattern": "^0*[1-9]\\d*$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3178,7 +3178,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3232,7 +3232,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^\\d+$"
+                          "pattern": "^0*[1-9]\\d*$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3370,7 +3370,7 @@
                       },
                       "dseq": {
                         "type": "string",
-                        "pattern": "^\\d+$",
+                        "pattern": "^0*[1-9]\\d*$",
                         "description": "Deployment sequence number"
                       }
                     },
@@ -3407,7 +3407,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^\\d+$"
+                          "pattern": "^0*[1-9]\\d*$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3480,7 +3480,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3518,7 +3518,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^\\d+$"
+                          "pattern": "^0*[1-9]\\d*$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3607,7 +3607,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3671,7 +3671,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^\\d+$"
+                          "pattern": "^0*[1-9]\\d*$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3805,7 +3805,7 @@
                     "properties": {
                       "dseq": {
                         "type": "string",
-                        "pattern": "^\\d+$",
+                        "pattern": "^0*[1-9]\\d*$",
                         "description": "Deployment sequence number"
                       },
                       "userId": {
@@ -3846,7 +3846,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^\\d+$"
+                          "pattern": "^0*[1-9]\\d*$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3920,7 +3920,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3951,7 +3951,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^\\d+$"
+                                  "pattern": "^0*[1-9]\\d*$"
                                 }
                               },
                               "required": [
@@ -3989,7 +3989,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -4342,7 +4342,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -4400,7 +4400,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -4456,7 +4456,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^\\d+$"
+                                  "pattern": "^0*[1-9]\\d*$"
                                 }
                               },
                               "required": [
@@ -4494,7 +4494,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -4828,7 +4828,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -5003,7 +5003,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^\\d+$"
+                                  "pattern": "^0*[1-9]\\d*$"
                                 }
                               },
                               "required": [
@@ -5041,7 +5041,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -5577,7 +5577,7 @@
                       "properties": {
                         "dseq": {
                           "type": "string",
-                          "pattern": "^\\d+$"
+                          "pattern": "^0*[1-9]\\d*$"
                         },
                         "manifest": {
                           "type": "string"
@@ -5681,7 +5681,7 @@
                                       },
                                       "dseq": {
                                         "type": "string",
-                                        "pattern": "^\\d+$"
+                                        "pattern": "^0*[1-9]\\d*$"
                                       }
                                     },
                                     "required": [
@@ -5719,7 +5719,7 @@
                                         },
                                         "dseq": {
                                           "type": "string",
-                                          "pattern": "^\\d+$"
+                                          "pattern": "^0*[1-9]\\d*$"
                                         },
                                         "gseq": {
                                           "type": "number"
@@ -5976,7 +5976,7 @@
                     "properties": {
                       "dseq": {
                         "type": "string",
-                        "pattern": "^\\d+$",
+                        "pattern": "^0*[1-9]\\d*$",
                         "description": "Deployment sequence number"
                       },
                       "deposit": {
@@ -6019,7 +6019,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^\\d+$"
+                                  "pattern": "^0*[1-9]\\d*$"
                                 }
                               },
                               "required": [
@@ -6057,7 +6057,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -6462,7 +6462,7 @@
                           },
                           "dseq": {
                             "type": "string",
-                            "pattern": "^\\d+$"
+                            "pattern": "^0*[1-9]\\d*$"
                           },
                           "status": {
                             "type": "string"
@@ -6510,7 +6510,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^\\d+$"
+                                  "pattern": "^0*[1-9]\\d*$"
                                 },
                                 "gseq": {
                                   "type": "number"
@@ -6598,7 +6598,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -6619,7 +6619,7 @@
                     },
                     "dseq": {
                       "type": "string",
-                      "pattern": "^\\d+$"
+                      "pattern": "^0*[1-9]\\d*$"
                     },
                     "balance": {
                       "type": "number"
@@ -7349,7 +7349,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   }
                                 },
                                 "required": [
@@ -7387,7 +7387,7 @@
                                     },
                                     "dseq": {
                                       "type": "string",
-                                      "pattern": "^\\d+$"
+                                      "pattern": "^0*[1-9]\\d*$"
                                     },
                                     "gseq": {
                                       "type": "number"
@@ -7923,7 +7923,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^\\d+$"
+                                  "pattern": "^0*[1-9]\\d*$"
                                 }
                               },
                               "required": [
@@ -7961,7 +7961,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -8600,7 +8600,7 @@
                       "properties": {
                         "dseq": {
                           "type": "string",
-                          "pattern": "^\\d+$"
+                          "pattern": "^0*[1-9]\\d*$"
                         },
                         "gseq": {
                           "type": "number"
@@ -8650,7 +8650,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^\\d+$"
+                                  "pattern": "^0*[1-9]\\d*$"
                                 }
                               },
                               "required": [
@@ -8688,7 +8688,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -9130,7 +9130,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -9820,7 +9820,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$"
+              "pattern": "^0*[1-9]\\d*$"
             },
             "required": true,
             "name": "dseq",
@@ -9851,7 +9851,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -10268,7 +10268,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$"
+              "pattern": "^0*[1-9]\\d*$"
             },
             "required": true,
             "name": "dseq",
@@ -10299,7 +10299,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^\\d+$"
+                                    "pattern": "^0*[1-9]\\d*$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -13820,7 +13820,7 @@
                           },
                           "dseq": {
                             "type": "string",
-                            "pattern": "^\\d+$"
+                            "pattern": "^0*[1-9]\\d*$"
                           },
                           "denom": {
                             "type": "string"
@@ -16886,7 +16886,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^\\d+$"
+              "pattern": "^0*[1-9]\\d*$"
             },
             "required": false,
             "name": "dseq",
@@ -16937,7 +16937,7 @@
                         "properties": {
                           "dseq": {
                             "type": "string",
-                            "pattern": "^\\d+$"
+                            "pattern": "^0*[1-9]\\d*$"
                           },
                           "oseq": {
                             "type": "number"

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4382,7 +4382,7 @@
       },
       "put": {
         "summary": "Update a deployment (deprecated)",
-        "description": "Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. This endpoint will be removed in a future release.",
+        "description": "Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. Use PATCH /v1/deployments/{dseq} instead. This endpoint will be removed in a future release.",
         "operationId": "updateDeployment",
         "deprecated": true,
         "tags": [
@@ -4802,6 +4802,639 @@
                   },
                   "required": [
                     "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Patch a deployment",
+        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
+        "operationId": "patchDeployment",
+        "tags": [
+          "Deployments"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^d+$",
+              "description": "Deployment sequence number"
+            },
+            "required": true,
+            "description": "Deployment sequence number",
+            "name": "dseq",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "services": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "object",
+                          "properties": {
+                            "image": {
+                              "type": "string"
+                            },
+                            "command": {
+                              "type": "array",
+                              "nullable": true,
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "args": {
+                              "type": "array",
+                              "nullable": true,
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "env": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "description": "Merged into the service's env. A null value removes the variable."
+                            },
+                            "credentials": {
+                              "type": "object",
+                              "nullable": true,
+                              "properties": {
+                                "host": {
+                                  "type": "string"
+                                },
+                                "username": {
+                                  "type": "string"
+                                },
+                                "password": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "host",
+                                "username",
+                                "password"
+                              ],
+                              "description": "Private registry pull credentials. Null clears them."
+                            },
+                            "expose": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "object",
+                                "properties": {
+                                  "accept": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "description": "Custom domains. Replaces the existing list."
+                                  },
+                                  "httpOptions": {
+                                    "type": "object",
+                                    "properties": {
+                                      "maxBodySize": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true
+                                      },
+                                      "readTimeout": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true
+                                      },
+                                      "sendTimeout": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true
+                                      },
+                                      "nextTries": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true
+                                      },
+                                      "nextTimeout": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true
+                                      },
+                                      "nextCases": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "description": "Keyed by container port. Only hosts and http options are patchable; endpoint kind and count are fixed at create."
+                            },
+                            "storage": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "object",
+                                "properties": {
+                                  "mount": {
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean"
+                                  }
+                                }
+                              },
+                              "description": "Keyed by volume name. Mount point only — sizes are fixed at create."
+                            }
+                          }
+                        },
+                        "description": "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
+                      },
+                      "ifManifestVersion": {
+                        "type": "string",
+                        "maxLength": 64,
+                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on."
+                      }
+                    },
+                    "required": [
+                      "services"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Deployment patched successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "deployment": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "object",
+                              "properties": {
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "dseq": {
+                                  "type": "string",
+                                  "pattern": "^d+$"
+                                }
+                              },
+                              "required": [
+                                "owner",
+                                "dseq"
+                              ]
+                            },
+                            "state": {
+                              "type": "string"
+                            },
+                            "hash": {
+                              "type": "string"
+                            },
+                            "created_at": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "state",
+                            "hash",
+                            "created_at"
+                          ]
+                        },
+                        "leases": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "object",
+                                "properties": {
+                                  "owner": {
+                                    "type": "string"
+                                  },
+                                  "dseq": {
+                                    "type": "string",
+                                    "pattern": "^d+$"
+                                  },
+                                  "gseq": {
+                                    "type": "number"
+                                  },
+                                  "oseq": {
+                                    "type": "number"
+                                  },
+                                  "provider": {
+                                    "type": "string"
+                                  },
+                                  "bseq": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                  "bseq"
+                                ]
+                              },
+                              "state": {
+                                "type": "string"
+                              },
+                              "price": {
+                                "type": "object",
+                                "properties": {
+                                  "denom": {
+                                    "type": "string"
+                                  },
+                                  "amount": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount"
+                                ]
+                              },
+                              "created_at": {
+                                "type": "string"
+                              },
+                              "closed_on": {
+                                "type": "string"
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "object",
+                                "nullable": true,
+                                "properties": {
+                                  "forwarded_ports": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "port": {
+                                            "type": "number"
+                                          },
+                                          "externalPort": {
+                                            "type": "number"
+                                          },
+                                          "host": {
+                                            "type": "string"
+                                          },
+                                          "available": {
+                                            "type": "number"
+                                          }
+                                        },
+                                        "required": [
+                                          "port",
+                                          "externalPort"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "ips": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "IP": {
+                                            "type": "string"
+                                          },
+                                          "Port": {
+                                            "type": "number"
+                                          },
+                                          "ExternalPort": {
+                                            "type": "number"
+                                          },
+                                          "Protocol": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol"
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "services": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "available": {
+                                          "type": "number"
+                                        },
+                                        "total": {
+                                          "type": "number"
+                                        },
+                                        "uris": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "observed_generation": {
+                                          "type": "number"
+                                        },
+                                        "replicas": {
+                                          "type": "number"
+                                        },
+                                        "updated_replicas": {
+                                          "type": "number"
+                                        },
+                                        "ready_replicas": {
+                                          "type": "number"
+                                        },
+                                        "available_replicas": {
+                                          "type": "number"
+                                        }
+                                      },
+                                      "required": [
+                                        "name",
+                                        "available",
+                                        "total",
+                                        "uris",
+                                        "observed_generation",
+                                        "replicas",
+                                        "updated_replicas",
+                                        "ready_replicas",
+                                        "available_replicas"
+                                      ]
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status"
+                            ]
+                          }
+                        },
+                        "escrow_account": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "object",
+                              "properties": {
+                                "scope": {
+                                  "type": "string"
+                                },
+                                "xid": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "scope",
+                                "xid"
+                              ]
+                            },
+                            "state": {
+                              "type": "object",
+                              "properties": {
+                                "owner": {
+                                  "type": "string"
+                                },
+                                "state": {
+                                  "type": "string"
+                                },
+                                "transferred": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "denom": {
+                                        "type": "string"
+                                      },
+                                      "amount": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
+                                  }
+                                },
+                                "settled_at": {
+                                  "type": "string"
+                                },
+                                "funds": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "denom": {
+                                        "type": "string"
+                                      },
+                                      "amount": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "denom",
+                                      "amount"
+                                    ]
+                                  }
+                                },
+                                "deposits": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "owner": {
+                                        "type": "string"
+                                      },
+                                      "height": {
+                                        "type": "string"
+                                      },
+                                      "source": {
+                                        "type": "string"
+                                      },
+                                      "balance": {
+                                        "type": "object",
+                                        "properties": {
+                                          "denom": {
+                                            "type": "string"
+                                          },
+                                          "amount": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "denom",
+                                          "amount"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "owner",
+                                      "height",
+                                      "source",
+                                      "balance"
+                                    ]
+                                  }
+                                }
+                              },
+                              "required": [
+                                "owner",
+                                "state",
+                                "transferred",
+                                "settled_at",
+                                "funds",
+                                "deposits"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "state"
+                          ]
+                        },
+                        "manifestVersion": {
+                          "type": "string",
+                          "description": "Base64 manifest version this patch recorded and committed on chain."
+                        }
+                      },
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account",
+                        "manifestVersion"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The patch names a service, port or volume the stored SDL does not declare, supplies a secret name it does not reference, or leaves a reference with no value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No SDL is recorded for this deployment, so there is nothing to patch",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The deployment definition changed since the manifest version this patch expected",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The stored secrets could not be read. Permanent rather than transient: `code` is `stored_secrets_unreadable` and the stored token is left untouched, so a retry cannot help",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message",
+                    "code"
                   ]
                 }
               }

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -3052,7 +3052,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3080,7 +3080,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^d+$"
+                          "pattern": "^\\d+$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3178,7 +3178,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3232,7 +3232,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^d+$"
+                          "pattern": "^\\d+$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3370,7 +3370,7 @@
                       },
                       "dseq": {
                         "type": "string",
-                        "pattern": "^d+$",
+                        "pattern": "^\\d+$",
                         "description": "Deployment sequence number"
                       }
                     },
@@ -3407,7 +3407,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^d+$"
+                          "pattern": "^\\d+$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3480,7 +3480,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3518,7 +3518,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^d+$"
+                          "pattern": "^\\d+$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3607,7 +3607,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3671,7 +3671,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^d+$"
+                          "pattern": "^\\d+$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3805,7 +3805,7 @@
                     "properties": {
                       "dseq": {
                         "type": "string",
-                        "pattern": "^d+$",
+                        "pattern": "^\\d+$",
                         "description": "Deployment sequence number"
                       },
                       "userId": {
@@ -3846,7 +3846,7 @@
                         },
                         "dseq": {
                           "type": "string",
-                          "pattern": "^d+$"
+                          "pattern": "^\\d+$"
                         },
                         "autoTopUpEnabled": {
                           "type": "boolean"
@@ -3920,7 +3920,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -3951,7 +3951,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^d+$"
+                                  "pattern": "^\\d+$"
                                 }
                               },
                               "required": [
@@ -3989,7 +3989,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -4342,7 +4342,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -4400,7 +4400,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -4456,7 +4456,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^d+$"
+                                  "pattern": "^\\d+$"
                                 }
                               },
                               "required": [
@@ -4494,7 +4494,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -4828,7 +4828,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -5003,7 +5003,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^d+$"
+                                  "pattern": "^\\d+$"
                                 }
                               },
                               "required": [
@@ -5041,7 +5041,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -5577,7 +5577,7 @@
                       "properties": {
                         "dseq": {
                           "type": "string",
-                          "pattern": "^d+$"
+                          "pattern": "^\\d+$"
                         },
                         "manifest": {
                           "type": "string"
@@ -5681,7 +5681,7 @@
                                       },
                                       "dseq": {
                                         "type": "string",
-                                        "pattern": "^d+$"
+                                        "pattern": "^\\d+$"
                                       }
                                     },
                                     "required": [
@@ -5719,7 +5719,7 @@
                                         },
                                         "dseq": {
                                           "type": "string",
-                                          "pattern": "^d+$"
+                                          "pattern": "^\\d+$"
                                         },
                                         "gseq": {
                                           "type": "number"
@@ -5976,7 +5976,7 @@
                     "properties": {
                       "dseq": {
                         "type": "string",
-                        "pattern": "^d+$",
+                        "pattern": "^\\d+$",
                         "description": "Deployment sequence number"
                       },
                       "deposit": {
@@ -6019,7 +6019,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^d+$"
+                                  "pattern": "^\\d+$"
                                 }
                               },
                               "required": [
@@ -6057,7 +6057,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -6462,7 +6462,7 @@
                           },
                           "dseq": {
                             "type": "string",
-                            "pattern": "^d+$"
+                            "pattern": "^\\d+$"
                           },
                           "status": {
                             "type": "string"
@@ -6510,7 +6510,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^d+$"
+                                  "pattern": "^\\d+$"
                                 },
                                 "gseq": {
                                   "type": "number"
@@ -6598,7 +6598,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "description": "Deployment sequence number"
             },
             "required": true,
@@ -6619,7 +6619,7 @@
                     },
                     "dseq": {
                       "type": "string",
-                      "pattern": "^d+$"
+                      "pattern": "^\\d+$"
                     },
                     "balance": {
                       "type": "number"
@@ -7349,7 +7349,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   }
                                 },
                                 "required": [
@@ -7387,7 +7387,7 @@
                                     },
                                     "dseq": {
                                       "type": "string",
-                                      "pattern": "^d+$"
+                                      "pattern": "^\\d+$"
                                     },
                                     "gseq": {
                                       "type": "number"
@@ -7923,7 +7923,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^d+$"
+                                  "pattern": "^\\d+$"
                                 }
                               },
                               "required": [
@@ -7961,7 +7961,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -8589,7 +8589,9 @@
                 "type": "object",
                 "properties": {
                   "manifest": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "The manifest to send to the provider, in YAML format (deprecated)",
+                    "deprecated": true
                   },
                   "leases": {
                     "type": "array",
@@ -8598,7 +8600,7 @@
                       "properties": {
                         "dseq": {
                           "type": "string",
-                          "pattern": "^d+$"
+                          "pattern": "^\\d+$"
                         },
                         "gseq": {
                           "type": "number"
@@ -8620,7 +8622,6 @@
                   }
                 },
                 "required": [
-                  "manifest",
                   "leases"
                 ]
               }
@@ -8649,7 +8650,7 @@
                                 },
                                 "dseq": {
                                   "type": "string",
-                                  "pattern": "^d+$"
+                                  "pattern": "^\\d+$"
                                 }
                               },
                               "required": [
@@ -8687,7 +8688,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -9129,7 +9130,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -9819,7 +9820,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$"
+              "pattern": "^\\d+$"
             },
             "required": true,
             "name": "dseq",
@@ -9850,7 +9851,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -10267,7 +10268,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$"
+              "pattern": "^\\d+$"
             },
             "required": true,
             "name": "dseq",
@@ -10298,7 +10299,7 @@
                                   },
                                   "dseq": {
                                     "type": "string",
-                                    "pattern": "^d+$"
+                                    "pattern": "^\\d+$"
                                   },
                                   "gseq": {
                                     "type": "number"
@@ -13819,7 +13820,7 @@
                           },
                           "dseq": {
                             "type": "string",
-                            "pattern": "^d+$"
+                            "pattern": "^\\d+$"
                           },
                           "denom": {
                             "type": "string"
@@ -16885,7 +16886,7 @@
           {
             "schema": {
               "type": "string",
-              "pattern": "^d+$"
+              "pattern": "^\\d+$"
             },
             "required": false,
             "name": "dseq",
@@ -16936,7 +16937,7 @@
                         "properties": {
                           "dseq": {
                             "type": "string",
-                            "pattern": "^d+$"
+                            "pattern": "^\\d+$"
                           },
                           "oseq": {
                             "type": "number"

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4914,28 +4914,23 @@
                                     "properties": {
                                       "maxBodySize": {
                                         "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true
+                                        "minimum": 0
                                       },
                                       "readTimeout": {
                                         "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true
+                                        "minimum": 0
                                       },
                                       "sendTimeout": {
                                         "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true
+                                        "minimum": 0
                                       },
                                       "nextTries": {
                                         "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true
+                                        "minimum": 0
                                       },
                                       "nextTimeout": {
                                         "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true
+                                        "minimum": 0
                                       },
                                       "nextCases": {
                                         "type": "array",

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4874,7 +4874,7 @@
                                 "type": "string",
                                 "nullable": true
                               },
-                              "description": "Merged into the service's env. A null value removes the variable."
+                              "description": "Merged into the service's env, keyed by environment variable name. A null value removes the variable."
                             },
                             "credentials": {
                               "type": "object",
@@ -5371,12 +5371,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "error": {
+                      "type": "string"
+                    },
                     "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
                       "type": "string"
                     }
                   },
                   "required": [
-                    "message"
+                    "error",
+                    "message",
+                    "code",
+                    "type"
                   ]
                 }
               }
@@ -5389,12 +5401,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "error": {
+                      "type": "string"
+                    },
                     "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
                       "type": "string"
                     }
                   },
                   "required": [
-                    "message"
+                    "error",
+                    "message",
+                    "code",
+                    "type"
                   ]
                 }
               }
@@ -5407,34 +5431,84 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "error": {
+                      "type": "string"
+                    },
                     "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
                       "type": "string"
                     }
                   },
                   "required": [
-                    "message"
+                    "error",
+                    "message",
+                    "code",
+                    "type"
                   ]
                 }
               }
             }
           },
           "500": {
-            "description": "The stored secrets could not be read. Permanent rather than transient: `code` is `stored_secrets_unreadable` and the stored token is left untouched, so a retry cannot help",
+            "description": "The deployment's stored state could not be read. Permanent rather than transient, so a retry cannot help, and the stored token is left untouched: `code` is `stored_secrets_unreadable` when the sealed secrets would not open and `stored_sdl_unreadable` when the recorded SDL would not parse",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "error": {
+                      "type": "string"
+                    },
                     "message": {
                       "type": "string"
                     },
                     "code": {
                       "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
                     }
                   },
                   "required": [
+                    "error",
                     "message",
-                    "code"
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 500 above",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
                   ]
                 }
               }

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4811,7 +4811,7 @@
       },
       "patch": {
         "summary": "Patch a deployment",
-        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
+        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.",
         "operationId": "patchDeployment",
         "tags": [
           "Deployments"
@@ -4966,7 +4966,7 @@
                       "ifManifestVersion": {
                         "type": "string",
                         "maxLength": 64,
-                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on."
+                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed."
                       }
                     },
                     "required": [
@@ -5420,7 +5420,7 @@
             }
           },
           "409": {
-            "description": "The deployment definition changed since the manifest version this patch expected",
+            "description": "The deployment definition changed since the manifest version this patch expected. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
+++ b/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
@@ -5,6 +5,7 @@ import { ConstantBackoff, handleWhenResult, retry } from "cockatiel";
 import { CompactEncrypt } from "jose";
 import fs from "node:fs";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
@@ -183,31 +184,13 @@ describe("Managed Wallet API Deployment Flow", () => {
             count: 1
     `;
 
-    const { data: sdlSecretsContext } = await api.v1.getSDLSecretsContext();
-    const pubKey = await crypto.subtle.importKey("jwk", sdlSecretsContext.jwk, { name: "RSA-OAEP", hash: "SHA-256" }, false, ["encrypt"]);
-    const sealedSecrets = await new CompactEncrypt(
-      new TextEncoder().encode(
-        JSON.stringify({
-          TEST_SECRET: "secret-value",
-          TEST_ANOTHER_SECRET: "another secret value"
-        })
-      )
-    )
-      .setProtectedHeader({
-        alg: "RSA-OAEP-256",
-        enc: "A256GCM",
-        kid: sdlSecretsContext.kid,
-        sub: sdlSecretsContext.sub,
-        exp: Math.floor(Date.now() / 1000) + 5 * 60
-      })
-      .encrypt(pubKey);
-
     console.log("Creating deployment...");
-    const deploymentResponse = await api.v1.createDeployment({
-      data: {
-        sdl,
-        sealedSecrets
-      } as any // sealedSecrets currently is a hidden field in the API spec
+    const deploymentResponse = await createDeployment(api, {
+      sdl,
+      secrets: {
+        TEST_SECRET: "secret-value",
+        TEST_ANOTHER_SECRET: "another secret value"
+      }
     });
 
     expect(deploymentResponse.data).toMatchObject({
@@ -266,17 +249,113 @@ describe("Managed Wallet API Deployment Flow", () => {
           })
         })
       });
-
-      const closedDeploymentResponse = await api.v1.closeDeployment({
-        dseq: deploymentResponse.data.dseq
-      });
-      expect(closedDeploymentResponse.data.success).toBe(true);
-    } catch (e) {
-      // Final step: Close deployment in case of error to release escrow funds and cleanup
+    } finally {
       await api.v1.closeDeployment({
         dseq: deploymentResponse.data.dseq
       });
-      throw e;
+    }
+  });
+
+  it("can patch deployment's env variables", { timeout: 2 * 60 * 1000 }, async () => {
+    const { api } = await setup();
+    const sdl = `
+      version: "2.0"
+      services:
+        web:
+          image: ghcr.io/akash-network/hello-akash-world:2.1.0
+          env:
+            - TEST_ENV=ac-secret://TEST_SECRET
+            - TEST_ANOTHER_ENV=ac-secret://TEST_ANOTHER_SECRET
+            - TEST_VAR=test me
+          expose:
+            - port: 3000
+              as: 80
+              to:
+                - global: true
+      profiles:
+        compute:
+          web:
+            resources:
+              cpu:
+                units: 0.5
+              memory:
+                size: 512Mi
+              storage:
+                - size: 512Mi
+        placement:
+          dcloud:
+            pricing:
+              web:
+                denom: uact
+                amount: 1000
+      deployment:
+        web:
+          dcloud:
+            profile: web
+            count: 1
+    `;
+
+    console.log("Creating deployment...");
+    const deploymentResponse = await createDeployment(api, {
+      sdl,
+      secrets: {
+        TEST_SECRET: "secret-value",
+        TEST_ANOTHER_SECRET: "another secret value"
+      }
+    });
+
+    try {
+      const bid = await waitForBids(api, deploymentResponse.data.dseq);
+      await api.v1.createLease({
+        leases: [
+          {
+            dseq: bid.bid.id.dseq,
+            gseq: bid.bid.id.gseq,
+            oseq: bid.bid.id.oseq,
+            provider: bid.bid.id.provider
+          }
+        ],
+        manifest: deploymentResponse.data.manifest
+      });
+
+      await delay(5000); // Wait for the lease to be active
+
+      const patchResponse = await api.v1.patchDeployment({
+        dseq: deploymentResponse.data.dseq,
+        data: {
+          services: {
+            web: {
+              env: {
+                TEST_ENV: "ac-secret://NEW_TEST_SECRET",
+                NEW_REGULAR_VAR: "new-value",
+                NEW_DATABASE_URL: "ac-secret://WEB_DATABASE_URL"
+              }
+            }
+          },
+          sealedSecrets: await encryptSecrets(api, {
+            NEW_TEST_SECRET: "new-secret-value",
+            WEB_DATABASE_URL: "postgres://user:password@host:5432/db"
+          }) // this field is hidden in the API spec
+        } as any
+      });
+
+      expect(patchResponse.data).toMatchObject({
+        deployment: expect.objectContaining({
+          id: expect.objectContaining({
+            dseq: deploymentResponse.data.dseq
+          })
+        })
+      });
+
+      const updatedDeployment = await api.v2.getDeploymentSetting({ dseq: deploymentResponse.data.dseq });
+      expect(updatedDeployment.data).toMatchObject({
+        dseq: deploymentResponse.data.dseq,
+        sdl: expect.stringMatching(/TEST_ENV=ac-secret:\/\/NEW_TEST_SECRET|NEW_REGULAR_VAR=new-value|NEW_DATABASE_URL=ac-secret:\/\/WEB_DATABASE_URL/)
+      });
+    } finally {
+      await api.v1.closeDeployment({
+        dseq: deploymentResponse.data.dseq
+      });
     }
   });
 
@@ -306,5 +385,47 @@ describe("Managed Wallet API Deployment Flow", () => {
 
       return data[0];
     });
+  }
+
+  async function createDeployment(api: Awaited<ReturnType<typeof setup>>["api"], input: { sdl: string; secrets?: Record<string, string> }) {
+    let sealedSecrets: string | undefined = undefined;
+
+    if (input.secrets) {
+      const { data: sdlSecretsContext } = await api.v1.getSDLSecretsContext();
+      const pubKey = await crypto.subtle.importKey("jwk", sdlSecretsContext.jwk, { name: "RSA-OAEP", hash: "SHA-256" }, false, ["encrypt"]);
+      sealedSecrets = await new CompactEncrypt(new TextEncoder().encode(JSON.stringify(input.secrets)))
+        .setProtectedHeader({
+          alg: "RSA-OAEP-256",
+          enc: "A256GCM",
+          kid: sdlSecretsContext.kid,
+          sub: sdlSecretsContext.sub,
+          exp: Math.floor(Date.now() / 1000) + 5 * 60
+        })
+        .encrypt(pubKey);
+    }
+
+    const deploymentResponse = await api.v1.createDeployment({
+      data: {
+        sdl: input.sdl,
+        sealedSecrets
+      } as any // sealedSecrets currently is a hidden field in the API spec
+    });
+    return deploymentResponse;
+  }
+
+  async function encryptSecrets(api: Awaited<ReturnType<typeof setup>>["api"], secrets: Record<string, string>) {
+    const { data: sdlSecretsContext } = await api.v1.getSDLSecretsContext();
+    const pubKey = await crypto.subtle.importKey("jwk", sdlSecretsContext.jwk, { name: "RSA-OAEP", hash: "SHA-256" }, false, ["encrypt"]);
+    const sealedSecrets = await new CompactEncrypt(new TextEncoder().encode(JSON.stringify(secrets)))
+      .setProtectedHeader({
+        alg: "RSA-OAEP-256",
+        enc: "A256GCM",
+        kid: sdlSecretsContext.kid,
+        sub: sdlSecretsContext.sub,
+        exp: Math.floor(Date.now() / 1000) + 5 * 60
+      })
+      .encrypt(pubKey);
+
+    return sealedSecrets;
   }
 });

--- a/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
+++ b/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
@@ -3,6 +3,7 @@ import { operations } from "@akashnetwork/console-api-types";
 import { createApi } from "@akashnetwork/openapi-sdk";
 import { ConstantBackoff, handleWhenResult, retry } from "cockatiel";
 import { CompactEncrypt } from "jose";
+import { load as parseYaml } from "js-yaml";
 import fs from "node:fs";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -382,6 +383,199 @@ describe("Managed Wallet API Deployment Flow", () => {
     }
   });
 
+  it("can patch every patchable deployment value", { timeout: 5 * 60 * 1000 }, async () => {
+    const { api } = await setup();
+    const sdl = `
+      version: "2.0"
+      services:
+        web:
+          image: ghcr.io/akash-network/hello-akash-world:2.1.0
+          env:
+            - INITIAL_ENV=ac-secret://INITIAL_SECRET
+            - REMOVABLE_ENV=remove me
+          expose:
+            - port: 3000
+              as: 80
+              http_options:
+                max_body_size: 1048576
+                next_cases:
+                  - error
+              to:
+                - global: true
+          params:
+            storage:
+              data:
+                mount: /mnt/initial
+                readOnly: false
+      profiles:
+        compute:
+          web:
+            resources:
+              cpu:
+                units: 0.5
+              memory:
+                size: 512Mi
+              storage:
+                - size: 512Mi
+                - name: data
+                  size: 512Mi
+        placement:
+          dcloud:
+            pricing:
+              web:
+                denom: uact
+                amount: 1000
+      deployment:
+        web:
+          dcloud:
+            profile: web
+            count: 1
+    `;
+
+    const deploymentResponse = await createDeployment(api, { sdl, secrets: { INITIAL_SECRET: "initial-secret-value" } });
+    const dseq = deploymentResponse.data.dseq;
+
+    try {
+      const bid = await waitForBids(api, dseq);
+      await api.v1.createLease({
+        leases: [
+          {
+            dseq: bid.bid.id.dseq,
+            gseq: bid.bid.id.gseq,
+            oseq: bid.bid.id.oseq,
+            provider: bid.bid.id.provider
+          }
+        ],
+        manifest: deploymentResponse.data.manifest
+      });
+
+      await delay(5000);
+
+      await applyPatch(api, dseq, {
+        services: {
+          web: {
+            image: "ghcr.io/akash-network/hello-akash-world:sha-2140a1d",
+            command: ["/bin/sh"],
+            args: ["-c", "npm start"]
+          }
+        }
+      });
+      expect(await readPatchedService(api, dseq, "web")).toMatchObject({
+        image: "ghcr.io/akash-network/hello-akash-world:sha-2140a1d",
+        command: ["/bin/sh"],
+        args: ["-c", "npm start"]
+      });
+
+      await applyPatch(api, dseq, {
+        services: {
+          web: {
+            env: {
+              PATCHED_PLAIN: "patched-value",
+              PATCHED_REFERENCE: "ac-secret://PATCHED_SECRET",
+              REMOVABLE_ENV: null
+            }
+          }
+        },
+        sealedSecrets: await encryptSecrets(api, { PATCHED_SECRET: "patched-secret-value" })
+      });
+      const withPatchedEnv = await readPatchedService(api, dseq, "web");
+      expect(withPatchedEnv.env).toEqual(
+        expect.arrayContaining([
+          "INITIAL_ENV=ac-secret://INITIAL_SECRET",
+          "PATCHED_REFERENCE=ac-secret://PATCHED_SECRET",
+          expect.stringMatching(/^PATCHED_PLAIN=ac-secret:\/\//)
+        ])
+      );
+      expect(withPatchedEnv.env).not.toContainEqual(expect.stringMatching(/^REMOVABLE_ENV=/));
+
+      await applyPatch(api, dseq, {
+        services: {
+          web: {
+            expose: {
+              "3000": {
+                httpOptions: {
+                  maxBodySize: 2097152,
+                  readTimeout: 45000,
+                  sendTimeout: 45000,
+                  nextTries: 2,
+                  nextTimeout: 30000,
+                  nextCases: ["error", "timeout"]
+                }
+              }
+            },
+            storage: {
+              data: {
+                mount: "/mnt/patched",
+                readOnly: true
+              }
+            }
+          }
+        }
+      });
+      const withPatchedRouting = await readPatchedService(api, dseq, "web");
+      expect(withPatchedRouting.expose[0].http_options).toMatchObject({
+        max_body_size: 2097152,
+        read_timeout: 45000,
+        send_timeout: 45000,
+        next_tries: 2,
+        next_timeout: 30000,
+        next_cases: ["error", "timeout"]
+      });
+      expect(withPatchedRouting.params?.storage?.data).toEqual({ mount: "/mnt/patched", readOnly: true });
+
+      await applyPatch(api, dseq, {
+        services: {
+          web: {
+            credentials: { host: "ghcr.io", username: "patched-user", password: "patched-password" }
+          }
+        }
+      });
+      expect((await readPatchedService(api, dseq, "web")).credentials).toMatchObject({
+        host: "ghcr.io",
+        username: expect.stringMatching(/^ac-secret:\/\//),
+        password: expect.stringMatching(/^ac-secret:\/\//)
+      });
+
+      await applyPatch(api, dseq, {
+        services: {
+          web: { credentials: null, command: null, args: null }
+        }
+      });
+      const withClearedFields = await readPatchedService(api, dseq, "web");
+      expect(withClearedFields.credentials).toBeUndefined();
+      expect(withClearedFields.command).toBeUndefined();
+      expect(withClearedFields.args).toBeUndefined();
+
+      const customDomain = `patch-e2e-${dseq}.example.com`;
+      const acceptPatch = await applyPatch(api, dseq, {
+        services: {
+          web: { expose: { "3000": { accept: [customDomain] } } }
+        }
+      });
+      expect((await readPatchedService(api, dseq, "web")).expose[0].accept).toEqual([customDomain]);
+
+      const guardedPatch = await applyPatch(api, dseq, {
+        services: {
+          web: { env: { GUARDED_ENV: "ac-secret://INITIAL_SECRET" } }
+        },
+        ifManifestVersion: acceptPatch.manifestVersion
+      });
+      expect(guardedPatch.manifestVersion).not.toBe(acceptPatch.manifestVersion);
+      expect((await readPatchedService(api, dseq, "web")).env).toContain("GUARDED_ENV=ac-secret://INITIAL_SECRET");
+
+      await expect(
+        applyPatch(api, dseq, {
+          services: {
+            web: { env: { STALE_ENV: "ac-secret://INITIAL_SECRET" } }
+          },
+          ifManifestVersion: acceptPatch.manifestVersion
+        })
+      ).rejects.toMatchObject({ status: 409 });
+    } finally {
+      await api.v1.closeDeployment({ dseq });
+    }
+  });
+
   async function setup() {
     const apiKey = z.string().parse(process.env.CONSOLE_API_E2E_API_KEY);
     const baseUrl = z.string().url().parse(process.env.TEST_API_BASE_URL);
@@ -434,6 +628,38 @@ describe("Managed Wallet API Deployment Flow", () => {
       } as any // sealedSecrets currently is a hidden field in the API spec
     });
     return deploymentResponse;
+  }
+
+  type PatchDeploymentData = NonNullable<paths["/v1/deployments/{dseq}"]["patch"]["requestBody"]>["content"]["application/json"]["data"];
+
+  type StoredService = {
+    image: string;
+    command?: string[];
+    args?: string[];
+    env?: string[];
+    credentials?: { host: string; username: string; password: string };
+    expose: Array<{ port: number; accept?: string[]; http_options?: Record<string, unknown> }>;
+    params?: { storage?: Record<string, { mount?: string; readOnly?: boolean }> };
+  };
+
+  async function applyPatch(api: Awaited<ReturnType<typeof setup>>["api"], dseq: string, data: PatchDeploymentData & { sealedSecrets?: string }) {
+    const patchResponse = await api.v1.patchDeployment({ dseq, data } as any); // sealedSecrets currently is a hidden field in the API spec
+
+    expect(patchResponse.data).toMatchObject({
+      deployment: expect.objectContaining({
+        id: expect.objectContaining({ dseq })
+      }),
+      manifestVersion: expect.any(String)
+    });
+
+    return patchResponse.data;
+  }
+
+  async function readPatchedService(api: Awaited<ReturnType<typeof setup>>["api"], dseq: string, serviceName: string) {
+    const { data } = await api.v2.getDeploymentSetting({ dseq });
+    const document = parseYaml(z.string().parse(data.sdl)) as { services: Record<string, StoredService> };
+
+    return document.services[serviceName];
   }
 
   async function encryptSecrets(api: Awaited<ReturnType<typeof setup>>["api"], secrets: Record<string, string>) {

--- a/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
+++ b/apps/api/test/e2e/managed-api-deployment-flow.spec.ts
@@ -352,6 +352,29 @@ describe("Managed Wallet API Deployment Flow", () => {
         dseq: deploymentResponse.data.dseq,
         sdl: expect.stringMatching(/TEST_ENV=ac-secret:\/\/NEW_TEST_SECRET|NEW_REGULAR_VAR=new-value|NEW_DATABASE_URL=ac-secret:\/\/WEB_DATABASE_URL/)
       });
+
+      const patchResponse2 = await api.v1.patchDeployment({
+        dseq: deploymentResponse.data.dseq,
+        data: {
+          services: {
+            web: {
+              image: "ghcr.io/akash-network/hello-akash-world:sha-2140a1d"
+            }
+          }
+        }
+      });
+      expect(patchResponse2.data).toMatchObject({
+        deployment: expect.objectContaining({
+          id: expect.objectContaining({
+            dseq: deploymentResponse.data.dseq
+          })
+        })
+      });
+      const updatedDeployment2 = await api.v2.getDeploymentSetting({ dseq: deploymentResponse.data.dseq });
+      expect(updatedDeployment2.data).toMatchObject({
+        dseq: deploymentResponse.data.dseq,
+        sdl: expect.stringMatching(/image:\s*ghcr.io\/akash-network\/hello-akash-world:sha-2140a1d/)
+      });
     } finally {
       await api.v1.closeDeployment({
         dseq: deploymentResponse.data.dseq

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -87,7 +87,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^\\d+$",
+                                  "pattern": "^0*[1-9]\\d*$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -526,7 +526,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                               "id": {
                                 "properties": {
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -671,7 +671,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                               "id": {
                                 "properties": {
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "owner": {
@@ -1110,7 +1110,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                 "id": {
                                   "properties": {
                                     "dseq": {
-                                      "pattern": "^\\d+$",
+                                      "pattern": "^0*[1-9]\\d*$",
                                       "type": "string",
                                     },
                                     "gseq": {
@@ -1421,7 +1421,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -1867,7 +1867,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "type": "number",
                           },
                           "dseq": {
-                            "pattern": "^\\d+$",
+                            "pattern": "^0*[1-9]\\d*$",
                             "type": "string",
                           },
                           "gpuUnits": {
@@ -1877,7 +1877,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "items": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^\\d+$",
+                                  "pattern": "^0*[1-9]\\d*$",
                                   "type": "string",
                                 },
                                 "gseq": {
@@ -3198,7 +3198,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "dseq",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -3223,7 +3223,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -3646,7 +3646,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "dseq",
             "required": true,
             "schema": {
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -3671,7 +3671,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -5506,7 +5506,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "properties": {
                       "dseq": {
                         "description": "Deployment sequence number",
-                        "pattern": "^\\d+$",
+                        "pattern": "^0*[1-9]\\d*$",
                         "type": "string",
                       },
                       "userId": {
@@ -5545,7 +5545,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^\\d+$",
+                          "pattern": "^0*[1-9]\\d*$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -5634,7 +5634,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -5655,7 +5655,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^\\d+$",
+                          "pattern": "^0*[1-9]\\d*$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -5760,7 +5760,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -5807,7 +5807,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^\\d+$",
+                          "pattern": "^0*[1-9]\\d*$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -5951,7 +5951,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -5969,7 +5969,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "type": "string",
                     },
                     "dseq": {
-                      "pattern": "^\\d+$",
+                      "pattern": "^0*[1-9]\\d*$",
                       "type": "string",
                     },
                     "events": {
@@ -6653,7 +6653,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                   "id": {
                                     "properties": {
                                       "dseq": {
-                                        "pattern": "^\\d+$",
+                                        "pattern": "^0*[1-9]\\d*$",
                                         "type": "string",
                                       },
                                       "owner": {
@@ -6813,7 +6813,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                           "type": "number",
                                         },
                                         "dseq": {
-                                          "pattern": "^\\d+$",
+                                          "pattern": "^0*[1-9]\\d*$",
                                           "type": "string",
                                         },
                                         "gseq": {
@@ -6984,7 +6984,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "data": {
                       "properties": {
                         "dseq": {
-                          "pattern": "^\\d+$",
+                          "pattern": "^0*[1-9]\\d*$",
                           "type": "string",
                         },
                         "manifest": {
@@ -7053,7 +7053,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -7109,7 +7109,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -7152,7 +7152,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^\\d+$",
+                                  "pattern": "^0*[1-9]\\d*$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -7312,7 +7312,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -7532,7 +7532,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -7700,7 +7700,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^\\d+$",
+                                  "pattern": "^0*[1-9]\\d*$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -7860,7 +7860,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -8235,7 +8235,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -8284,7 +8284,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^\\d+$",
+                                  "pattern": "^0*[1-9]\\d*$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -8444,7 +8444,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -8671,7 +8671,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       },
                       "dseq": {
                         "description": "Deployment sequence number",
-                        "pattern": "^\\d+$",
+                        "pattern": "^0*[1-9]\\d*$",
                         "type": "string",
                       },
                     },
@@ -8709,7 +8709,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^\\d+$",
+                                  "pattern": "^0*[1-9]\\d*$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -8869,7 +8869,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -9617,7 +9617,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "items": {
                       "properties": {
                         "dseq": {
-                          "pattern": "^\\d+$",
+                          "pattern": "^0*[1-9]\\d*$",
                           "type": "string",
                         },
                         "gseq": {
@@ -9673,7 +9673,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^\\d+$",
+                                  "pattern": "^0*[1-9]\\d*$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -9833,7 +9833,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^\\d+$",
+                                    "pattern": "^0*[1-9]\\d*$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -10059,7 +10059,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "dseq",
             "required": false,
             "schema": {
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -10103,7 +10103,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "type": "number",
                           },
                           "dseq": {
-                            "pattern": "^\\d+$",
+                            "pattern": "^0*[1-9]\\d*$",
                             "type": "string",
                           },
                           "durationInBlocks": {
@@ -13926,7 +13926,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "type": "string",
                           },
                           "dseq": {
-                            "pattern": "^\\d+$",
+                            "pattern": "^0*[1-9]\\d*$",
                             "type": "string",
                           },
                           "leases": {
@@ -16516,7 +16516,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "properties": {
                       "dseq": {
                         "description": "Deployment sequence number",
-                        "pattern": "^\\d+$",
+                        "pattern": "^0*[1-9]\\d*$",
                         "type": "string",
                       },
                       "userId": {
@@ -16555,7 +16555,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^\\d+$",
+                          "pattern": "^0*[1-9]\\d*$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -16635,7 +16635,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -16666,7 +16666,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^\\d+$",
+                          "pattern": "^0*[1-9]\\d*$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -16762,7 +16762,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^\\d+$",
+              "pattern": "^0*[1-9]\\d*$",
               "type": "string",
             },
           },
@@ -16819,7 +16819,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^\\d+$",
+                          "pattern": "^0*[1-9]\\d*$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7608,7 +7608,6 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                   "httpOptions": {
                                     "properties": {
                                       "maxBodySize": {
-                                        "exclusiveMinimum": true,
                                         "minimum": 0,
                                         "type": "integer",
                                       },
@@ -7619,22 +7618,18 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                         "type": "array",
                                       },
                                       "nextTimeout": {
-                                        "exclusiveMinimum": true,
                                         "minimum": 0,
                                         "type": "integer",
                                       },
                                       "nextTries": {
-                                        "exclusiveMinimum": true,
                                         "minimum": 0,
                                         "type": "integer",
                                       },
                                       "readTimeout": {
-                                        "exclusiveMinimum": true,
                                         "minimum": 0,
                                         "type": "integer",
                                       },
                                       "sendTimeout": {
-                                        "exclusiveMinimum": true,
                                         "minimum": 0,
                                         "type": "integer",
                                       },

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7592,7 +7592,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                 "nullable": true,
                                 "type": "string",
                               },
-                              "description": "Merged into the service's env. A null value removes the variable.",
+                              "description": "Merged into the service's env, keyed by environment variable name. A null value removes the variable.",
                               "type": "object",
                             },
                             "expose": {
@@ -8069,12 +8069,24 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
               "application/json": {
                 "schema": {
                   "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
                     "message": {
+                      "type": "string",
+                    },
+                    "type": {
                       "type": "string",
                     },
                   },
                   "required": [
+                    "error",
                     "message",
+                    "code",
+                    "type",
                   ],
                   "type": "object",
                 },
@@ -8087,12 +8099,24 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
               "application/json": {
                 "schema": {
                   "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
                     "message": {
+                      "type": "string",
+                    },
+                    "type": {
                       "type": "string",
                     },
                   },
                   "required": [
+                    "error",
                     "message",
+                    "code",
+                    "type",
                   ],
                   "type": "object",
                 },
@@ -8105,12 +8129,24 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
               "application/json": {
                 "schema": {
                   "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
                     "message": {
+                      "type": "string",
+                    },
+                    "type": {
                       "type": "string",
                     },
                   },
                   "required": [
+                    "error",
                     "message",
+                    "code",
+                    "type",
                   ],
                   "type": "object",
                 },
@@ -8126,19 +8162,57 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "code": {
                       "type": "string",
                     },
+                    "error": {
+                      "type": "string",
+                    },
                     "message": {
+                      "type": "string",
+                    },
+                    "type": {
                       "type": "string",
                     },
                   },
                   "required": [
+                    "error",
                     "message",
                     "code",
+                    "type",
                   ],
                   "type": "object",
                 },
               },
             },
-            "description": "The stored secrets could not be read. Permanent rather than transient: \`code\` is \`stored_secrets_unreadable\` and the stored token is left untouched, so a retry cannot help",
+            "description": "The deployment's stored state could not be read. Permanent rather than transient, so a retry cannot help, and the stored token is left untouched: \`code\` is \`stored_secrets_unreadable\` when the sealed secrets would not open and \`stored_sdl_unreadable\` when the recorded SDL would not parse",
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 500 above",
           },
         },
         "security": [

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7522,7 +7522,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
       "patch": {
-        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
+        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.",
         "operationId": "patchDeployment",
         "parameters": [
           {
@@ -7545,7 +7545,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "ifManifestVersion": {
-                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on.",
+                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed.",
                         "maxLength": 64,
                         "type": "string",
                       },
@@ -8147,7 +8147,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 },
               },
             },
-            "description": "The deployment definition changed since the manifest version this patch expected",
+            "description": "The deployment definition changed since the manifest version this patch expected. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds",
           },
           "500": {
             "content": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7562,6 +7562,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "ifManifestVersion": {
                         "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it.",
                         "maxLength": 64,
+                        "minLength": 1,
                         "type": "string",
                       },
                       "services": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7545,7 +7545,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "ifManifestVersion": {
-                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed.",
+                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it.",
                         "maxLength": 64,
                         "type": "string",
                       },
@@ -8147,7 +8147,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 },
               },
             },
-            "description": "The deployment definition changed since the manifest version this patch expected. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds",
+            "description": "The deployment definition changed between this patch reading it and writing it. A patch naming no \`ifManifestVersion\` is guarded on the version it read, so a concurrent patch produces this too. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds",
           },
           "500": {
             "content": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7521,9 +7521,642 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
           "Deployments",
         ],
       },
+      "patch": {
+        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
+        "operationId": "patchDeployment",
+        "parameters": [
+          {
+            "description": "Deployment sequence number",
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "description": "Deployment sequence number",
+              "pattern": "^d+$",
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "ifManifestVersion": {
+                        "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on.",
+                        "maxLength": 64,
+                        "type": "string",
+                      },
+                      "services": {
+                        "additionalProperties": {
+                          "properties": {
+                            "args": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "nullable": true,
+                              "type": "array",
+                            },
+                            "command": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "nullable": true,
+                              "type": "array",
+                            },
+                            "credentials": {
+                              "description": "Private registry pull credentials. Null clears them.",
+                              "nullable": true,
+                              "properties": {
+                                "host": {
+                                  "type": "string",
+                                },
+                                "password": {
+                                  "type": "string",
+                                },
+                                "username": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "host",
+                                "username",
+                                "password",
+                              ],
+                              "type": "object",
+                            },
+                            "env": {
+                              "additionalProperties": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "description": "Merged into the service's env. A null value removes the variable.",
+                              "type": "object",
+                            },
+                            "expose": {
+                              "additionalProperties": {
+                                "properties": {
+                                  "accept": {
+                                    "description": "Custom domains. Replaces the existing list.",
+                                    "items": {
+                                      "type": "string",
+                                    },
+                                    "type": "array",
+                                  },
+                                  "httpOptions": {
+                                    "properties": {
+                                      "maxBodySize": {
+                                        "exclusiveMinimum": true,
+                                        "minimum": 0,
+                                        "type": "integer",
+                                      },
+                                      "nextCases": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "nextTimeout": {
+                                        "exclusiveMinimum": true,
+                                        "minimum": 0,
+                                        "type": "integer",
+                                      },
+                                      "nextTries": {
+                                        "exclusiveMinimum": true,
+                                        "minimum": 0,
+                                        "type": "integer",
+                                      },
+                                      "readTimeout": {
+                                        "exclusiveMinimum": true,
+                                        "minimum": 0,
+                                        "type": "integer",
+                                      },
+                                      "sendTimeout": {
+                                        "exclusiveMinimum": true,
+                                        "minimum": 0,
+                                        "type": "integer",
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                },
+                                "type": "object",
+                              },
+                              "description": "Keyed by container port. Only hosts and http options are patchable; endpoint kind and count are fixed at create.",
+                              "type": "object",
+                            },
+                            "image": {
+                              "type": "string",
+                            },
+                            "storage": {
+                              "additionalProperties": {
+                                "properties": {
+                                  "mount": {
+                                    "type": "string",
+                                  },
+                                  "readOnly": {
+                                    "type": "boolean",
+                                  },
+                                },
+                                "type": "object",
+                              },
+                              "description": "Keyed by volume name. Mount point only — sizes are fixed at create.",
+                              "type": "object",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        "description": "Keyed by service name. Only the named services are touched; omitted services keep their current definition.",
+                        "type": "object",
+                      },
+                    },
+                    "required": [
+                      "services",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "deployment": {
+                          "properties": {
+                            "created_at": {
+                              "type": "string",
+                            },
+                            "hash": {
+                              "type": "string",
+                            },
+                            "id": {
+                              "properties": {
+                                "dseq": {
+                                  "pattern": "^d+$",
+                                  "type": "string",
+                                },
+                                "owner": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "owner",
+                                "dseq",
+                              ],
+                              "type": "object",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "state",
+                            "hash",
+                            "created_at",
+                          ],
+                          "type": "object",
+                        },
+                        "escrow_account": {
+                          "properties": {
+                            "id": {
+                              "properties": {
+                                "scope": {
+                                  "type": "string",
+                                },
+                                "xid": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "scope",
+                                "xid",
+                              ],
+                              "type": "object",
+                            },
+                            "state": {
+                              "properties": {
+                                "deposits": {
+                                  "items": {
+                                    "properties": {
+                                      "balance": {
+                                        "properties": {
+                                          "amount": {
+                                            "type": "string",
+                                          },
+                                          "denom": {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "denom",
+                                          "amount",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "height": {
+                                        "type": "string",
+                                      },
+                                      "owner": {
+                                        "type": "string",
+                                      },
+                                      "source": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "owner",
+                                      "height",
+                                      "source",
+                                      "balance",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                                "funds": {
+                                  "items": {
+                                    "properties": {
+                                      "amount": {
+                                        "type": "string",
+                                      },
+                                      "denom": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "denom",
+                                      "amount",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                                "owner": {
+                                  "type": "string",
+                                },
+                                "settled_at": {
+                                  "type": "string",
+                                },
+                                "state": {
+                                  "type": "string",
+                                },
+                                "transferred": {
+                                  "items": {
+                                    "properties": {
+                                      "amount": {
+                                        "type": "string",
+                                      },
+                                      "denom": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "denom",
+                                      "amount",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                              },
+                              "required": [
+                                "owner",
+                                "state",
+                                "transferred",
+                                "settled_at",
+                                "funds",
+                                "deposits",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "state",
+                          ],
+                          "type": "object",
+                        },
+                        "leases": {
+                          "items": {
+                            "properties": {
+                              "closed_on": {
+                                "type": "string",
+                              },
+                              "created_at": {
+                                "type": "string",
+                              },
+                              "id": {
+                                "properties": {
+                                  "bseq": {
+                                    "type": "number",
+                                  },
+                                  "dseq": {
+                                    "pattern": "^d+$",
+                                    "type": "string",
+                                  },
+                                  "gseq": {
+                                    "type": "number",
+                                  },
+                                  "oseq": {
+                                    "type": "number",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                  "provider": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                  "bseq",
+                                ],
+                                "type": "object",
+                              },
+                              "price": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "reason": {
+                                "type": "string",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                              "status": {
+                                "nullable": true,
+                                "properties": {
+                                  "forwarded_ports": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "available": {
+                                            "type": "number",
+                                          },
+                                          "externalPort": {
+                                            "type": "number",
+                                          },
+                                          "host": {
+                                            "type": "string",
+                                          },
+                                          "port": {
+                                            "type": "number",
+                                          },
+                                        },
+                                        "required": [
+                                          "port",
+                                          "externalPort",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "ips": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "ExternalPort": {
+                                            "type": "number",
+                                          },
+                                          "IP": {
+                                            "type": "string",
+                                          },
+                                          "Port": {
+                                            "type": "number",
+                                          },
+                                          "Protocol": {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "services": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "available": {
+                                          "type": "number",
+                                        },
+                                        "available_replicas": {
+                                          "type": "number",
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                        },
+                                        "observed_generation": {
+                                          "type": "number",
+                                        },
+                                        "ready_replicas": {
+                                          "type": "number",
+                                        },
+                                        "replicas": {
+                                          "type": "number",
+                                        },
+                                        "total": {
+                                          "type": "number",
+                                        },
+                                        "updated_replicas": {
+                                          "type": "number",
+                                        },
+                                        "uris": {
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "required": [
+                                        "name",
+                                        "available",
+                                        "total",
+                                        "uris",
+                                        "observed_generation",
+                                        "replicas",
+                                        "updated_replicas",
+                                        "ready_replicas",
+                                        "available_replicas",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "type": "object",
+                                  },
+                                },
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services",
+                                ],
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                        "manifestVersion": {
+                          "description": "Base64 manifest version this patch recorded and committed on chain.",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account",
+                        "manifestVersion",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment patched successfully",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The patch names a service, port or volume the stored SDL does not declare, supplies a secret name it does not reference, or leaves a reference with no value",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "No SDL is recorded for this deployment, so there is nothing to patch",
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The deployment definition changed since the manifest version this patch expected",
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                    "code",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The stored secrets could not be read. Permanent rather than transient: \`code\` is \`stored_secrets_unreadable\` and the stored token is left untouched, so a retry cannot help",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+          {
+            "ApiKeyAuth": [],
+          },
+        ],
+        "summary": "Patch a deployment",
+        "tags": [
+          "Deployments",
+        ],
+      },
       "put": {
         "deprecated": true,
-        "description": "Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. This endpoint will be removed in a future release.",
+        "description": "Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. Use PATCH /v1/deployments/{dseq} instead. This endpoint will be removed in a future release.",
         "operationId": "updateDeployment",
         "parameters": [
           {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7657,7 +7657,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                 },
                                 "type": "object",
                               },
-                              "description": "Keyed by volume name. Mount point only — sizes are fixed at create.",
+                              "description": "Keyed by volume name. Mount point and read-only flag only — sizes are fixed at create.",
                               "type": "object",
                             },
                           },
@@ -8177,7 +8177,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 },
               },
             },
-            "description": "The deployment's stored state could not be read. Permanent rather than transient, so a retry cannot help, and the stored token is left untouched: \`code\` is \`stored_secrets_unreadable\` when the sealed secrets would not open and \`stored_sdl_unreadable\` when the recorded SDL would not parse",
+            "description": "The deployment's stored state could not be read: \`code\` is \`stored_secrets_unreadable\` when the sealed secrets would not open and \`stored_sdl_unreadable\` when the recorded SDL would not parse. Both are permanent rather than transient, so a retry cannot help, and both leave the stored token untouched. A 500 carrying any other \`code\` is an unexpected failure and promises neither of those things",
           },
           "503": {
             "content": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -87,7 +87,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^d+$",
+                                  "pattern": "^\\d+$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -526,7 +526,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                               "id": {
                                 "properties": {
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -671,7 +671,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                               "id": {
                                 "properties": {
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "owner": {
@@ -1110,7 +1110,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                 "id": {
                                   "properties": {
                                     "dseq": {
-                                      "pattern": "^d+$",
+                                      "pattern": "^\\d+$",
                                       "type": "string",
                                     },
                                     "gseq": {
@@ -1421,7 +1421,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -1867,7 +1867,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "type": "number",
                           },
                           "dseq": {
-                            "pattern": "^d+$",
+                            "pattern": "^\\d+$",
                             "type": "string",
                           },
                           "gpuUnits": {
@@ -1877,7 +1877,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "items": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^d+$",
+                                  "pattern": "^\\d+$",
                                   "type": "string",
                                 },
                                 "gseq": {
@@ -3198,7 +3198,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "dseq",
             "required": true,
             "schema": {
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -3223,7 +3223,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -3646,7 +3646,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "dseq",
             "required": true,
             "schema": {
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -3671,7 +3671,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -5506,7 +5506,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "properties": {
                       "dseq": {
                         "description": "Deployment sequence number",
-                        "pattern": "^d+$",
+                        "pattern": "^\\d+$",
                         "type": "string",
                       },
                       "userId": {
@@ -5545,7 +5545,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^d+$",
+                          "pattern": "^\\d+$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -5634,7 +5634,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -5655,7 +5655,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^d+$",
+                          "pattern": "^\\d+$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -5760,7 +5760,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -5807,7 +5807,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^d+$",
+                          "pattern": "^\\d+$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -5951,7 +5951,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -5969,7 +5969,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "type": "string",
                     },
                     "dseq": {
-                      "pattern": "^d+$",
+                      "pattern": "^\\d+$",
                       "type": "string",
                     },
                     "events": {
@@ -6653,7 +6653,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                   "id": {
                                     "properties": {
                                       "dseq": {
-                                        "pattern": "^d+$",
+                                        "pattern": "^\\d+$",
                                         "type": "string",
                                       },
                                       "owner": {
@@ -6813,7 +6813,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                           "type": "number",
                                         },
                                         "dseq": {
-                                          "pattern": "^d+$",
+                                          "pattern": "^\\d+$",
                                           "type": "string",
                                         },
                                         "gseq": {
@@ -6984,7 +6984,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "data": {
                       "properties": {
                         "dseq": {
-                          "pattern": "^d+$",
+                          "pattern": "^\\d+$",
                           "type": "string",
                         },
                         "manifest": {
@@ -7053,7 +7053,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -7109,7 +7109,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -7152,7 +7152,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^d+$",
+                                  "pattern": "^\\d+$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -7312,7 +7312,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -7532,7 +7532,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -7700,7 +7700,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^d+$",
+                                  "pattern": "^\\d+$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -7860,7 +7860,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -8235,7 +8235,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -8284,7 +8284,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^d+$",
+                                  "pattern": "^\\d+$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -8444,7 +8444,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -8671,7 +8671,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       },
                       "dseq": {
                         "description": "Deployment sequence number",
-                        "pattern": "^d+$",
+                        "pattern": "^\\d+$",
                         "type": "string",
                       },
                     },
@@ -8709,7 +8709,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^d+$",
+                                  "pattern": "^\\d+$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -8869,7 +8869,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -9617,7 +9617,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "items": {
                       "properties": {
                         "dseq": {
-                          "pattern": "^d+$",
+                          "pattern": "^\\d+$",
                           "type": "string",
                         },
                         "gseq": {
@@ -9673,7 +9673,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "id": {
                               "properties": {
                                 "dseq": {
-                                  "pattern": "^d+$",
+                                  "pattern": "^\\d+$",
                                   "type": "string",
                                 },
                                 "owner": {
@@ -9833,7 +9833,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "type": "number",
                                   },
                                   "dseq": {
-                                    "pattern": "^d+$",
+                                    "pattern": "^\\d+$",
                                     "type": "string",
                                   },
                                   "gseq": {
@@ -10059,7 +10059,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "dseq",
             "required": false,
             "schema": {
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -10103,7 +10103,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "type": "number",
                           },
                           "dseq": {
-                            "pattern": "^d+$",
+                            "pattern": "^\\d+$",
                             "type": "string",
                           },
                           "durationInBlocks": {
@@ -13926,7 +13926,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "type": "string",
                           },
                           "dseq": {
-                            "pattern": "^d+$",
+                            "pattern": "^\\d+$",
                             "type": "string",
                           },
                           "leases": {
@@ -16516,7 +16516,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "properties": {
                       "dseq": {
                         "description": "Deployment sequence number",
-                        "pattern": "^d+$",
+                        "pattern": "^\\d+$",
                         "type": "string",
                       },
                       "userId": {
@@ -16555,7 +16555,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^d+$",
+                          "pattern": "^\\d+$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -16635,7 +16635,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -16666,7 +16666,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^d+$",
+                          "pattern": "^\\d+$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {
@@ -16762,7 +16762,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "required": true,
             "schema": {
               "description": "Deployment sequence number",
-              "pattern": "^d+$",
+              "pattern": "^\\d+$",
               "type": "string",
             },
           },
@@ -16819,7 +16819,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "string",
                         },
                         "dseq": {
-                          "pattern": "^d+$",
+                          "pattern": "^\\d+$",
                           "type": "string",
                         },
                         "estimatedTopUpAmount": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -5566,6 +5566,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "nullable": true,
                           "type": "integer",
                         },
+                        "sdl": {
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "topUpFrequencyMs": {
                           "type": "number",
                         },
@@ -5581,6 +5585,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -5676,6 +5681,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "nullable": true,
                           "type": "integer",
                         },
+                        "sdl": {
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "topUpFrequencyMs": {
                           "type": "number",
                         },
@@ -5691,6 +5700,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -5828,6 +5838,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "nullable": true,
                           "type": "integer",
                         },
+                        "sdl": {
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "topUpFrequencyMs": {
                           "type": "number",
                         },
@@ -5843,6 +5857,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -7599,7 +7614,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                               "additionalProperties": {
                                 "properties": {
                                   "accept": {
-                                    "description": "Custom domains. Replaces the existing list.",
+                                    "description": "Custom domains. Replaces the existing list. Emptying it is rejected by providers that do not generate a hostname of their own, which leaves the patch recorded but undeployed.",
                                     "items": {
                                       "type": "string",
                                     },
@@ -7608,29 +7623,48 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                   "httpOptions": {
                                     "properties": {
                                       "maxBodySize": {
-                                        "minimum": 0,
+                                        "maximum": 104857600,
+                                        "minimum": 1,
                                         "type": "integer",
                                       },
                                       "nextCases": {
+                                        "description": "Conditions the proxy retries on. Replaces the existing list; "off" disables retrying and stands alone.",
                                         "items": {
+                                          "enum": [
+                                            "error",
+                                            "timeout",
+                                            "500",
+                                            "502",
+                                            "503",
+                                            "504",
+                                            "403",
+                                            "404",
+                                            "429",
+                                            "off",
+                                          ],
                                           "type": "string",
                                         },
+                                        "minItems": 1,
                                         "type": "array",
                                       },
                                       "nextTimeout": {
+                                        "maximum": 4294967295,
                                         "minimum": 0,
                                         "type": "integer",
                                       },
                                       "nextTries": {
+                                        "maximum": 4294967295,
                                         "minimum": 0,
                                         "type": "integer",
                                       },
                                       "readTimeout": {
-                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "minimum": 1,
                                         "type": "integer",
                                       },
                                       "sendTimeout": {
-                                        "minimum": 0,
+                                        "maximum": 4294967295,
+                                        "minimum": 1,
                                         "type": "integer",
                                       },
                                     },
@@ -16576,6 +16610,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "nullable": true,
                           "type": "integer",
                         },
+                        "sdl": {
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "topUpFrequencyMs": {
                           "type": "number",
                         },
@@ -16591,6 +16629,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -16628,6 +16667,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
     },
     "/v2/deployment-settings/{dseq}": {
       "get": {
+        "operationId": "getDeploymentSetting",
         "parameters": [
           {
             "in": "path",
@@ -16687,6 +16727,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "nullable": true,
                           "type": "integer",
                         },
+                        "sdl": {
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "topUpFrequencyMs": {
                           "type": "number",
                         },
@@ -16702,6 +16746,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",
@@ -16840,6 +16885,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "nullable": true,
                           "type": "integer",
                         },
+                        "sdl": {
+                          "nullable": true,
+                          "type": "string",
+                        },
                         "topUpFrequencyMs": {
                           "type": "number",
                         },
@@ -16855,6 +16904,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "id",
                         "userId",
                         "dseq",
+                        "sdl",
                         "autoTopUpEnabled",
                         "estimatedTopUpAmount",
                         "topUpFrequencyMs",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7522,7 +7522,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
       "patch": {
-        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
+        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.",
         "operationId": "patchDeployment",
         "parameters": [
           {
@@ -7592,7 +7592,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                 "nullable": true,
                                 "type": "string",
                               },
-                              "description": "Merged into the service's env, keyed by environment variable name. A null value removes the variable.",
+                              "description": "Merged into the service's env, keyed by environment variable name. A null value removes the variable. A patched variable is re-appended, so the order of the stored env list may change.",
                               "type": "object",
                             },
                             "expose": {

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -1,0 +1,115 @@
+import { faker } from "@faker-js/faker";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { startJobQueues } from "@src/app/providers/jobs.provider";
+import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
+import type { UserWalletOutput } from "@src/billing/repositories";
+import { UserWalletRepository } from "@src/billing/repositories";
+import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import { app } from "@src/rest-app";
+import type { UserOutput } from "@src/user/repositories";
+import { UserRepository } from "@src/user/repositories";
+
+import { registerFakeSdlSecretsKms, warmSealingKeyAsBootWould } from "@test/mocks/sdl-secrets-kms.mock";
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { createApiKey } from "@test/seeders/api-key.seeder";
+import { createUser } from "@test/seeders/user.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+registerFakeSdlSecretsKms();
+
+const DSEQ = "1234";
+
+describe("PATCH /v1/deployments/{dseq} route wiring", () => {
+  const userRepository = container.resolve(UserRepository);
+  const apiKeyAuthService = container.resolve(ApiKeyAuthService);
+  const userWalletRepository = container.resolve(UserWalletRepository);
+  const blockHttpService = container.resolve(BlockHttpService);
+
+  let knownUsers: Record<string, UserOutput>;
+  let knownApiKeys: Record<string, ReturnType<typeof createApiKey>>;
+  let knownWallets: Record<string, UserWalletOutput[]>;
+
+  beforeAll(async () => {
+    await startJobQueues();
+    await warmSealingKeyAsBootWould();
+  }, 20_000);
+
+  beforeEach(() => {
+    knownUsers = {};
+    knownApiKeys = {};
+    knownWallets = {};
+
+    vi.spyOn(userRepository, "findById").mockImplementation(async id =>
+      knownUsers[id] ? { ...knownUsers[id], trial: false, userWallets: { isTrialing: false } } : undefined
+    );
+    vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async key => knownApiKeys[key!]);
+    vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(faker.number.int({ min: 1000000, max: 10000000 }));
+    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue({
+      findByUserId: async (id: string) => knownWallets[id],
+      findOneByUserId: async (id: string) => knownWallets[id][0]
+    } as unknown as UserWalletRepository);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  afterAll(async () => {
+    await container.dispose();
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("rejects an unauthenticated request", async () => {
+    const response = await patch(undefined, { services: { web: { image: "nginx" } } });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("reaches the controller and answers 404 for a deployment the console recorded nothing for", async () => {
+    const { apiKey } = await persistedUser();
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx" } } });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("refuses a body naming no services before it reaches the controller", async () => {
+    const { apiKey } = await persistedUser();
+
+    const response = await patch(apiKey, { services: {} });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("refuses an env key that is not an environment variable name", async () => {
+    const { apiKey } = await persistedUser();
+
+    const response = await patch(apiKey, { services: { web: { env: { "A=B": "c" } } } });
+
+    expect(response.status).toBe(400);
+  });
+
+  function patch(apiKey: string | undefined, data: Record<string, unknown>) {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    if (apiKey) headers.set("x-api-key", apiKey);
+
+    return app.request(`/v1/deployments/${DSEQ}`, { method: "PATCH", body: JSON.stringify({ data }), headers });
+  }
+
+  async function persistedUser() {
+    const dbUser = await userRepository.create({ userId: faker.string.uuid() });
+    const apiKey = faker.string.alphanumeric(24);
+    const user = createUser({ id: dbUser.id, userId: dbUser.userId ?? undefined });
+
+    knownUsers[dbUser.id] = user;
+    knownApiKeys[apiKey] = createApiKey({ userId: dbUser.id });
+    knownWallets[dbUser.id] = [createUserWallet({ userId: dbUser.id, address: createAkashAddress() })];
+
+    return { user, apiKey };
+  }
+});

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import nock from "nock";
 import { container } from "tsyringe";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 import { startJobQueues } from "@src/app/providers/jobs.provider";
 import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
@@ -47,10 +48,12 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     );
     vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async key => knownApiKeys[key!]);
     vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(faker.number.int({ min: 1000000, max: 10000000 }));
-    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue({
-      findByUserId: async (id: string) => knownWallets[id],
-      findOneByUserId: async (id: string) => knownWallets[id][0]
-    } as unknown as UserWalletRepository);
+    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(
+      mock<UserWalletRepository>({
+        findByUserId: async (id: string) => knownWallets[id],
+        findOneByUserId: async (id: string) => knownWallets[id][0]
+      })
+    );
   });
 
   afterEach(() => {

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -89,6 +89,14 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     expect(response.status).toBe(400);
   });
 
+  it("refuses a service patch naming no field before it reaches the controller", async () => {
+    const { apiKey } = await persistedUser();
+
+    const response = await patch(apiKey, { services: { web: {} } });
+
+    expect(response.status).toBe(400);
+  });
+
   it("refuses an env key that is not an environment variable name", async () => {
     const { apiKey } = await persistedUser();
 

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -3,87 +3,48 @@ import nock from "nock";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { container } from "tsyringe";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { startJobQueues } from "@src/app/providers/jobs.provider";
-import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
-import type { UserWalletOutput } from "@src/billing/repositories";
-import { UserWalletRepository } from "@src/billing/repositories";
-import { ManagedSignerService } from "@src/billing/services";
-import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import { ApiKeyRepository } from "@src/auth/repositories/api-key/api-key.repository";
+import { ApiKeyGeneratorService } from "@src/auth/services/api-key/api-key-generator.service";
+import { BILLING_CONFIG } from "@src/billing/providers";
 import { CORE_CONFIG } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
-import { ProviderService } from "@src/provider/services/provider/provider.service";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { app } from "@src/rest-app";
-import type { UserOutput } from "@src/user/repositories";
-import { UserRepository } from "@src/user/repositories";
 import { deploymentVersion, marketVersion } from "@src/utils/constants";
 
 import { registerFakeSdlSecretsKms, warmSealingKeyAsBootWould } from "@test/mocks/sdl-secrets-kms.mock";
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
-import { createApiKey } from "@test/seeders/api-key.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { createDeploymentGrantResponseSeed } from "@test/seeders/deployment-grant-response.seeder";
 import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
-import { createManyLeaseApiResponses } from "@test/seeders/lease-api-response.seeder";
-import { createUser } from "@test/seeders/user.seeder";
-import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+import { createFeeAllowanceResponse } from "@test/seeders/fee-allowance-response.seeder";
+import { createLeaseApiResponse } from "@test/seeders/lease-api-response.seeder";
+import { createLeaseStatus } from "@test/seeders/lease-status.seeder";
+import { createProvider } from "@test/seeders/provider.seeder";
 
 registerFakeSdlSecretsKms();
 
 const DSEQ = "1234";
 const REPLACED_MANIFEST_VERSION = "AAAA";
+const STORED_SDL = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
 
 describe("PATCH /v1/deployments/{dseq} route wiring", () => {
-  const userRepository = container.resolve(UserRepository);
-  const apiKeyAuthService = container.resolve(ApiKeyAuthService);
-  const userWalletRepository = container.resolve(UserWalletRepository);
-  const blockHttpService = container.resolve(BlockHttpService);
-  const signerService = container.resolve(ManagedSignerService);
-  const providerService = container.resolve(ProviderService);
   const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
-
-  let knownUsers: Record<string, UserOutput>;
-  let knownApiKeys: Record<string, ReturnType<typeof createApiKey>>;
-  let knownWallets: Record<string, UserWalletOutput[]>;
 
   beforeAll(async () => {
     await startJobQueues();
     await warmSealingKeyAsBootWould();
   }, 20_000);
 
-  beforeEach(() => {
-    knownUsers = {};
-    knownApiKeys = {};
-    knownWallets = {};
-
-    vi.spyOn(userRepository, "findById").mockImplementation(async id =>
-      knownUsers[id] ? { ...knownUsers[id], trial: false, userWallets: { isTrialing: false } } : undefined
-    );
-    vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async key => knownApiKeys[key!]);
-    vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(faker.number.int({ min: 1000000, max: 10000000 }));
-    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(
-      mock<UserWalletRepository>({
-        findByUserId: async (id: string) => knownWallets[id],
-        findOneByUserId: async (id: string) => knownWallets[id][0]
-      })
-    );
-    vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
-      code: 0,
-      transactionHash: "fake-transaction-hash",
-      hash: "fake-transaction-hash",
-      rawLog: "fake-raw-log"
-    });
-    vi.spyOn(providerService, "sendManifest").mockResolvedValue(true);
-  });
-
   afterEach(() => {
-    vi.restoreAllMocks();
     nock.cleanAll();
   });
 
   afterAll(async () => {
     await container.dispose();
-    vi.restoreAllMocks();
     nock.cleanAll();
   });
 
@@ -94,7 +55,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
   });
 
   it("reaches the controller and answers 404 for a deployment the console recorded nothing for", async () => {
-    const { apiKey } = await persistedUser();
+    const { apiKey } = await setup();
 
     const response = await patch(apiKey, { services: { web: { image: "nginx" } } });
 
@@ -102,7 +63,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
   });
 
   it("refuses a body naming no services before it reaches the controller", async () => {
-    const { apiKey } = await persistedUser();
+    const { apiKey } = await setup();
 
     const response = await patch(apiKey, { services: {} });
 
@@ -110,7 +71,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
   });
 
   it("refuses a service patch naming no field before it reaches the controller", async () => {
-    const { apiKey } = await persistedUser();
+    const { apiKey } = await setup();
 
     const response = await patch(apiKey, { services: { web: {} } });
 
@@ -118,7 +79,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
   });
 
   it("refuses an empty seal offered as the only thing the patch would write", async () => {
-    const { apiKey } = await persistedUser();
+    const { apiKey } = await setup();
 
     const response = await patch(apiKey, { services: { web: {} }, sealedSecrets: "" });
 
@@ -126,7 +87,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
   });
 
   it("refuses an env key that is not an environment variable name", async () => {
-    const { apiKey } = await persistedUser();
+    const { apiKey } = await setup();
 
     const response = await patch(apiKey, { services: { web: { env: { "A=B": "c" } } } });
 
@@ -134,7 +95,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
   });
 
   it("answers 200 with the patched deployment under data", async () => {
-    const { apiKey } = await patchableDeployment();
+    const { apiKey } = await setup({ recordsDefinition: true });
 
     const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
@@ -150,7 +111,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
   });
 
   it("hands back the manifest version it recorded rather than the one the patch replaced", async () => {
-    const { apiKey, user } = await patchableDeployment();
+    const { apiKey, user } = await setup({ recordsDefinition: true });
 
     const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
@@ -160,6 +121,24 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     expect(data.manifestVersion).not.toBe(REPLACED_MANIFEST_VERSION);
   });
 
+  it("pushes the patched manifest to the provider holding the lease", async () => {
+    const { apiKey, sentManifests } = await setup({ recordsDefinition: true });
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+    expect(response.status).toBe(200);
+    expect(sentManifests()).toEqual([expect.stringContaining("nginx:1.27")]);
+  });
+
+  it("broadcasts an update of the deployment the patch rewrote", async () => {
+    const { apiKey, broadcastMessages } = await setup({ recordsDefinition: true });
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+    expect(response.status).toBe(200);
+    expect(broadcastMessages()).toEqual([{ typeUrl: `/akash.deployment.${deploymentVersion}.MsgUpdateDeployment`, value: expect.any(String) }]);
+  });
+
   function patch(apiKey: string | undefined, data: Record<string, unknown>) {
     const headers = new Headers({ "Content-Type": "application/json" });
     if (apiKey) headers.set("x-api-key", apiKey);
@@ -167,44 +146,87 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     return app.request(`/v1/deployments/${DSEQ}`, { method: "PATCH", body: JSON.stringify({ data }), headers });
   }
 
-  async function persistedUser() {
-    const dbUser = await userRepository.create({ userId: faker.string.uuid() });
-    const apiKey = faker.string.alphanumeric(24);
-    const user = createUser({ id: dbUser.id, userId: dbUser.userId ?? undefined });
+  async function persistApiKeyFor(userId: string) {
+    const apiKeyGenerator = container.resolve(ApiKeyGeneratorService);
+    const apiKey = apiKeyGenerator.generateApiKey();
 
-    knownUsers[dbUser.id] = user;
-    knownApiKeys[apiKey] = createApiKey({ userId: dbUser.id });
-    knownWallets[dbUser.id] = [createUserWallet({ userId: dbUser.id, address: createAkashAddress() })];
-
-    return { user, apiKey, address: knownWallets[dbUser.id][0].address! };
-  }
-
-  async function patchableDeployment() {
-    const { user, apiKey, address } = await persistedUser();
-
-    await deploymentSettingRepository.upsertDefinition({
-      userId: user.id,
-      dseq: DSEQ,
-      sdl: fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8"),
-      manifestVersion: REPLACED_MANIFEST_VERSION
+    await container.resolve(ApiKeyRepository).create({
+      userId,
+      name: faker.company.name(),
+      hashedKey: apiKeyGenerator.hashApiKeySha256(apiKey),
+      keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
     });
-    mockChainOf(address);
 
-    return { user, apiKey, address };
+    return apiKey;
   }
 
-  function mockChainOf(address: string) {
+  function nockChain({ address, provider }: { address: string; provider: string }) {
     const restUrl = container.resolve(CORE_CONFIG).REST_API_NODE_URL;
-    const leases = createManyLeaseApiResponses(1, { owner: address, dseq: DSEQ, state: "active" });
+    const leases = [createLeaseApiResponse({ owner: address, dseq: DSEQ, provider, state: "active" })];
 
     nock(restUrl)
       .persist()
-      .get(`/akash/deployment/${deploymentVersion}/deployments/info?id.owner=${address}&id.dseq=${DSEQ}`)
-      .reply(200, createDeploymentInfoSeed({ owner: address, dseq: DSEQ }));
-    nock(restUrl).persist().get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}`).reply(200, { leases });
-    nock(restUrl)
+      .get(`/akash/deployment/${deploymentVersion}/deployments/info`)
+      .query({ "id.owner": address, "id.dseq": DSEQ })
+      .reply(200, createDeploymentInfoSeed({ owner: address, dseq: DSEQ }))
+      .get(`/akash/market/${marketVersion}/leases/list`)
+      .query(query => query["filters.owner"] === address && query["filters.dseq"] === DSEQ)
+      .reply(200, { leases })
+      .get(/\/cosmos\/feegrant\/v1beta1\/allowances?\/.*/)
+      .reply(200, createFeeAllowanceResponse({ grantee: address, amount: "5000000" }))
+      .get(/\/cosmos\/authz\/v1beta1\/grants\?.*/)
+      .reply(200, createDeploymentGrantResponseSeed({ grantee: address, amount: "20000000", grantType: "/akash.escrow.v1.DepositAuthorization" }));
+  }
+
+  function nockTxSigner() {
+    const broadcastMessages: { typeUrl: string }[] = [];
+
+    nock(container.resolve(BILLING_CONFIG).TX_SIGNER_BASE_URL)
       .persist()
-      .get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}&pagination.limit=1000`)
-      .reply(200, { leases });
+      .post("/v1/tx/derived")
+      .reply(200, (_uri, body) => {
+        broadcastMessages.push(...(body as { data: { messages: { typeUrl: string }[] } }).data.messages);
+        return { data: { code: 0, hash: "SOME_HASH", rawLog: "[]" } };
+      });
+
+    return () => broadcastMessages;
+  }
+
+  function nockProviderProxy() {
+    const sentManifests: string[] = [];
+
+    nock(container.resolve(DeploymentConfigService).get("PROVIDER_PROXY_URL"))
+      .persist()
+      .post("/", body => (body as { url: string }).url.endsWith("/manifest"))
+      .reply(200, (_uri, body) => {
+        sentManifests.push((body as { body: string }).body);
+        return { ok: true };
+      })
+      .post("/", body => (body as { url: string }).url.includes("/status"))
+      .reply(200, createLeaseStatus());
+
+    return () => sentManifests;
+  }
+
+  async function setup(input: { recordsDefinition?: boolean } = {}) {
+    const { user, address } = await seedUserWithWallet({ isTrialing: false, activatedAt: new Date() });
+    const apiKey = await persistApiKeyFor(user.id);
+    const provider = createAkashAddress();
+
+    await createProvider({ owner: provider, deletedHeight: null });
+    nockChain({ address, provider });
+    const broadcastMessages = nockTxSigner();
+    const sentManifests = nockProviderProxy();
+
+    if (input.recordsDefinition) {
+      await deploymentSettingRepository.upsertDefinition({
+        userId: user.id,
+        dseq: DSEQ,
+        sdl: STORED_SDL,
+        manifestVersion: REPLACED_MANIFEST_VERSION
+      });
+    }
+
+    return { user, apiKey, sentManifests, broadcastMessages };
   }
 });

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -97,6 +97,14 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     expect(response.status).toBe(400);
   });
 
+  it("refuses an empty seal offered as the only thing the patch would write", async () => {
+    const { apiKey } = await persistedUser();
+
+    const response = await patch(apiKey, { services: { web: {} }, sealedSecrets: "" });
+
+    expect(response.status).toBe(400);
+  });
+
   it("refuses an env key that is not an environment variable name", async () => {
     const { apiKey } = await persistedUser();
 

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -1,5 +1,7 @@
 import { faker } from "@faker-js/faker";
 import nock from "nock";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { container } from "tsyringe";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -8,26 +10,37 @@ import { startJobQueues } from "@src/app/providers/jobs.provider";
 import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
 import type { UserWalletOutput } from "@src/billing/repositories";
 import { UserWalletRepository } from "@src/billing/repositories";
+import { ManagedSignerService } from "@src/billing/services";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import { CORE_CONFIG } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { app } from "@src/rest-app";
 import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
+import { deploymentVersion, marketVersion } from "@src/utils/constants";
 
 import { registerFakeSdlSecretsKms, warmSealingKeyAsBootWould } from "@test/mocks/sdl-secrets-kms.mock";
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { createApiKey } from "@test/seeders/api-key.seeder";
+import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
+import { createManyLeaseApiResponses } from "@test/seeders/lease-api-response.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 registerFakeSdlSecretsKms();
 
 const DSEQ = "1234";
+const REPLACED_MANIFEST_VERSION = "AAAA";
 
 describe("PATCH /v1/deployments/{dseq} route wiring", () => {
   const userRepository = container.resolve(UserRepository);
   const apiKeyAuthService = container.resolve(ApiKeyAuthService);
   const userWalletRepository = container.resolve(UserWalletRepository);
   const blockHttpService = container.resolve(BlockHttpService);
+  const signerService = container.resolve(ManagedSignerService);
+  const providerService = container.resolve(ProviderService);
+  const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
 
   let knownUsers: Record<string, UserOutput>;
   let knownApiKeys: Record<string, ReturnType<typeof createApiKey>>;
@@ -54,6 +67,13 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
         findOneByUserId: async (id: string) => knownWallets[id][0]
       })
     );
+    vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
+      code: 0,
+      transactionHash: "fake-transaction-hash",
+      hash: "fake-transaction-hash",
+      rawLog: "fake-raw-log"
+    });
+    vi.spyOn(providerService, "sendManifest").mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -113,6 +133,33 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     expect(response.status).toBe(400);
   });
 
+  it("answers 200 with the patched deployment under data", async () => {
+    const { apiKey } = await patchableDeployment();
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: {
+        deployment: expect.any(Object),
+        escrow_account: expect.any(Object),
+        leases: expect.arrayContaining([expect.any(Object)]),
+        manifestVersion: expect.any(String)
+      }
+    });
+  });
+
+  it("hands back the manifest version it recorded rather than the one the patch replaced", async () => {
+    const { apiKey, user } = await patchableDeployment();
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+    const { data } = (await response.json()) as { data: { manifestVersion: string } };
+    const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: DSEQ });
+    expect(data.manifestVersion).toBe(setting?.manifestVersion);
+    expect(data.manifestVersion).not.toBe(REPLACED_MANIFEST_VERSION);
+  });
+
   function patch(apiKey: string | undefined, data: Record<string, unknown>) {
     const headers = new Headers({ "Content-Type": "application/json" });
     if (apiKey) headers.set("x-api-key", apiKey);
@@ -129,6 +176,35 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     knownApiKeys[apiKey] = createApiKey({ userId: dbUser.id });
     knownWallets[dbUser.id] = [createUserWallet({ userId: dbUser.id, address: createAkashAddress() })];
 
-    return { user, apiKey };
+    return { user, apiKey, address: knownWallets[dbUser.id][0].address! };
+  }
+
+  async function patchableDeployment() {
+    const { user, apiKey, address } = await persistedUser();
+
+    await deploymentSettingRepository.upsertDefinition({
+      userId: user.id,
+      dseq: DSEQ,
+      sdl: fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8"),
+      manifestVersion: REPLACED_MANIFEST_VERSION
+    });
+    mockChainOf(address);
+
+    return { user, apiKey, address };
+  }
+
+  function mockChainOf(address: string) {
+    const restUrl = container.resolve(CORE_CONFIG).REST_API_NODE_URL;
+    const leases = createManyLeaseApiResponses(1, { owner: address, dseq: DSEQ, state: "active" });
+
+    nock(restUrl)
+      .persist()
+      .get(`/akash/deployment/${deploymentVersion}/deployments/info?id.owner=${address}&id.dseq=${DSEQ}`)
+      .reply(200, createDeploymentInfoSeed({ owner: address, dseq: DSEQ }));
+    nock(restUrl).persist().get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}`).reply(200, { leases });
+    nock(restUrl)
+      .persist()
+      .get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}&pagination.limit=1000`)
+      .reply(200, { leases });
   }
 });

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -53,6 +53,7 @@ describe("Deployment Settings", () => {
           userId: user.id,
           dseq,
           autoTopUpEnabled: true,
+          sdl: null,
           createdAt: expect.any(String),
           updatedAt: expect.any(String),
           estimatedTopUpAmount: expect.any(Number),
@@ -79,7 +80,7 @@ describe("Deployment Settings", () => {
       expect(response.status).toBe(200);
       const body = await response.text();
       const { data } = JSON.parse(body) as { data: Record<string, unknown> };
-      expect(data).not.toHaveProperty("sdl");
+      expect(data).toHaveProperty("sdl");
       expect(data).not.toHaveProperty("manifestVersion");
       expect(data).not.toHaveProperty("sealedSecrets");
       expect(body).not.toContain(sealedSecrets);
@@ -147,6 +148,7 @@ describe("Deployment Settings", () => {
           id: settings.id,
           userId: user.id,
           dseq,
+          sdl: null,
           autoTopUpEnabled: true,
           createdAt: expect.any(String),
           updatedAt: expect.any(String),

--- a/packages/console-api-types/src/notifications/schema.d.ts
+++ b/packages/console-api-types/src/notifications/schema.d.ts
@@ -118,6 +118,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -158,6 +159,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -294,6 +296,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -341,6 +344,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -510,6 +514,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {
@@ -557,6 +562,7 @@ export interface components {
               dseq: string;
               type: string;
               suppressedBySystem?: boolean;
+              reclaimNotifiedAt?: string;
             };
             conditions:
               | {

--- a/packages/console-api-types/src/operations.gen.ts
+++ b/packages/console-api-types/src/operations.gen.ts
@@ -223,6 +223,16 @@ export const operations = {
       queryParams: [],
       hasBody: false
     }
+  },
+  v2: {
+    getDeploymentSetting: {
+      path: "/v2/deployment-settings/{dseq}",
+      method: "get",
+      operationId: "getDeploymentSetting",
+      pathParams: ["dseq"],
+      queryParams: ["userId"],
+      hasBody: false
+    }
   }
 } as const;
 

--- a/packages/console-api-types/src/operations.gen.ts
+++ b/packages/console-api-types/src/operations.gen.ts
@@ -122,6 +122,7 @@ export const operations = {
       hasBody: false
     },
     updateDeployment: { path: "/v1/deployments/{dseq}", method: "put", operationId: "updateDeployment", pathParams: ["dseq"], queryParams: [], hasBody: true },
+    patchDeployment: { path: "/v1/deployments/{dseq}", method: "patch", operationId: "patchDeployment", pathParams: ["dseq"], queryParams: [], hasBody: true },
     createDeployment: { path: "/v1/deployments", method: "post", operationId: "createDeployment", pathParams: [], queryParams: [], hasBody: true },
     listDeployments: { path: "/v1/deployments", method: "get", operationId: "listDeployments", pathParams: [], queryParams: ["skip", "limit"], hasBody: false },
     depositDeployment: { path: "/v1/deposit-deployment", method: "post", operationId: "depositDeployment", pathParams: [], queryParams: [], hasBody: true },

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -8257,7 +8257,7 @@ export interface operations {
                 image?: string;
                 command?: string[] | null;
                 args?: string[] | null;
-                /** @description Merged into the service's env. A null value removes the variable. */
+                /** @description Merged into the service's env, keyed by environment variable name. A null value removes the variable. */
                 env?: {
                   [key: string]: string | null;
                 };
@@ -8405,7 +8405,10 @@ export interface operations {
         };
         content: {
           "application/json": {
+            error: string;
             message: string;
+            code: string;
+            type: string;
           };
         };
       };
@@ -8416,7 +8419,10 @@ export interface operations {
         };
         content: {
           "application/json": {
+            error: string;
             message: string;
+            code: string;
+            type: string;
           };
         };
       };
@@ -8427,19 +8433,38 @@ export interface operations {
         };
         content: {
           "application/json": {
+            error: string;
             message: string;
+            code: string;
+            type: string;
           };
         };
       };
-      /** @description The stored secrets could not be read. Permanent rather than transient: `code` is `stored_secrets_unreadable` and the stored token is left untouched, so a retry cannot help */
+      /** @description The deployment's stored state could not be read. Permanent rather than transient, so a retry cannot help, and the stored token is left untouched: `code` is `stored_secrets_unreadable` when the sealed secrets would not open and `stored_sdl_unreadable` when the recorded SDL would not parse */
       500: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "application/json": {
+            error: string;
             message: string;
             code: string;
+            type: string;
+          };
+        };
+      };
+      /** @description The key management service is temporarily unreachable. Transient and worth retrying, unlike the 500 above */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+            message: string;
+            code: string;
+            type: string;
           };
         };
       };

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -2110,7 +2110,7 @@ export interface paths {
     head?: never;
     /**
      * Patch a deployment
-     * @description Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.
+     * @description Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.
      */
     patch: operations["patchDeployment"];
     trace?: never;
@@ -8257,7 +8257,7 @@ export interface operations {
                 image?: string;
                 command?: string[] | null;
                 args?: string[] | null;
-                /** @description Merged into the service's env, keyed by environment variable name. A null value removes the variable. */
+                /** @description Merged into the service's env, keyed by environment variable name. A null value removes the variable. A patched variable is re-appended, so the order of the stored env list may change. */
                 env?: {
                   [key: string]: string | null;
                 };

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -8782,7 +8782,11 @@ export interface operations {
     requestBody?: {
       content: {
         "application/json": {
-          manifest: string;
+          /**
+           * @deprecated
+           * @description The manifest to send to the provider, in YAML format (deprecated)
+           */
+          manifest?: string;
           leases: {
             dseq: string;
             gseq: number;

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -8291,7 +8291,7 @@ export interface operations {
                 };
               };
             };
-            /** @description Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. */
+            /** @description Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it. */
             ifManifestVersion?: string;
           };
         };
@@ -8426,7 +8426,7 @@ export interface operations {
           };
         };
       };
-      /** @description The deployment definition changed since the manifest version this patch expected. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds */
+      /** @description The deployment definition changed between this patch reading it and writing it. A patch naming no `ifManifestVersion` is guarded on the version it read, so a concurrent patch produces this too. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds */
       409: {
         headers: {
           [name: string]: unknown;

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -1665,6 +1665,7 @@ export interface paths {
                 id: string;
                 userId: string;
                 dseq: string;
+                sdl: string | null;
                 autoTopUpEnabled: boolean;
                 estimatedTopUpAmount: number;
                 topUpFrequencyMs: number;
@@ -1735,6 +1736,7 @@ export interface paths {
                 id: string;
                 userId: string;
                 dseq: string;
+                sdl: string | null;
                 autoTopUpEnabled: boolean;
                 estimatedTopUpAmount: number;
                 topUpFrequencyMs: number;
@@ -1832,6 +1834,7 @@ export interface paths {
                 id: string;
                 userId: string;
                 dseq: string;
+                sdl: string | null;
                 autoTopUpEnabled: boolean;
                 estimatedTopUpAmount: number;
                 topUpFrequencyMs: number;
@@ -1866,62 +1869,7 @@ export interface paths {
       cookie?: never;
     };
     /** Get deployment settings by dseq */
-    get: {
-      parameters: {
-        query?: {
-          userId?: string;
-        };
-        header?: never;
-        path: {
-          dseq: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Returns deployment settings */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                /** Format: uuid */
-                id: string;
-                userId: string;
-                dseq: string;
-                autoTopUpEnabled: boolean;
-                estimatedTopUpAmount: number;
-                topUpFrequencyMs: number;
-                /** @description Runtime limit in hours chosen at deployment creation, or null for always-on funding */
-                runtimeLimitHours: number | null;
-                /**
-                 * Format: date-time
-                 * @description When the runtime limit is reached, anchored at lease start; null until the lease starts or when no limit is set
-                 */
-                runtimeEndsAt: string | null;
-                /** Format: date-time */
-                createdAt: string;
-                /** Format: date-time */
-                updatedAt: string;
-              };
-            };
-          };
-        };
-        /** @description Deployment settings not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              message: string;
-            };
-          };
-        };
-      };
-    };
+    get: operations["getDeploymentSetting"];
     put?: never;
     post?: never;
     delete?: never;
@@ -1962,6 +1910,7 @@ export interface paths {
                 id: string;
                 userId: string;
                 dseq: string;
+                sdl: string | null;
                 autoTopUpEnabled: boolean;
                 estimatedTopUpAmount: number;
                 topUpFrequencyMs: number;
@@ -2062,6 +2011,7 @@ export interface paths {
                 id: string;
                 userId: string;
                 dseq: string;
+                sdl: string | null;
                 autoTopUpEnabled: boolean;
                 estimatedTopUpAmount: number;
                 topUpFrequencyMs: number;
@@ -7966,6 +7916,63 @@ export interface operations {
               /** @description USD amount every deployment is bootstrapped with at creation, before funding tops it up toward the target runway */
               defaultDepositUsd: number;
             };
+          };
+        };
+      };
+    };
+  };
+  getDeploymentSetting: {
+    parameters: {
+      query?: {
+        userId?: string;
+      };
+      header?: never;
+      path: {
+        dseq: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Returns deployment settings */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              /** Format: uuid */
+              id: string;
+              userId: string;
+              dseq: string;
+              sdl: string | null;
+              autoTopUpEnabled: boolean;
+              estimatedTopUpAmount: number;
+              topUpFrequencyMs: number;
+              /** @description Runtime limit in hours chosen at deployment creation, or null for always-on funding */
+              runtimeLimitHours: number | null;
+              /**
+               * Format: date-time
+               * @description When the runtime limit is reached, anchored at lease start; null until the lease starts or when no limit is set
+               */
+              runtimeEndsAt: string | null;
+              /** Format: date-time */
+              createdAt: string;
+              /** Format: date-time */
+              updatedAt: string;
+            };
+          };
+        };
+      };
+      /** @description Deployment settings not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            message: string;
           };
         };
       };

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -2100,7 +2100,7 @@ export interface paths {
     /**
      * Update a deployment (deprecated)
      * @deprecated
-     * @description Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. This endpoint will be removed in a future release.
+     * @description Deprecated. Resubmits the whole SDL, so rotating one secret means re-supplying every other value the document carries, and the console cannot return a stored value for you to resupply. Use PATCH /v1/deployments/{dseq} instead. This endpoint will be removed in a future release.
      */
     put: operations["updateDeployment"];
     post?: never;
@@ -2108,7 +2108,11 @@ export interface paths {
     delete: operations["closeDeployment"];
     options?: never;
     head?: never;
-    patch?: never;
+    /**
+     * Patch a deployment
+     * @description Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.
+     */
+    patch: operations["patchDeployment"];
     trace?: never;
   };
   "/v1/deployments": {
@@ -8228,6 +8232,214 @@ export interface operations {
             data: {
               success: boolean;
             };
+          };
+        };
+      };
+    };
+  };
+  patchDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Deployment sequence number */
+        dseq: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          data: {
+            /** @description Keyed by service name. Only the named services are touched; omitted services keep their current definition. */
+            services: {
+              [key: string]: {
+                image?: string;
+                command?: string[] | null;
+                args?: string[] | null;
+                /** @description Merged into the service's env. A null value removes the variable. */
+                env?: {
+                  [key: string]: string | null;
+                };
+                /** @description Private registry pull credentials. Null clears them. */
+                credentials?: {
+                  host: string;
+                  username: string;
+                  password: string;
+                } | null;
+                /** @description Keyed by container port. Only hosts and http options are patchable; endpoint kind and count are fixed at create. */
+                expose?: {
+                  [key: string]: {
+                    /** @description Custom domains. Replaces the existing list. */
+                    accept?: string[];
+                    httpOptions?: {
+                      maxBodySize?: number;
+                      readTimeout?: number;
+                      sendTimeout?: number;
+                      nextTries?: number;
+                      nextTimeout?: number;
+                      nextCases?: string[];
+                    };
+                  };
+                };
+                /** @description Keyed by volume name. Mount point only — sizes are fixed at create. */
+                storage?: {
+                  [key: string]: {
+                    mount?: string;
+                    readOnly?: boolean;
+                  };
+                };
+              };
+            };
+            /** @description Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on. */
+            ifManifestVersion?: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Deployment patched successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              deployment: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                };
+                state: string;
+                hash: string;
+                created_at: string;
+              };
+              leases: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                  gseq: number;
+                  oseq: number;
+                  provider: string;
+                  bseq: number;
+                };
+                state: string;
+                price: {
+                  denom: string;
+                  amount: string;
+                };
+                created_at: string;
+                closed_on: string;
+                reason?: string;
+                status: {
+                  forwarded_ports: {
+                    [key: string]: {
+                      port: number;
+                      externalPort: number;
+                      host?: string;
+                      available?: number;
+                    }[];
+                  };
+                  ips: {
+                    [key: string]: {
+                      IP: string;
+                      Port: number;
+                      ExternalPort: number;
+                      Protocol: string;
+                    }[];
+                  };
+                  services: {
+                    [key: string]: {
+                      name: string;
+                      available: number;
+                      total: number;
+                      uris: string[];
+                      observed_generation: number;
+                      replicas: number;
+                      updated_replicas: number;
+                      ready_replicas: number;
+                      available_replicas: number;
+                    };
+                  };
+                } | null;
+              }[];
+              escrow_account: {
+                id: {
+                  scope: string;
+                  xid: string;
+                };
+                state: {
+                  owner: string;
+                  state: string;
+                  transferred: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  settled_at: string;
+                  funds: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  deposits: {
+                    owner: string;
+                    height: string;
+                    source: string;
+                    balance: {
+                      denom: string;
+                      amount: string;
+                    };
+                  }[];
+                };
+              };
+              /** @description Base64 manifest version this patch recorded and committed on chain. */
+              manifestVersion: string;
+            };
+          };
+        };
+      };
+      /** @description The patch names a service, port or volume the stored SDL does not declare, supplies a secret name it does not reference, or leaves a reference with no value */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            message: string;
+          };
+        };
+      };
+      /** @description No SDL is recorded for this deployment, so there is nothing to patch */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            message: string;
+          };
+        };
+      };
+      /** @description The deployment definition changed since the manifest version this patch expected */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            message: string;
+          };
+        };
+      };
+      /** @description The stored secrets could not be read. Permanent rather than transient: `code` is `stored_secrets_unreadable` and the stored token is left untouched, so a retry cannot help */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            message: string;
+            code: string;
           };
         };
       };

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -8282,7 +8282,7 @@ export interface operations {
                     };
                   };
                 };
-                /** @description Keyed by volume name. Mount point only — sizes are fixed at create. */
+                /** @description Keyed by volume name. Mount point and read-only flag only — sizes are fixed at create. */
                 storage?: {
                   [key: string]: {
                     mount?: string;
@@ -8440,7 +8440,7 @@ export interface operations {
           };
         };
       };
-      /** @description The deployment's stored state could not be read. Permanent rather than transient, so a retry cannot help, and the stored token is left untouched: `code` is `stored_secrets_unreadable` when the sealed secrets would not open and `stored_sdl_unreadable` when the recorded SDL would not parse */
+      /** @description The deployment's stored state could not be read: `code` is `stored_secrets_unreadable` when the sealed secrets would not open and `stored_sdl_unreadable` when the recorded SDL would not parse. Both are permanent rather than transient, so a retry cannot help, and both leave the stored token untouched. A 500 carrying any other `code` is an unexpected failure and promises neither of those things */
       500: {
         headers: {
           [name: string]: unknown;

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -2110,7 +2110,7 @@ export interface paths {
     head?: never;
     /**
      * Patch a deployment
-     * @description Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw.
+     * @description Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.
      */
     patch: operations["patchDeployment"];
     trace?: never;
@@ -8291,7 +8291,7 @@ export interface operations {
                 };
               };
             };
-            /** @description Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on. */
+            /** @description Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. */
             ifManifestVersion?: string;
           };
         };
@@ -8426,7 +8426,7 @@ export interface operations {
           };
         };
       };
-      /** @description The deployment definition changed since the manifest version this patch expected */
+      /** @description The deployment definition changed since the manifest version this patch expected. Re-sending the identical patch is not a conflict, because the version it recomputes is the one the row already holds */
       409: {
         headers: {
           [name: string]: unknown;

--- a/packages/dev-config/eslint/base.mjs
+++ b/packages/dev-config/eslint/base.mjs
@@ -75,6 +75,7 @@ export default [
           additionalVerbs: {
             get: { collection: ["export"] },
             post: { collection: ["deposit", "screen", "apply", "validate", "confirm", "accept"] },
+            patch: { single: ["patch"] },
             delete: { single: ["close"] }
           }
         }


### PR DESCRIPTION
## Why

Part of CON-864.

Mounts `PATCH /v1/deployments/{dseq}` on the pipeline the previous PRs built, and points the deprecated PUT at it now that it exists. This is the PR that makes the behaviour reachable.

## Review round 1 — one blocking finding, fixed here

`400` and `500` were not declared on the route, so the AC5 retry signal was absent from the generated client: a client cannot see a response that is not in the document, and `500 stored_secrets_unreadable` *is* the "do not retry" signal. Both are now declared and reach `openapi.json` and `schema.d.ts` — verified: response codes are `200 400 404 409 500` in both.

## What

`sealedSecrets` is accepted and validated but withheld from every generated document via the route's `undocumentedRequestFields`, exactly as the create route does it — verified: the string appears nowhere in the published spec or the generated types. The body limit matches the create route's, because a patch may carry a seal and the default allowance would shadow the stated secret limits.

`akash/operation-id-format` allows only the verb `update` for a single-resource PATCH, and `updateDeployment` is already taken by the PUT this supersedes; renaming that would break the generated SDK. So `patch` joins the allowed verbs for that shape rather than the route carrying a one-off eslint-disable. That is a one-line change to a shared config, with the incidental prettier reflow reverted — `main`'s own version of that file is already prettier-non-conforming, so the reflow came from the pre-commit hook and is not ours to land.

The route description records that the definition is written **before** the chain transaction is broadcast, so a failed broadcast leaves the console describing a manifest version the chain never saw.

### The committed `openapi.json` is already stale on `main`, and I did not absorb the drift

A full regeneration brings in **9 hunks that are not ours**: `reclaimNotifiedAt` in several places, a lease `manifest` field deprecation plus its removal from `required`, and `suppressedBySystem`. Absorbing them would misattribute three other features to this PR. So only this route's path item is taken from the generator, and it is **proved byte-identical** to what the generator produced for it, with `/v1/deployments/{dseq}` verified as the only path differing from the previous commit. **Separate repo-hygiene item for someone to own — not ours.**

### A repo-wide naming decision riding in this PR — flagging it explicitly

`patch: { single: ["patch"] }` in `packages/dev-config/eslint/base.mjs` newly permits `patchFoo` as an operationId across **every workspace** where the rule previously mandated `updateFoo`. It is additive, narrow and needed here — `updateDeployment` is taken by the PUT this supersedes, and renaming that would break the generated SDK — but it is a repo-wide convention change arriving inside a feature PR rather than on its own, and it should be read as such rather than as incidental.

### A generator hazard worth fixing separately

`npm run sdk:gen:swagger` is `rm -rf ./swagger && npm run build:app && …`. The `rm -rf` runs **before** the step that can fail, so any type error in the build project deletes the committed spec and leaves a deletion the developer has to notice and restore by hand. It cost exactly that once during this work (it was failing on `main` at the time, since fixed by an unrelated commit). Reordering, or writing to a temp path and moving on success, would remove it.

## Demo


Rotating one credential must not mean re-entering the others, and changing unrelated configuration must not mean re-entering any of them. This drives the new endpoint against a real database, the real cipher and the real route — not the test suite.

Eight scenarios: rotate one secret, change the SDL with no secrets at all, drop a reference, tamper with a stored token, name a key the deployment does not have, use a stale `ifManifestVersion`, patch beside a plaintext value in a service the request never named, and misspell a secret name.

Secret values are throwaways generated per run and are never printed, not even a prefix — the document reports names, lengths and equality only, which is also what makes it reproducible under `showboat verify`.

### The published contract

The route is mounted; `sealedSecrets` is accepted and validated but withheld from every generated document, the same treatment the create route gives it.

```bash
cd apps/api && python3 -c "
import json
d = json.load(open(\"swagger/openapi.json\"))
op = d[\"paths\"][\"/v1/deployments/{dseq}\"]
print(\"methods:\", \" \".join(sorted(op)))
patch = op[\"patch\"]
print(\"operationId:\", patch[\"operationId\"])
print(\"response codes:\", \" \".join(sorted(patch[\"responses\"])))
body = patch[\"requestBody\"][\"content\"][\"application/json\"][\"schema\"][\"properties\"][\"data\"]
print(\"published request fields:\", \" \".join(body[\"properties\"]))
print(\"sealedSecrets anywhere in the spec:\", \"sealedSecrets\" in json.dumps(d))
print(\"put deprecated:\", op[\"put\"].get(\"deprecated\"))
"
```

```output
methods: delete get patch put
operationId: patchDeployment
response codes: 200 400 404 409 500
published request fields: services ifManifestVersion
sealedSecrets anywhere in the spec: False
put deprecated: True
```

### The eight scenarios

The driver seeds a deployment the way CON-863 stores one — values in a sealed token, the SDL referencing them by name — then drives the endpoint over HTTP and reports what the row and the token actually hold afterwards. It copies itself into the functional suite, runs, and removes itself.

```bash
cp .work/con-864/demo-driver.ts apps/api/test/functional/_con864_demo.spec.ts
rm -f /tmp/con864-demo.txt
cd apps/api && CON864_DEMO_OUT=/tmp/con864-demo.txt LOG_LEVEL=fatal npm run test:functional -- _con864_demo >/dev/null 2>&1
rm -f test/functional/_con864_demo.spec.ts
cat /tmp/con864-demo.txt
```

```output

=== 1. ROTATE ONE SECRET, THE OTHERS MUST SURVIVE ===
  stored token opens to: {"s0_e0":"<36 chars, withheld>","s0_e1":"<36 chars, withheld>"}
  PATCH status: 200
  token now opens to: {"s0_e0":"<36 chars, withheld>","s0_e1":"<36 chars, withheld>"}
  s0_e0 now holds the value this request supplied: true
  s0_e0 is no longer the value it held before: true
  s0_e1 is byte-identical to before the patch: true

=== 2. CHANGE THE SDL, SUPPLY NO SECRETS AT ALL ===
  PATCH status (no sealedSecrets in the request): 200
  recorded sdl carries the new image: true
  recorded sdl still references, never carries, the values: true
  every stored value still resolves: true
  the recorded document resolves end to end: true

=== 3. DROP A REFERENCE FROM THE SDL ===
  names in the token before: ["s0_e0","s0_e1"]
  PATCH status: 200
  names in the re-sealed token after: ["s0_e0"]
  recorded sdl still mentions DATABASE_URL: false

=== 4. TAMPER WITH THE STORED TOKEN ===
  flipped one character of the ciphertext segment: true
  PATCH status: 500
  body: {"error":"InternalServerError","message":"Unable to read stored secrets","code":"stored_secrets_unreadable","type":"server_error"}
  stored sdl unchanged: true
  manifest version unchanged: true
  the tampered token was NOT overwritten: true

=== 5. A KEY THE DEPLOYMENT DOES NOT HAVE ===
  PATCH status for an unknown service: 400
  message: "api" is not a service of this deployment
  nothing persisted: true

=== 6. A STALE ifManifestVersion ===
  PATCH status with a stale expected version: 409
  nothing persisted: true
  PATCH status with the current expected version: 200

=== 7. A PLAINTEXT VALUE IN A SERVICE THE PATCH NEVER NAMED ===
  stored sdl holds LOG_LEVEL in the clear: true
  PATCH status: 200
  LOG_LEVEL is STILL in the clear, readable to its owner: true
  it was not pulled into the token: ["s0_e0"]

=== 8. A MISSPELLED SECRET NAME ===
  PATCH status: 400
  message: Invalid SDL: a value was supplied for "s0_eTYPO" but no service's SDL references it
  nothing persisted: true
```

### The latent collision this uncovered

Derivation named a secret from its slot's position alone. Nothing checked whether another slot in the same document was already referencing that name — and a patched document *always* carries references.

The evidence below was produced by reverting `sdl-secrets-derivation.service.ts` to its pre-fix state and rerunning its spec. It is recorded rather than executed by this document, so nothing here can damage a reader's checkout. **The reproduction overwrites a tracked source file in place — run it only in a scratch clone:**

    FILE=apps/api/src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service.ts
    git show <commit-before-the-fix>:$FILE > $FILE
    ( cd apps/api && npm run test:unit -- sdl-secrets-derivation )
    git checkout HEAD -- $FILE

Recorded result:

     Test Files  1 failed (1)
          Tests  4 failed | 41 passed (45)

    × does not mint the name a reference elsewhere already holds
    × leaves that reference resolving to its own stored value rather than to the derived one
    × keeps one name per slot when positions have shifted under the references
    × avoids a name a registry credential reference is standing on

The failure that matters:

    - Expected
    + Received

      [
    -   "A=ac-secret://s0_e0_2",
    +   "A=ac-secret://s0_e0",
        "B=ac-secret://s0_e0",

Both `A` and `B` reference `ac-secret://s0_e0`. `A`'s newly supplied value is stored under that name, so **`B` silently resolves to `A`'s value** — one secret leaking into a second position, with no error anywhere. Most of that spec passes either way, which is why nothing already in the repo caught it.

Unreachable from create and update as they stand, because both derive from a *submitted* document: with no seal, intake refuses a document carrying references at all, and with a seal, env values are not derived. A patch derives from the document the console *stored*, which always carries references — so this endpoint is what would have made it live.

Measured: 725 non-excluded changed lines. `apps/api` tsc 42 against a 42 baseline, lint 0, functional 406/406, generated types validate clean.

### Review round 4 — the 500's contract, and a test double

**The 500's documented code promised more than the route keeps.** Both 500s this path raises deliberately already attach an explicit `errorCode` (`stored_secrets_unreadable`, `stored_sdl_unreadable`), but the description read as though every 500 carried one of them, while an unexpected failure falls through `HonoErrorHandlerService` to `unknown_error` or `internal_server_error`. A client gating retries on the literal code could not tell them apart. The description now names what the two codes guarantee — permanent, non-retryable, stored token untouched — and says a 500 carrying any other code guarantees neither. That keeps AC5's non-retryable signal real for the cases it applies to instead of implying it covers every 500.

**The wallet double in the new route spec is built with `mock<UserWalletRepository>()`** rather than an object literal cast through `as unknown as`, which `.claude/instructions/use-mock-instead-of-as-unknown-as-in-tests.md` forbids. Reversing an earlier decline of mine: the pattern was declined where it appeared in code modelled on an existing sibling, but a brand-new file is a different call and it is a one-line change.

The generated artifacts — `openapi.json`, the docs snapshot and `packages/console-api-types/src/schema.d.ts` — are regenerated for both this description and the `storage` read-only correction made in the expose/storage PR.

### Review round 5 — what the route now promises on a retry

The chain-sync job this route's description leaned on is gone (see #3829), so the commit that claimed the recorded version reaches the chain durably is dropped rather than contradicted. What replaces it is the honest and more useful statement: a failed broadcast still leaves the console describing a version the chain never saw, **and re-sending the identical request repairs it**, because the patch recomputes the same manifest version, the guarded write accepts it rather than answering 409, and the call goes on to broadcast and push the manifest.

Said in three places and regenerated: the route description, the 409's description, and `ifManifestVersion`'s own field description.

Also fixes a test the dseq-pattern commit left failing: it regenerated `openapi.json` but not the snapshot `docs.spec.ts` asserts against, so 47 `"pattern"` entries still read the old broken `^d+$`. Kept as its own commit so the omission and its repair stay legible.

### A regression this stack introduced, and where the completeness check lives now

**Rotating a secret without touching a service field answered 400.** That is the endpoint's headline case and an acceptance criterion — a caller replacing one credential sends `{ services: { web: {} }, sealedSecrets }` and changes no field. The end-to-end test for it was failing (`expected 400 to be 200`).

The cause was placement, not strictness. The completeness check sat on `PatchServiceSchema`, which cannot see its sibling `sealedSecrets`, so a service patch naming no field looked vacuous however much the request as a whole was about to write. It moves to the `data` object — the smallest scope that can see both:

```ts
function patchesSomething(data) {
  return data.sealedSecrets !== undefined || Object.values(data.services).some(assignsAField);
}
```

`services` stays required with at least one entry, as the Spec declares, so naming a service and changing none of its fields remains the idiom for a secrets-only rotation. Everything the deeper check legitimately refused it still refuses: `{}`, and a lone `{ env: {} }`, `{ expose: {} }` or `{ storage: {} }` with no seal.

The one-level depth boundary is unchanged — `{ expose: { "80": {} } }` still goes to the writer, which is the only layer that can tell whether the document declares that port, and `command: []` is still a write because it clears the list.

`deployment.schema.spec.ts` now targets `PatchDeploymentRequestSchema` rather than a service patch in isolation, so the secrets-only shape is pinned by a unit failure and not only by the functional suite. Its three new cases were verified to fail against the old placement.

The emitted OpenAPI is byte-identical either way — `.refine` produces a `ZodEffects` that the generator unwraps — so `swagger/openapi.json` needs no regeneration for this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for partially updating deployments through `PATCH /v1/deployments/{dseq}`, including service settings, environment variables, credentials, exposure, storage, and secret rotation.
  * Added manifest-version conflict handling and deployment result details.
  * Deployment settings now include the stored SDL when available.
  * Added support for reclaim notification timestamps in alert data.

* **Documentation**
  * Updated API documentation with PATCH usage, validation, and retry guidance.

* **Deprecations**
  * Deprecated the legacy full-deployment PUT update endpoint and provider manifest responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
