### PR TITLE
test(deployment): cover patching a deployment in functional tests

### DIFF
--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -1,0 +1,543 @@
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { generateManifest, manifestToSortedJSON, yaml } from "@akashnetwork/chain-sdk";
+import { faker } from "@faker-js/faker";
+import { eq } from "drizzle-orm";
+import { CompactEncrypt } from "jose";
+import nock from "nock";
+import { randomUUID } from "node:crypto";
+import { container } from "tsyringe";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { startJobQueues } from "@src/app/providers/jobs.provider";
+import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
+import { AuthService } from "@src/auth/services/auth.service";
+import type { UserWalletOutput } from "@src/billing/repositories";
+import { UserWalletRepository } from "@src/billing/repositories";
+import { ManagedSignerService } from "@src/billing/services";
+import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import type { ApiPgDatabase } from "@src/core";
+import { CORE_CONFIG, POSTGRES_DB, resolveTable } from "@src/core";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import { SDL_SECRETS_CONTENT_ENCRYPTION, SDL_SECRETS_SEAL_ALGORITHM } from "@src/deployment/config/sdl-secrets.config";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import { ProviderService } from "@src/provider/services/provider/provider.service";
+import { app } from "@src/rest-app";
+import type { UserOutput } from "@src/user/repositories";
+import { UserRepository } from "@src/user/repositories";
+import { deploymentVersion, marketVersion } from "@src/utils/constants";
+
+import { registerFakeSdlSecretsKms, SDL_SECRETS_KID, warmSealingKeyAsBootWould } from "@test/mocks/sdl-secrets-kms.mock";
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { createApiKey } from "@test/seeders/api-key.seeder";
+import { createDeployment } from "@test/seeders/deployment.seeder";
+import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
+import { createManyLeaseApiResponses } from "@test/seeders/lease-api-response.seeder";
+import { createLeaseStatus } from "@test/seeders/lease-status.seeder";
+import { createUser } from "@test/seeders/user.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const { client: kmsClient, publicKey } = registerFakeSdlSecretsKms();
+
+const DSEQ = "1234";
+
+function storedSdl(env: string[], image = "nginx") {
+  return [
+    'version: "2.0"',
+    "services:",
+    "  web:",
+    `    image: ${image}`,
+    "    env:",
+    ...env.map(entry => `      - ${JSON.stringify(entry)}`),
+    "    expose:",
+    "      - port: 80",
+    "        as: 80",
+    "        to:",
+    "          - global: true",
+    "profiles:",
+    "  compute:",
+    "    web:",
+    "      resources:",
+    "        cpu:",
+    "          units: 0.1",
+    "        memory:",
+    "          size: 128Mi",
+    "        storage:",
+    "          - size: 128Mi",
+    "  placement:",
+    "    dcloud:",
+    "      pricing:",
+    "        web:",
+    "          denom: uakt",
+    "          amount: 1000",
+    "deployment:",
+    "  web:",
+    "    dcloud:",
+    "      profile: web",
+    "      count: 1",
+    ""
+  ].join("\n");
+}
+
+describe("PATCH /v1/deployments/{dseq}", () => {
+  const userRepository = container.resolve(UserRepository);
+  const apiKeyAuthService = container.resolve(ApiKeyAuthService);
+  const userWalletRepository = container.resolve(UserWalletRepository);
+  const blockHttpService = container.resolve(BlockHttpService);
+  const signerService = container.resolve(ManagedSignerService);
+  const providerService = container.resolve(ProviderService);
+  const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+
+  let knownUsers: Record<string, UserOutput>;
+  let knownApiKeys: Record<string, ReturnType<typeof createApiKey>>;
+  let knownWallets: Record<string, UserWalletOutput[]>;
+
+  beforeAll(async () => {
+    await startJobQueues();
+    await warmSealingKeyAsBootWould();
+  }, 20_000);
+
+  beforeEach(() => {
+    knownUsers = {};
+    knownApiKeys = {};
+    knownWallets = {};
+
+    vi.spyOn(userRepository, "findById").mockImplementation(async id =>
+      knownUsers[id] ? { ...knownUsers[id], trial: false, userWallets: { isTrialing: false } } : undefined
+    );
+    vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async key => knownApiKeys[key!]);
+    vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(faker.number.int({ min: 1000000, max: 10000000 }));
+    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue({
+      findByUserId: async (id: string) => knownWallets[id],
+      findOneByUserId: async (id: string) => knownWallets[id][0]
+    } as unknown as UserWalletRepository);
+    vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
+      code: 200,
+      transactionHash: "fake-transaction-hash",
+      hash: "fake-transaction-hash",
+      rawLog: "fake-raw-log"
+    });
+    vi.spyOn(providerService, "sendManifest").mockResolvedValue(true);
+    vi.spyOn(providerService, "getLeaseStatus").mockResolvedValue(createLeaseStatus());
+    vi.spyOn(providerService, "toProviderAuth").mockResolvedValue(mock());
+    kmsClient.asymmetricDecrypt.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  afterAll(async () => {
+    await container.dispose();
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("leaves every other name opening to its original plaintext when one value is replaced", async () => {
+    const secrets = { s0_e0: randomUUID(), s0_e1: `postgres://app:${randomUUID()}@db.internal/app` };
+    const { apiKey, user } = await patchable({ secrets });
+    const rotated = randomUUID();
+
+    const response = await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } } }, { s0_e0: rotated });
+
+    expect(response.status).toBe(200);
+    await expect(openStored(user)).resolves.toEqual({ s0_e0: rotated, s0_e1: secrets.s0_e1 });
+  });
+
+  it("keeps every stored value resolvable when the sdl changes and no secrets are supplied", async () => {
+    const secrets = { s0_e0: randomUUID(), s0_e1: randomUUID() };
+    const { apiKey, user } = await patchable({ secrets });
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+    expect(response.status).toBe(200);
+    const setting = await settingOf(user);
+    expect(setting?.sdl).toContain("nginx:1.27");
+    await expect(openStored(user)).resolves.toEqual(secrets);
+    expect((await container.resolve(SdlService).generateResolvedManifest({ sdl: setting!.sdl!, secrets })).ok).toBe(true);
+  });
+
+  it("drops a name from the re-sealed token once the sdl stops referencing it", async () => {
+    const secrets = { s0_e0: randomUUID(), s0_e1: randomUUID() };
+    const { apiKey, user } = await patchable({ secrets });
+
+    const response = await patch(apiKey, { services: { web: { env: { DATABASE_URL: null } } } });
+
+    expect(response.status).toBe(200);
+    await expect(openStored(user)).resolves.toEqual({ s0_e0: secrets.s0_e0 });
+  });
+
+  describe("a reference with no value anywhere", () => {
+    it("fails with a 4xx naming it", async () => {
+      const { apiKey } = await patchable({ secrets: { s0_e0: randomUUID() }, env: ["API_TOKEN=ac-secret://s0_e0", "ORPHAN=ac-secret://s0_e9"] });
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("ac-secret://s0_e9");
+    });
+
+    it("persists nothing", async () => {
+      const { apiKey, user } = await patchable({
+        secrets: { s0_e0: randomUUID() },
+        env: ["API_TOKEN=ac-secret://s0_e0", "ORPHAN=ac-secret://s0_e9"]
+      });
+      const before = await settingOf(user);
+
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect(await settingOf(user)).toMatchObject({
+        sdl: before!.sdl,
+        manifestVersion: before!.manifestVersion,
+        sealedSecrets: before!.sealedSecrets
+      });
+    });
+  });
+
+  describe("a stored token something has tampered with", () => {
+    it("fails with the permanent error rather than a retryable one", async () => {
+      const { apiKey, user } = await patchable();
+      await flipFirstCiphertextCharacterOfToken(user);
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toMatchObject({ message: "Unable to read stored secrets", code: "stored_secrets_unreadable" });
+    });
+
+    it("leaves the row intact, tampered token and all", async () => {
+      const { apiKey, user } = await patchable();
+      const tampered = await flipFirstCiphertextCharacterOfToken(user);
+      const before = await settingOf(user);
+
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect(await settingOf(user)).toMatchObject({
+        sdl: before!.sdl,
+        manifestVersion: before!.manifestVersion,
+        sealedSecrets: tampered
+      });
+    });
+  });
+
+  it("sends a lease provider a manifest reflecting both the new sdl and the new value", async () => {
+    const { apiKey } = await patchable({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
+    const rotated = randomUUID();
+    const kept = randomUUID();
+    await patch(apiKey, { services: { web: { env: { DATABASE_URL: kept } } } });
+    vi.mocked(providerService.sendManifest).mockClear();
+
+    await patch(apiKey, { services: { web: { image: "nginx:1.27", env: { API_TOKEN: rotated } } } }, { s0_e0: rotated });
+
+    const expected = await manifestOf(storedSdl([`API_TOKEN=${rotated}`, `DATABASE_URL=${kept}`], "nginx:1.27"));
+    expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ manifest: expected }));
+  });
+
+  describe("what it spends on the key service", () => {
+    it("unwraps once for a patch that changes twelve secrets and supplies none", async () => {
+      const env = Array.from({ length: 12 }, (_, index) => `VAR_${index}=ac-secret://s0_e${index}`);
+      const secrets = Object.fromEntries(env.map((_, index) => [`s0_e${index}`, randomUUID()]));
+      const { apiKey } = await patchable({ secrets, env });
+
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(1);
+    });
+
+    it("unwraps the seal and the data key once each when a patch supplies values", async () => {
+      const env = Array.from({ length: 12 }, (_, index) => `VAR_${index}=ac-secret://s0_e${index}`);
+      const secrets = Object.fromEntries(env.map((_, index) => [`s0_e${index}`, randomUUID()]));
+      const { apiKey } = await patchable({ secrets, env });
+      const supplied = Object.fromEntries(env.map((_, index) => [`s0_e${index}`, randomUUID()]));
+
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, supplied);
+
+      expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("where the sdl comes from", () => {
+    it("ignores an sdl the request tries to carry", async () => {
+      const { apiKey, user } = await patchable();
+
+      const response = await request(apiKey, {
+        services: { web: { image: "nginx:1.27" } },
+        sdl: storedSdl(["INJECTED=ac-secret://s0_e0"], "attacker/image")
+      });
+
+      expect(response.status).toBe(200);
+      expect((await settingOf(user))?.sdl).not.toContain("attacker/image");
+    });
+
+    it("answers 404 for a deployment the console recorded no sdl for", async () => {
+      const { apiKey } = await patchable({ record: false });
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe("the version a patch expects", () => {
+    it("applies the patch when the expected version is still current", async () => {
+      const { apiKey, user } = await patchable();
+      const current = (await settingOf(user))!.manifestVersion!;
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: current });
+
+      expect(response.status).toBe(200);
+    });
+
+    it("answers 409 and persists nothing when the deployment has moved on", async () => {
+      const { apiKey, user } = await patchable();
+      const before = await settingOf(user);
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: "AAAAmovedon" });
+
+      expect(response.status).toBe(409);
+      expect((await settingOf(user))?.sdl).toBe(before!.sdl);
+    });
+  });
+
+  describe("a key the deployment does not have", () => {
+    it("answers 400 naming a service the sdl does not declare", async () => {
+      const { apiKey } = await patchable();
+
+      const response = await patch(apiKey, { services: { api: { image: "nginx" } } });
+
+      expect(response.status).toBe(400);
+      expect(((await response.json()) as { message: string }).message).toContain("is not a service of this deployment");
+    });
+
+    it("answers 400 naming a port the service does not expose", async () => {
+      const { apiKey } = await patchable();
+
+      const response = await patch(apiKey, { services: { web: { expose: { "8080": { accept: ["x.test"] } } } } });
+
+      expect(response.status).toBe(400);
+      expect(((await response.json()) as { message: string }).message).toContain('exposes no port "8080"');
+    });
+
+    it("refuses a patch naming no services at all", async () => {
+      const { apiKey } = await patchable();
+
+      const response = await patch(apiKey, { services: {} });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("a plaintext value in a service the patch never named", () => {
+    it("stays in the clear, readable to its owner", async () => {
+      const { apiKey, user } = await patchable({ env: ["API_TOKEN=ac-secret://s0_e0", "LOG_LEVEL=debug"], secrets: { s0_e0: randomUUID() } });
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect(response.status).toBe(200);
+      expect((await settingOf(user))?.sdl).toContain("LOG_LEVEL=debug");
+    });
+
+    it("is not pulled into the sealed token", async () => {
+      const token = randomUUID();
+      const { apiKey, user } = await patchable({ env: ["API_TOKEN=ac-secret://s0_e0", "LOG_LEVEL=debug"], secrets: { s0_e0: token } });
+
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      await expect(openStored(user)).resolves.toEqual({ s0_e0: token });
+    });
+
+    it("is sealed once the patch does name it", async () => {
+      const { apiKey, user } = await patchable({ env: ["API_TOKEN=ac-secret://s0_e0", "LOG_LEVEL=debug"], secrets: { s0_e0: randomUUID() } });
+
+      const response = await patch(apiKey, { services: { web: { env: { LOG_LEVEL: "trace" } } } });
+
+      expect(response.status).toBe(200);
+      const setting = await settingOf(user);
+      expect(setting?.sdl).not.toContain("LOG_LEVEL=trace");
+      expect(Object.values(await openStored(user))).toContain("trace");
+    });
+  });
+
+  describe("a supplied secret name the sdl does not reference", () => {
+    it("answers 400 naming it rather than silently dropping it", async () => {
+      const { apiKey } = await patchable();
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, { s0_eTYPO: randomUUID() });
+
+      expect(response.status).toBe(400);
+      expect(((await response.json()) as { message: string }).message).toContain("s0_eTYPO");
+    });
+
+    it("persists nothing", async () => {
+      const { apiKey, user } = await patchable();
+      const before = await settingOf(user);
+
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, { s0_eTYPO: randomUUID() });
+
+      expect((await settingOf(user))?.sdl).toBe(before!.sdl);
+    });
+  });
+
+  it("refuses an expected manifest version longer than the column can hold", async () => {
+    const { apiKey } = await patchable();
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: "A".repeat(65) });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("accepts an expected manifest version exactly at the column's bound", async () => {
+    const { apiKey } = await patchable();
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: "A".repeat(64) });
+
+    expect(response.status).toBe(409);
+  });
+
+  it("returns the manifest version it recorded", async () => {
+    const { apiKey, user } = await patchable();
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+    const { data } = (await response.json()) as { data: { manifestVersion: string } };
+    expect(data.manifestVersion).toBe((await settingOf(user))!.manifestVersion);
+  });
+
+  it("rejects an unauthenticated request", async () => {
+    const response = await app.request(`/v1/deployments/${DSEQ}`, {
+      method: "PATCH",
+      body: JSON.stringify({ data: { services: { web: { image: "nginx" } } } }),
+      headers: new Headers({ "Content-Type": "application/json" })
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  async function manifestOf(sdl: string) {
+    const manifest = generateManifest(yaml.raw<SDLInput>(sdl));
+    expect(manifest.ok).toBe(true);
+
+    return manifestToSortedJSON((manifest as Extract<typeof manifest, { ok: true }>).value.groups);
+  }
+
+  async function recordedVersionFor(sdl: string, secrets: Record<string, string>) {
+    const resolved = await container.resolve(SdlService).generateResolvedManifest({ sdl, secrets });
+
+    return resolved.ok ? Buffer.from(resolved.value.manifestVersion).toString("base64") : Buffer.from("unresolvable-fixture").toString("base64");
+  }
+
+  async function settingOf(user: UserOutput) {
+    return await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: DSEQ });
+  }
+
+  async function openStored(user: UserOutput) {
+    const setting = await settingOf(user);
+
+    return await container.resolve(ExecutionContextService).runWithContext(async () => {
+      container.resolve(AuthService).currentUser = user;
+
+      return await container.resolve(SdlSecretsService).openStored({ userId: user.id, dseq: DSEQ, sealedSecrets: setting!.sealedSecrets! });
+    });
+  }
+
+  async function flipFirstCiphertextCharacterOfToken(user: UserOutput) {
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const table = resolveTable("DeploymentSettings");
+    const setting = await settingOf(user);
+    const segments = setting!.sealedSecrets!.split(".");
+    segments[3] = `${segments[3][0] === "A" ? "B" : "A"}${segments[3].slice(1)}`;
+    const tampered = segments.join(".");
+
+    await db.update(table).set({ sealedSecrets: tampered }).where(eq(table.id, setting!.id));
+
+    return tampered;
+  }
+
+  async function sealFor(user: UserOutput, secrets: Record<string, string>) {
+    return await new CompactEncrypt(new TextEncoder().encode(JSON.stringify(secrets)))
+      .setProtectedHeader({
+        alg: SDL_SECRETS_SEAL_ALGORITHM,
+        enc: SDL_SECRETS_CONTENT_ENCRYPTION,
+        kid: SDL_SECRETS_KID,
+        sub: user.id,
+        exp: Math.floor(Date.now() / 1000) + 300
+      })
+      .encrypt(publicKey);
+  }
+
+  function patch(apiKey: string, data: Record<string, unknown>, secrets?: Record<string, string>) {
+    return request(apiKey, data, secrets);
+  }
+
+  async function request(apiKey: string, data: Record<string, unknown>, secrets?: Record<string, string>) {
+    const user = knownUsers[knownApiKeys[apiKey].userId];
+    const sealedSecrets = secrets ? await sealFor(user, secrets) : undefined;
+
+    return await app.request(`/v1/deployments/${DSEQ}`, {
+      method: "PATCH",
+      body: JSON.stringify({ data: { ...data, sealedSecrets } }),
+      headers: new Headers({ "Content-Type": "application/json", "x-api-key": apiKey })
+    });
+  }
+
+  function referencedNamesIn(env: string[]) {
+    return env.flatMap(entry => entry.match(/ac-secret:\/\/([A-Za-z_][A-Za-z0-9_]*)/)?.slice(1) ?? []);
+  }
+
+  async function patchable(input: { secrets?: Record<string, string>; env?: string[]; record?: boolean } = {}) {
+    const dbUser = await userRepository.create({ userId: faker.string.uuid() });
+    const apiKey = faker.string.alphanumeric(24);
+    const user = createUser({ id: dbUser.id, userId: dbUser.userId ?? undefined });
+    const address = createAkashAddress();
+
+    knownUsers[dbUser.id] = user;
+    knownApiKeys[apiKey] = createApiKey({ userId: dbUser.id });
+    knownWallets[dbUser.id] = [createUserWallet({ userId: dbUser.id, address })];
+
+    const env = input.env ?? ["API_TOKEN=ac-secret://s0_e0", "DATABASE_URL=ac-secret://s0_e1"];
+    const sdl = storedSdl(env);
+    const secrets = input.secrets ?? Object.fromEntries(referencedNamesIn(env).map(name => [name, randomUUID()]));
+
+    await mockChain(address);
+
+    if (input.record !== false) {
+      const sealedSecrets = await container.resolve(ExecutionContextService).runWithContext(async () => {
+        container.resolve(AuthService).currentUser = user;
+
+        return await container.resolve(SdlSecretsService).sealForStorage({ userId: user.id, dseq: DSEQ, secrets });
+      });
+
+      await deploymentSettingRepository.upsertDefinition({
+        userId: user.id,
+        dseq: DSEQ,
+        sdl,
+        manifestVersion: await recordedVersionFor(sdl, secrets),
+        sealedSecrets
+      });
+    } else {
+      await deploymentSettingRepository.createDefaultIfMissing({ userId: user.id, dseq: DSEQ });
+    }
+
+    kmsClient.asymmetricDecrypt.mockClear();
+
+    return { user, apiKey, address, sdl, secrets };
+  }
+
+  async function mockChain(address: string) {
+    const restUrl = container.resolve(CORE_CONFIG).REST_API_NODE_URL;
+    const info = createDeploymentInfoSeed({ owner: address, dseq: DSEQ });
+    const leases = createManyLeaseApiResponses(1, { owner: address, dseq: DSEQ, state: "active" });
+
+    nock(restUrl).persist().get(`/akash/deployment/${deploymentVersion}/deployments/info?id.owner=${address}&id.dseq=${DSEQ}`).reply(200, info);
+    nock(restUrl).persist().get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}`).reply(200, { leases });
+    nock(restUrl)
+      .persist()
+      .get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}&pagination.limit=1000`)
+      .reply(200, { leases });
+
+    await createDeployment({ owner: address, dseq: DSEQ });
+  }
+});

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -313,7 +313,11 @@ describe("PATCH /v1/deployments/{dseq}", () => {
       const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: "AAAAmovedon" });
 
       expect(response.status).toBe(409);
-      expect((await settingOf(user))?.sdl).toBe(before!.sdl);
+      expect(await settingOf(user)).toMatchObject({
+        sdl: before!.sdl,
+        manifestVersion: before!.manifestVersion,
+        sealedSecrets: before!.sealedSecrets
+      });
     });
   });
 
