### PR TITLE
fix(billing): count the deployments that were active during the usage window

### DIFF
--- a/apps/api/src/billing/services/usage/usage.service.spec.ts
+++ b/apps/api/src/billing/services/usage/usage.service.spec.ts
@@ -42,7 +42,7 @@ describe(UsageService.name, () => {
         const result = await service.getHistoryStats(address, startDate, endDate);
 
         expect(usageRepository.getHistory).toHaveBeenCalledWith(address, startDate, endDate);
-        expect(deploymentRepository.countActiveByOwner).toHaveBeenCalledWith(address, startDate, endDate);
+        expect(deploymentRepository.countActiveByOwner).toHaveBeenCalledWith(address, { startDate, endDate });
 
         expect(result).toEqual({
           totalSpent: 15.55,
@@ -93,7 +93,7 @@ describe(UsageService.name, () => {
         const result = await service.getHistoryStats(address, startDate, endDate);
 
         expect(usageRepository.getHistory).toHaveBeenCalledWith(address, startDate, endDate);
-        expect(deploymentRepository.countActiveByOwner).toHaveBeenCalledWith(address, startDate, endDate);
+        expect(deploymentRepository.countActiveByOwner).toHaveBeenCalledWith(address, { startDate, endDate });
 
         expect(result).toEqual({
           totalSpent: 0,

--- a/apps/api/src/billing/services/usage/usage.service.ts
+++ b/apps/api/src/billing/services/usage/usage.service.ts
@@ -18,7 +18,7 @@ export class UsageService {
   async getHistoryStats(address: string, startDate: string, endDate: string): Promise<UsageHistoryStats> {
     const [historyData, totalDeployments] = await Promise.all([
       this.getHistory(address, startDate, endDate),
-      this.deploymentRepository.countActiveByOwner(address, startDate, endDate)
+      this.deploymentRepository.countActiveByOwner(address, { startDate, endDate })
     ]);
 
     if (historyData.length === 0) {

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.integration.ts
@@ -17,6 +17,9 @@ import {
 
 const BID_TYPE = "/akash.market.v1beta5.MsgCreateBid";
 
+/** Well above the ascending bands the GPU tests claim, so date-based blocks never collide with them. */
+const BLOCK_HEIGHT_BAND = 9_000_000;
+
 describe(DeploymentRepository.name, () => {
   describe("findAllWithGpuResources", () => {
     it("yields a single-GPU deployment with its bid message", async () => {
@@ -109,6 +112,7 @@ describe(DeploymentRepository.name, () => {
   });
 
   let testBand = 0;
+  let blockHeightCounter = 0;
 
   describe("findClosureStates", () => {
     it("reports a deployment the chain has closed as closed", async () => {
@@ -175,6 +179,84 @@ describe(DeploymentRepository.name, () => {
     });
   });
 
+  describe("countActiveByOwner", () => {
+    const WINDOW = { startDate: "2025-03-01", endDate: "2025-03-31" };
+
+    it("counts a deployment that is still open inside the window", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-03-05" });
+
+      await expect(repository.countActiveByOwner(owner, WINDOW)).resolves.toBe(1);
+    });
+
+    it("counts a deployment that closed inside the window", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-03-05", closedOn: "2025-03-10" });
+
+      await expect(repository.countActiveByOwner(owner, WINDOW)).resolves.toBe(1);
+    });
+
+    it("counts a deployment that spans the whole window", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-02-01", closedOn: "2025-04-10" });
+
+      await expect(repository.countActiveByOwner(owner, WINDOW)).resolves.toBe(1);
+    });
+
+    it("counts a deployment created on the last day of the window", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-03-31" });
+
+      await expect(repository.countActiveByOwner(owner, WINDOW)).resolves.toBe(1);
+    });
+
+    it("counts a deployment closed on the first day of the window", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-02-01", closedOn: "2025-03-01" });
+
+      await expect(repository.countActiveByOwner(owner, WINDOW)).resolves.toBe(1);
+    });
+
+    it("leaves out a deployment that closed before the window", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-02-01", closedOn: "2025-02-20" });
+
+      await expect(repository.countActiveByOwner(owner, WINDOW)).resolves.toBe(0);
+    });
+
+    it("leaves out a deployment created after the window", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-04-05" });
+
+      await expect(repository.countActiveByOwner(owner, WINDOW)).resolves.toBe(0);
+    });
+
+    it("counts only the deployments of the owner asked for", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-03-05" });
+      await seedDeployment({ owner: createAkashAddress(), createdOn: "2025-03-05" });
+
+      await expect(repository.countActiveByOwner(owner, WINDOW)).resolves.toBe(1);
+    });
+
+    it("counts every deployment overlapping the window, whatever its state", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-03-02" });
+      await seedDeployment({ owner, createdOn: "2025-03-03", closedOn: "2025-03-20" });
+      await seedDeployment({ owner, createdOn: "2025-01-10", closedOn: "2025-01-20" });
+
+      await expect(repository.countActiveByOwner(owner, WINDOW)).resolves.toBe(2);
+    });
+
+    it("counts only the deployments still open when no window is given", async () => {
+      const { repository, owner } = setup();
+      await seedDeployment({ owner, createdOn: "2025-03-02" });
+      await seedDeployment({ owner, createdOn: "2025-03-03", closedOn: "2025-03-20" });
+
+      await expect(repository.countActiveByOwner(owner)).resolves.toBe(1);
+    });
+  });
+
   function setup() {
     // Resolve CHAIN_DB so the chain Sequelize instance (and its models) is initialized before the
     // static models this repository still reads through are used.
@@ -184,7 +266,7 @@ describe(DeploymentRepository.name, () => {
     // Each test owns a disjoint, ascending height band so its query (minHeight = base) sees only
     // its own deployments: lower bands are filtered out, higher bands are seeded by later tests.
     const base = 1_000_000 + testBand * 10_000;
-    return { repository, base, band: testBand };
+    return { repository, base, band: testBand, owner: createAkashAddress() };
   }
 
   async function collect<T>(generator: AsyncGenerator<T>) {
@@ -197,6 +279,21 @@ describe(DeploymentRepository.name, () => {
   // test), distinct bands keep ids unique across tests in the shared per-file database.
   function orderedId(band: number, seq: number) {
     return `${band.toString(16).padStart(8, "0")}-0000-4000-8000-${seq.toString(16).padStart(12, "0")}`;
+  }
+
+  async function seedDeployment(input: { owner: string; createdOn: string; closedOn?: string }) {
+    const createdHeight = await seedBlockAt(input.createdOn);
+    const closedHeight = input.closedOn ? await seedBlockAt(input.closedOn) : undefined;
+
+    return await createDeployment({ owner: input.owner, createdHeight, closedHeight, dseq: faker.string.numeric(12) });
+  }
+
+  async function seedBlockAt(date: string) {
+    blockHeightCounter += 1;
+    const height = BLOCK_HEIGHT_BAND + blockHeightCounter;
+    await createAkashBlock({ height, datetime: new Date(`${date}T12:00:00.000Z`) });
+
+    return height;
   }
 
   async function seedGpuDeployment(input: {

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
@@ -21,6 +21,18 @@ export interface DeploymentsBeforeCutoffOptions {
   cutoffHeight: number;
 }
 
+/** Both dates are inclusive calendar days, as the usage history window defines them. */
+export interface DeploymentActivityWindow {
+  startDate: string;
+  endDate: string;
+}
+
+function startOfDayAfter(date: string) {
+  const dayAfter = new Date(`${date}T00:00:00.000Z`);
+  dayAfter.setUTCDate(dayAfter.getUTCDate() + 1);
+  return dayAfter;
+}
+
 export interface DatabaseDeploymentListParams {
   owner?: string;
   state?: "active" | "closed";
@@ -75,13 +87,16 @@ export class DeploymentRepository {
     });
   }
 
-  async countActiveByOwner(owner: string, startDate?: string, endDate?: string): Promise<number> {
+  async countActiveByOwner(owner: string, window?: DeploymentActivityWindow): Promise<number> {
+    if (!window) {
+      return await Deployment.count({ where: { owner, closedHeight: null } });
+    }
+
     return await Deployment.count({
       where: {
         owner,
-        closedHeight: null,
-        ...(startDate && { "$createdBlock.datetime$": { [Op.gte]: startDate } }),
-        ...(endDate && { "$closedBlock.datetime$": { [Op.lte]: endDate } })
+        "$createdBlock.datetime$": { [Op.lt]: startOfDayAfter(window.endDate) },
+        [Op.or]: [{ closedHeight: null }, { "$closedBlock.datetime$": { [Op.gte]: window.startDate } }]
       },
       include: [
         { model: Block, as: "createdBlock" },

--- a/apps/api/test/functional/usage.spec.ts
+++ b/apps/api/test/functional/usage.spec.ts
@@ -432,6 +432,27 @@ describe("GET /v1/usage/history/stats", () => {
     return { owners, expectUsageStats };
   }
 
+  async function seedDeploymentsAroundWindow() {
+    await initDb();
+    const now = new Date();
+    now.setUTCHours(12, 0, 0, 0);
+    const owner = createAkashAddress();
+
+    const blocks = await Promise.all([
+      createAkashBlock({ height: 900001, datetime: subDays(now, 10) }),
+      createAkashBlock({ height: 900002, datetime: subDays(now, 8) }),
+      createAkashBlock({ height: 900003, datetime: subDays(now, 2) })
+    ]);
+
+    await Promise.all([
+      createDeployment({ owner, dseq: "9001", createdHeight: blocks[0].height, closedHeight: blocks[2].height }),
+      createDeployment({ owner, dseq: "9002", createdHeight: blocks[2].height, closedHeight: null }),
+      createDeployment({ owner, dseq: "9003", createdHeight: blocks[0].height, closedHeight: blocks[1].height })
+    ]);
+
+    return { owner, startDate: formatUTCDate(subDays(now, 5)), endDate: formatUTCDate(now) };
+  }
+
   it("returns usage stats for a valid address with default date range", async () => {
     const { owners, expectUsageStats } = setup();
     const response = await app.request(`/v1/usage/history/stats?address=${owners[0]}`);
@@ -461,6 +482,16 @@ describe("GET /v1/usage/history/stats", () => {
     expect(data.averageSpentPerDay).toBe(0);
     expect(data.totalDeployments).toBe(0);
     expect(data.averageDeploymentsPerDay).toBe(0);
+  });
+
+  it("counts the deployments that were active during the window", async () => {
+    const { expectUsageStats } = setup();
+    const { owner, startDate, endDate } = await seedDeploymentsAroundWindow();
+
+    const response = await app.request(`/v1/usage/history/stats?address=${owner}&startDate=${startDate}&endDate=${endDate}`);
+    const data = await expectUsageStats(response);
+
+    expect(data.totalDeployments).toBe(2);
   });
 
   it("responds with 400 for invalid address format", async () => {


### PR DESCRIPTION
## Why

Fixes CON-949.

`countActiveByOwner` asks for deployments with no `closedHeight` and, in the same `where`, for a `closedBlock` dated on or before `endDate`. `closedBlock` is a left join on `closedHeight`, so it is empty for exactly the rows the first condition keeps, the date comparison is NULL for all of them, and the count comes back 0. Every caller that passes dates gets 0, which is `/v1/usage/history/stats`, which is the Total Deployments card on the usage page and the average per day underneath it. Confirmed against a copy of the production database: an owner with 112 open deployments counts 112 with no `endDate` and 0 with one.

It was coherent when the dates arrived in #1820, which paired them with `closedHeight` NOT NULL and counted deployments that had started and finished inside the window. #2269 flipped that to NULL so the date-less callers would stop counting closed deployments as active, and left the two date bounds in place.

## What

A deployment counts when it overlaps the window at all: created on or before `endDate`, and either still open or closed on or after `startDate`. That is the population the Total Spent card beside it already bills for, since a deployment created last month still costs money this month, and it matches the per-day `activeDeployments` series in the history rows below it. The alternative reading, deployments *created* in the window, would report 0 for anyone still paying for something they launched earlier, so it is not the one I took.

The date pair is now a single optional window object rather than two optional strings. With no window the behaviour is unchanged, still the deployments open right now, and the two callers that want that (`ActiveDeploymentsCountService` and the wallet balance reload check) no longer pay for the block joins. Passing half a window is no longer expressible, which is the shape the bug grew out of.

`endDate` is compared against the start of the following day, so a deployment created during the last day of the window is counted; the previous `<= endDate` would have dropped it.

## Tests

Ten integration cases on the repository cover both boundaries (created on the last day, closed on the first day), both exclusions (closed before, created after), a deployment spanning the whole window, owner isolation, a mixed set, and the no-window path. One functional case on `/v1/usage/history/stats` seeds three deployments around a window and expects 2.

I checked they actually catch this: with the old predicate restored, 7 of the integration cases fail and the functional one fails with `expected +0 to be 2`, which is the bug as reported.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Historical usage statistics now accurately count deployments that were active during the selected date range.
  - Date-range calculations include deployments spanning the full window, including those created before or closed after it.
  - Boundary dates are handled consistently for more reliable deployment activity totals.

- **Bug Fixes**
  - Corrected deployment activity counting for open and closed deployments across historical reporting periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->