### PR TITLE
test(dx): add stryker mutation testing for changed lines

### DIFF
--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -28,6 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_SCRIPT_NAME: ${{ github.event_name == 'merge_group' && 'test' || 'test:cov' }}
+      # Stryker fails the mutation step when the score over the changed lines drops below this.
+      STRYKER_BREAK: 80
+      # A diff this wide is a PR to split, not a mutation run to sit through.
+      MAX_MUTATION_RANGES: 200
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -81,6 +85,98 @@ jobs:
       - name: Run tests
         if: ${{ steps.tests_details.outputs.has_tests == 'true' }}
         run: npm run "$TEST_SCRIPT_NAME" --workspace=apps/${{ inputs.app }}
+
+      - name: Find mutation testing targets
+        id: mutation_targets
+        if: ${{ github.event_name == 'pull_request' && steps.tests_details.outputs.has_tests == 'true' && !contains(github.event.pull_request.labels.*.name, 'ignore-mutations-testing') }}
+        env:
+          APP_PATH: apps/${{ inputs.app }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: | # shell
+          test_script=$(jq -r '.scripts["test:unit"] // .scripts.test // ""' "$APP_PATH/package.json")
+          if [[ "$test_script" != *vitest* ]]; then
+            echo "Mutation testing skipped: $APP_PATH does not run its unit tests on vitest." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+
+          # Stryker mutates `file:startLine-endLine`, so only the lines this PR added or changed get mutants.
+          # Tests, type declarations and declarative wiring produce mutants no test should pin.
+          mutate=$(git diff --unified=0 "$BASE_SHA" HEAD -- "$APP_PATH/src" | awk -v prefix="$APP_PATH/" '
+            /^\+\+\+ / {
+              file = substr($0, 7)
+              sub("^" prefix, "", file)
+              mutatable = file ~ /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/ &&
+                file !~ /\.(spec|integration|test|e2e)\.[a-z]+$/ &&
+                file !~ /\.d\.ts$/ &&
+                file !~ /(^|\/)(test|tests|__tests__|__mocks__|scripts?|drizzle|migrations)\// &&
+                file !~ /(^|\/)(routes?|routers?|http-schemas|schemas|config|providers)\// &&
+                file !~ /\.schema\.ts$/ &&
+                file !~ /(^|\/)index\.tsx?$/ &&
+                file !~ /\.gen\.ts$/
+              next
+            }
+            /^@@ / && mutatable {
+              split(substr($3, 2), hunk, ",")
+              start = hunk[1] + 0
+              count = (length(hunk) < 2 ? 1 : hunk[2] + 0)
+              if (count > 0) printf "%s%s:%d-%d", (found++ ? "," : ""), file, start, start + count - 1
+            }
+          ')
+
+          if [[ -z "$mutate" ]]; then
+            echo "Mutation testing skipped: no mutatable source line changed in $APP_PATH." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          ranges=$(( $(tr -cd ',' <<< "$mutate" | wc -c) + 1 ))
+          if (( ranges > MAX_MUTATION_RANGES )); then
+            echo "Mutation testing skipped: $ranges changed line ranges exceed the limit of $MAX_MUTATION_RANGES." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Reuse whatever the app's own unit-test script exports, so mutation runs see the env its tests need.
+          test_env=$(awk '{ for (i = 1; i <= NF; i++) { if ($i ~ /^[A-Za-z_][A-Za-z0-9_]*=[A-Za-z0-9_.:\/-]*$/) printf "%s ", $i; else exit } }' <<< "$test_script")
+
+          echo "mutate=$mutate" >> "$GITHUB_OUTPUT"
+          echo "test_env=$test_env" >> "$GITHUB_OUTPUT"
+          echo "ranges=$ranges" >> "$GITHUB_OUTPUT"
+
+      - name: Run mutation testing
+        if: ${{ steps.mutation_targets.outputs.mutate != '' }}
+        working-directory: apps/${{ inputs.app }}
+        env:
+          APP: ${{ inputs.app }}
+          MUTATE: ${{ steps.mutation_targets.outputs.mutate }}
+          TEST_ENV: ${{ steps.mutation_targets.outputs.test_env }}
+          RANGES: ${{ steps.mutation_targets.outputs.ranges }}
+          STRYKER_JSON_REPORT: ${{ github.workspace }}/mutation-report.json
+        run: | # shell
+          status=0
+          # $TEST_ENV is an unquoted list of KEY=value tokens on purpose: `env` applies them, and nothing else gets re-parsed.
+          # shellcheck disable=SC2086
+          env $TEST_ENV npx stryker run "$GITHUB_WORKSPACE/stryker.config.mjs" --mutate "$MUTATE" || status=$?
+
+          {
+            echo "### Mutation testing: $APP"
+            echo
+            echo "Mutated $RANGES changed line range(s); the score has to stay at or above ${STRYKER_BREAK}%."
+            echo
+            jq -r '
+              [.files | to_entries[] | .key as $file | .value.mutants[]
+                | select(.status == "Survived" or .status == "NoCoverage")
+                | "| `\($file):\(.location.start.line)` | \(.mutatorName) | \(.status) |"] as $rows
+              | if ($rows | length) == 0
+                then "Every mutant was killed."
+                else (["| location | mutator | status |", "| --- | --- | --- |"] + $rows | join("\n"))
+                end
+            ' "$STRYKER_JSON_REPORT" || echo "Stryker produced no report; see the step log."
+            echo
+            echo "Add the \`ignore-mutations-testing\` label to skip this check."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit $status
 
       - name: Teardown tests environment
         if: ${{ always() && steps.tests_details.outputs.requires_env_setup == 'true' }}

--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -138,7 +138,13 @@ jobs:
           {
             echo "### Mutation testing: $APP"
             echo
-            echo "Mutated $RANGES changed line range(s), scoped to the files the app measures coverage on, against their own specs: \`$TEST_FILES\`."
+            # A fenced block, not an inline code span: the spec paths come from PR-controlled file names,
+            # and a backtick in one would otherwise close the span and let raw markdown into the summary.
+            echo "Mutated $RANGES changed line range(s), scoped to the files the app measures coverage on, against their own specs:"
+            echo
+            echo '```'
+            echo "$TEST_FILES"
+            echo '```'
             echo
             echo "$summary"
             echo

--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -92,10 +92,20 @@ jobs:
         env:
           APP_PATH: apps/${{ inputs.app }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_REF: refs/pull/${{ github.event.pull_request.number }}/merge
         run: | # shell
-          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          # The checkout is the merge commit, so its first parent is the base tip: diffing against it
+          # leaves out whatever landed on the base branch after the PR was opened.
+          git fetch --no-tags --depth=2 origin "+$MERGE_REF:$MERGE_REF" || true
 
-          node script/mutation-targets.mjs "$APP_PATH" "$BASE_SHA" --out mutation-targets.json
+          if git cat-file -e "HEAD^1^{commit}" 2> /dev/null; then
+            base=HEAD^1
+          else
+            git fetch --no-tags --depth=1 origin "$BASE_SHA"
+            base="$BASE_SHA"
+          fi
+
+          node script/mutation-targets.mjs "$APP_PATH" "$base" --out mutation-targets.json
 
           jq -r '"mutate=\(.mutate)", "ranges=\(.ranges)", "test_env=\(.testEnv)"' mutation-targets.json >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -107,7 +107,7 @@ jobs:
 
           node script/mutation-targets.mjs "$APP_PATH" "$base" --out mutation-targets.json
 
-          jq -r '"mutate=\(.mutate)", "ranges=\(.ranges)", "test_env=\(.testEnv)"' mutation-targets.json >> "$GITHUB_OUTPUT"
+          jq -r '"mutate=\(.mutate)", "ranges=\(.ranges)", "test_files=\(.testFiles)", "test_env=\(.testEnv)"' mutation-targets.json >> "$GITHUB_OUTPUT"
 
           skip=$(jq -r '.skip // empty' mutation-targets.json)
           if [[ -n "$skip" ]]; then
@@ -120,6 +120,7 @@ jobs:
         env:
           APP: ${{ inputs.app }}
           MUTATE: ${{ steps.mutation_targets.outputs.mutate }}
+          TEST_FILES: ${{ steps.mutation_targets.outputs.test_files }}
           TEST_ENV: ${{ steps.mutation_targets.outputs.test_env }}
           RANGES: ${{ steps.mutation_targets.outputs.ranges }}
           STRYKER_JSON_REPORT: ${{ github.workspace }}/mutation-report.json
@@ -127,17 +128,17 @@ jobs:
           status=0
           # $TEST_ENV is an unquoted list of KEY=value tokens on purpose: `env` applies them, and nothing else gets re-parsed.
           # shellcheck disable=SC2086
-          env $TEST_ENV npx stryker run "$GITHUB_WORKSPACE/stryker.config.mjs" --mutate "$MUTATE" || status=$?
+          env $TEST_ENV npx stryker run "$GITHUB_WORKSPACE/stryker.config.mjs" --mutate "$MUTATE" --testFiles "$TEST_FILES" || status=$?
 
           score_status=0
           summary=$(node "$GITHUB_WORKSPACE/script/mutation-report.mjs" "$STRYKER_JSON_REPORT" \
             --min "$MUTATION_MIN_SCORE" \
-            --reproduce "cd apps/$APP && npx stryker run ../../stryker.config.mjs --mutate '$MUTATE'") || score_status=$?
+            --reproduce "cd apps/$APP && npx stryker run ../../stryker.config.mjs --mutate '$MUTATE' --testFiles '$TEST_FILES'") || score_status=$?
 
           {
             echo "### Mutation testing: $APP"
             echo
-            echo "Mutated $RANGES changed line range(s), scoped to the files the app measures coverage on."
+            echo "Mutated $RANGES changed line range(s), scoped to the files the app measures coverage on, against their own specs: \`$TEST_FILES\`."
             echo
             echo "$summary"
             echo

--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TEST_SCRIPT_NAME: ${{ github.event_name == 'merge_group' && 'test' || 'test:cov' }}
-      # Stryker fails the mutation step when the score over the changed lines drops below this.
-      STRYKER_BREAK: 80
+      # The mutation step fails when the score over the reached mutants of the changed lines drops below this.
+      MUTATION_MIN_SCORE: 80
       # A diff this wide is a PR to split, not a mutation run to sit through.
       MAX_MUTATION_RANGES: 200
     steps:
@@ -93,55 +93,16 @@ jobs:
           APP_PATH: apps/${{ inputs.app }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: | # shell
-          test_script=$(jq -r '.scripts["test:unit"] // .scripts.test // ""' "$APP_PATH/package.json")
-          if [[ "$test_script" != *vitest* ]]; then
-            echo "Mutation testing skipped: $APP_PATH does not run its unit tests on vitest." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
           git fetch --no-tags --depth=1 origin "$BASE_SHA"
 
-          # Stryker mutates `file:startLine-endLine`, so only the lines this PR added or changed get mutants.
-          # Tests, type declarations and declarative wiring produce mutants no test should pin.
-          mutate=$(git diff --unified=0 "$BASE_SHA" HEAD -- "$APP_PATH/src" | awk -v prefix="$APP_PATH/" '
-            /^\+\+\+ / {
-              file = substr($0, 7)
-              sub("^" prefix, "", file)
-              mutatable = file ~ /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/ &&
-                file !~ /\.(spec|integration|test|e2e)\.[a-z]+$/ &&
-                file !~ /\.d\.ts$/ &&
-                file !~ /(^|\/)(test|tests|__tests__|__mocks__|scripts?|drizzle|migrations)\// &&
-                file !~ /(^|\/)(routes?|routers?|http-schemas|schemas|config|providers)\// &&
-                file !~ /\.schema\.ts$/ &&
-                file !~ /(^|\/)index\.tsx?$/ &&
-                file !~ /\.gen\.ts$/
-              next
-            }
-            /^@@ / && mutatable {
-              split(substr($3, 2), hunk, ",")
-              start = hunk[1] + 0
-              count = (length(hunk) < 2 ? 1 : hunk[2] + 0)
-              if (count > 0) printf "%s%s:%d-%d", (found++ ? "," : ""), file, start, start + count - 1
-            }
-          ')
+          node script/mutation-targets.mjs "$APP_PATH" "$BASE_SHA" --out mutation-targets.json
 
-          if [[ -z "$mutate" ]]; then
-            echo "Mutation testing skipped: no mutatable source line changed in $APP_PATH." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+          jq -r '"mutate=\(.mutate)", "ranges=\(.ranges)", "test_env=\(.testEnv)"' mutation-targets.json >> "$GITHUB_OUTPUT"
+
+          skip=$(jq -r '.skip // empty' mutation-targets.json)
+          if [[ -n "$skip" ]]; then
+            echo "Mutation testing skipped: $skip." >> "$GITHUB_STEP_SUMMARY"
           fi
-
-          ranges=$(( $(tr -cd ',' <<< "$mutate" | wc -c) + 1 ))
-          if (( ranges > MAX_MUTATION_RANGES )); then
-            echo "Mutation testing skipped: $ranges changed line ranges exceed the limit of $MAX_MUTATION_RANGES." >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          # Reuse whatever the app's own unit-test script exports, so mutation runs see the env its tests need.
-          test_env=$(awk '{ for (i = 1; i <= NF; i++) { if ($i ~ /^[A-Za-z_][A-Za-z0-9_]*=[A-Za-z0-9_.:\/-]*$/) printf "%s ", $i; else exit } }' <<< "$test_script")
-
-          echo "mutate=$mutate" >> "$GITHUB_OUTPUT"
-          echo "test_env=$test_env" >> "$GITHUB_OUTPUT"
-          echo "ranges=$ranges" >> "$GITHUB_OUTPUT"
 
       - name: Run mutation testing
         if: ${{ steps.mutation_targets.outputs.mutate != '' }}
@@ -158,25 +119,23 @@ jobs:
           # shellcheck disable=SC2086
           env $TEST_ENV npx stryker run "$GITHUB_WORKSPACE/stryker.config.mjs" --mutate "$MUTATE" || status=$?
 
+          score_status=0
+          summary=$(node "$GITHUB_WORKSPACE/script/mutation-report.mjs" "$STRYKER_JSON_REPORT" \
+            --min "$MUTATION_MIN_SCORE" \
+            --reproduce "cd apps/$APP && npx stryker run ../../stryker.config.mjs --mutate '$MUTATE'") || score_status=$?
+
           {
             echo "### Mutation testing: $APP"
             echo
-            echo "Mutated $RANGES changed line range(s); the score has to stay at or above ${STRYKER_BREAK}%."
+            echo "Mutated $RANGES changed line range(s), scoped to the files the app measures coverage on."
             echo
-            jq -r '
-              [.files | to_entries[] | .key as $file | .value.mutants[]
-                | select(.status == "Survived" or .status == "NoCoverage")
-                | "| `\($file):\(.location.start.line)` | \(.mutatorName) | \(.status) |"] as $rows
-              | if ($rows | length) == 0
-                then "Every mutant was killed."
-                else (["| location | mutator | status |", "| --- | --- | --- |"] + $rows | join("\n"))
-                end
-            ' "$STRYKER_JSON_REPORT" || echo "Stryker produced no report; see the step log."
+            echo "$summary"
             echo
             echo "Add the \`ignore-mutations-testing\` label to skip this check."
           } >> "$GITHUB_STEP_SUMMARY"
 
-          exit $status
+          if (( status != 0 )); then exit $status; fi
+          exit $score_status
 
       - name: Teardown tests environment
         if: ${{ always() && steps.tests_details.outputs.requires_env_setup == 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ profile-results.json
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 .github/workflows/test*.yml
+
+.stryker-tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ profile-results.json
 .github/workflows/test*.yml
 
 .stryker-tmp/
+**/reports/mutation/

--- a/apps/api/vitest.mutation.config.ts
+++ b/apps/api/vitest.mutation.config.ts
@@ -1,0 +1,5 @@
+import { unitProjectsOnly } from "@akashnetwork/dev-config/vitest/mutation.mjs";
+
+import config from "./vitest.config";
+
+export default unitProjectsOnly(config);

--- a/apps/deploy-web/vitest.mutation.config.ts
+++ b/apps/deploy-web/vitest.mutation.config.ts
@@ -1,0 +1,5 @@
+import { unitProjectsOnly } from "@akashnetwork/dev-config/vitest/mutation.mjs";
+
+import config from "./vitest.config";
+
+export default unitProjectsOnly(config);

--- a/apps/notifications/vitest.mutation.config.ts
+++ b/apps/notifications/vitest.mutation.config.ts
@@ -1,0 +1,5 @@
+import { unitProjectsOnly } from "@akashnetwork/dev-config/vitest/mutation.mjs";
+
+import config from "./vitest.config";
+
+export default unitProjectsOnly(config);

--- a/apps/provider-inventory/vitest.mutation.config.ts
+++ b/apps/provider-inventory/vitest.mutation.config.ts
@@ -1,0 +1,5 @@
+import { unitProjectsOnly } from "@akashnetwork/dev-config/vitest/mutation.mjs";
+
+import config from "./vitest.config";
+
+export default unitProjectsOnly(config);

--- a/apps/provider-proxy/vitest.mutation.config.ts
+++ b/apps/provider-proxy/vitest.mutation.config.ts
@@ -1,0 +1,5 @@
+import { unitProjectsOnly } from "@akashnetwork/dev-config/vitest/mutation.mjs";
+
+import config from "./vitest.config";
+
+export default unitProjectsOnly(config);

--- a/apps/tx-signer/vitest.mutation.config.ts
+++ b/apps/tx-signer/vitest.mutation.config.ts
@@ -1,0 +1,5 @@
+import { unitProjectsOnly } from "@akashnetwork/dev-config/vitest/mutation.mjs";
+
+import config from "./vitest.config";
+
+export default unitProjectsOnly(config);

--- a/knip.json
+++ b/knip.json
@@ -41,7 +41,7 @@
       "drizzle": false
     },
     "apps/deploy-web": {
-      "entry": ["next.config.js", "postcss.config.js", "src/pages/**/*.tsx", "src/pages/**/*.ts", "src/stubs/empty.ts"],
+      "entry": ["next.config.js", "postcss.config.js", "vitest.mutation.config.ts", "src/pages/**/*.tsx", "src/pages/**/*.ts", "src/stubs/empty.ts"],
       "ignoreDependencies": [
         "sharp",
         "@nivo/core",
@@ -95,7 +95,9 @@
         ".eslintrc.ts.js",
         ".eslintrc.next.js",
         "tsup-plugins.ts",
-        "eslint-plugin-akash/index.js"
+        "eslint-plugin-akash/index.js",
+        "vitest/mutation.mjs",
+        "vitest/mutation.d.mts"
       ],
       "ignoreDependencies": ["eslint-plugin-akash", "next"]
     },

--- a/knip.json
+++ b/knip.json
@@ -22,7 +22,7 @@
   ],
   "workspaces": {
     ".": {
-      "entry": [".eslintrc.js", ".prettierrc.js"],
+      "entry": [".eslintrc.js", ".prettierrc.js", "script/*.mjs"],
       "ignoreDependencies": [
         "@interchain-ui/react",
         "drizzle-orm",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "@akashnetwork/dev-config": "*",
         "@commitlint/cli": "^19.5.0",
         "@commitlint/config-conventional": "^19.5.0",
+        "@stryker-mutator/core": "^10.0.0",
+        "@stryker-mutator/vitest-runner": "^10.0.0",
         "cross-env": "^7.0.3",
         "eslint": "^9.39.5",
         "eslint-plugin-import-x": "^4.17.1",
@@ -11744,6 +11746,380 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+      "integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.3.tgz",
+      "integrity": "sha512-XEYX2WA8SBkLPczL6/yXPHLPCvDoptmh9v56Cy05BSV1Smk1vWy19bTC4qJBuIffw7+6l4CcaYYzGqG60RfW1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.3.0.tgz",
+      "integrity": "sha512-pZHXJImFtERmSNMBHcjwuz8Ck5vEFEYNUZnwbb8aJpjHv/TwGuFErNxF2Hp8+V+pNJs2EYPMlyWscvFEqO9jOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-JMD5Jy/ScL5TZE18m83Nw25HjqGFLoWXwnEkW7IdwwAhZpB9Bus55/WU7zn3UqR1MOCjjTQOIYpiD4vjWA3LPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.1.tgz",
+      "integrity": "sha512-y43COoyVUjPWIobn2Qep/uI1drPS78aaZZZ9kVi94Tyu/GuW2N8d8Q4rifJXGAXCEAXCPTTMjD8gC1HyvM5ukA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/external-editor": "^3.0.4",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.3.tgz",
+      "integrity": "sha512-3NQJiXNJ/aj9wiAsr7pECdp5Qe9J0X9YUJCKsaFXS+ddOxfL6J4AIl3w3T4Gq3kK0WsQY5GMoDokK5X94m6lHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
+      "integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+      "integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.4.tgz",
+      "integrity": "sha512-3xQkQrOvgOzpSN2ciTVdRDlg1FWMCA8l+0KfB6SNlILoTCGzJTzO/gc0Rwjcb3usuGyKdaGtI6OiyMdeMeLWkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.1.tgz",
+      "integrity": "sha512-5KaqwZNLRpUuWcoCrYghPP9TMaXL5v2Sk4xqePM7RCVegcJStoXdWibio60YIC1bec+z1fCyb67N6XPJIkZtGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.2.0.tgz",
+      "integrity": "sha512-CvVcW09emkBESEOW+4R8CjLNkP3fB3XrjeL8CDvfpjgrJN+V9oerXmJAXXM3l+4xqYPD5Yaujzy/Ph0PLOdDuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.7.0.tgz",
+      "integrity": "sha512-yQwBMYvpJ6jqrXtKiOwRD5XezjJoyt3VQvIyjsr5Arqb519nfIohOQymWVJ8/vEgg8xtZerrCsqlSaqt/LPC9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.2.3",
+        "@inquirer/confirm": "^6.3.0",
+        "@inquirer/editor": "^5.3.1",
+        "@inquirer/expand": "^5.1.3",
+        "@inquirer/input": "^5.1.4",
+        "@inquirer/number": "^4.2.1",
+        "@inquirer/password": "^5.2.0",
+        "@inquirer/rawlist": "^5.3.3",
+        "@inquirer/search": "^4.3.1",
+        "@inquirer/select": "^5.2.3"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.3.tgz",
+      "integrity": "sha512-Mu7WrtmDLaXBDEyrRLS70SZgX9ZSm4Up1w0ZxiH8C1OOp9oaVCn2k8q3QGgmlnhsKYUhuaU3zFWhAP6wxkVIMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.1.tgz",
+      "integrity": "sha512-0VWOvsHWI0rPj6CG70MoP4oXNCB6adcyN8bVFZXnh11eLDdPIK2f2XCmva78acPPDfJisfab7qNakwBh7hdBXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.3.tgz",
+      "integrity": "sha512-KuRTodDa6xBXX2noIpjuitpX/QT7Sfav7dIZ/OfUY54Hxg95nrGoshSzxx6Ey7qqLbImKdiGkSDt7KjPXjQgmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.7",
+        "@inquirer/core": "^12.0.1",
+        "@inquirer/figures": "^2.0.8",
+        "@inquirer/type": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.1.0.tgz",
+      "integrity": "sha512-FMiJpuHUG3Dk0ex+UIXkre7i+i4OcwHWk9YdcVtZHFwb/r2rnrU2ipTCNAB7A+QOP0ryzIcqOfy76fRyyvOEAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@interchain-ui/react": {
       "version": "1.23.31",
       "license": "SEE LICENSE IN LICENSE",
@@ -20032,6 +20408,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sentry-internal/browser-utils": {
       "version": "8.55.0",
       "license": "MIT",
@@ -20973,6 +21356,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "dev": true,
@@ -21013,6 +21409,998 @@
     "node_modules/@streamparser/json": {
       "version": "0.0.20",
       "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/api": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-10.0.0.tgz",
+      "integrity": "sha512-ZtAJ0ZT3MVRCWJTBE2h90XB/6E+4lifHYtcTyNG6nU2nLekPgTo4gD5esjX6Okxo1b/JB4jJzyxYB54fwKAoJw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-metrics": "3.8.4",
+        "mutation-testing-report-schema": "3.8.4",
+        "tslib": "~2.8.0",
+        "typed-inject": "~5.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-10.0.0.tgz",
+      "integrity": "sha512-ZvMsRyaXQQ5e6Thcid9pkuODv6Fn9E3nrBQJUap+hcJuGJ4unm26afo3m6YKSjn8kinyxJ/3TXf0cTWRDaTxVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@inquirer/prompts": "^8.0.0",
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/instrumenter": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "ajv": "~8.20.0",
+        "chalk": "~5.6.0",
+        "commander": "~14.0.0",
+        "diff-match-patch": "1.0.5",
+        "emoji-regex": "~10.6.0",
+        "execa": "~9.6.0",
+        "json-rpc-2.0": "^1.7.0",
+        "lodash.groupby": "~4.6.0",
+        "minimatch": "~10.2.4",
+        "mutation-server-protocol": "~0.4.0",
+        "mutation-testing-elements": "3.8.4",
+        "mutation-testing-metrics": "3.8.4",
+        "mutation-testing-report-schema": "3.8.4",
+        "npm-run-path": "~6.0.0",
+        "progress": "~2.0.3",
+        "rxjs": "~7.8.1",
+        "semver": "^7.6.3",
+        "source-map": "~0.7.4",
+        "tree-kill": "~1.2.2",
+        "tslib": "2.8.1",
+        "typed-inject": "~5.0.0",
+        "typed-rest-client": "~2.3.0"
+      },
+      "bin": {
+        "stryker": "bin/stryker.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/core/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/core/node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-10.0.0.tgz",
+      "integrity": "sha512-B7Wmn1KlEWyFeOz6D6oGvQGRfi5Xw3VemG6dEKvFQp4qLvxD9Mf4kcZghfxffgnYwXd3bFgqXsJ+ZGlhdfIOrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/core": "~8.0.0",
+        "@babel/generator": "~8.0.0",
+        "@babel/parser": "~8.0.0",
+        "@babel/plugin-proposal-decorators": "~8.0.0",
+        "@babel/plugin-transform-explicit-resource-management": "^8.0.0",
+        "@babel/preset-react": "~8.0.0",
+        "@babel/preset-typescript": "~8.0.0",
+        "@babel/traverse": "~8.0.4",
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "angular-html-parser": "~10.11.0",
+        "semver": "~7.8.0",
+        "tslib": "2.8.1",
+        "weapon-regex": "~2.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/code-frame": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-8.0.0.tgz",
+      "integrity": "sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "js-tokens": "^10.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/compat-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
+        "convert-source-map": "^2.0.0",
+        "empathic": "^2.0.1",
+        "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
+        "json5": "^2.2.3",
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/generator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "@types/jsesc": "^2.5.0",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-annotate-as-pure": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz",
+      "integrity": "sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-compilation-targets": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz",
+      "integrity": "sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/helper-replace-supers": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-globals": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-8.0.0.tgz",
+      "integrity": "sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz",
+      "integrity": "sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-module-imports": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-8.0.0.tgz",
+      "integrity": "sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-module-transforms": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-8.0.1.tgz",
+      "integrity": "sha512-UgAhl1kqiW5ciE0yCXqqvnb4H2n3IELJ7lIIQRezwDPilPEZX5i+Rvbja9MFTkwUn2biEiSMeV31aUzR4Lwakw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-optimise-call-expression": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz",
+      "integrity": "sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-plugin-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz",
+      "integrity": "sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-replace-supers": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz",
+      "integrity": "sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^8.0.0",
+        "@babel/helper-optimise-call-expression": "^8.0.0",
+        "@babel/traverse": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz",
+      "integrity": "sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-string-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-validator-identifier": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helper-validator-option": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/parser": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^8.0.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-proposal-decorators": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-8.0.2.tgz",
+      "integrity": "sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-decorators": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-syntax-decorators": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-8.0.1.tgz",
+      "integrity": "sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-syntax-jsx": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-8.0.1.tgz",
+      "integrity": "sha512-n0jtCOxEovhU7METqSQjcZO9pX53nu9uNIjMS+hEt+Nt9jA7oOZoBIgbCxhhASmF6T6rPDGge5UAvh6Z4eFz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-syntax-typescript": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-8.0.3.tgz",
+      "integrity": "sha512-jmTPwps7oSQSZaV1SxkQ3C12UWyufGysGc5OzDpZzvPAIX4mO7dJT3hoqkWVrSImvkcMiknir1iLN1SNV/CZzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-destructuring": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-8.0.1.tgz",
+      "integrity": "sha512-RtR8uLDl0QcCmqMNIkM8gmDeYZ3rS0ZH+sa+I6sfc09yFoqfp9AEPgBstq9KyfVb0lFCVSRFfJXCI70FIl5ccw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-explicit-resource-management": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-8.0.1.tgz",
+      "integrity": "sha512-VzDIYwBlLCpV6mJfloRdJm8HmYnMqs7O+bGha8yfg2kP7jAdxeCw6yZBVBeaKKQUThtSU52iy+3lB7DhYsbOBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-transform-destructuring": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-8.0.1.tgz",
+      "integrity": "sha512-PMuzulWrrzFNmY3lXSk/tV9NRb7y0eZZLJY4UEo2TKszroxvUZHAPPi+T9FDyrQhod+TQA+t+8/QYaaMpiEuhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-8.0.1.tgz",
+      "integrity": "sha512-soLishXlkyu6jcICPyO3HEP7A3GCzKEnn7XfvYrImuWEOwFAz93qShmWSYPf5ww0ZkO4By0zsN2bVIDF54fSdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-8.0.1.tgz",
+      "integrity": "sha512-NgkoF7Uq+30TmOPDdNUimT0Nta02uVjqJRFNlVWKrbOCu/CkzfHa4aMnIs0lMpkMmZmWA1e42Va+F04i/pY1zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-module-imports": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/plugin-syntax-jsx": "^8.0.1",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-8.0.1.tgz",
+      "integrity": "sha512-Hb+HUZpV9KFHjm+F+P3aLDMi8QXU9l3ROCQv20z18Me2sGyW5nNNR5YTevNlgHvCpFek3BnAwhDGq/BRndXViw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-8.0.1.tgz",
+      "integrity": "sha512-7/8UwU8hoPBurXa9tUiTTC8aACTRy5tCqLUtqikHp2eGiWoEB57AduOdbQ71OOMTEvawKrGhv3WfzkDpI+/oSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-plugin-utils": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/plugin-transform-typescript": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-8.0.1.tgz",
+      "integrity": "sha512-0Svqp3413Eg0GElldykF/T7SNsxQO5YVGD70fZyAdZTnX8WRgcopmbiU7GTa5xY5ZnJcEpNbfns8/GjX+/1yeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^8.0.0",
+        "@babel/helper-create-class-features-plugin": "^8.0.1",
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^8.0.0",
+        "@babel/plugin-syntax-typescript": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/preset-react": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-8.0.1.tgz",
+      "integrity": "sha512-jrFuPp/pTddFZbtmWhdLNAYc6UMcpboeUPnw0BBrm4nOmcAko/1TRcFi1PzWCeOFRU+VaSiKmat87W1HvR7mIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-transform-react-display-name": "^8.0.1",
+        "@babel/plugin-transform-react-jsx": "^8.0.1",
+        "@babel/plugin-transform-react-jsx-development": "^8.0.1",
+        "@babel/plugin-transform-react-pure-annotations": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/preset-typescript": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-8.0.1.tgz",
+      "integrity": "sha512-qrPhQIN1NLrPmzgazF9XKQqXrOcp/WJly+K+6ReFonn24FZqRJO7clxOJo6Ni75L+2vAqI3cHVU2OJLBxoPp5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^8.0.1",
+        "@babel/helper-validator-option": "^8.0.0",
+        "@babel/plugin-transform-modules-commonjs": "^8.0.1",
+        "@babel/plugin-transform-typescript": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^8.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/template": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-8.0.0.tgz",
+      "integrity": "sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/traverse": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+      "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-globals": "^8.0.0",
+        "@babel/parser": "^8.0.4",
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.4",
+        "obug": "^2.1.1"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/@babel/types": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@stryker-mutator/instrumenter/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@stryker-mutator/util": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-10.0.0.tgz",
+      "integrity": "sha512-LzOpHiJaCp2ABQgnPMlrQQcsK43bd5Vo/2FGL78aN62yDoeRQ+4j3tzeuXxK5OAHdC3fUz6TDoy4IsoAuLAd3w==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stryker-mutator/vitest-runner": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@stryker-mutator/vitest-runner/-/vitest-runner-10.0.0.tgz",
+      "integrity": "sha512-SHK2/vfvRUpiz7jXPnQMBnr6zLdm69DK03Mo5mPhaZWcRSygrKUqYsPqWsXsK+5ySHzlMTfCyFK5NQ/X9sJFFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stryker-mutator/api": "10.0.0",
+        "@stryker-mutator/util": "10.0.0",
+        "semver": "^7.7.4",
+        "tslib": "~2.8.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@stryker-mutator/core": "10.0.0",
+        "vitest": ">=2.0.0"
+      }
+    },
+    "node_modules/@stryker-mutator/vitest-runner/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@stylistic/eslint-plugin": {
       "version": "5.10.0",
@@ -21880,6 +23268,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
       "dev": true,
@@ -21960,6 +23355,13 @@
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
+    },
+    "node_modules/@types/jsesc": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
+      "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -24239,6 +25641,16 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/angular-html-parser": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.11.0.tgz",
+      "integrity": "sha512-3vERzJ65UFDr3C7uozLJwsNcQS3FS784dSh583oDgDTTZMgXe3/pdyXgKndxiP5R2lvYRfW6gSl145Hnyf2OFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/animejs": {
       "version": "3.2.2",
       "license": "MIT"
@@ -25553,6 +26965,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "license": "MIT",
@@ -25731,6 +27150,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/client-only": {
@@ -27054,6 +28483,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/des.js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.3",
       "license": "MIT"
@@ -27122,6 +28562,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -28022,6 +29469,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/encodeurl": {
@@ -29237,9 +30694,36 @@
       "version": "2.1.1",
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.0.1",
       "license": "MIT"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -29298,6 +30782,22 @@
       },
       "engines": {
         "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -30987,7 +32487,9 @@
       }
     },
     "node_modules/import-meta-resolve": {
-      "version": "4.1.0",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -31620,6 +33122,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakmap": {
@@ -32590,6 +34105,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/js-md4": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/js-md4/-/js-md4-0.3.2.tgz",
+      "integrity": "sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-sha3": {
       "version": "0.8.0",
       "license": "MIT"
@@ -32738,6 +34260,13 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "license": "MIT"
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.8.0.tgz",
+      "integrity": "sha512-4nw+XlJbk5XokA7BtqHGu+0PEiUPfAkRzXXd1Cgjy1c3F2UI/3Gy7yr76wyJEv3X1F1SRGGF8xPAPPhelBiGmA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema": {
@@ -33674,6 +35203,13 @@
     },
     "node_modules/lodash.escape": {
       "version": "4.0.1",
+      "license": "MIT"
+    },
+    "node_modules/lodash.groupby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
+      "integrity": "sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -36374,6 +37910,63 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mutation-server-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mutation-server-protocol/-/mutation-server-protocol-0.4.1.tgz",
+      "integrity": "sha512-SBGK0j8hLDne7bktgThKI8kGvGTx3rY3LAeQTmOKZ5bVnL/7TorLMvcVF7dIPJCu5RNUWhkkuF53kurygYVt3g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "zod": "^4.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mutation-server-protocol/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/mutation-testing-elements": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.8.4.tgz",
+      "integrity": "sha512-5CF1SNa7at5ZH33vEr+21wNebTSrtNIVvnzaUlxortHajOrIPaSLczIWvg6sI/fsExekQ7jookwf2cHftkckqQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mutation-testing-metrics": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.8.4.tgz",
+      "integrity": "sha512-DZcmndJBH6nrNs3tpiB3OcMVq9KkG2cHCpJSnDxSxPwi9qrafRmoec40xjhkbzOoX1n7/4UkDqg5tIj4A6nvCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mutation-testing-report-schema": "3.8.4"
+      }
+    },
+    "node_modules/mutation-testing-report-schema": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.8.4.tgz",
+      "integrity": "sha512-s4G71R6Lt/PpZ0cqeglIcgyBdzLM8E+SeCHZAPg1wkSsPtRBa4XfPzAozYKdiJk/TLbNEEb7En9t0/bveuPuxA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "license": "MIT",
@@ -37369,6 +38962,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "license": "MIT"
@@ -38226,6 +39832,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.1.tgz",
+      "integrity": "sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/proc-log": {
@@ -42916,6 +44538,16 @@
       "version": "1.14.1",
       "license": "0BSD"
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/turbo": {
       "version": "2.3.3",
       "dev": true,
@@ -43128,6 +44760,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typed-inject": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/typed-inject/-/typed-inject-5.0.0.tgz",
+      "integrity": "sha512-0Ql2ORqBORLMdAW89TQKZsb1PQkFGImFfVmncXWe7a+AA3+7dh7Se9exxZowH4kbnlvKEFkMxUYdHUpjYWFJaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.3.1.tgz",
+      "integrity": "sha512-k4kX5Up6qA68D0Cby2AK+6+vM5k3qTxe+/3FqhnHRExjY5cfbOnzjQZbP/LXleF8hVoDvDqxlgk9KK83HoBZlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "des.js": "^1.1.0",
+        "js-md4": "^0.3.2",
+        "qs": "6.15.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.13.8"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
+    },
+    "node_modules/typed-rest-client/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "license": "MIT"
@@ -43246,6 +44921,13 @@
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/undici": {
@@ -44396,6 +46078,13 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/weapon-regex": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-2.0.4.tgz",
+      "integrity": "sha512-ubuhY5Lo4phWcMsJqe8j62m9uhsuo/VpfK5XsSgYGRGDSt10hwVwOBTriPRd0dac+KYbGNXOrfXjM6xCp2NUKg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "license": "MIT",
@@ -45207,6 +46896,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "husky": "^9.1.6",
         "knip": "^6.4.1",
         "lint-staged": "^16.2.7",
+        "picomatch": "^4.0.4",
         "sort-package-json": "^2.14.0",
         "tsup": "^8.5.1",
         "turbo": "^2.3.3",
@@ -2044,19 +2045,6 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "apps/deploy-web/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "apps/deploy-web/node_modules/rollup": {
@@ -9557,16 +9545,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@dotenvx/dotenvx/node_modules/which": {
@@ -19808,6 +19786,18 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-babel/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "28.0.1",
       "license": "MIT",
@@ -19842,16 +19832,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -19895,6 +19875,18 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/plugin-replace": {
       "version": "2.4.2",
       "license": "MIT",
@@ -19936,6 +19928,18 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
+    "node_modules/@rollup/plugin-replace/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.3.0",
       "license": "MIT",
@@ -19954,16 +19958,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -22432,18 +22426,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@stylistic/eslint-plugin/node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@supercharge/promise-pool": {
@@ -25715,6 +25697,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/append-field": {
@@ -33958,6 +33952,19 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-util/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/jest-validate": {
       "version": "29.7.0",
       "dev": true,
@@ -34533,19 +34540,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/knip/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/knip/node_modules/strip-json-comments": {
@@ -37474,6 +37468,18 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime": {
       "version": "1.6.0",
       "license": "MIT",
@@ -39195,10 +39201,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -40658,6 +40666,18 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/readonly-date": {
@@ -43441,18 +43461,6 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinyrainbow": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
@@ -45216,17 +45224,6 @@
         "@swc/core": "^1.2.108"
       }
     },
-    "node_modules/unplugin-swc/node_modules/picomatch": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/unplugin-swc/node_modules/unplugin": {
       "version": "2.3.11",
       "dev": true,
@@ -45903,19 +45900,6 @@
       "version": "2.0.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/vitest/node_modules/std-env": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "husky": "^9.1.6",
     "knip": "^6.4.1",
     "lint-staged": "^16.2.7",
+    "picomatch": "^4.0.4",
     "sort-package-json": "^2.14.0",
     "tsup": "^8.5.1",
     "turbo": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@akashnetwork/dev-config": "*",
     "@commitlint/cli": "^19.5.0",
     "@commitlint/config-conventional": "^19.5.0",
+    "@stryker-mutator/core": "^10.0.0",
+    "@stryker-mutator/vitest-runner": "^10.0.0",
     "cross-env": "^7.0.3",
     "eslint": "^9.39.5",
     "eslint-plugin-import-x": "^4.17.1",

--- a/packages/dev-config/vitest/mutation.d.mts
+++ b/packages/dev-config/vitest/mutation.d.mts
@@ -1,0 +1,3 @@
+type ProjectAwareConfig = { test?: { projects?: unknown[] } };
+
+export declare function unitProjectsOnly<TConfig extends ProjectAwareConfig>(config: TConfig): TConfig;

--- a/packages/dev-config/vitest/mutation.mjs
+++ b/packages/dev-config/vitest/mutation.mjs
@@ -1,0 +1,6 @@
+/** Mutation testing reruns the suite per mutant, so only unit projects take part: the rest need services and are orders of magnitude slower. */
+export function unitProjectsOnly(config) {
+  const unitProjects = (config.test?.projects ?? []).filter(project => project?.test?.name?.startsWith("unit"));
+
+  return unitProjects.length > 0 ? { ...config, test: { ...config.test, projects: unitProjects } } : config;
+}

--- a/script/mutation-report.mjs
+++ b/script/mutation-report.mjs
@@ -49,7 +49,7 @@ function summary() {
     lines.push(
       ...survived
         .slice(0, MAX_SURVIVOR_ROWS)
-        .map(({ file, location, mutatorName, replacement }) => `| \`${file}:${location.start.line}\` | ${mutatorName} | ${inlineCode(truncate(replacement))} |`)
+        .map(({ file, location, mutatorName, replacement }) => `| \`${file}:${location.start.line}\` | ${mutatorName} | ${replacementCell(replacement)} |`)
     );
 
     if (survived.length > MAX_SURVIVOR_ROWS) lines.push(`| _and ${survived.length - MAX_SURVIVOR_ROWS} more_ | | |`);
@@ -77,17 +77,13 @@ function fileList(mutants) {
   );
 }
 
-/** Replacements are code and routinely contain backticks, so the fence has to outgrow the longest run inside them. */
-function inlineCode(text) {
-  const longestBacktickRun = Math.max(0, ...[...text.matchAll(/`+/g)].map(([run]) => run.length));
-  const fence = "`".repeat(longestBacktickRun + 1);
-  const padding = longestBacktickRun > 0 ? " " : "";
-
-  return `${fence}${padding}${text}${padding}${fence}`;
+/** An HTML code element keeps the raw replacement intact where a markdown code span cannot: backticks stay literal and the entity keeps a pipe from ending the cell. */
+function replacementCell(replacement) {
+  return `<code>${truncate(replacement).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/\|/g, "&#124;")}</code>`;
 }
 
 function truncate(replacement = "") {
-  const singleLine = replacement.replace(/\s+/g, " ").replace(/\|/g, "\\|");
+  const singleLine = replacement.replace(/\s+/g, " ");
 
   return singleLine.length > 80 ? `${singleLine.slice(0, 77)}...` : singleLine;
 }

--- a/script/mutation-report.mjs
+++ b/script/mutation-report.mjs
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+
+const [reportPath, ...flags] = process.argv.slice(2);
+const minScore = Number(flags[flags.indexOf("--min") + 1] ?? 0);
+const reproduceCommand = flags.includes("--reproduce") ? flags[flags.indexOf("--reproduce") + 1] : null;
+
+if (!reportPath) {
+  process.stderr.write("usage: node script/mutation-report.mjs <stryker-report.json> --min <score> [--reproduce <command>]\n");
+  process.exit(2);
+}
+
+const MAX_SURVIVOR_ROWS = 50;
+const KILLED = ["Killed", "Timeout"];
+const UNREACHED = ["NoCoverage", "Ignored", "CompileError", "RuntimeError"];
+
+const mutants = readMutants(reportPath);
+const killed = mutants.filter(({ status }) => KILLED.includes(status));
+const survived = mutants.filter(({ status }) => !KILLED.includes(status) && !UNREACHED.includes(status));
+const unreached = mutants.filter(({ status }) => UNREACHED.includes(status));
+const reached = killed.length + survived.length;
+/** Scored over reached mutants only: an untested file has nothing to say about test quality, and coverage is measured elsewhere. */
+const score = reached === 0 ? null : (killed.length / reached) * 100;
+
+process.stdout.write(summary());
+process.exit(score !== null && score < minScore ? 1 : 0);
+
+function readMutants(path) {
+  let report;
+
+  try {
+    report = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    process.stdout.write("Stryker produced no report; see the step log.\n");
+    process.exit(1);
+  }
+
+  return Object.entries(report.files ?? {}).flatMap(([file, { mutants = [] }]) => mutants.map(mutant => ({ ...mutant, file })));
+}
+
+function summary() {
+  const lines = [
+    score === null
+      ? `No mutant on the changed lines was reached by a unit test, so there is no score to judge. ${mutants.length} mutant(s) were generated.`
+      : `Mutation score **${score.toFixed(1)}%** over ${reached} reached mutant(s) — ${killed.length} killed, ${survived.length} survived. Minimum is ${minScore}%.`
+  ];
+
+  if (survived.length > 0) {
+    lines.push("", "| survivor | mutator | replacement |", "| --- | --- | --- |");
+    lines.push(
+      ...survived
+        .slice(0, MAX_SURVIVOR_ROWS)
+        .map(({ file, location, mutatorName, replacement }) => `| \`${file}:${location.start.line}\` | ${mutatorName} | ${inlineCode(truncate(replacement))} |`)
+    );
+
+    if (survived.length > MAX_SURVIVOR_ROWS) lines.push(`| _and ${survived.length - MAX_SURVIVOR_ROWS} more_ | | |`);
+  }
+
+  if (unreached.length > 0) {
+    lines.push("", `${unreached.length} mutant(s) were never reached by a unit test and do not count towards the score: ${fileList(unreached)}.`);
+  }
+
+  if (survived.length > 0 && reproduceCommand) {
+    lines.push("", "Reproduce with:", "", "```", reproduceCommand, "```");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function fileList(mutants) {
+  const files = [...new Set(mutants.map(({ file }) => file))];
+
+  return (
+    files
+      .slice(0, 10)
+      .map(file => `\`${file}\``)
+      .join(", ") + (files.length > 10 ? ` and ${files.length - 10} more` : "")
+  );
+}
+
+/** Replacements are code and routinely contain backticks, so the fence has to outgrow the longest run inside them. */
+function inlineCode(text) {
+  const longestBacktickRun = Math.max(0, ...[...text.matchAll(/`+/g)].map(([run]) => run.length));
+  const fence = "`".repeat(longestBacktickRun + 1);
+  const padding = longestBacktickRun > 0 ? " " : "";
+
+  return `${fence}${padding}${text}${padding}${fence}`;
+}
+
+function truncate(replacement = "") {
+  const singleLine = replacement.replace(/\s+/g, " ").replace(/\|/g, "\\|");
+
+  return singleLine.length > 80 ? `${singleLine.slice(0, 77)}...` : singleLine;
+}

--- a/script/mutation-targets.mjs
+++ b/script/mutation-targets.mjs
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import picomatch from "picomatch";
+import { resolveConfig } from "vitest/node";
+
+const MAX_RANGES = Number(process.env.MAX_MUTATION_RANGES ?? 200);
+
+/** A mutant in a declaration or a generated file pins nothing, and no app's coverage config bothers to exclude them. */
+const NEVER_MUTATED = ["**/*.d.ts", "**/*.gen.ts"];
+
+const [workspacePath, baseRef, ...flags] = process.argv.slice(2);
+const outFile = flags[flags.indexOf("--out") + 1];
+
+if (!workspacePath || !baseRef) {
+  process.stderr.write("usage: node script/mutation-targets.mjs <workspace-path> <base-ref> [--out <file>]\n");
+  process.exit(2);
+}
+
+report(await mutationTargets(workspacePath, baseRef));
+
+async function mutationTargets(workspace, base) {
+  const testScript = unitTestScriptOf(workspace);
+
+  if (!testScript.includes("vitest")) {
+    return { skip: `${workspace} does not run its unit tests on vitest` };
+  }
+
+  const isMutatable = await coverageScopeOf(workspace);
+  const ranges = changedLineRanges(workspace, base).filter(({ file }) => isMutatable(file));
+
+  if (ranges.length === 0) {
+    return { skip: `no mutatable source line changed in ${workspace}` };
+  }
+
+  if (ranges.length > MAX_RANGES) {
+    return { skip: `${ranges.length} changed line ranges exceed the limit of ${MAX_RANGES}` };
+  }
+
+  return {
+    mutate: ranges.map(({ file, start, end }) => `${file}:${start}-${end}`).join(","),
+    ranges: ranges.length,
+    testEnv: envPrefixOf(testScript)
+  };
+}
+
+/**
+ * Whatever a workspace measures coverage on is what its tests are expected to cover, so mutating exactly that set
+ * keeps the two from drifting: a file the workspace excludes from coverage cannot drag the mutation score down.
+ */
+async function coverageScopeOf(workspace) {
+  const { vitestConfig } = await resolveConfig({ root: workspace });
+  const { include = [], exclude = [] } = vitestConfig.coverage;
+  const isMeasured = picomatch(include);
+  const isExcluded = picomatch([...exclude, ...NEVER_MUTATED]);
+
+  return file => isMeasured(file) && !isExcluded(file);
+}
+
+function changedLineRanges(workspace, base) {
+  const diff = execFileSync("git", ["diff", "--unified=0", base, "HEAD", "--", `${workspace}/src`], { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+  const ranges = [];
+  let file = null;
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++ ")) {
+      const target = line.slice(4);
+      file = target === "/dev/null" ? null : target.replace(/^b\//, "").replace(`${workspace}/`, "");
+      continue;
+    }
+
+    if (!file || !line.startsWith("@@ ")) continue;
+
+    const [start, count = "1"] = line.split(" ")[2].slice(1).split(",");
+    if (Number(count) > 0) ranges.push({ file, start: Number(start), end: Number(start) + Number(count) - 1 });
+  }
+
+  return ranges;
+}
+
+function unitTestScriptOf(workspace) {
+  const { scripts = {} } = JSON.parse(readFileSync(join(workspace, "package.json"), "utf8"));
+
+  return scripts["test:unit"] ?? scripts.test ?? "";
+}
+
+function envPrefixOf(testScript) {
+  const assignments = [];
+
+  for (const token of testScript.split(/\s+/)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*=\S*$/.test(token)) break;
+    assignments.push(token);
+  }
+
+  return assignments.join(" ");
+}
+
+function report({ mutate = "", ranges = 0, testEnv = "", skip = null }) {
+  const json = JSON.stringify({ mutate, ranges, testEnv, skip });
+
+  if (outFile) writeFileSync(outFile, `${json}\n`);
+  else process.stdout.write(`${json}\n`);
+}

--- a/script/mutation-targets.mjs
+++ b/script/mutation-targets.mjs
@@ -27,7 +27,7 @@ async function mutationTargets(workspace, base) {
   }
 
   const isMutatable = await coverageScopeOf(workspace);
-  const ranges = changedLineRanges(workspace, base).filter(({ file }) => isMutatable(file));
+  const ranges = changedLineRanges(workspace, mergeBaseWith(base)).filter(({ file }) => isMutatable(file));
 
   if (ranges.length === 0) {
     return { skip: `no mutatable source line changed in ${workspace}` };
@@ -57,6 +57,15 @@ async function coverageScopeOf(workspace) {
   return file => isMeasured(file) && !isExcluded(file);
 }
 
+/** A shallow CI checkout has no common history to merge-base against, in which case the given ref is already the base. */
+function mergeBaseWith(base) {
+  try {
+    return git(["merge-base", base, "HEAD"]).trim();
+  } catch {
+    return base;
+  }
+}
+
 function changedLineRanges(workspace, base) {
   const diff = execFileSync("git", ["diff", "--unified=0", base, "HEAD", "--", `${workspace}/src`], { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
   const ranges = [];
@@ -76,6 +85,10 @@ function changedLineRanges(workspace, base) {
   }
 
   return ranges;
+}
+
+function git(args) {
+  return execFileSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] });
 }
 
 function unitTestScriptOf(workspace) {

--- a/script/mutation-targets.mjs
+++ b/script/mutation-targets.mjs
@@ -7,8 +7,8 @@ import { resolveConfig } from "vitest/node";
 const MAX_RANGES = Number(process.env.MAX_MUTATION_RANGES ?? 200);
 const SPEC_EXTENSIONS = [".spec.ts", ".spec.tsx", ".spec.mts"];
 
-/** A mutant in a declaration or a generated file pins nothing, and no app's coverage config bothers to exclude them. */
-const NEVER_MUTATED = ["**/*.d.ts", "**/*.gen.ts"];
+/** A mutant in a declaration, a generated file or a spec pins nothing, and not every app's coverage config bothers to exclude them. */
+const NEVER_MUTATED = ["**/*.d.ts", "**/*.gen.ts", "**/*.spec.*", "**/*.test.*"];
 
 /** An unset coverage.include means vitest measures whatever the tests load, which has no glob form, so the source tree stands in for it. */
 const WHOLE_SOURCE_TREE = ["src/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}"];
@@ -31,21 +31,24 @@ async function mutationTargets(workspace, base) {
   }
 
   const isMutatable = await coverageScopeOf(workspace);
-  const ranges = changedLineRanges(workspace, mergeBaseWith(base)).filter(({ file }) => isMutatable(file));
+  const changed = changedLineRanges(workspace, mergeBaseWith(base)).filter(({ file }) => isMutatable(file));
+
+  if (changed.length === 0) {
+    return { skip: `no mutatable source line changed in ${workspace}` };
+  }
+
+  const specsBySource = colocatedSpecsBySource(workspace, changed);
+  const ranges = changed.filter(({ file }) => specsBySource.has(file));
 
   if (ranges.length === 0) {
-    return { skip: `no mutatable source line changed in ${workspace}` };
+    return { skip: `none of the changed files in ${workspace} has a colocated spec, so no mutant could be killed` };
   }
 
   if (ranges.length > MAX_RANGES) {
     return { skip: `${ranges.length} changed line ranges exceed the limit of ${MAX_RANGES}` };
   }
 
-  const specs = colocatedSpecsOf(workspace, ranges);
-
-  if (specs.length === 0) {
-    return { skip: `none of the changed files in ${workspace} has a colocated spec, so no mutant could be killed` };
-  }
+  const specs = [...new Set([...specsBySource.values()].flat())];
 
   return {
     mutate: ranges.map(({ file, start, end }) => `${file}:${start}-${end}`).join(","),
@@ -106,15 +109,15 @@ function git(args) {
  * A changed file's own spec is the suite that has to kill its mutants, so running just those turns the dry run from
  * the whole suite into seconds; a file without one only ever contributed mutants nothing would reach.
  */
-function colocatedSpecsOf(workspace, ranges) {
+function colocatedSpecsBySource(workspace, ranges) {
   const sources = [...new Set(ranges.map(({ file }) => file))];
-  const specs = sources.flatMap(source => {
+  const specsOf = source => {
     const withoutExtension = source.replace(/\.[^./]+$/, "");
 
     return SPEC_EXTENSIONS.map(extension => `${withoutExtension}${extension}`).filter(spec => existsSync(join(workspace, spec)));
-  });
+  };
 
-  return [...new Set(specs)];
+  return new Map(sources.map(source => [source, specsOf(source)]).filter(([, specs]) => specs.length > 0));
 }
 
 function unitTestScriptOf(workspace) {

--- a/script/mutation-targets.mjs
+++ b/script/mutation-targets.mjs
@@ -10,6 +10,9 @@ const SPEC_EXTENSIONS = [".spec.ts", ".spec.tsx", ".spec.mts"];
 /** A mutant in a declaration or a generated file pins nothing, and no app's coverage config bothers to exclude them. */
 const NEVER_MUTATED = ["**/*.d.ts", "**/*.gen.ts"];
 
+/** An unset coverage.include means vitest measures whatever the tests load, which has no glob form, so the source tree stands in for it. */
+const WHOLE_SOURCE_TREE = ["src/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}"];
+
 const [workspacePath, baseRef, ...flags] = process.argv.slice(2);
 const outFile = flags[flags.indexOf("--out") + 1];
 
@@ -58,8 +61,8 @@ async function mutationTargets(workspace, base) {
  */
 async function coverageScopeOf(workspace) {
   const { vitestConfig } = await resolveConfig({ root: workspace });
-  const { include = [], exclude = [] } = vitestConfig.coverage;
-  const isMeasured = picomatch(include);
+  const { include, exclude = [] } = vitestConfig.coverage;
+  const isMeasured = picomatch(include?.length ? include : WHOLE_SOURCE_TREE);
   const isExcluded = picomatch([...exclude, ...NEVER_MUTATED]);
 
   return file => isMeasured(file) && !isExcluded(file);

--- a/script/mutation-targets.mjs
+++ b/script/mutation-targets.mjs
@@ -1,10 +1,11 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import picomatch from "picomatch";
 import { resolveConfig } from "vitest/node";
 
 const MAX_RANGES = Number(process.env.MAX_MUTATION_RANGES ?? 200);
+const SPEC_EXTENSIONS = [".spec.ts", ".spec.tsx", ".spec.mts"];
 
 /** A mutant in a declaration or a generated file pins nothing, and no app's coverage config bothers to exclude them. */
 const NEVER_MUTATED = ["**/*.d.ts", "**/*.gen.ts"];
@@ -37,9 +38,16 @@ async function mutationTargets(workspace, base) {
     return { skip: `${ranges.length} changed line ranges exceed the limit of ${MAX_RANGES}` };
   }
 
+  const specs = colocatedSpecsOf(workspace, ranges);
+
+  if (specs.length === 0) {
+    return { skip: `none of the changed files in ${workspace} has a colocated spec, so no mutant could be killed` };
+  }
+
   return {
     mutate: ranges.map(({ file, start, end }) => `${file}:${start}-${end}`).join(","),
     ranges: ranges.length,
+    testFiles: specs.join(","),
     testEnv: envPrefixOf(testScript)
   };
 }
@@ -91,6 +99,21 @@ function git(args) {
   return execFileSync("git", args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, stdio: ["ignore", "pipe", "ignore"] });
 }
 
+/**
+ * A changed file's own spec is the suite that has to kill its mutants, so running just those turns the dry run from
+ * the whole suite into seconds; a file without one only ever contributed mutants nothing would reach.
+ */
+function colocatedSpecsOf(workspace, ranges) {
+  const sources = [...new Set(ranges.map(({ file }) => file))];
+  const specs = sources.flatMap(source => {
+    const withoutExtension = source.replace(/\.[^./]+$/, "");
+
+    return SPEC_EXTENSIONS.map(extension => `${withoutExtension}${extension}`).filter(spec => existsSync(join(workspace, spec)));
+  });
+
+  return [...new Set(specs)];
+}
+
 function unitTestScriptOf(workspace) {
   const { scripts = {} } = JSON.parse(readFileSync(join(workspace, "package.json"), "utf8"));
 
@@ -108,8 +131,8 @@ function envPrefixOf(testScript) {
   return assignments.join(" ");
 }
 
-function report({ mutate = "", ranges = 0, testEnv = "", skip = null }) {
-  const json = JSON.stringify({ mutate, ranges, testEnv, skip });
+function report({ mutate = "", ranges = 0, testFiles = "", testEnv = "", skip = null }) {
+  const json = JSON.stringify({ mutate, ranges, testFiles, testEnv, skip });
 
   if (outFile) writeFileSync(outFile, `${json}\n`);
   else process.stdout.write(`${json}\n`);

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -1,0 +1,35 @@
+/**
+ * Run from a workspace directory, mutating only the lines the diff touched:
+ *   cd apps/api && npx stryker run ../../stryker.config.mjs --mutate 'src/x.ts:10-24'
+ * CI does that for every changed file of the app it validates.
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const number = (name, fallback) => Number(process.env[name] ?? fallback);
+const breakThreshold = process.env.STRYKER_BREAK ? number("STRYKER_BREAK", 0) : null;
+
+/** Relative on purpose: an absolute path would point vitest at the real workspace instead of Stryker's mutated copy. */
+const unitOnlyConfigFile = ["vitest.mutation.config.ts", "vitest.mutation.config.mts"].find(name => existsSync(join(process.cwd(), name)));
+
+export default {
+  testRunner: "vitest",
+  vitest: {
+    /** Off by default: vitest's related-file detection fails on some suites, and Stryker treats that as zero tests. */
+    related: process.env.STRYKER_VITEST_RELATED === "true",
+    ...(unitOnlyConfigFile ? { configFile: unitOnlyConfigFile } : {})
+  },
+  coverageAnalysis: "perTest",
+  reporters: ["clear-text", "json"],
+  jsonReporter: { fileName: process.env.STRYKER_JSON_REPORT ?? "reports/mutation/mutation.json" },
+  clearTextReporter: { logTests: false, reportTests: false, reportMutants: true, reportScoreTable: true },
+  tempDirName: ".stryker-tmp",
+  concurrency: number("STRYKER_CONCURRENCY", 2),
+  timeoutMS: number("STRYKER_TIMEOUT_MS", 60_000),
+  timeoutFactor: 2.5,
+  maxTestRunnerReuse: 20,
+  ignorePatterns: [".stryker-tmp", "coverage", "dist", ".next", "reports"],
+  ignoreStatic: true,
+  thresholds: { high: 100, low: 100, break: breakThreshold },
+  logLevel: "info"
+};

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -26,6 +26,8 @@ export default {
   tempDirName: ".stryker-tmp",
   concurrency: number("STRYKER_CONCURRENCY", 2),
   timeoutMS: number("STRYKER_TIMEOUT_MS", 60_000),
+  /** The dry run executes the whole unit suite once, which outlasts Stryker's 5-minute default on a CI runner. */
+  dryRunTimeoutMinutes: number("STRYKER_DRY_RUN_TIMEOUT_MINUTES", 20),
   timeoutFactor: 2.5,
   maxTestRunnerReuse: 20,
   ignorePatterns: [".stryker-tmp", "coverage", "dist", ".next", "reports"],


### PR DESCRIPTION
## Why

Tests in this repo are measured by coverage, which says a line ran — not that anything would
notice if the line were wrong. Mutation testing closes that gap: it changes the implementation in
small, plausible ways and checks whether the suite objects.

Part of CON-948 — the label the escape hatch needs and the threshold tuning stay open there.

## What

Adds [StrykerJS](https://stryker-mutator.io) and wires it into app validation.

**Only the changed lines are mutated, against their own specs.** CI turns the PR's
`git diff --unified=0` hunks into Stryker's `file:startLine-endLine` form and pairs every changed
file with its colocated `*.spec.ts`, passed to Stryker as `--testFiles`. So a PR produces tens of
mutants instead of thousands, and Stryker's dry run — which executes the suite once to collect
per-test coverage — runs those specs instead of everything: a real 9-range slice of `apps/api`'s
lease service scored an identical 47.6% over 21 mutants in **26 seconds** against its own spec,
where the full unit suite needed 3m56s and timed out outright on a CI runner.

The diff is taken between the merge commit and its first parent, which is the base tip — the same
diff GitHub shows — so commits that land on `main` after the PR opens are never attributed to it.

**Unit tests only.** The six apps with several vitest projects get a `vitest.mutation.config.ts`
that passes their own config through `unitProjectsOnly()` from `@akashnetwork/dev-config`, so
integration and functional suites — which need services and are orders of magnitude slower per
mutant — stay out of it. `stryker.config.mjs` picks that file up automatically when a workspace
has one; workspaces whose config has no projects need nothing.

**The app's own test env is reused.** The env assignments a workspace's `test:unit` script sets
(`NODE_ENV=test DEPLOYMENT_ENV=staging` for `deploy-web`) are prepended to the Stryker command, so
mutation runs see what its tests need.

**What is mutatable comes from the app, not from CI.** `script/mutation-targets.mjs` resolves the
workspace's own vitest config through `resolveConfig` from `vitest/node` and mutates exactly the
files it measures coverage on. So `apps/api`'s `server.ts`, `bootstrap-entry.ts` and
`swagger-gen-app.ts`, and `apps/notifications`' `main.ts`, `*.module.ts` and `*.config.ts` are out
of scope because those apps already exclude them from coverage — and an app changes the mutation
scope by editing one list, not two.

**A file with no colocated spec is not mutated.** If none of a PR's changed files has one, the
step reports that and does not run: there is no suite that was ever going to kill those mutants.
When only some have specs, the rest are dropped from the mutation scope rather than counted
towards the range limit. A spec is never mutated either, whatever an app excludes from coverage.

**Untested code is not a mutation failure.** `script/mutation-report.mjs` scores the run over the
mutants a unit test actually reached: `Survived` counts against you, `NoCoverage` is reported
separately and does not. Editing a file that has no unit tests is a coverage concern, and the
coverage upload already speaks to it; without this, adding mutation testing would have turned
every such PR red.

### The CI step

Two steps in `reusable-validate-app.yml`, immediately after `Run tests`:

- run on `pull_request` only, and only for apps whose unit tests run on vitest;
- skipped entirely by the **`ignore-mutations-testing`** label;
- skipped with a note when the diff changes no mutatable line, or when it spans more than
  `MAX_MUTATION_RANGES` (200) line ranges — a diff that wide is a PR to split;
- write the score, the surviving mutants and the reproduce command to the job summary;
- fail when the score over the reached mutants falls below `MUTATION_MIN_SCORE` (80). Both numbers
  are job-level env vars in one place, so tuning them is a one-line change.

### Notes for review

- **The `ignore-mutations-testing` label does not exist yet** and has to be created in the repo
  settings before it can be applied. The other `ignore-*` labels were created the same way.
- **80% is a starting point**, not a measured target. Worth watching on the first few PRs and
  raising or lowering deliberately. For reference, a real slice of `apps/api`'s lease service
  scored 47.6% over 21 mutants — 11 survivors, all of them assertions the suite genuinely lacks.
- `picomatch` joins the root devDependencies: it is what vitest itself matches coverage globs
  with, so the mutation scope and the coverage report agree on what a pattern means. npm re-hoists
  it from 2.3.1 to 4.0.7 in the lockfile; every package still resolves the major it asked for.
- `import-meta-resolve` moves from 4.1.0 to 4.2.0 in the lockfile: npm dedupes it once Stryker
  asks for the same range. Nothing else changes version, and nothing is removed.
- To run it by hand:
  `cd apps/api && npx stryker run ../../stryker.config.mjs --mutate 'src/x.ts:10-24' --testFiles 'src/x.spec.ts'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added mutation testing for eligible unit-test projects.
  * Pull request validation now reports mutation results and enforces configurable score and change-size thresholds.
  * Unsupported, unmeasured, or oversized mutation runs are skipped automatically.
  * Reports identify killed, surviving, and unreached mutations, with actionable details for surviving results.
* **Chores**
  * Added mutation-testing tooling and configuration across supported applications.
  * Temporary mutation-testing files and reports are excluded from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

