### PR TITLE
fix(billing): count the usage history window in inclusive days and declare its 400

### DIFF
--- a/apps/api/src/billing/http-schemas/usage.schema.spec.ts
+++ b/apps/api/src/billing/http-schemas/usage.schema.spec.ts
@@ -41,11 +41,17 @@ describe("Usage Schema", () => {
     });
 
     it("defaults endDate to today and covers 30 days when both dates are omitted", () => {
-      const result = GetUsageHistoryQuerySchema.parse({ address });
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2024-11-15T23:59:59.999Z"));
 
-      expect(result.endDate).toBe(new Date().toISOString().split("T")[0]);
-      const windowDays = (Date.parse(result.endDate) - Date.parse(result.startDate)) / (24 * 60 * 60 * 1000) + 1;
-      expect(windowDays).toBe(30);
+      try {
+        const result = GetUsageHistoryQuerySchema.parse({ address });
+
+        expect(result.endDate).toBe("2024-11-15");
+        expect(result.startDate).toBe("2024-10-17");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("accepts a single-day range", () => {

--- a/apps/api/src/billing/http-schemas/usage.schema.spec.ts
+++ b/apps/api/src/billing/http-schemas/usage.schema.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { GetUsageHistoryQuerySchema } from "./usage.schema";
 
@@ -6,31 +6,30 @@ describe("Usage Schema", () => {
   describe("GetUsageHistoryQuerySchema", () => {
     const address = "akash18andxgtd6r08zzfpcdqg9pdr6smks7gv76tyt6";
 
-    it("derives startDate as 30 days before the provided endDate", () => {
+    it("defaults startDate so the window covers the 30 days ending at endDate", () => {
       const result = GetUsageHistoryQuerySchema.parse({ address, endDate: "2024-01-31" });
 
-      expect(result.startDate).toBe("2024-01-01");
+      expect(result.startDate).toBe("2024-01-02");
       expect(result.endDate).toBe("2024-01-31");
     });
 
     it("derives startDate across month and year boundaries", () => {
       const result = GetUsageHistoryQuerySchema.parse({ address, endDate: "2024-01-15" });
 
-      expect(result.startDate).toBe("2023-12-16");
+      expect(result.startDate).toBe("2023-12-17");
       expect(result.endDate).toBe("2024-01-15");
     });
 
     it("computes startDate in UTC regardless of the process timezone", () => {
-      const originalTimezone = process.env.TZ;
-      process.env.TZ = "America/New_York";
+      vi.stubEnv("TZ", "America/New_York");
 
       try {
         const result = GetUsageHistoryQuerySchema.parse({ address, endDate: "2024-11-15" });
 
-        expect(result.startDate).toBe("2024-10-16");
+        expect(result.startDate).toBe("2024-10-17");
         expect(result.endDate).toBe("2024-11-15");
       } finally {
-        process.env.TZ = originalTimezone;
+        vi.unstubAllEnvs();
       }
     });
 
@@ -41,23 +40,43 @@ describe("Usage Schema", () => {
       expect(result.endDate).toBe("2024-01-31");
     });
 
-    it("defaults endDate to today and spans a 30-day window when both dates are omitted", () => {
+    it("defaults endDate to today and covers 30 days when both dates are omitted", () => {
       const result = GetUsageHistoryQuerySchema.parse({ address });
 
-      expect(result.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-      const spanInDays = (Date.parse(result.endDate) - Date.parse(result.startDate)) / (24 * 60 * 60 * 1000);
-      expect(spanInDays).toBe(30);
+      expect(result.endDate).toBe(new Date().toISOString().split("T")[0]);
+      const windowDays = (Date.parse(result.endDate) - Date.parse(result.startDate)) / (24 * 60 * 60 * 1000) + 1;
+      expect(windowDays).toBe(30);
+    });
+
+    it("accepts a single-day range", () => {
+      const result = GetUsageHistoryQuerySchema.parse({ address, startDate: "2024-01-31", endDate: "2024-01-31" });
+
+      expect(result.startDate).toBe("2024-01-31");
+      expect(result.endDate).toBe("2024-01-31");
+    });
+
+    it("accepts a range of exactly 366 days", () => {
+      const result = GetUsageHistoryQuerySchema.parse({ address, startDate: "2024-01-01", endDate: "2024-12-31" });
+
+      expect(result.startDate).toBe("2024-01-01");
+      expect(result.endDate).toBe("2024-12-31");
     });
 
     it("rejects a range wider than 366 days", () => {
       expect(() => GetUsageHistoryQuerySchema.parse({ address, startDate: "2023-01-01", endDate: "2024-12-31" })).toThrow(
-        "Date range cannot exceed 366 days and startDate must be before endDate"
+        "Date range cannot exceed 366 days and startDate must not be after endDate"
+      );
+    });
+
+    it("rejects a range of 367 days", () => {
+      expect(() => GetUsageHistoryQuerySchema.parse({ address, startDate: "2024-01-01", endDate: "2025-01-01" })).toThrow(
+        "Date range cannot exceed 366 days and startDate must not be after endDate"
       );
     });
 
     it("rejects a startDate after the endDate", () => {
       expect(() => GetUsageHistoryQuerySchema.parse({ address, startDate: "2024-02-01", endDate: "2024-01-01" })).toThrow(
-        "Date range cannot exceed 366 days and startDate must be before endDate"
+        "Date range cannot exceed 366 days and startDate must not be after endDate"
       );
     });
   });

--- a/apps/api/src/billing/http-schemas/usage.schema.ts
+++ b/apps/api/src/billing/http-schemas/usage.schema.ts
@@ -2,44 +2,57 @@ import { z } from "@hono/zod-openapi";
 
 import { AkashAddressSchema } from "@src/utils/schema";
 
+const DEFAULT_USAGE_WINDOW_DAYS = 30;
+const MAX_USAGE_WINDOW_DAYS = 366;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function toIsoDate(date: Date) {
+  return date.toISOString().split("T")[0];
+}
+
+function startOfInclusiveWindow(endDate: string, windowDays: number) {
+  const date = new Date(`${endDate}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() - (windowDays - 1));
+  return toIsoDate(date);
+}
+
+function countInclusiveDays(startDate: string, endDate: string) {
+  return (Date.parse(endDate) - Date.parse(startDate)) / MS_PER_DAY + 1;
+}
+
 export const GetUsageHistoryQuerySchema = z
   .object({
     address: AkashAddressSchema.openapi({
       description: "The wallet address to get billing and usage data for",
       example: "akash18andxgtd6r08zzfpcdqg9pdr6smks7gv76tyt6"
     }),
-    startDate: z.string().date().optional().openapi({
-      description: "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
-      example: "2024-01-01"
-    }),
+    startDate: z
+      .string()
+      .date()
+      .optional()
+      .openapi({
+        description: `Start date (YYYY-MM-DD), inclusive. Defaults to a ${DEFAULT_USAGE_WINDOW_DAYS}-day window ending at endDate`,
+        example: "2024-01-01"
+      }),
     endDate: z.string().date().optional().openapi({
-      description: "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
+      description: "End date (YYYY-MM-DD), inclusive. Defaults to today (UTC)",
       example: "2024-01-31"
     })
   })
   .transform(data => {
-    const endDate = data.endDate ?? new Date().toISOString().split("T")[0];
+    const endDate = data.endDate ?? toIsoDate(new Date());
+    const startDate = data.startDate ?? startOfInclusiveWindow(endDate, DEFAULT_USAGE_WINDOW_DAYS);
 
-    if (data.startDate) {
-      return { ...data, startDate: data.startDate, endDate };
-    }
-
-    const startDate = new Date(`${endDate}T00:00:00.000Z`);
-    startDate.setUTCDate(startDate.getUTCDate() - 30);
-
-    return { ...data, startDate: startDate.toISOString().split("T")[0], endDate };
+    return { ...data, startDate, endDate };
   })
   .refine(
     data => {
-      const end = new Date(data.endDate);
-      const start = new Date(data.startDate);
+      const windowDays = countInclusiveDays(data.startDate, data.endDate);
 
-      const daysDiff = Math.ceil((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000));
-
-      return start <= end && daysDiff <= 366;
+      return windowDays >= 1 && windowDays <= MAX_USAGE_WINDOW_DAYS;
     },
     {
-      message: "Date range cannot exceed 366 days and startDate must be before endDate"
+      message: `Date range cannot exceed ${MAX_USAGE_WINDOW_DAYS} days and startDate must not be after endDate`
     }
   );
 

--- a/apps/api/src/billing/routes/usage/usage.router.ts
+++ b/apps/api/src/billing/routes/usage/usage.router.ts
@@ -26,7 +26,8 @@ const getUsageHistoryRoute = createRoute({
       }
     },
     400: {
-      description: "Invalid address format"
+      description:
+        "Invalid address format or invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days"
     }
   }
 });
@@ -50,7 +51,8 @@ const getUsageHistoryStatsRoute = createRoute({
       }
     },
     400: {
-      description: "Invalid address format"
+      description:
+        "Invalid address format or invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days"
     }
   }
 });

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -1777,7 +1777,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "description": "Start date (YYYY-MM-DD), inclusive. Defaults to a 30-day window ending at endDate",
               "example": "2024-01-01"
             },
             "required": false,
@@ -1788,7 +1788,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
+              "description": "End date (YYYY-MM-DD), inclusive. Defaults to today (UTC)",
               "example": "2024-01-31"
             },
             "required": false,
@@ -1875,7 +1875,7 @@
             }
           },
           "400": {
-            "description": "Invalid address format"
+            "description": "Invalid address format or invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days"
           }
         }
       }
@@ -1902,7 +1902,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "description": "Start date (YYYY-MM-DD), inclusive. Defaults to a 30-day window ending at endDate",
               "example": "2024-01-01"
             },
             "required": false,
@@ -1913,7 +1913,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
+              "description": "End date (YYYY-MM-DD), inclusive. Defaults to today (UTC)",
               "example": "2024-01-31"
             },
             "required": false,
@@ -1961,7 +1961,7 @@
             }
           },
           "400": {
-            "description": "Invalid address format"
+            "description": "Invalid address format or invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days"
           }
         }
       }

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -14213,7 +14213,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "startDate",
             "required": false,
             "schema": {
-              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "description": "Start date (YYYY-MM-DD), inclusive. Defaults to a 30-day window ending at endDate",
               "example": "2024-01-01",
               "format": "date",
               "type": "string",
@@ -14224,7 +14224,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "endDate",
             "required": false,
             "schema": {
-              "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
+              "description": "End date (YYYY-MM-DD), inclusive. Defaults to today (UTC)",
               "example": "2024-01-31",
               "format": "date",
               "type": "string",
@@ -14310,7 +14310,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "description": "Returns billing and usage data",
           },
           "400": {
-            "description": "Invalid address format",
+            "description": "Invalid address format or invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days",
           },
         },
         "security": [],
@@ -14338,7 +14338,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "startDate",
             "required": false,
             "schema": {
-              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "description": "Start date (YYYY-MM-DD), inclusive. Defaults to a 30-day window ending at endDate",
               "example": "2024-01-01",
               "format": "date",
               "type": "string",
@@ -14349,7 +14349,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "endDate",
             "required": false,
             "schema": {
-              "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
+              "description": "End date (YYYY-MM-DD), inclusive. Defaults to today (UTC)",
               "example": "2024-01-31",
               "format": "date",
               "type": "string",
@@ -14396,7 +14396,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "description": "Returns usage stats data",
           },
           "400": {
-            "description": "Invalid address format",
+            "description": "Invalid address format or invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days",
           },
         },
         "security": [],

--- a/apps/api/test/functional/usage.spec.ts
+++ b/apps/api/test/functional/usage.spec.ts
@@ -1,5 +1,5 @@
 import { subDays } from "date-fns";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { UsageHistoryResponse, UsageHistoryStats } from "@src/billing/http-schemas/usage.schema";
 import { app, initDb } from "@src/rest-app";
@@ -413,10 +413,17 @@ describe("GET /v1/usage/history", () => {
 
   it("uses current date as default endDate when not provided", async () => {
     const { now, owners } = await setup();
-    const startDate = formatUTCDate(subDays(now, 5));
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(now);
 
-    const response = await app.request(`/v1/usage/history?address=${owners[0]}&startDate=${startDate}`);
-    await expectUsageHistory(response, 6);
+    try {
+      const startDate = formatUTCDate(subDays(now, 5));
+
+      const response = await app.request(`/v1/usage/history?address=${owners[0]}&startDate=${startDate}`);
+      await expectUsageHistory(response, 6);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/api/test/functional/usage.spec.ts
+++ b/apps/api/test/functional/usage.spec.ts
@@ -300,7 +300,7 @@ describe("GET /v1/usage/history", () => {
   it("returns usage history for a valid address with default date range", async () => {
     const { owners } = await setup();
     const response = await app.request(`/v1/usage/history?address=${owners[0]}`);
-    await expectUsageHistory(response, 31);
+    await expectUsageHistory(response, 30);
   });
 
   it("returns usage history for a valid address with custom date range", async () => {
@@ -318,7 +318,7 @@ describe("GET /v1/usage/history", () => {
   it("returns empty array for address with no leases", async () => {
     const { owners } = await setup();
     const response = await app.request(`/v1/usage/history?address=${owners[2]}`);
-    const data = await expectUsageHistory(response, 31);
+    const data = await expectUsageHistory(response, 30);
 
     data.forEach(day => {
       expect(day.activeDeployments).toBe(0);
@@ -382,9 +382,21 @@ describe("GET /v1/usage/history", () => {
     expect(response.status).toBe(400);
   });
 
-  it("responds with 400 when date range exceeds 365 days", async () => {
+  it("returns a full window for a range of exactly 366 days", async () => {
     const { owners, now } = await setup();
-    const startDate = formatUTCDate(subDays(now, 400));
+    const startDate = formatUTCDate(subDays(now, 365));
+    const endDate = formatUTCDate(now);
+
+    const response = await app.request(`/v1/usage/history?address=${owners[0]}&startDate=${startDate}&endDate=${endDate}`);
+    const data = await expectUsageHistory(response, 366);
+
+    expect(data[0].date).toBe(startDate);
+    expect(data[data.length - 1].date).toBe(endDate);
+  });
+
+  it("responds with 400 when the date range spans 367 days", async () => {
+    const { owners, now } = await setup();
+    const startDate = formatUTCDate(subDays(now, 366));
     const endDate = formatUTCDate(now);
 
     const response = await app.request(`/v1/usage/history?address=${owners[0]}&startDate=${startDate}&endDate=${endDate}`);
@@ -396,7 +408,7 @@ describe("GET /v1/usage/history", () => {
     const endDate = formatUTCDate(now);
 
     const response = await app.request(`/v1/usage/history?address=${owners[0]}&endDate=${endDate}`);
-    await expectUsageHistory(response, 31); // 30 days before endDate + endDate itself
+    await expectUsageHistory(response, 30);
   });
 
   it("uses current date as default endDate when not provided", async () => {
@@ -404,7 +416,7 @@ describe("GET /v1/usage/history", () => {
     const startDate = formatUTCDate(subDays(now, 5));
 
     const response = await app.request(`/v1/usage/history?address=${owners[0]}&startDate=${startDate}`);
-    await expectUsageHistory(response, 6); // 5 days + today
+    await expectUsageHistory(response, 6);
   });
 });
 
@@ -484,10 +496,20 @@ describe("GET /v1/usage/history/stats", () => {
     expect(response.status).toBe(400);
   });
 
-  it("responds with 400 when date range exceeds 365 days", async () => {
+  it("returns stats for a range of exactly 366 days", async () => {
+    const { owners, expectUsageStats } = setup();
+    const now = new Date();
+    const startDate = formatUTCDate(subDays(now, 365));
+    const endDate = formatUTCDate(now);
+
+    const response = await app.request(`/v1/usage/history/stats?address=${owners[0]}&startDate=${startDate}&endDate=${endDate}`);
+    await expectUsageStats(response);
+  });
+
+  it("responds with 400 when the date range spans 367 days", async () => {
     const { owners } = setup();
     const now = new Date();
-    const startDate = formatUTCDate(subDays(now, 400));
+    const startDate = formatUTCDate(subDays(now, 366));
     const endDate = formatUTCDate(now);
 
     const response = await app.request(`/v1/usage/history/stats?address=${owners[0]}&startDate=${startDate}&endDate=${endDate}`);

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -494,7 +494,7 @@ export interface paths {
             }[];
           };
         };
-        /** @description Invalid address format */
+        /** @description Invalid address format or invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days */
         400: {
           headers: {
             [name: string]: unknown;
@@ -562,7 +562,7 @@ export interface paths {
             };
           };
         };
-        /** @description Invalid address format */
+        /** @description Invalid address format or invalid date range: dates must be YYYY-MM-DD, startDate must not be after endDate and the range cannot exceed 366 days */
         400: {
           headers: {
             [name: string]: unknown;


### PR DESCRIPTION
## Why

`/v1/usage/history` and `/v1/usage/history/stats` count their date window as the gap between the two dates, but the SQL behind them builds the rows with `generate_series(startDate, endDate)`, which is inclusive on both ends. A call with no dates therefore returned 31 rows, not the 30 the parameter descriptions promised, and the 366-day cap let a 367-date span through. `/v1/gpu-breakdown` was modelled on this schema and inherited both defects; #3811 fixed them there and left this route for a follow-up.

## What

The default window now covers exactly 30 dates ending at `endDate`, and the cap accepts at most 366, so `2024-01-01` to `2024-12-31` is fine and `2024-01-01` to `2025-01-01` is a 400. The two routes declare that 400 in the OpenAPI spec, which they previously described as "Invalid address format" only, and the parameter descriptions say the dates are inclusive and that `endDate` defaults to today in UTC rather than to "today by UTC 23:59:59" (it has always been a `::date` cast). `openapi.json`, the `console-api-types` schema and the docs snapshot are regenerated.

The helpers are copied from `gpu.schema.ts` byte for byte so a later refactor can lift them into one shared helper without changing behavior.

Not marked BREAKING: `getHistoryStats` divides its averages by the row count, so a date-less caller now sees averages over 30 days instead of 31, but the only caller in this repo is deploy-web, which always sends both dates and whose picker already caps at 366 inclusive dates.

Tests: the schema spec gains single-day, exactly-366 and 367-date cases and restores an unset `TZ` with `vi.unstubAllEnvs` instead of writing the string `"undefined"` into `process.env`; the functional spec expects 30 rows where it expected 31, and both routes get an exactly-366 acceptance case next to the 367-date rejection.

Unrelated bug found while reading this code, filed as CON-949 (ref CON-949, not fixed here): `countActiveByOwner` in `deployment.repository.ts` combines `closedHeight: null` with `closedBlock.datetime <= endDate`, and that join is NULL for every open deployment. Confirmed against a copy of the production database: an owner with 112 open deployments counts 112 with no `endDate` and 0 with one, so `totalDeployments` on `/v1/usage/history/stats` is always 0 for deploy-web, which always sends both dates.