@@ -392,7 +396,11 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
       await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, { s0_eTYPO: randomUUID() });
 
-      expect((await settingOf(user))?.sdl).toBe(before!.sdl);
+      expect(await settingOf(user)).toMatchObject({
+        sdl: before!.sdl,
+        manifestVersion: before!.manifestVersion,
+        sealedSecrets: before!.sealedSecrets
+      });
     });
   });
 
@@ -441,8 +449,11 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
       await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
-      expect((await settingOf(user))?.sdl).toBe(before!.sdl);
-      expect((await settingOf(user))?.sealedSecrets).toBe(before!.sealedSecrets);
+      expect(await settingOf(user)).toMatchObject({
+        sdl: before!.sdl,
+        manifestVersion: before!.manifestVersion,
+        sealedSecrets: before!.sealedSecrets
+      });
     });
 
     it("accepts a merged set exactly at the count", async () => {

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -132,11 +132,15 @@ describe("PATCH /v1/deployments/{dseq}", () => {
   });
 
   it("drops the name a moved variable used to be stored under", async () => {
-    const { apiKey, user } = await setup({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
+    const secrets = { s0_e0: randomUUID(), s0_e1: randomUUID() };
+    const { apiKey, user } = await setup({ secrets });
+    const rotated = randomUUID();
 
-    await patch(apiKey, { services: { web: { env: { API_TOKEN: randomUUID() } } } });
+    await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } } });
 
-    expect(Object.keys(await openStored(user))).not.toContain("s0_e0");
+    const stored = await openStored(user);
+    expect(Object.keys(stored)).not.toContain("s0_e0");
+    expect(Object.values(stored).sort()).toEqual([rotated, secrets.s0_e1].sort());
   });
 
   it("keeps every stored value resolvable when the sdl changes and no secrets are supplied", async () => {

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -343,6 +343,32 @@ describe("PATCH /v1/deployments/{dseq}", () => {
         sealedSecrets: before!.sealedSecrets
       });
     });
