### PR TITLE
fix(indexer): give the planner real distinct counts for provider snapshot join keys

### DIFF
--- a/apps/indexer/drizzle/0011_fix_provider_snapshot_join_key_statistics.sql
+++ b/apps/indexer/drizzle/0011_fix_provider_snapshot_join_key_statistics.sql
@@ -1,0 +1,19 @@
+-- ANALYZE samples 30k rows, which underestimates the distinct counts of these two FK columns by
+-- 10-20x and makes the planner hash the whole node and GPU tables instead of probing their indexes
+-- once the gpu breakdown window passes ~120 days. The fractions are stable as the tables grow:
+-- each snapshot has ~3.7 nodes and each GPU node ~5.8 GPUs.
+ALTER TABLE "providerSnapshotNode" ALTER COLUMN "snapshotId" SET (n_distinct = -0.27);--> statement-breakpoint
+ALTER TABLE "providerSnapshotNodeGPU" ALTER COLUMN "snapshotNodeId" SET (n_distinct = -0.17);--> statement-breakpoint
+
+-- Statistics on lower(vendor)/lower(name) so the case-insensitive gpu breakdown filter is not
+-- estimated at a handful of rows. Expression statistics need Postgres 14.
+DO $$
+BEGIN
+  IF current_setting('server_version_num')::int >= 140000 THEN
+    EXECUTE 'CREATE STATISTICS IF NOT EXISTS provider_snapshot_node_gpu_lower_vendor_name (mcv) ON lower(vendor), lower(name) FROM "providerSnapshotNodeGPU"';
+  END IF;
+END
+$$;--> statement-breakpoint
+
+ANALYZE "providerSnapshotNode";--> statement-breakpoint
+ANALYZE "providerSnapshotNodeGPU";

--- a/apps/indexer/drizzle/meta/_journal.json
+++ b/apps/indexer/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1763100000000,
       "tag": "0010_add_arch_to_provider_snapshot_node_cpu",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1763200000000,
+      "tag": "0011_fix_provider_snapshot_join_key_statistics",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Why

#3811 bounded `/v1/gpu-breakdown` to a date window but never measured the new query on production-size data. Measured now on a copy of the production database (715 GB, snapshots through 2026-03-12): the 30-day default is fast, but from about 120 days up the planner abandons the index probes and hashes `providerSnapshotNode` and `providerSnapshotNodeGPU` whole, which costs 30x more than the nested-loop plan it passed over.

The reason is statistics, not the SQL. `ANALYZE` samples 30k rows, and on a high-cardinality FK column that sample lands 10 to 20 times below the truth: `providerSnapshotNode.snapshotId` is recorded as 171,288 distinct values against 3.49M real, and `providerSnapshotNodeGPU.snapshotNodeId` as 405,255 against 4.37M. The planner therefore expects 27 and 63 rows per index probe where 1 to 6 turn up, and concludes that hashing 38M rows beats 14k probes. No change to the query shape can fix that, because the estimate is what drives the choice.

Prod runs the same `default_statistics_target`, so the same plans are expected there.

## What

`n_distinct` overrides on the two join keys, plus extended statistics on `lower(vendor)` and `lower(name)` so the case-insensitive filter is no longer estimated at about four rows (which is what made the planner scan the GPU table first). The overrides are negative, which Postgres reads as a fraction of the table rather than a fixed count, so they stay correct as the tables grow: each snapshot has around 3.7 nodes and each GPU node around 5.8 GPUs.

Measured on the production copy, same six windows before and after, two runs each, sessions pinned to UTC as Sequelize pins them:

| Window | Filter | Before (warm) | After (warm) | Plan after |
|---|---|---|---|---|
| 30 d | none | 21 ms | 19 ms | index nested loops |
| 30 d | nvidia/h100 | 27 ms | 21 ms | index nested loops |
| 90 d | none | 79 ms | 56 ms | index nested loops |
| 180 d | none | 4801 ms | 169 ms | index nested loops |
| 366 d | none | 8179 ms | 224 ms | index nested loops |
| 366 d | nvidia/h100 | 7174 ms | 237 ms | index nested loops |

No sequential scan of either table survives at any window, and every result set hashes identically before and after, which it must: statistics change the plan, not the rows.

The `CREATE STATISTICS` is guarded on `server_version_num >= 140000` because expression statistics need Postgres 14. Prod runs 14.22 and the CI database image is 14.18, so the branch executes in both; the guard only keeps the file applicable to an older sandbox, testnet or local database. `ALTER COLUMN SET (...)` and `CREATE STATISTICS` take only `SHARE UPDATE EXCLUSIVE`, so the migration does not block writes. The two `ANALYZE`s are what make the overrides take effect; I left out an `ANALYZE` of `providerSnapshot` that was in the investigation script, since autovacuum keeps that table current in prod and a one-shot analyze in a migration buys nothing.

## A note on what CI checked

`validate (api)` is skipped on this PR, because the path filter only triggers it on `apps/api/**` and the api's workspace dependencies, and the indexer's drizzle folder is neither. The api functional suite is the only thing in CI that applies these migrations to a real database, so nothing here exercised the migration. That gap predates this PR and affects every indexer migration; widening the api filter to cover `apps/indexer/drizzle/**` would be its own change.

I ran it locally instead, twice: `apps/api` functional gpu specs against a freshly migrated database (14 passing), and `drizzle-kit`'s migrator against a scratch database, reading back `n_distinct=-0.27` and `n_distinct=-0.17` on the two columns and `stxkind {m,e}` on the statistics object, which confirms both the MCV and the per-expression statistics were built.

## Verification still outstanding

Local numbers on the production copy are roughly 3 to 4x faster than prod for the same query, so the 366-day window should land near 1 s rather than the 15 to 40 s it would take today. That needs confirming on `console-api-mainnet-staging.akash.network` once this deploys, against the Loki p50/p95 for the route. I will record it here.