+
+    it("refuses the slower of two concurrent patches that both read the same version", async () => {
+      const { apiKey } = await patchable();
+      const { atBarrier, release } = holdTheFirstSeal();
+
+      const slower = patch(apiKey, { services: { web: { image: "nginx:slower" } } });
+      await atBarrier;
+      const faster = await patch(apiKey, { services: { web: { image: "nginx:faster" } } });
+      release();
+
+      expect(faster.status).toBe(200);
+      expect((await slower).status).toBe(409);
+    });
+
+    it("keeps what the faster of two concurrent patches wrote", async () => {
+      const { apiKey, user } = await patchable();
+      const { atBarrier, release } = holdTheFirstSeal();
+
+      const slower = patch(apiKey, { services: { web: { image: "nginx:slower" } } });
+      await atBarrier;
+      await patch(apiKey, { services: { web: { image: "nginx:faster" } } });
+      release();
+      await slower;
+
+      expect((await settingOf(user))!.sdl).toContain("nginx:faster");
+    });
   });
 
   describe("a patch re-sent after a broadcast the client never saw succeed", () => {
@@ -589,6 +615,28 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     const resolved = await container.resolve(SdlService).generateResolvedManifest({ sdl, secrets });
 
     return resolved.ok ? Buffer.from(resolved.value.manifestVersion).toString("base64") : Buffer.from("unresolvable-fixture").toString("base64");
+  }
+
+  function holdTheFirstSeal() {
+    const sdlSecretsService = container.resolve(SdlSecretsService);
+    const seal = sdlSecretsService.sealForStorage.bind(sdlSecretsService);
+    let reached!: () => void;
+    let release!: () => void;
+    const atBarrier = new Promise<void>(resolve => (reached = resolve));
+    const held = new Promise<void>(resolve => (release = resolve));
+    let isFirst = true;
+
+    vi.spyOn(sdlSecretsService, "sealForStorage").mockImplementation(async input => {
+      if (isFirst) {
+        isFirst = false;
+        reached();
+        await held;
+      }
+
+      return await seal(input);
+    });
+
+    return { atBarrier, release };
   }
 
   async function manifestVersionOf(response: Response) {

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -42,6 +42,7 @@ import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 const { client: kmsClient, publicKey } = registerFakeSdlSecretsKms();
 
 const DSEQ = "1234";
+const SEAL_BARRIER_TIMEOUT_MS = 10_000;
 
 function storedSdl(env: string[], image = "nginx") {
   return [
@@ -611,7 +612,14 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     const seal = sdlSecretsService.sealForStorage.bind(sdlSecretsService);
     let reached!: () => void;
     let release!: () => void;
-    const atBarrier = new Promise<void>(resolve => (reached = resolve));
+    const atBarrier = new Promise<void>((resolve, reject) => {
+      const abandonBarrier = setTimeout(() => reject(new Error("the first patch never reached the seal it was meant to be held at")), SEAL_BARRIER_TIMEOUT_MS);
+
+      reached = () => {
+        clearTimeout(abandonBarrier);
+        resolve();
+      };
+    });
     const held = new Promise<void>(resolve => (release = resolve));
     let isFirst = true;
 

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -110,10 +110,12 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     );
     vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async key => knownApiKeys[key!]);
     vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(faker.number.int({ min: 1000000, max: 10000000 }));
-    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue({
-      findByUserId: async (id: string) => knownWallets[id],
-      findOneByUserId: async (id: string) => knownWallets[id][0]
-    } as unknown as UserWalletRepository);
+    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(
+      mock<UserWalletRepository>({
+        findByUserId: async (id: string) => knownWallets[id],
+        findOneByUserId: async (id: string) => knownWallets[id][0]
+      })
+    );
     vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
       code: 200,
       transactionHash: "fake-transaction-hash",

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -6,13 +6,12 @@ import { CompactEncrypt } from "jose";
 import nock from "nock";
 import { randomUUID } from "node:crypto";
 import { container } from "tsyringe";
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { startJobQueues } from "@src/app/providers/jobs.provider";
 import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
 import { AuthService } from "@src/auth/services/auth.service";
-import type { UserWalletOutput } from "@src/billing/repositories";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { ManagedSignerService } from "@src/billing/services";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
@@ -91,42 +90,10 @@ describe("PATCH /v1/deployments/{dseq}", () => {
   const providerService = container.resolve(ProviderService);
   const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
 
-  let knownUsers: Record<string, UserOutput>;
-  let knownApiKeys: Record<string, ReturnType<typeof createApiKey>>;
-  let knownWallets: Record<string, UserWalletOutput[]>;
-
   beforeAll(async () => {
     await startJobQueues();
     await warmSealingKeyAsBootWould();
   }, 20_000);
-
-  beforeEach(() => {
-    knownUsers = {};
-    knownApiKeys = {};
-    knownWallets = {};
-
-    vi.spyOn(userRepository, "findById").mockImplementation(async id =>
-      knownUsers[id] ? { ...knownUsers[id], trial: false, userWallets: { isTrialing: false } } : undefined
-    );
-    vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async key => knownApiKeys[key!]);
-    vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(faker.number.int({ min: 1000000, max: 10000000 }));
-    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(
-      mock<UserWalletRepository>({
-        findByUserId: async (id: string) => knownWallets[id],
-        findOneByUserId: async (id: string) => knownWallets[id][0]
-      })
-    );
-    vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
-      code: 200,
-      transactionHash: "fake-transaction-hash",
-      hash: "fake-transaction-hash",
-      rawLog: "fake-raw-log"
-    });
-    vi.spyOn(providerService, "sendManifest").mockResolvedValue(true);
-    vi.spyOn(providerService, "getLeaseStatus").mockResolvedValue(createLeaseStatus());
-    vi.spyOn(providerService, "toProviderAuth").mockResolvedValue(mock());
-    kmsClient.asymmetricDecrypt.mockClear();
-  });
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -141,10 +108,10 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   it("leaves every other name opening to its original plaintext when one value is replaced", async () => {
     const secrets = { s0_e0: randomUUID(), s0_e1: `postgres://app:${randomUUID()}@db.internal/app` };
-    const { apiKey, user } = await patchable({ secrets });
+    const { apiKey, user } = await setup({ secrets });
     const rotated = randomUUID();
 
-    const response = await patch(apiKey, { services: { web: {} } }, { s0_e0: rotated });
+    const response = await patch(apiKey, { services: { web: {} } }, await sealFor(user, { s0_e0: rotated }));
 
     expect(response.status).toBe(200);
     await expect(openStored(user)).resolves.toEqual({ s0_e0: rotated, s0_e1: secrets.s0_e1 });
@@ -152,7 +119,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   it("leaves every other name resolvable when a patched variable moves and is renamed", async () => {
     const secrets = { s0_e0: randomUUID(), s0_e1: randomUUID() };
-    const { apiKey, user } = await patchable({ secrets });
+    const { apiKey, user } = await setup({ secrets });
     const rotated = randomUUID();
 
     const response = await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } } });
@@ -165,7 +132,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
   });
 
   it("drops the name a moved variable used to be stored under", async () => {
-    const { apiKey, user } = await patchable({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
+    const { apiKey, user } = await setup({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
 
     await patch(apiKey, { services: { web: { env: { API_TOKEN: randomUUID() } } } });
 
@@ -174,7 +141,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   it("keeps every stored value resolvable when the sdl changes and no secrets are supplied", async () => {
     const secrets = { s0_e0: randomUUID(), s0_e1: randomUUID() };
-    const { apiKey, user } = await patchable({ secrets });
+    const { apiKey, user } = await setup({ secrets });
 
     const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
@@ -187,7 +154,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   it("drops a name from the re-sealed token once the sdl stops referencing it", async () => {
     const secrets = { s0_e0: randomUUID(), s0_e1: randomUUID() };
-    const { apiKey, user } = await patchable({ secrets });
+    const { apiKey, user } = await setup({ secrets });
 
     const response = await patch(apiKey, { services: { web: { env: { DATABASE_URL: null } } } });
 
@@ -197,7 +164,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("a reference with no value anywhere", () => {
     it("fails with a 4xx naming it", async () => {
-      const { apiKey } = await patchable({ secrets: { s0_e0: randomUUID() }, env: ["API_TOKEN=ac-secret://s0_e0", "ORPHAN=ac-secret://s0_e9"] });
+      const { apiKey } = await setup({ secrets: { s0_e0: randomUUID() }, env: ["API_TOKEN=ac-secret://s0_e0", "ORPHAN=ac-secret://s0_e9"] });
 
       const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
@@ -206,7 +173,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("persists nothing", async () => {
-      const { apiKey, user } = await patchable({
+      const { apiKey, user } = await setup({
         secrets: { s0_e0: randomUUID() },
         env: ["API_TOKEN=ac-secret://s0_e0", "ORPHAN=ac-secret://s0_e9"]
       });
@@ -224,7 +191,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("a stored token something has tampered with", () => {
     it("fails with the permanent error rather than a retryable one", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       await flipFirstCiphertextCharacterOfToken(user);
 
       const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
@@ -234,17 +201,17 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("still refuses when every value is supplied fresh, the case where overwriting could have succeeded", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       const tampered = await flipFirstCiphertextCharacterOfToken(user);
 
-      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, { s0_e0: randomUUID(), s0_e1: randomUUID() });
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, await sealFor(user, { s0_e0: randomUUID(), s0_e1: randomUUID() }));
 
       expect(response.status).toBe(500);
       expect((await settingOf(user))?.sealedSecrets).toBe(tampered);
     });
 
     it("leaves the row intact, tampered token and all", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       const tampered = await flipFirstCiphertextCharacterOfToken(user);
       const before = await settingOf(user);
 
@@ -259,13 +226,13 @@ describe("PATCH /v1/deployments/{dseq}", () => {
   });
 
   it("sends a lease provider a manifest reflecting both the new sdl and the new value", async () => {
-    const { apiKey } = await patchable({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
+    const { apiKey, user } = await setup({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
     const rotated = randomUUID();
     const kept = randomUUID();
     await patch(apiKey, { services: { web: { env: { DATABASE_URL: kept } } } });
     vi.mocked(providerService.sendManifest).mockClear();
 
-    await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, { s0_e0: rotated });
+    await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, await sealFor(user, { s0_e0: rotated }));
 
     const expected = await manifestOf(storedSdl([`API_TOKEN=${rotated}`, `DATABASE_URL=${kept}`], "nginx:1.27"));
     expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ manifest: expected }));
@@ -275,7 +242,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     it("unwraps once for a patch that changes twelve secrets and supplies none", async () => {
       const env = Array.from({ length: 12 }, (_, index) => `VAR_${index}=ac-secret://s0_e${index}`);
       const secrets = Object.fromEntries(env.map((_, index) => [`s0_e${index}`, randomUUID()]));
-      const { apiKey } = await patchable({ secrets, env });
+      const { apiKey } = await setup({ secrets, env });
 
       await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
@@ -285,10 +252,10 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     it("unwraps the seal and the data key once each when a patch supplies values", async () => {
       const env = Array.from({ length: 12 }, (_, index) => `VAR_${index}=ac-secret://s0_e${index}`);
       const secrets = Object.fromEntries(env.map((_, index) => [`s0_e${index}`, randomUUID()]));
-      const { apiKey } = await patchable({ secrets, env });
+      const { apiKey, user } = await setup({ secrets, env });
       const supplied = Object.fromEntries(env.map((_, index) => [`s0_e${index}`, randomUUID()]));
 
-      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, supplied);
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, await sealFor(user, supplied));
 
       expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(2);
     });
@@ -296,9 +263,9 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("where the sdl comes from", () => {
     it("ignores an sdl the request tries to carry", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
 
-      const response = await request(apiKey, {
+      const response = await patch(apiKey, {
         services: { web: { image: "nginx:1.27" } },
         sdl: storedSdl(["INJECTED=ac-secret://s0_e0"], "attacker/image")
       });
@@ -312,7 +279,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("answers 404 for a deployment the console recorded no sdl for", async () => {
-      const { apiKey } = await patchable({ record: false });
+      const { apiKey } = await setup({ record: false });
 
       const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
@@ -322,7 +289,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("the version a patch expects", () => {
     it("applies the patch when the expected version is still current", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       const current = (await settingOf(user))!.manifestVersion!;
 
       const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: current });
@@ -331,7 +298,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("answers 409 and persists nothing when the deployment has moved on", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       const before = await settingOf(user);
 
       const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: "AAAAmovedon" });
@@ -345,7 +312,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("refuses the slower of two concurrent patches that both read the same version", async () => {
-      const { apiKey } = await patchable();
+      const { apiKey } = await setup();
       const { atBarrier, release } = holdTheFirstSeal();
 
       const slower = patch(apiKey, { services: { web: { image: "nginx:slower" } } });
@@ -358,7 +325,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("keeps what the faster of two concurrent patches wrote", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       const { atBarrier, release } = holdTheFirstSeal();
 
       const slower = patch(apiKey, { services: { web: { image: "nginx:slower" } } });
@@ -373,7 +340,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("a patch re-sent after a broadcast the client never saw succeed", () => {
     it("answers 200 rather than 409, the row already carrying the version this patch computes", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       const original = (await settingOf(user))!.manifestVersion!;
       await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: original });
 
@@ -383,7 +350,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("recomputes the version the first attempt recorded, rather than a new one", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       const original = (await settingOf(user))!.manifestVersion!;
       await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: original });
       const applied = (await settingOf(user))!.manifestVersion;
@@ -394,7 +361,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("answers 200 for a re-sent env patch, whose stored name and position churn on the first attempt", async () => {
-      const { apiKey, user } = await patchable({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
+      const { apiKey, user } = await setup({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
       const original = (await settingOf(user))!.manifestVersion!;
       const rotated = randomUUID();
       await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } }, ifManifestVersion: original });
@@ -405,7 +372,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("recomputes the same version for a re-sent env patch", async () => {
-      const { apiKey, user } = await patchable({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
+      const { apiKey, user } = await setup({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
       const original = (await settingOf(user))!.manifestVersion!;
       const rotated = randomUUID();
       await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } }, ifManifestVersion: original });
@@ -419,7 +386,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("a key the deployment does not have", () => {
     it("answers 400 naming a service the sdl does not declare", async () => {
-      const { apiKey } = await patchable();
+      const { apiKey } = await setup();
 
       const response = await patch(apiKey, { services: { api: { image: "nginx" } } });
 
@@ -428,7 +395,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("answers 400 naming a port the service does not expose", async () => {
-      const { apiKey } = await patchable();
+      const { apiKey } = await setup();
 
       const response = await patch(apiKey, { services: { web: { expose: { "8080": { accept: ["x.test"] } } } } });
 
@@ -437,7 +404,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("refuses a patch naming no services at all", async () => {
-      const { apiKey } = await patchable();
+      const { apiKey } = await setup();
 
       const response = await patch(apiKey, { services: {} });
 
@@ -447,7 +414,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("a plaintext value in a service the patch never named", () => {
     it("stays in the clear, readable to its owner", async () => {
-      const { apiKey, user } = await patchable({ env: ["API_TOKEN=ac-secret://s0_e0", "LOG_LEVEL=debug"], secrets: { s0_e0: randomUUID() } });
+      const { apiKey, user } = await setup({ env: ["API_TOKEN=ac-secret://s0_e0", "LOG_LEVEL=debug"], secrets: { s0_e0: randomUUID() } });
 
       const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
@@ -457,7 +424,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
     it("is not pulled into the sealed token", async () => {
       const token = randomUUID();
-      const { apiKey, user } = await patchable({ env: ["API_TOKEN=ac-secret://s0_e0", "LOG_LEVEL=debug"], secrets: { s0_e0: token } });
+      const { apiKey, user } = await setup({ env: ["API_TOKEN=ac-secret://s0_e0", "LOG_LEVEL=debug"], secrets: { s0_e0: token } });
 
       await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
@@ -465,7 +432,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("is sealed once the patch does name it", async () => {
-      const { apiKey, user } = await patchable({ env: ["API_TOKEN=ac-secret://s0_e0", "LOG_LEVEL=debug"], secrets: { s0_e0: randomUUID() } });
+      const { apiKey, user } = await setup({ env: ["API_TOKEN=ac-secret://s0_e0", "LOG_LEVEL=debug"], secrets: { s0_e0: randomUUID() } });
 
       const response = await patch(apiKey, { services: { web: { env: { LOG_LEVEL: "trace" } } } });
 
@@ -478,19 +445,19 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("a supplied secret name the sdl does not reference", () => {
     it("answers 400 naming it rather than silently dropping it", async () => {
-      const { apiKey } = await patchable();
+      const { apiKey, user } = await setup();
 
-      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, { s0_eTYPO: randomUUID() });
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, await sealFor(user, { s0_eTYPO: randomUUID() }));
 
       expect(response.status).toBe(400);
       expect(((await response.json()) as { message: string }).message).toContain("s0_eTYPO");
     });
 
     it("persists nothing", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       const before = await settingOf(user);
 
-      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, { s0_eTYPO: randomUUID() });
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, await sealFor(user, { s0_eTYPO: randomUUID() }));
 
       expect(await settingOf(user)).toMatchObject({
         sdl: before!.sdl,
@@ -502,7 +469,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("http options over the wire", () => {
     it("accepts zero as a way to clear a timeout", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
 
       const response = await patch(apiKey, { services: { web: { expose: { "80": { httpOptions: { readTimeout: 0 } } } } } });
 
@@ -511,7 +478,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("refuses a negative timeout", async () => {
-      const { apiKey } = await patchable();
+      const { apiKey } = await setup();
 
       const response = await patch(apiKey, { services: { web: { expose: { "80": { httpOptions: { readTimeout: -1 } } } } } });
 
@@ -519,7 +486,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("adds no options node for a patch that assigns none", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
 
       const response = await patch(apiKey, { services: { web: { expose: { "80": { httpOptions: {} } } } } });
 
@@ -530,7 +497,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
   describe("the size of the set it would store", () => {
     it("refuses a merged set past the count a deployment may carry", async () => {
-      const { apiKey } = await patchable();
+      const { apiKey } = await setup();
       capSecretCountAt(1);
 
       const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
@@ -539,7 +506,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("persists nothing when the merged set is refused", async () => {
-      const { apiKey, user } = await patchable();
+      const { apiKey, user } = await setup();
       const before = await settingOf(user);
       capSecretCountAt(1);
 
@@ -553,7 +520,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
 
     it("accepts a merged set exactly at the count", async () => {
-      const { apiKey } = await patchable();
+      const { apiKey } = await setup();
       capSecretCountAt(2);
 
       const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
@@ -563,7 +530,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
   });
 
   it("refuses an expected manifest version longer than the column can hold", async () => {
-    const { apiKey } = await patchable();
+    const { apiKey } = await setup();
 
     const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: "A".repeat(65) });
 
@@ -571,7 +538,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
   });
 
   it("accepts an expected manifest version exactly at the column's bound", async () => {
-    const { apiKey } = await patchable();
+    const { apiKey } = await setup();
 
     const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: "A".repeat(64) });
 
@@ -579,7 +546,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
   });
 
   it("returns the manifest version it recorded", async () => {
-    const { apiKey, user } = await patchable();
+    const { apiKey, user } = await setup();
 
     const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
@@ -684,15 +651,8 @@ describe("PATCH /v1/deployments/{dseq}", () => {
       .encrypt(publicKey);
   }
 
-  function patch(apiKey: string, data: Record<string, unknown>, secrets?: Record<string, string>) {
-    return request(apiKey, data, secrets);
-  }
-
-  async function request(apiKey: string, data: Record<string, unknown>, secrets?: Record<string, string>) {
-    const user = knownUsers[knownApiKeys[apiKey].userId];
-    const sealedSecrets = secrets ? await sealFor(user, secrets) : undefined;
-
-    return await app.request(`/v1/deployments/${DSEQ}`, {
+  function patch(apiKey: string, data: Record<string, unknown>, sealedSecrets?: string) {
+    return app.request(`/v1/deployments/${DSEQ}`, {
       method: "PATCH",
       body: JSON.stringify({ data: { ...data, sealedSecrets } }),
       headers: new Headers({ "Content-Type": "application/json", "x-api-key": apiKey })
@@ -703,15 +663,34 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     return env.flatMap(entry => entry.match(/ac-secret:\/\/([A-Za-z_][A-Za-z0-9_]*)/)?.slice(1) ?? []);
   }
 
-  async function patchable(input: { secrets?: Record<string, string>; env?: string[]; record?: boolean } = {}) {
+  async function setup(input: { secrets?: Record<string, string>; env?: string[]; record?: boolean } = {}) {
     const dbUser = await userRepository.create({ userId: faker.string.uuid() });
     const apiKey = faker.string.alphanumeric(24);
     const user = createUser({ id: dbUser.id, userId: dbUser.userId ?? undefined });
     const address = createAkashAddress();
+    const wallets = [createUserWallet({ userId: dbUser.id, address })];
+    const apiKeys: Record<string, ReturnType<typeof createApiKey>> = { [apiKey]: createApiKey({ userId: dbUser.id }) };
 
-    knownUsers[dbUser.id] = user;
-    knownApiKeys[apiKey] = createApiKey({ userId: dbUser.id });
-    knownWallets[dbUser.id] = [createUserWallet({ userId: dbUser.id, address })];
+    vi.spyOn(userRepository, "findById").mockImplementation(async id =>
+      id === dbUser.id ? { ...user, trial: false, userWallets: { isTrialing: false } } : undefined
+    );
+    vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async key => apiKeys[key!]);
+    vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(faker.number.int({ min: 1000000, max: 10000000 }));
+    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(
+      mock<UserWalletRepository>({
+        findByUserId: async () => wallets,
+        findOneByUserId: async () => wallets[0]
+      })
+    );
+    vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
+      code: 200,
+      transactionHash: "fake-transaction-hash",
+      hash: "fake-transaction-hash",
+      rawLog: "fake-raw-log"
+    });
+    vi.spyOn(providerService, "sendManifest").mockResolvedValue(true);
+    vi.spyOn(providerService, "getLeaseStatus").mockResolvedValue(createLeaseStatus());
+    vi.spyOn(providerService, "toProviderAuth").mockResolvedValue(mock());
 
     const env = input.env ?? ["API_TOKEN=ac-secret://s0_e0", "DATABASE_URL=ac-secret://s0_e1"];
     const sdl = storedSdl(env);

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -148,6 +148,28 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     await expect(openStored(user)).resolves.toEqual({ s0_e0: rotated, s0_e1: secrets.s0_e1 });
   });
 
+  it("leaves every other name resolvable when a patched variable moves and is renamed", async () => {
+    const secrets = { s0_e0: randomUUID(), s0_e1: randomUUID() };
+    const { apiKey, user } = await patchable({ secrets });
+    const rotated = randomUUID();
+
+    const response = await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } } });
+
+    expect(response.status).toBe(200);
+    const stored = await openStored(user);
+    expect(Object.values(stored)).toEqual(expect.arrayContaining([rotated, secrets.s0_e1]));
+    const setting = await settingOf(user);
+    expect((await container.resolve(SdlService).generateResolvedManifest({ sdl: setting!.sdl!, secrets: stored })).ok).toBe(true);
+  });
+
+  it("drops the name a moved variable used to be stored under", async () => {
+    const { apiKey, user } = await patchable({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
+
+    await patch(apiKey, { services: { web: { env: { API_TOKEN: randomUUID() } } } });
+
+    expect(Object.keys(await openStored(user))).not.toContain("s0_e0");
+  });
+
   it("keeps every stored value resolvable when the sdl changes and no secrets are supplied", async () => {
     const secrets = { s0_e0: randomUUID(), s0_e1: randomUUID() };
     const { apiKey, user } = await patchable({ secrets });

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -345,6 +345,52 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
   });
 
+  describe("a patch re-sent after a broadcast the client never saw succeed", () => {
+    it("answers 200 rather than 409, the row already carrying the version this patch computes", async () => {
+      const { apiKey, user } = await patchable();
+      const original = (await settingOf(user))!.manifestVersion!;
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: original });
+
+      const retry = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: original });
+
+      expect(retry.status).toBe(200);
+    });
+
+    it("recomputes the version the first attempt recorded, rather than a new one", async () => {
+      const { apiKey, user } = await patchable();
+      const original = (await settingOf(user))!.manifestVersion!;
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: original });
+      const applied = (await settingOf(user))!.manifestVersion;
+
+      const retry = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, ifManifestVersion: original });
+
+      expect(await manifestVersionOf(retry)).toBe(applied);
+    });
+
+    it("answers 200 for a re-sent env patch, whose stored name and position churn on the first attempt", async () => {
+      const { apiKey, user } = await patchable({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
+      const original = (await settingOf(user))!.manifestVersion!;
+      const rotated = randomUUID();
+      await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } }, ifManifestVersion: original });
+
+      const retry = await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } }, ifManifestVersion: original });
+
+      expect(retry.status).toBe(200);
+    });
+
+    it("recomputes the same version for a re-sent env patch", async () => {
+      const { apiKey, user } = await patchable({ secrets: { s0_e0: randomUUID(), s0_e1: randomUUID() } });
+      const original = (await settingOf(user))!.manifestVersion!;
+      const rotated = randomUUID();
+      await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } }, ifManifestVersion: original });
+      const applied = (await settingOf(user))!.manifestVersion;
+
+      const retry = await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } }, ifManifestVersion: original });
+
+      expect(await manifestVersionOf(retry)).toBe(applied);
+    });
+  });
+
   describe("a key the deployment does not have", () => {
     it("answers 400 naming a service the sdl does not declare", async () => {
       const { apiKey } = await patchable();
@@ -543,6 +589,12 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     const resolved = await container.resolve(SdlService).generateResolvedManifest({ sdl, secrets });
 
     return resolved.ok ? Buffer.from(resolved.value.manifestVersion).toString("base64") : Buffer.from("unresolvable-fixture").toString("base64");
+  }
+
+  async function manifestVersionOf(response: Response) {
+    const { data } = (await response.json()) as { data?: { manifestVersion?: string } };
+
+    return data?.manifestVersion;
   }
 
   async function settingOf(user: UserOutput) {

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -243,24 +243,30 @@ describe("PATCH /v1/deployments/{dseq}", () => {
   });
 
   describe("what it spends on the key service", () => {
-    it("unwraps once for a patch that changes twelve secrets and supplies none", async () => {
+    it("opens the stored token once for a patch that changes twelve secrets and supplies none", async () => {
       const env = Array.from({ length: 12 }, (_, index) => `VAR_${index}=ac-secret://s0_e${index}`);
       const secrets = Object.fromEntries(env.map((_, index) => [`s0_e${index}`, randomUUID()]));
       const { apiKey } = await setup({ secrets, env });
+      const storedTokenOpens = countStoredTokenOpens();
 
       await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
 
+      expect(storedTokenOpens()).toBe(1);
       expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(1);
     });
 
-    it("unwraps the seal and the data key once each when a patch supplies values", async () => {
+    it("opens the stored token once and the supplied seal once when a patch supplies values", async () => {
       const env = Array.from({ length: 12 }, (_, index) => `VAR_${index}=ac-secret://s0_e${index}`);
       const secrets = Object.fromEntries(env.map((_, index) => [`s0_e${index}`, randomUUID()]));
       const { apiKey, user } = await setup({ secrets, env });
       const supplied = Object.fromEntries(env.map((_, index) => [`s0_e${index}`, randomUUID()]));
+      const storedTokenOpens = countStoredTokenOpens();
+      const suppliedSealOpens = countSuppliedSealOpens();
 
       await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, await sealFor(user, supplied));
 
+      expect(storedTokenOpens()).toBe(1);
+      expect(suppliedSealOpens()).toBe(1);
       expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(2);
     });
   });
@@ -586,6 +592,18 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     const resolved = await container.resolve(SdlService).generateResolvedManifest({ sdl, secrets });
 
     return resolved.ok ? Buffer.from(resolved.value.manifestVersion).toString("base64") : Buffer.from("unresolvable-fixture").toString("base64");
+  }
+
+  function countStoredTokenOpens() {
+    const opens = vi.spyOn(container.resolve(SdlSecretsService), "openStored");
+
+    return () => opens.mock.calls.length;
+  }
+
+  function countSuppliedSealOpens() {
+    const opens = vi.spyOn(container.resolve(SdlSecretsService), "receiveForMerge");
+
+    return () => opens.mock.calls.length;
   }
 
   function holdTheFirstSeal() {

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -21,6 +21,7 @@ import { CORE_CONFIG, POSTGRES_DB, resolveTable } from "@src/core";
 import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
 import { SDL_SECRETS_CONTENT_ENCRYPTION, SDL_SECRETS_SEAL_ALGORITHM } from "@src/deployment/config/sdl-secrets.config";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
@@ -141,7 +142,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     const { apiKey, user } = await patchable({ secrets });
     const rotated = randomUUID();
 
-    const response = await patch(apiKey, { services: { web: { env: { API_TOKEN: rotated } } } }, { s0_e0: rotated });
+    const response = await patch(apiKey, { services: { web: {} } }, { s0_e0: rotated });
 
     expect(response.status).toBe(200);
     await expect(openStored(user)).resolves.toEqual({ s0_e0: rotated, s0_e1: secrets.s0_e1 });
@@ -208,6 +209,16 @@ describe("PATCH /v1/deployments/{dseq}", () => {
       expect(await response.json()).toMatchObject({ message: "Unable to read stored secrets", code: "stored_secrets_unreadable" });
     });
 
+    it("still refuses when every value is supplied fresh, the case where overwriting could have succeeded", async () => {
+      const { apiKey, user } = await patchable();
+      const tampered = await flipFirstCiphertextCharacterOfToken(user);
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, { s0_e0: randomUUID(), s0_e1: randomUUID() });
+
+      expect(response.status).toBe(500);
+      expect((await settingOf(user))?.sealedSecrets).toBe(tampered);
+    });
+
     it("leaves the row intact, tampered token and all", async () => {
       const { apiKey, user } = await patchable();
       const tampered = await flipFirstCiphertextCharacterOfToken(user);
@@ -230,7 +241,7 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     await patch(apiKey, { services: { web: { env: { DATABASE_URL: kept } } } });
     vi.mocked(providerService.sendManifest).mockClear();
 
-    await patch(apiKey, { services: { web: { image: "nginx:1.27", env: { API_TOKEN: rotated } } } }, { s0_e0: rotated });
+    await patch(apiKey, { services: { web: { image: "nginx:1.27" } } }, { s0_e0: rotated });
 
     const expected = await manifestOf(storedSdl([`API_TOKEN=${rotated}`, `DATABASE_URL=${kept}`], "nginx:1.27"));
     expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ manifest: expected }));
@@ -269,7 +280,11 @@ describe("PATCH /v1/deployments/{dseq}", () => {
       });
 
       expect(response.status).toBe(200);
-      expect((await settingOf(user))?.sdl).not.toContain("attacker/image");
+      const stored = (await settingOf(user))!.sdl!;
+      expect(stored).toContain("API_TOKEN");
+      expect(stored).toContain("DATABASE_URL");
+      expect(stored).not.toContain("INJECTED");
+      expect(stored).not.toContain("attacker/image");
     });
 
     it("answers 404 for a deployment the console recorded no sdl for", async () => {
@@ -381,6 +396,65 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     });
   });
 
+  describe("http options over the wire", () => {
+    it("accepts zero as a way to clear a timeout", async () => {
+      const { apiKey, user } = await patchable();
+
+      const response = await patch(apiKey, { services: { web: { expose: { "80": { httpOptions: { readTimeout: 0 } } } } } });
+
+      expect(response.status).toBe(200);
+      expect((await settingOf(user))?.sdl).toContain("read_timeout: 0");
+    });
+
+    it("refuses a negative timeout", async () => {
+      const { apiKey } = await patchable();
+
+      const response = await patch(apiKey, { services: { web: { expose: { "80": { httpOptions: { readTimeout: -1 } } } } } });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("adds no options node for a patch that assigns none", async () => {
+      const { apiKey, user } = await patchable();
+
+      const response = await patch(apiKey, { services: { web: { expose: { "80": { httpOptions: {} } } } } });
+
+      expect(response.status).toBe(200);
+      expect((await settingOf(user))?.sdl).not.toContain("http_options");
+    });
+  });
+
+  describe("the size of the set it would store", () => {
+    it("refuses a merged set past the count a deployment may carry", async () => {
+      const { apiKey } = await patchable();
+      capSecretCountAt(1);
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("persists nothing when the merged set is refused", async () => {
+      const { apiKey, user } = await patchable();
+      const before = await settingOf(user);
+      capSecretCountAt(1);
+
+      await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect((await settingOf(user))?.sdl).toBe(before!.sdl);
+      expect((await settingOf(user))?.sealedSecrets).toBe(before!.sealedSecrets);
+    });
+
+    it("accepts a merged set exactly at the count", async () => {
+      const { apiKey } = await patchable();
+      capSecretCountAt(2);
+
+      const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+      expect(response.status).toBe(200);
+    });
+  });
+
   it("refuses an expected manifest version longer than the column can hold", async () => {
     const { apiKey } = await patchable();
 
@@ -415,6 +489,13 @@ describe("PATCH /v1/deployments/{dseq}", () => {
 
     expect(response.status).toBe(401);
   });
+
+  function capSecretCountAt(maxCount: number) {
+    const config = container.resolve(DeploymentConfigService);
+    const passThrough = config.get.bind(config);
+
+    vi.spyOn(config, "get").mockImplementation((key: Parameters<typeof passThrough>[0]) => (key === "SDL_SECRETS_MAX_COUNT" ? maxCount : passThrough(key)));
+  }
 
   async function manifestOf(sdl: string) {
     const manifest = generateManifest(yaml.raw<SDLInput>(sdl));

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -479,13 +479,21 @@ describe("PATCH /v1/deployments/{dseq}", () => {
   });
 
   describe("http options over the wire", () => {
-    it("accepts zero as a way to clear a timeout", async () => {
-      const { apiKey, user } = await setup();
+    it("refuses a zero timeout, which one provider reads as its proxy's own default and another as none at all", async () => {
+      const { apiKey } = await setup();
 
       const response = await patch(apiKey, { services: { web: { expose: { "80": { httpOptions: { readTimeout: 0 } } } } } });
 
+      expect(response.status).toBe(400);
+    });
+
+    it("records the smallest timeout every provider reads the same way", async () => {
+      const { apiKey, user } = await setup();
+
+      const response = await patch(apiKey, { services: { web: { expose: { "80": { httpOptions: { readTimeout: 1 } } } } } });
+
       expect(response.status).toBe(200);
-      expect((await settingOf(user))?.sdl).toContain("read_timeout: 0");
+      expect((await settingOf(user))?.sdl).toContain("read_timeout: 1");
     });
 
     it("refuses a negative timeout", async () => {

--- a/apps/api/test/functional/deployment-patch.spec.ts
+++ b/apps/api/test/functional/deployment-patch.spec.ts
@@ -701,6 +701,21 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     return env.flatMap(entry => entry.match(/ac-secret:\/\/([A-Za-z_][A-Za-z0-9_]*)/)?.slice(1) ?? []);
   }
 
+  async function mockChain(address: string) {
+    const restUrl = container.resolve(CORE_CONFIG).REST_API_NODE_URL;
+    const info = createDeploymentInfoSeed({ owner: address, dseq: DSEQ });
+    const leases = createManyLeaseApiResponses(1, { owner: address, dseq: DSEQ, state: "active" });
+
+    nock(restUrl).persist().get(`/akash/deployment/${deploymentVersion}/deployments/info?id.owner=${address}&id.dseq=${DSEQ}`).reply(200, info);
+    nock(restUrl).persist().get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}`).reply(200, { leases });
+    nock(restUrl)
+      .persist()
+      .get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}&pagination.limit=1000`)
+      .reply(200, { leases });
+
+    await createDeployment({ owner: address, dseq: DSEQ });
+  }
+
   async function setup(input: { secrets?: Record<string, string>; env?: string[]; record?: boolean } = {}) {
     const dbUser = await userRepository.create({ userId: faker.string.uuid() });
     const apiKey = faker.string.alphanumeric(24);
@@ -757,20 +772,5 @@ describe("PATCH /v1/deployments/{dseq}", () => {
     kmsClient.asymmetricDecrypt.mockClear();
 
     return { user, apiKey, address, sdl, secrets };
-  }
-
-  async function mockChain(address: string) {
-    const restUrl = container.resolve(CORE_CONFIG).REST_API_NODE_URL;
-    const info = createDeploymentInfoSeed({ owner: address, dseq: DSEQ });
-    const leases = createManyLeaseApiResponses(1, { owner: address, dseq: DSEQ, state: "active" });
-
-    nock(restUrl).persist().get(`/akash/deployment/${deploymentVersion}/deployments/info?id.owner=${address}&id.dseq=${DSEQ}`).reply(200, info);
-    nock(restUrl).persist().get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}`).reply(200, { leases });
-    nock(restUrl)
-      .persist()
-      .get(`/akash/market/${marketVersion}/leases/list?filters.owner=${address}&filters.dseq=${DSEQ}&pagination.limit=1000`)
-      .reply(200, { leases });
-
-    await createDeployment({ owner: address, dseq: DSEQ });
   }
 });


### PR DESCRIPTION
## Why

Closes CON-864.

End-to-end coverage of the new endpoint over the real route, the real database and the real cipher, seeded at the repository and driven only over HTTP.

## What

Thirty-three tests. Each acceptance criterion gets an assertion that **fails on a wrong implementation** rather than one that merely passes:

- replacing one secret leaves every other name opening to its original plaintext
- an SDL-only patch keeps every stored value resolvable, and the recorded document still resolves end to end
- dropping a reference drops that name from the re-sealed token
- an unresolvable reference answers 400 naming it, with all three columns byte-unchanged
- a tampered token answers the permanent 500 with `stored_secrets_unreadable`, and the **tampered bytes are still in the row** — proving it was never overwritten
- a patch followed by a lease sends a manifest built from both the new image and the new value
- a plaintext value in a service the patch never named stays in the clear and out of the token
- a misspelled supplied secret name answers 400 rather than a silent 200
- `ifManifestVersion` is refused past the column's 64-character bound and accepted at it
- a zero timeout is accepted and a negative one refused, and an empty `httpOptions` writes no node

### Review round 3 — four fixtures that could not fail

Every one is now verified red under the exact mutation it exists to catch.

**The incoming seal was never load-bearing in AC1 or AC6.** Both fixtures supplied the rotated value twice — once as a plaintext `env` patch, once in the seal — and because the plaintext patch is a written position, `derived` produced the same name and wins the overlay. **Deleting the incoming seal from the merge entirely left 26/26 green**, and so did inverting precedence so the stored value beat the supplied one. All the suite proved was that the seal gets *decrypted*. Both fixtures now supply the value only through the seal. Dropping the seal reddens both; inverting precedence reddens both. This is the Spec's central mechanism — "open the stored token, open the incoming one, overlay" — and it was untested end to end.

**AC8's marker was planted in the one field the patch overwrites.** Adding an optional `sdl` to the request and honouring it — making PATCH behave exactly like the deprecated PUT, the single regression AC8 exists to prevent — **left 26/26 green**, because `attacker/image` was erased by the patch before the assertion looked, while the rest of the injected document did land. It now asserts on content the patch never touches (`API_TOKEN` and `DATABASE_URL` present, `INJECTED` absent).

**AC5's "leaves the row intact" was saved by the wrong thing.** Making the decrypt swallow and return an empty set left it green, because the surviving references then resolve to nothing, the resolve step 400s, and the write is never reached. The case where the data destruction the Spec singles out could *actually* happen — a tampered token **plus every value supplied fresh**, so resolution succeeds and only the token is unreadable — was untested. Added.

**The merged-set bound had no end-to-end guard**: removing `assertStorable` left 26/26 green, caught only by unit specs. Three functional tests now cover it, capping the configured count for the one test rather than seeding a hundred secrets.

### A flake I introduced and fixed

The tamper helper flipped the **last** base64url character of the ciphertext segment. The last character of a base64url segment can carry fewer than six significant bits, so a change there may decode to the very same bytes — the tamper sometimes did not tamper, and the test passed for the wrong reason (observed once: 200 instead of 500). It now flips the **first** character, which carries six fully significant bits, and the helper is named for what it does. Stable across five consecutive runs.

### On the key-service economy tests

They count the opens themselves — `SdlSecretsService.openStored` once, and `receiveForMerge` once on the supplied path — beside the `asymmetricDecrypt` tally. The tally alone **cannot discriminate the likeliest wrong implementation**, because `DataKeyUnwrapperService` memoises the data key per request, so opening the stored token once per referenced name would still show one call. The open counts redden under exactly that duplication, verified in review round 6; the tally stays as the KMS-cost assertion it always was.

### Pre-existing suite flakiness, measured

`origin/main` itself fails 2–3 tests on some full functional runs before any CON-864 code is present (observed 3, 2, 2 failures, then 404/404 clean). The same specs pass every time when run per-file. `addresses.spec.ts` is one of them and is not a file this stack touches. So the honest claim is not "green on every run" but: tsc and lint are deterministic at 42/0 at every boundary, every boundary reaches a clean full-suite run, and the specs this stack adds are stable under repetition.

## Demo

Two of the eight scenarios exercise assertions this PR owns; the full demo is on the PATCH exposure PR.

    === 4. TAMPER WITH THE STORED TOKEN ===
      flipped one character of the ciphertext segment: true
      PATCH status: 500
      body: {"error":"InternalServerError","message":"Unable to read stored secrets","code":"stored_secrets_unreadable","type":"server_error"}
      stored sdl unchanged: true
      manifest version unchanged: true
      the tampered token was NOT overwritten: true

    === 6. A STALE ifManifestVersion ===
      PATCH status with a stale expected version: 409
      nothing persisted: true
      PATCH status with the current expected version: 200

Measured: 624 non-excluded changed lines. `apps/api` tsc 42 against a 42 baseline, lint 0, `deployment-patch` functional 33/33 across 3 consecutive runs, full functional 439/439.

### Review round 4

The wallet double is built with `mock<UserWalletRepository>()` rather than an object literal cast through `as unknown as`, which `.claude/instructions/use-mock-instead-of-as-unknown-as-in-tests.md` forbids. Reversing an earlier decline of mine: propagating that pattern into a brand-new file is a different call from leaving it where it already sat, and it is a one-line change. The pre-existing instance in `deployment-sealed-secrets.spec.ts` is left alone.

### Review round 5 — the retry a client is actually left holding

Four tests pin the premise the guarded write now rests on: **re-applying a patch to its own output recomputes the identical manifest version**, so a client retrying with the `ifManifestVersion` it originally read is answered 200 rather than 409.

Covered on two paths:

- the plain `image` assignment, where nothing about the document moves; and
- the `env` path, which is the one that could have broken the premise — the first attempt drops the patched variable from its position, re-appends it, and mints a fresh derived name for its value. The second attempt converges on the same document and therefore the same version.

Two of the four assert the version the **retry itself computes**, read off the response body rather than off the row, so they fail rather than falsely pass when the retry is refused. All four fail when the `or` in the version guard is reverted to a plain `eq`.

### Review round 6

Four review findings and one stale fixture, each verified red under the mutation it exists to catch.

**The moved-variable fixture asserted only an absence.** `drops the name a moved variable used to be stored under` checked that `s0_e0` was gone and nothing else, so it said nothing about the values that survived. The failure mode raised — the merge returning `{}` — did already redden it, though not for the reason it looks: an emptied set leaves `DATABASE_URL` unresolvable, the request 400s, and the row keeps its original token. The gap that was real is the value channel: clobbering one held value on open, with every name still referenced and the write still reached, passed. It now asserts the stored values are exactly the rotated one plus `s0_e1`'s original plaintext.

**The key-service economy tests counted the wrong thing.** `asymmetricDecrypt` is bounded by the per-request memoisation of the data key, so a regression opening the stored token once per referenced name left both at their expected counts. Both now count `openStored` (and `receiveForMerge` on the supplied path). Verified with an extra `openStored` in `patchByUserIdAndDseq`: `expected 2 to be 1` on the new assertion, **1 passed** with only the old one.

**The concurrency barrier could hang instead of failing.** `atBarrier` resolved only from inside the intercepted `sealForStorage`, so a patch failing anywhere upstream of it — auth, the stored-definition read, the SDL parse, the nock-backed chain read — hung both tests until the 30s test timeout and buried the real error. It now rejects at 10s naming what did not happen, verified by making the interceptor never reach the barrier: red at 10049ms with that error.

**`setup` was not the last declaration in the describe block.** `mockChain`, reached only from `setup`, sat below it. Moved above, per the convention.

**A fixture asserting the old zero-timeout contract.** The base now refuses a zero read or send timeout, the spelling providers disagree on, so `accepts zero as a way to clear a timeout` failed against its own base. It asserts the 400, and the boundary above it is covered by a patch that records the smallest accepted timeout.

`deployment-patch` functional 42/42, `deployment-patch-route` 10/10, `apps/api` tsc 0, lint 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for deployment updates, including secret rotation, SDL validation, provider manifest propagation, authentication, version handling, retries, and persistence safeguards.
  - Added validation coverage for invalid services, ports, HTTP options, secret limits, plaintext secrets, and supplied secrets.
  - Improved assertions for moved variables, encrypted secret handling, and key-management operations.
  - Added coverage confirming zero HTTP read timeouts are rejected while the minimum accepted timeout is supported.
  - Strengthened concurrent update tests to fail cleanly when synchronization times out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->