### PR TITLE
fix(deployment): stop deployment settings rows from outliving deployments that never existed

### DIFF
--- a/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
@@ -1,4 +1,4 @@
-import { secondsToMilliseconds } from "date-fns";
+import { addMinutes, addSeconds, secondsToMilliseconds } from "date-fns";
 import { sql } from "drizzle-orm";
 import { PgBoss, type Queue as PgBossQueue } from "pg-boss";
 import { container } from "tsyringe";
@@ -149,6 +149,60 @@ describe(JobQueueService.name, () => {
     await jobQueue.cancelCreatedBy({ name: "cancel-retrying", singletonKey });
 
     expect((await findJob()).state).toBe("cancelled");
+  });
+
+  it("reports a job waiting under the key when it is not due before the instant asked about", async () => {
+    const singletonKey = "row-1";
+    const { jobQueue, handler, enqueue } = await setup({ queueName: "waiting-far" });
+    await jobQueue.registerHandlers([handler]);
+    await enqueue({ singletonKey, startAfter: addMinutes(new Date(), 1).toISOString() });
+
+    const waiting = await jobQueue.hasWaitingSingleton({ name: "waiting-far", singletonKey, notDueBefore: addSeconds(new Date(), 30) });
+
+    expect(waiting).toBe(true);
+  });
+
+  it("leaves out a job under the key that comes due before the instant asked about", async () => {
+    const singletonKey = "row-1";
+    const { jobQueue, handler, enqueue } = await setup({ queueName: "waiting-soon" });
+    await jobQueue.registerHandlers([handler]);
+    await enqueue({ singletonKey, startAfter: addMinutes(new Date(), 1).toISOString() });
+
+    const waiting = await jobQueue.hasWaitingSingleton({ name: "waiting-soon", singletonKey, notDueBefore: addMinutes(new Date(), 5) });
+
+    expect(waiting).toBe(false);
+  });
+
+  it("leaves out a job under the key once a worker holds it", async () => {
+    const singletonKey = "row-1";
+    let release!: () => void;
+    const held = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const { jobQueue, handler, enqueue, findJob } = await setup({ queueName: "waiting-active", handle: () => held });
+    await jobQueue.registerHandlers([handler]);
+    await enqueue({ singletonKey });
+    await jobQueue.startWorkers({ concurrency: 1, pollingIntervalSeconds: 0.5 });
+    await waitForJobState(findJob, "active");
+
+    const waiting = await jobQueue.hasWaitingSingleton({ name: "waiting-active", singletonKey, notDueBefore: new Date(0) });
+
+    expect(waiting).toBe(false);
+    release();
+    await waitForJobState(findJob, "completed");
+  });
+
+  it("reports a job under the key that is waiting on a retry", async () => {
+    const singletonKey = "row-1";
+    const { jobQueue, handler, enqueue, findJob } = await setup({ queueName: "waiting-retry", handle: vi.fn().mockRejectedValue(new Error("boom")) });
+    await jobQueue.registerHandlers([handler]);
+    await enqueue({ singletonKey });
+    await jobQueue.startWorkers({ concurrency: 1, pollingIntervalSeconds: 0.5 });
+    await waitForJobState(findJob, "retry");
+
+    const waiting = await jobQueue.hasWaitingSingleton({ name: "waiting-retry", singletonKey, notDueBefore: new Date(0) });
+
+    expect(waiting).toBe(true);
   });
 
   function waitForJobState(findJob: () => Promise<JobRow>, state: string) {

--- a/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
@@ -78,6 +78,18 @@ describe(JobQueueService.name, () => {
     expect(after.created_on).toEqual(before.created_on);
   });
 
+  it("rewrites a queue created as standard onto the exclusive policy its handler declares, so a second job under one key is refused", async () => {
+    const singletonKey = "row-1";
+    const { jobQueue, handler, createLegacyQueue, enqueue, findQueue } = await setup({ queueName: "exclusive-late", policy: "exclusive" });
+    await createLegacyQueue({ policy: "standard" });
+
+    await jobQueue.registerHandlers([handler]);
+
+    expect((await findQueue()).policy).toBe("exclusive");
+    expect(await enqueue({ singletonKey })).toEqual(expect.any(String));
+    expect(await enqueue({ singletonKey })).toBeNull();
+  });
+
   it("gives a queue it creates for the first time the same base delay", async () => {
     const { jobQueue, handler, findQueue } = await setup({ queueName: "never-seen" });
 
@@ -176,8 +188,8 @@ describe(JobQueueService.name, () => {
         handle: input.handle ?? vi.fn().mockResolvedValue(undefined)
       } satisfies JobHandler<Job>,
       enqueue: (options?: EnqueueOptions) => jobQueue.enqueue(new ScopedJob(), options),
-      createLegacyQueue: () =>
-        pgBoss.createQueue(queueName, { retryLimit: RETRY_LIMIT, retryBackoff: true, retryDelayMax: RETRY_DELAY_MAX_IN_SECONDS, policy }),
+      createLegacyQueue: (overrides?: { policy?: PgBossQueue["policy"] }) =>
+        pgBoss.createQueue(queueName, { retryLimit: RETRY_LIMIT, retryBackoff: true, retryDelayMax: RETRY_DELAY_MAX_IN_SECONDS, policy, ...overrides }),
       findQueue: async () => {
         const rows = await db.execute<QueueRow>(
           sql`select name, policy, retry_limit, retry_backoff, retry_delay, retry_delay_max, created_on::text, updated_on::text

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -326,6 +326,39 @@ describe(JobQueueService.name, () => {
     });
   });
 
+  describe("hasPendingSingleton", () => {
+    it("reports a job the queue still holds under the key", async () => {
+      const { service, pgBoss, txService } = setup();
+      txService.getConnection.mockReturnValue(undefined);
+      const executeSql = vi.fn().mockResolvedValue({ rows: [{ "?column?": 1 }] });
+      vi.spyOn(pgBoss, "getDb").mockReturnValue({ executeSql });
+
+      await expect(service.hasPendingSingleton({ name: "test-job", singletonKey: "singleton-1" })).resolves.toBe(true);
+
+      expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("state IN ('created', 'retry', 'active')"), ["test-job", "singleton-1"]);
+    });
+
+    it("reports no job when the key holds none the queue has yet to finish", async () => {
+      const { service, pgBoss, txService } = setup();
+      txService.getConnection.mockReturnValue(undefined);
+      vi.spyOn(pgBoss, "getDb").mockReturnValue({ executeSql: vi.fn().mockResolvedValue({ rows: [] }) });
+
+      await expect(service.hasPendingSingleton({ name: "test-job", singletonKey: "singleton-1" })).resolves.toBe(false);
+    });
+
+    it("reads on the ambient transaction connection when one is active", async () => {
+      const { service, pgBoss, txService } = setup();
+      const unsafe = vi.fn().mockResolvedValue([{ "?column?": 1 }]);
+      txService.getConnection.mockReturnValue({ unsafe } as unknown as Sql);
+      const getDb = vi.spyOn(pgBoss, "getDb");
+
+      await expect(service.hasPendingSingleton({ name: "test-job", singletonKey: "singleton-1" })).resolves.toBe(true);
+
+      expect(unsafe).toHaveBeenCalledWith(expect.stringContaining("singleton_key = $2"), ["test-job", "singleton-1"]);
+      expect(getDb).not.toHaveBeenCalled();
+    });
+  });
+
   describe("cancelCreatedBy", () => {
     it("cancels created jobs on the pg-boss connection when no transaction is active", async () => {
       const { service, pgBoss, txService } = setup();

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -326,24 +326,29 @@ describe(JobQueueService.name, () => {
     });
   });
 
-  describe("hasPendingSingleton", () => {
-    it("reports a job the queue still holds under the key", async () => {
+  describe("hasWaitingSingleton", () => {
+    it("asks for a job under the key that no worker holds yet and that is not due before the instant given", async () => {
       const { service, pgBoss, txService } = setup();
       txService.getConnection.mockReturnValue(undefined);
       const executeSql = vi.fn().mockResolvedValue({ rows: [{ "?column?": 1 }] });
       vi.spyOn(pgBoss, "getDb").mockReturnValue({ executeSql });
 
-      await expect(service.hasPendingSingleton({ name: "test-job", singletonKey: "singleton-1" })).resolves.toBe(true);
+      await expect(
+        service.hasWaitingSingleton({ name: "test-job", singletonKey: "singleton-1", notDueBefore: new Date("2026-01-01T00:03:00.000Z") })
+      ).resolves.toBe(true);
 
-      expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("state IN ('created', 'retry', 'active')"), ["test-job", "singleton-1"]);
+      expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("state IN ('created', 'retry')"), ["test-job", "singleton-1", "2026-01-01T00:03:00.000Z"]);
+      expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("start_after > $3"), expect.anything());
     });
 
-    it("reports no job when the key holds none the queue has yet to finish", async () => {
+    it("reports no job when nothing under the key is still waiting", async () => {
       const { service, pgBoss, txService } = setup();
       txService.getConnection.mockReturnValue(undefined);
       vi.spyOn(pgBoss, "getDb").mockReturnValue({ executeSql: vi.fn().mockResolvedValue({ rows: [] }) });
 
-      await expect(service.hasPendingSingleton({ name: "test-job", singletonKey: "singleton-1" })).resolves.toBe(false);
+      await expect(
+        service.hasWaitingSingleton({ name: "test-job", singletonKey: "singleton-1", notDueBefore: new Date("2026-01-01T00:03:00.000Z") })
+      ).resolves.toBe(false);
     });
 
     it("reads on the ambient transaction connection when one is active", async () => {
@@ -352,9 +357,11 @@ describe(JobQueueService.name, () => {
       txService.getConnection.mockReturnValue({ unsafe } as unknown as Sql);
       const getDb = vi.spyOn(pgBoss, "getDb");
 
-      await expect(service.hasPendingSingleton({ name: "test-job", singletonKey: "singleton-1" })).resolves.toBe(true);
+      await expect(
+        service.hasWaitingSingleton({ name: "test-job", singletonKey: "singleton-1", notDueBefore: new Date("2026-01-01T00:03:00.000Z") })
+      ).resolves.toBe(true);
 
-      expect(unsafe).toHaveBeenCalledWith(expect.stringContaining("singleton_key = $2"), ["test-job", "singleton-1"]);
+      expect(unsafe).toHaveBeenCalledWith(expect.stringContaining("singleton_key = $2"), ["test-job", "singleton-1", "2026-01-01T00:03:00.000Z"]);
       expect(getDb).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -111,17 +111,54 @@ describe(JobQueueService.name, () => {
       expect(pgBoss.getQueues).toHaveBeenCalledWith(["test", "another"]);
     });
 
-    it("warns when a handler declares a policy the live queue does not carry", async () => {
-      const { service, logger } = setup({ queues: [liveQueue({ policy: "standard" })] });
+    it("rewrites the policy of an unpartitioned live queue onto the one its handler declares", async () => {
+      const { service, pgBoss, logger } = setup({ queues: [liveQueue({ policy: "standard", partition: false })] });
 
       await service.registerHandlers([new SingletonTestHandler(vi.fn())]);
 
+      expect(pgBoss.getDb().executeSql).toHaveBeenCalledWith(expect.stringMatching(/UPDATE \S+\.queue SET policy = \$2/), ["test", "singleton"]);
+      expect(logger.info).toHaveBeenCalledWith({ event: "JOB_QUEUE_POLICY_CONVERGED", queue: "test", from: "standard", to: "singleton" });
+    });
+
+    it("rewrites the policy back to standard for a handler that stopped declaring one", async () => {
+      const { service, pgBoss } = setup({ queues: [liveQueue({ policy: "singleton", partition: false })] });
+
+      await service.registerHandlers([new TestHandler(vi.fn())]);
+
+      expect(pgBoss.getDb().executeSql).toHaveBeenCalledWith(expect.stringContaining("SET policy = $2"), ["test", "standard"]);
+    });
+
+    it("leaves the policy of a live queue that already matches its handler untouched", async () => {
+      const { service, pgBoss } = setup({ queues: [liveQueue({ policy: "singleton", partition: false })] });
+
+      await service.registerHandlers([new SingletonTestHandler(vi.fn())]);
+
+      expect(pgBoss.getDb().executeSql).not.toHaveBeenCalled();
+    });
+
+    it("warns instead of rewriting the policy of a partitioned queue, whose table lacks the other policies' indexes", async () => {
+      const { service, pgBoss, logger } = setup({ queues: [liveQueue({ policy: "standard", partition: true })] });
+
+      await service.registerHandlers([new SingletonTestHandler(vi.fn())]);
+
+      expect(pgBoss.getDb().executeSql).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith({
         event: "JOB_QUEUE_POLICY_UNCHANGEABLE",
         queue: "test",
         declared: "singleton",
         live: "standard"
       });
+    });
+
+    it("still converges the retry settings when the policy rewrite fails", async () => {
+      const error = new Error("update failed");
+      const { service, pgBoss, logger } = setup({ queues: [liveQueue({ policy: "standard", partition: false, retryDelay: 0 })] });
+      vi.mocked(pgBoss.getDb().executeSql).mockRejectedValue(error);
+
+      await service.registerHandlers([new SingletonTestHandler(vi.fn())]);
+
+      expect(logger.error).toHaveBeenCalledWith({ event: "JOB_QUEUE_POLICY_CONVERGE_FAILED", queue: "test", error });
+      expect(pgBoss.updateQueue).toHaveBeenCalledWith("test", expect.objectContaining({ retryDelay: 30 }));
     });
 
     it("starts workers even when it cannot converge the queue settings", async () => {
@@ -745,6 +782,7 @@ describe(JobQueueService.name, () => {
     return mock<QueueResult>({
       name: TestJob[JOB_NAME],
       policy: "standard",
+      partition: false,
       retryLimit: 5,
       retryBackoff: true,
       retryDelay: 30,

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -231,6 +231,26 @@ export class JobQueueService implements Disposable {
     return new Set(result.rows.map(row => row.singleton_key));
   }
 
+  /** Whether the queue already holds an unfinished job under this key: queued, waiting on a retry, or running. */
+  async hasPendingSingleton(query: { name: string; singletonKey: string }): Promise<boolean> {
+    const connection = this.txService.getConnection();
+    const db = connection ? this.#toTransactionDb(connection) : await this.pgBoss.getDb();
+    const schema = this.coreConfig.get("POSTGRES_BACKGROUND_JOBS_SCHEMA");
+    const result = (await db.executeSql(
+      `
+        SELECT 1
+        FROM ${schema}.job
+        WHERE name = $1
+          AND singleton_key = $2
+          AND state IN ('created', 'retry', 'active')
+        LIMIT 1
+      `,
+      [query.name, query.singletonKey]
+    )) as { rows: unknown[] };
+
+    return result.rows.length > 0;
+  }
+
   async cancelCreatedBy(query: { name: string; singletonKey: string }): Promise<void> {
     const connection = this.txService.getConnection();
     const db = connection ? this.#toTransactionDb(connection) : await this.pgBoss.getDb();

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -28,7 +28,7 @@ const QUEUE_RETRY_OPTIONS: QueueRetryOptions = {
   retryDelayMax: 5 * 60
 };
 
-const DEFAULT_QUEUE_POLICY: PgBossQueue["policy"] = "standard";
+const DEFAULT_QUEUE_POLICY: NonNullable<PgBossQueue["policy"]> = "standard";
 
 const RETRY_OPTION_KEYS = Object.keys(QUEUE_RETRY_OPTIONS) as (keyof QueueRetryOptions)[];
 
@@ -85,15 +85,7 @@ export class JobQueueService implements Disposable {
       const queue = liveQueues.get(handler.accepts[JOB_NAME]);
       if (!queue) continue;
 
-      const declaredPolicy = handler.policy ?? DEFAULT_QUEUE_POLICY;
-      if (queue.policy !== declaredPolicy) {
-        this.logger.warn({
-          event: "JOB_QUEUE_POLICY_UNCHANGEABLE",
-          queue: queue.name,
-          declared: declaredPolicy,
-          live: queue.policy
-        });
-      }
+      await this.#convergePolicy(queue, handler.policy ?? DEFAULT_QUEUE_POLICY);
 
       if (retryOptionsOf(queue).every(([key, value]) => value === QUEUE_RETRY_OPTIONS[key])) continue;
 
@@ -108,6 +100,25 @@ export class JobQueueService implements Disposable {
       } catch (error) {
         this.logger.error({ event: "JOB_QUEUE_RETRY_OPTIONS_CONVERGE_FAILED", queue: queue.name, error });
       }
+    }
+  }
+
+  /** pg-boss refuses this through `updateQueue` because a partitioned queue's own table only carries the index of the policy it was created with; the shared table of every unpartitioned queue carries all of them. */
+  async #convergePolicy(queue: PgBossQueueResult, declaredPolicy: NonNullable<PgBossQueue["policy"]>): Promise<void> {
+    if (queue.policy === declaredPolicy) return;
+
+    if (queue.partition) {
+      this.logger.warn({ event: "JOB_QUEUE_POLICY_UNCHANGEABLE", queue: queue.name, declared: declaredPolicy, live: queue.policy });
+      return;
+    }
+
+    const schema = this.coreConfig.get("POSTGRES_BACKGROUND_JOBS_SCHEMA");
+
+    try {
+      await this.pgBoss.getDb().executeSql(`UPDATE ${schema}.queue SET policy = $2, updated_on = now() WHERE name = $1`, [queue.name, declaredPolicy]);
+      this.logger.info({ event: "JOB_QUEUE_POLICY_CONVERGED", queue: queue.name, from: queue.policy, to: declaredPolicy });
+    } catch (error) {
+      this.logger.error({ event: "JOB_QUEUE_POLICY_CONVERGE_FAILED", queue: queue.name, error });
     }
   }
 

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -231,8 +231,8 @@ export class JobQueueService implements Disposable {
     return new Set(result.rows.map(row => row.singleton_key));
   }
 
-  /** Whether the queue already holds an unfinished job under this key: queued, waiting on a retry, or running. */
-  async hasPendingSingleton(query: { name: string; singletonKey: string }): Promise<boolean> {
+  /** Whether a job under this key is still waiting, so `cancelCreatedBy` can call it off, and will not come due before `notDueBefore`. */
+  async hasWaitingSingleton(query: { name: string; singletonKey: string; notDueBefore: Date }): Promise<boolean> {
     const connection = this.txService.getConnection();
     const db = connection ? this.#toTransactionDb(connection) : await this.pgBoss.getDb();
     const schema = this.coreConfig.get("POSTGRES_BACKGROUND_JOBS_SCHEMA");
@@ -242,10 +242,11 @@ export class JobQueueService implements Disposable {
         FROM ${schema}.job
         WHERE name = $1
           AND singleton_key = $2
-          AND state IN ('created', 'retry', 'active')
+          AND state IN ('created', 'retry')
+          AND start_after > $3::timestamptz
         LIMIT 1
       `,
-      [query.name, query.singletonKey]
+      [query.name, query.singletonKey, query.notDueBefore.toISOString()]
     )) as { rows: unknown[] };
 
     return result.rows.length > 0;

--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
@@ -10,35 +10,35 @@ import { DeploymentSettingController } from "./deployment-setting.controller";
 import { createUser } from "@test/seeders/user.seeder";
 
 describe(DeploymentSettingController.name, () => {
-  describe("findOrCreateV2", () => {
+  describe("findV2", () => {
     it("uses provided userId", async () => {
       const { controller, deploymentSettingService, setting } = setup();
       const userId = faker.string.uuid();
       const dseq = faker.string.numeric(6);
-      deploymentSettingService.findOrCreateByUserIdAndDseq.mockResolvedValue(setting);
+      deploymentSettingService.findByUserIdAndDseq.mockResolvedValue(setting);
 
-      const result = await controller.findOrCreateV2({ dseq, userId });
+      const result = await controller.findV2({ dseq, userId });
 
       expect(result).toEqual({ data: setting });
-      expect(deploymentSettingService.findOrCreateByUserIdAndDseq).toHaveBeenCalledWith({ userId, dseq });
+      expect(deploymentSettingService.findByUserIdAndDseq).toHaveBeenCalledWith({ userId, dseq });
     });
 
     it("defaults userId to current user when not provided", async () => {
       const { controller, deploymentSettingService, setting, user } = setup();
       const dseq = faker.string.numeric(6);
-      deploymentSettingService.findOrCreateByUserIdAndDseq.mockResolvedValue(setting);
+      deploymentSettingService.findByUserIdAndDseq.mockResolvedValue(setting);
 
-      const result = await controller.findOrCreateV2({ dseq });
+      const result = await controller.findV2({ dseq });
 
       expect(result).toEqual({ data: setting });
-      expect(deploymentSettingService.findOrCreateByUserIdAndDseq).toHaveBeenCalledWith({ userId: user.id, dseq });
+      expect(deploymentSettingService.findByUserIdAndDseq).toHaveBeenCalledWith({ userId: user.id, dseq });
     });
 
     it("throws 404 when setting not found", async () => {
       const { controller, deploymentSettingService } = setup();
-      deploymentSettingService.findOrCreateByUserIdAndDseq.mockResolvedValue(undefined);
+      deploymentSettingService.findByUserIdAndDseq.mockResolvedValue(undefined);
 
-      await expect(() => controller.findOrCreateV2({ dseq: faker.string.numeric(6) })).rejects.toThrow("Deployment setting not found");
+      await expect(() => controller.findV2({ dseq: faker.string.numeric(6) })).rejects.toThrow("Deployment setting not found");
     });
   });
 

--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.ts
@@ -12,7 +12,7 @@ import {
   type UpdateDeploymentSettingRequest
 } from "@src/deployment/http-schemas/deployment-setting.schema";
 
-type FindOrCreateV2Input = FindDeploymentSettingV2Params & FindDeploymentSettingV2Query;
+type FindV2Input = FindDeploymentSettingV2Params & FindDeploymentSettingV2Query;
 type UpsertV2Input = FindDeploymentSettingV2Params & FindDeploymentSettingV2Query & UpdateDeploymentSettingRequest["data"];
 import { DeploymentSettingService } from "@src/deployment/services/deployment-setting/deployment-setting.service";
 
@@ -24,8 +24,8 @@ export class DeploymentSettingController {
   ) {}
 
   @Protected([{ action: "read", subject: "DeploymentSetting" }])
-  async findOrCreateByUserIdAndDseq(params: FindDeploymentSettingParams): Promise<DeploymentSettingResponse> {
-    const setting = await this.deploymentSettingService.findOrCreateByUserIdAndDseq(params);
+  async findByUserIdAndDseq(params: FindDeploymentSettingParams): Promise<DeploymentSettingResponse> {
+    const setting = await this.deploymentSettingService.findByUserIdAndDseq(params);
     assert(setting, 404, "Deployment setting not found");
     return { data: setting };
   }
@@ -44,9 +44,9 @@ export class DeploymentSettingController {
   }
 
   @Protected([{ action: "read", subject: "DeploymentSetting" }])
-  async findOrCreateV2(input: FindOrCreateV2Input): Promise<DeploymentSettingResponse> {
+  async findV2(input: FindV2Input): Promise<DeploymentSettingResponse> {
     const userId = input.userId ?? this.authService.currentUser.id;
-    const setting = await this.deploymentSettingService.findOrCreateByUserIdAndDseq({ userId, dseq: input.dseq });
+    const setting = await this.deploymentSettingService.findByUserIdAndDseq({ userId, dseq: input.dseq });
     assert(setting, 404, "Deployment setting not found");
     return { data: setting };
   }

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -702,13 +702,13 @@ describe(DeploymentSettingRepository.name, () => {
       expect(open.map(deployment => deployment.id)).toContain(fundingOff.id);
     });
 
-    it("reports the owner address and dseq a chain lookup needs", async () => {
-      const { deploymentSettingRepository, settingId, wallet, findOpenDeployments } = await setup();
+    it("reports what a chain lookup and a compensation for the record need", async () => {
+      const { deploymentSettingRepository, settingId, user, wallet, findOpenDeployments } = await setup();
       const setting = await deploymentSettingRepository.findById(settingId);
 
       const open = await findOpenDeployments([wallet.address]);
 
-      expect(open).toContainEqual({ id: settingId, dseq: setting!.dseq, address: wallet.address });
+      expect(open).toContainEqual({ id: settingId, userId: user.id, dseq: setting!.dseq, address: wallet.address, createdAt: new Date(setting!.createdAt) });
     });
 
     it("passes over a deployment already marked closed", async () => {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -42,8 +42,10 @@ export type ExpiringRuntimeDeployment = {
 
 export type OpenDeployment = {
   id: string;
+  userId: string;
   dseq: string;
   address: string;
+  createdAt: Date;
 };
 
 export type LiveTrialDeployment = {
@@ -128,8 +130,10 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       const batch = await this.pg
         .select({
           id: this.table.id,
+          userId: this.table.userId,
           dseq: this.table.dseq,
-          address: UserWallets.address
+          address: UserWallets.address,
+          createdAt: this.table.createdAt
         })
         .from(this.table)
         .innerJoin(Users, eq(this.table.userId, Users.id))

--- a/apps/api/src/deployment/routes/deployment-setting/deployment-setting.router.ts
+++ b/apps/api/src/deployment/routes/deployment-setting/deployment-setting.router.ts
@@ -49,7 +49,7 @@ const getRoute = createRoute({
 });
 deploymentSettingRouter.openapi(getRoute, async function routeGetDeploymentSettings(c) {
   const params = c.req.valid("param");
-  const result = await container.resolve(DeploymentSettingController).findOrCreateByUserIdAndDseq(params);
+  const result = await container.resolve(DeploymentSettingController).findByUserIdAndDseq(params);
 
   return c.json(result, 200);
 });
@@ -183,7 +183,7 @@ const getRouteV2 = createRoute({
   }
 });
 deploymentSettingRouter.openapi(getRouteV2, async function routeGetDeploymentSettingsV2(c) {
-  const result = await container.resolve(DeploymentSettingController).findOrCreateV2({ ...c.req.valid("param"), ...c.req.valid("query") });
+  const result = await container.resolve(DeploymentSettingController).findV2({ ...c.req.valid("param"), ...c.req.valid("query") });
   return c.json(result, 200);
 });
 

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.integration.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.integration.ts
@@ -1,18 +1,88 @@
 import { faker } from "@faker-js/faker";
+import { subMinutes } from "date-fns";
+import { sql } from "drizzle-orm";
 import { container } from "tsyringe";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 
 import { CHAIN_DB } from "@src/chain";
 import type { ApiPgDatabase } from "@src/core";
-import { POSTGRES_DB, resolveTable } from "@src/core";
+import { JOB_NAME, JobQueueService, POSTGRES_DB, resolveTable } from "@src/core";
+import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import {
+  DeleteUnbackedDeploymentSetting,
+  DeleteUnbackedDeploymentSettingHandler,
+  unbackedDeploymentSettingKeyFor
+} from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { UserRepository } from "@src/user/repositories";
 import { ClosedDeploymentsReconcilerService } from "./closed-deployments-reconciler.service";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { createDeployment } from "@test/seeders/deployment.seeder";
 
+type CompensationJobRow = { state: string; priority: number; data: { deploymentSettingId: string; owner: string; dseq: string } };
+
+let jobQueueReady: Promise<JobQueueService> | undefined;
+
+/** pg-boss owns its own schema and creates it on start, so the queue the compensations land in is bootstrapped once per file, with no worker to drain it. */
+function bootstrapJobQueue() {
+  jobQueueReady ??= (async () => {
+    const jobQueue = container.resolve(JobQueueService);
+    await jobQueue.setup();
+    await jobQueue.registerHandlers([container.resolve(DeleteUnbackedDeploymentSettingHandler)]);
+
+    return jobQueue;
+  })();
+
+  return jobQueueReady;
+}
+
 describe(ClosedDeploymentsReconcilerService.name, () => {
+  afterAll(async () => {
+    if (jobQueueReady) await (await jobQueueReady).dispose();
+  });
+
+  it("hands a record the indexer never saw to the compensation queue once it has outlived the grace", async () => {
+    const { service, recordDeployment, findCompensation, graceInMinutes } = await setup();
+    const unbacked = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: null, recordedMinutesAgo: graceInMinutes + 1 });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(await findCompensation(unbacked)).toEqual([
+      { state: "created", priority: -1, data: { deploymentSettingId: unbacked.id, owner: unbacked.address, dseq: unbacked.dseq } }
+    ]);
+  });
+
+  it("queues one compensation for a record across two runs", async () => {
+    const { service, recordDeployment, findCompensation, graceInMinutes } = await setup();
+    const unbacked = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: null, recordedMinutesAgo: graceInMinutes + 1 });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(await findCompensation(unbacked)).toHaveLength(1);
+  });
+
+  it("leaves a record the indexer has not seen yet alone while it is within the grace", async () => {
+    const { service, recordDeployment, findCompensation, readClosed } = await setup();
+    const fresh = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: null });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(await readClosed(fresh.id)).toBe(false);
+    expect(await findCompensation(fresh)).toEqual([]);
+  });
+
+  it("queues no compensation during a dry run", async () => {
+    const { service, recordDeployment, findCompensation, graceInMinutes } = await setup();
+    const unbacked = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: null, recordedMinutesAgo: graceInMinutes + 1 });
+
+    await service.reconcileClosedDeployments({ dryRun: true });
+
+    expect(await findCompensation(unbacked)).toEqual([]);
+  });
+
   it("marks a record closed once the chain has closed its deployment", async () => {
     const { service, recordDeployment, readClosed } = await setup();
     const settled = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: true });
@@ -40,9 +110,9 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     expect(await readClosed(running.id)).toBe(false);
   });
 
-  it("leaves a record alone when the indexer holds no deployment for it", async () => {
-    const { service, recordDeployment, readClosed } = await setup();
-    const unindexed = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: null });
+  it("marks nothing closed for a record the indexer holds no deployment for", async () => {
+    const { service, recordDeployment, readClosed, graceInMinutes } = await setup();
+    const unindexed = await recordDeployment({ autoTopUpEnabled: true, closedOnChain: null, recordedMinutesAgo: graceInMinutes + 1 });
 
     await service.reconcileClosedDeployments({ dryRun: false });
 
@@ -78,6 +148,7 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
 
   async function setup() {
     container.resolve(CHAIN_DB);
+    await bootstrapJobQueue();
 
     const service = container.resolve(ClosedDeploymentsReconcilerService);
     const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
@@ -85,29 +156,46 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
     const deploymentSettingsTable = resolveTable("DeploymentSettings");
     const userWalletsTable = resolveTable("UserWallets");
+    const backgroundJobsSchema = sql.identifier(container.resolve(CoreConfigService).get("POSTGRES_BACKGROUND_JOBS_SCHEMA"));
+    const graceInMinutes = container.resolve(DeploymentConfigService).get("UNBACKED_DEPLOYMENT_SETTING_GRACE_IN_MIN");
 
     const user = await userRepository.create({ userId: faker.string.uuid() });
     const address = createAkashAddress();
     await db.insert(userWalletsTable).values({ userId: user.id, address, deploymentAllowance: "0", feeAllowance: "0", isTrialing: false });
 
-    async function recordDeployment(input: { autoTopUpEnabled: boolean; closedOnChain: boolean | null; padDseq?: boolean }) {
+    async function recordDeployment(input: { autoTopUpEnabled: boolean; closedOnChain: boolean | null; padDseq?: boolean; recordedMinutesAgo?: number }) {
       const dseq = faker.number.int({ min: 100_000, max: 9_999_999 }).toString();
 
       if (input.closedOnChain !== null) {
         await createDeployment({ owner: address, dseq, closedHeight: input.closedOnChain ? 5_000_000 : undefined });
       }
 
-      return await deploymentSettingRepository.create({
-        userId: user.id,
-        dseq: input.padDseq ? `000${dseq}` : dseq,
-        autoTopUpEnabled: input.autoTopUpEnabled
-      });
+      const [setting] = await db
+        .insert(deploymentSettingsTable)
+        .values({
+          userId: user.id,
+          dseq: input.padDseq ? `000${dseq}` : dseq,
+          autoTopUpEnabled: input.autoTopUpEnabled,
+          createdAt: subMinutes(new Date(), input.recordedMinutesAgo ?? 0)
+        })
+        .returning({ id: deploymentSettingsTable.id, dseq: deploymentSettingsTable.dseq });
+
+      return { ...setting, address };
     }
 
     async function readClosed(id: string) {
       return (await deploymentSettingRepository.findById(id))!.closed;
     }
 
-    return { service, deploymentSettingRepository, db, deploymentSettingsTable, user, address, recordDeployment, readClosed };
+    async function findCompensation(setting: { dseq: string }) {
+      const rows = await db.execute<CompensationJobRow>(
+        sql`select state, priority, data - 'version' as data from ${backgroundJobsSchema}.job
+            where name = ${DeleteUnbackedDeploymentSetting[JOB_NAME]} and singleton_key = ${unbackedDeploymentSettingKeyFor({ userId: user.id, dseq: setting.dseq })}`
+      );
+
+      return rows as unknown as CompensationJobRow[];
+    }
+
+    return { service, deploymentSettingRepository, db, deploymentSettingsTable, user, address, graceInMinutes, recordDeployment, readClosed, findCompensation };
   }
 });

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.spec.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.spec.ts
@@ -196,7 +196,6 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     await service.reconcileClosedDeployments({ dryRun: true });
 
     expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
-    expect(jobQueueService.findPendingSingletonKeys).not.toHaveBeenCalled();
     expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     expect(countersByName["closed_deployments_reconcile_rows_closed_total"].add).not.toHaveBeenCalled();
     expect(countersByName["closed_deployments_reconcile_rows_compensated_total"].add).not.toHaveBeenCalled();
@@ -212,6 +211,19 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     expect(logger.info).toHaveBeenCalledWith(
       expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", scanned: 2, closed: 1, compensated: 1, dryRun: true })
     );
+  });
+
+  it("leaves a row whose compensation is already waiting out of what a dry run reports", async () => {
+    const waiting = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, logger } = setup({
+      openDeployments: [waiting],
+      closureStates: [],
+      pendingCompensationKeys: [unbackedDeploymentSettingKeyFor(waiting)]
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: true });
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", compensated: 0, dryRun: true }));
   });
 
   it("keeps reconciling the remaining batches when one of them fails", async () => {
@@ -230,19 +242,34 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", failedBatches: 1, closed: 1 }));
   });
 
-  it("fails the batch rather than the run when the queue refuses a compensation", async () => {
+  it("keeps the closes a batch already committed when the queue refuses a compensation beside them", async () => {
+    const closed = openDeployment();
     const unbacked = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
     const { service, logger, countersByName } = setup({
-      openDeployments: [unbacked],
+      openDeployments: [closed, unbacked],
+      closureStates: [closureState(closed, true)],
+      enqueue: vi.fn().mockRejectedValue(new Error("queue down"))
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_COMPENSATION_ENQUEUE_FAILED" }));
+    expect(countersByName["closed_deployments_reconcile_rows_closed_total"].add).toHaveBeenCalledWith(1);
+    expect(countersByName["closed_deployments_reconcile_rows_compensated_total"].add).toHaveBeenCalledWith(0);
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", failedBatches: 0, closed: 1 }));
+  });
+
+  it("gives up on the rest of a batch's compensations once the queue refuses one, rather than a line per row", async () => {
+    const unbacked = Array.from({ length: 3 }, () => openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) }));
+    const { service, jobQueueService } = setup({
+      openDeployments: unbacked,
       closureStates: [],
       enqueue: vi.fn().mockRejectedValue(new Error("queue down"))
     });
 
     await service.reconcileClosedDeployments({ dryRun: false });
 
-    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_BATCH_FAILED" }));
-    expect(countersByName["closed_deployments_reconcile_rows_compensated_total"].add).not.toHaveBeenCalled();
-    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", failedBatches: 1 }));
+    expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
   });
 
   it("credits a failed batch with nothing it did not write", async () => {
@@ -299,16 +326,19 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END" }));
   });
 
-  it("reports a failure to read the waiting compensations rather than raising it", async () => {
+  it("keeps closing records the chain closed when the waiting compensations cannot be read", async () => {
+    const closed = openDeployment();
     const { service, deploymentSettingRepository, logger } = setup({
-      openDeployments: [openDeployment()],
+      openDeployments: [closed],
+      closureStates: [closureState(closed, true)],
       findPendingSingletonKeys: vi.fn().mockRejectedValue(new Error("queue unavailable"))
     });
 
-    await expect(service.reconcileClosedDeployments({ dryRun: false })).resolves.toBeUndefined();
+    await service.reconcileClosedDeployments({ dryRun: false });
 
-    expect(deploymentSettingRepository.findOpenDeploymentsIteratively).not.toHaveBeenCalled();
-    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_FAILED" }));
+    expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closed.id]);
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_PENDING_COMPENSATIONS_UNREADABLE" }));
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", closed: 1 }));
   });
 
   it("reads nothing from the chain when no record is open", async () => {

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.spec.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.spec.ts
@@ -1,15 +1,27 @@
 import { faker } from "@faker-js/faker";
 import type { Counter } from "@opentelemetry/api";
+import { subMinutes } from "date-fns";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { CreateLogger } from "@src/core";
+import type { CreateLogger, JobQueueService } from "@src/core";
 import type { MetricsService } from "@src/core/services/metrics/metrics.service";
 import type { DeploymentClosureState, DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import type { DeploymentSettingRepository, OpenDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import {
+  DeleteUnbackedDeploymentSetting,
+  unbackedDeploymentSettingKeyFor
+} from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
+import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { ClosedDeploymentsReconcilerService } from "./closed-deployments-reconciler.service";
 
+import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createAkashAddress } from "@test/seeders";
+
+const GRACE_IN_MIN = 60;
+const RETRY_LIMIT = 47;
+const RETRY_DELAY_IN_SEC = 30;
+const RETRY_DELAY_MAX_IN_MIN = 30;
 
 describe(ClosedDeploymentsReconcilerService.name, () => {
   it("marks a record closed when the chain has already closed its deployment", async () => {
@@ -44,14 +56,79 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     expect(countersByName["closed_deployments_reconcile_rows_confirmed_open_total"].add).toHaveBeenCalledWith(1);
   });
 
-  it("leaves a record alone when the indexer holds no deployment for it, rather than guessing it closed", async () => {
-    const unknown = openDeployment();
-    const { service, deploymentSettingRepository, countersByName } = setup({ openDeployments: [unknown], closureStates: [] });
+  it("leaves a record the indexer has not seen yet alone while it is younger than the grace a create is given", async () => {
+    const fresh = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN - 1) });
+    const { service, deploymentSettingRepository, jobQueueService, countersByName } = setup({ openDeployments: [fresh], closureStates: [] });
 
     await service.reconcileClosedDeployments({ dryRun: false });
 
     expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     expect(countersByName["closed_deployments_reconcile_rows_without_chain_state_total"].add).toHaveBeenCalledWith(1);
+  });
+
+  it("hands a record the indexer never saw to the compensation once it has outlived the grace, rather than deleting it itself", async () => {
+    const unbacked = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, deploymentSettingRepository, jobQueueService, countersByName } = setup({ openDeployments: [unbacked], closureStates: [] });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+    expect(deploymentSettingRepository.deleteById).not.toHaveBeenCalled();
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+      new DeleteUnbackedDeploymentSetting({ deploymentSettingId: unbacked.id, owner: unbacked.address, dseq: unbacked.dseq }),
+      expect.objectContaining({ singletonKey: unbackedDeploymentSettingKeyFor({ userId: unbacked.userId, dseq: unbacked.dseq }) })
+    );
+    expect(countersByName["closed_deployments_reconcile_rows_compensated_total"].add).toHaveBeenCalledWith(1);
+    expect(countersByName["closed_deployments_reconcile_rows_without_chain_state_total"].add).toHaveBeenCalledWith(0);
+  });
+
+  it("gives a backlog compensation the retry horizon of one enqueued at create, below the priority of those", async () => {
+    const unbacked = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, jobQueueService } = setup({ openDeployments: [unbacked], closureStates: [] });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(expect.anything(), {
+      singletonKey: expect.any(String),
+      priority: -1,
+      retryLimit: RETRY_LIMIT,
+      retryBackoff: true,
+      retryDelay: RETRY_DELAY_IN_SEC,
+      retryDelayMax: RETRY_DELAY_MAX_IN_MIN * 60
+    });
+  });
+
+  it("hands the compensation the dseq as stored, since the handler refuses a payload that does not match the row", async () => {
+    const padded = openDeployment({ dseq: "0000123", createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, jobQueueService } = setup({ openDeployments: [padded], closureStates: [] });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ dseq: "0000123" }) }), expect.anything());
+  });
+
+  it("skips a record whose compensation is already waiting, so hourly runs cannot stack jobs for one row", async () => {
+    const unbacked = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, jobQueueService, logger } = setup({
+      openDeployments: [unbacked],
+      closureStates: [],
+      pendingCompensationKeys: [unbackedDeploymentSettingKeyFor({ userId: unbacked.userId, dseq: unbacked.dseq })]
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", compensated: 0 }));
+  });
+
+  it("counts nothing for a compensation the queue refused as a duplicate", async () => {
+    const unbacked = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, logger } = setup({ openDeployments: [unbacked], closureStates: [], enqueue: vi.fn().mockResolvedValue(null) });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", compensated: 0 }));
   });
 
   it("asks the chain about a dseq without the leading zeros only a stored record can carry", async () => {
@@ -89,40 +166,52 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closed.id]);
   });
 
-  it("closes only the records the chain closed out of a mixed batch", async () => {
+  it("closes only the records the chain closed out of a mixed batch, and compensates only the ones it never saw", async () => {
     const closed = openDeployment();
     const running = openDeployment();
-    const unknown = openDeployment();
-    const { service, deploymentSettingRepository } = setup({
-      openDeployments: [closed, running, unknown],
+    const unbacked = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, deploymentSettingRepository, jobQueueService } = setup({
+      openDeployments: [closed, running, unbacked],
       closureStates: [closureState(closed, true), closureState(running, false)]
     });
 
     await service.reconcileClosedDeployments({ dryRun: false });
 
     expect(deploymentSettingRepository.markAsClosed).toHaveBeenCalledWith([closed.id]);
+    expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ deploymentSettingId: unbacked.id }) }),
+      expect.anything()
+    );
   });
 
-  it("writes nothing and records no metrics during a dry run", async () => {
+  it("writes nothing, enqueues nothing and records no metrics during a dry run", async () => {
     const closed = openDeployment();
-    const { service, deploymentSettingRepository, countersByName } = setup({
-      openDeployments: [closed],
+    const unbacked = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, deploymentSettingRepository, jobQueueService, countersByName } = setup({
+      openDeployments: [closed, unbacked],
       closureStates: [closureState(closed, true)]
     });
 
     await service.reconcileClosedDeployments({ dryRun: true });
 
     expect(deploymentSettingRepository.markAsClosed).not.toHaveBeenCalled();
+    expect(jobQueueService.findPendingSingletonKeys).not.toHaveBeenCalled();
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     expect(countersByName["closed_deployments_reconcile_rows_closed_total"].add).not.toHaveBeenCalled();
+    expect(countersByName["closed_deployments_reconcile_rows_compensated_total"].add).not.toHaveBeenCalled();
   });
 
-  it("reports what a dry run would have closed", async () => {
+  it("reports what a dry run would have closed and compensated", async () => {
     const closed = openDeployment();
-    const { service, logger } = setup({ openDeployments: [closed], closureStates: [closureState(closed, true)] });
+    const unbacked = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, logger } = setup({ openDeployments: [closed, unbacked], closureStates: [closureState(closed, true)] });
 
     await service.reconcileClosedDeployments({ dryRun: true });
 
-    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", scanned: 1, closed: 1, dryRun: true }));
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", scanned: 2, closed: 1, compensated: 1, dryRun: true })
+    );
   });
 
   it("keeps reconciling the remaining batches when one of them fails", async () => {
@@ -139,6 +228,21 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_BATCH_FAILED" }));
     expect(deploymentSettingRepository.markAsClosed).toHaveBeenLastCalledWith([second.id]);
     expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", failedBatches: 1, closed: 1 }));
+  });
+
+  it("fails the batch rather than the run when the queue refuses a compensation", async () => {
+    const unbacked = openDeployment({ createdAt: subMinutes(new Date(), GRACE_IN_MIN + 1) });
+    const { service, logger, countersByName } = setup({
+      openDeployments: [unbacked],
+      closureStates: [],
+      enqueue: vi.fn().mockRejectedValue(new Error("queue down"))
+    });
+
+    await service.reconcileClosedDeployments({ dryRun: false });
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_BATCH_FAILED" }));
+    expect(countersByName["closed_deployments_reconcile_rows_compensated_total"].add).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", failedBatches: 1 }));
   });
 
   it("credits a failed batch with nothing it did not write", async () => {
@@ -195,6 +299,18 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END" }));
   });
 
+  it("reports a failure to read the waiting compensations rather than raising it", async () => {
+    const { service, deploymentSettingRepository, logger } = setup({
+      openDeployments: [openDeployment()],
+      findPendingSingletonKeys: vi.fn().mockRejectedValue(new Error("queue unavailable"))
+    });
+
+    await expect(service.reconcileClosedDeployments({ dryRun: false })).resolves.toBeUndefined();
+
+    expect(deploymentSettingRepository.findOpenDeploymentsIteratively).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CLOSED_DEPLOYMENTS_RECONCILE_FAILED" }));
+  });
+
   it("reads nothing from the chain when no record is open", async () => {
     const { service, deploymentRepository, logger } = setup({ openDeployments: [] });
 
@@ -213,8 +329,10 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
   function openDeployment(overrides: Partial<OpenDeployment> = {}): OpenDeployment {
     return {
       id: faker.string.uuid(),
+      userId: faker.string.uuid(),
       dseq: faker.number.int({ min: 1000, max: 9_999_999 }).toString(),
       address: createAkashAddress(),
+      createdAt: new Date(),
       ...overrides
     };
   }
@@ -227,8 +345,11 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     openDeployments?: OpenDeployment[];
     batches?: OpenDeployment[][];
     closureStates?: DeploymentClosureState[];
+    pendingCompensationKeys?: string[];
     findClosureStates?: DeploymentRepository["findClosureStates"];
     markAsClosed?: DeploymentSettingRepository["markAsClosed"];
+    enqueue?: JobQueueService["enqueue"];
+    findPendingSingletonKeys?: JobQueueService["findPendingSingletonKeys"];
     readError?: Error;
   }) {
     const batches = input?.batches ?? [input?.openDeployments ?? []];
@@ -248,6 +369,18 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
       findClosureStates: input?.findClosureStates ?? vi.fn().mockResolvedValue(input?.closureStates ?? [])
     });
 
+    const jobQueueService = mock<JobQueueService>({
+      enqueue: input?.enqueue ?? vi.fn().mockResolvedValue(faker.string.uuid()),
+      findPendingSingletonKeys: input?.findPendingSingletonKeys ?? vi.fn().mockResolvedValue(new Set(input?.pendingCompensationKeys ?? []))
+    });
+
+    const deploymentConfig = mockConfigService<DeploymentConfigService>({
+      UNBACKED_DEPLOYMENT_SETTING_GRACE_IN_MIN: GRACE_IN_MIN,
+      UNBACKED_DEPLOYMENT_SETTING_RETRY_LIMIT: RETRY_LIMIT,
+      UNBACKED_DEPLOYMENT_SETTING_RETRY_DELAY_IN_SEC: RETRY_DELAY_IN_SEC,
+      UNBACKED_DEPLOYMENT_SETTING_RETRY_DELAY_MAX_IN_MIN: RETRY_DELAY_MAX_IN_MIN
+    });
+
     const countersByName: Record<string, Counter> = {};
     const metricsService = mock<MetricsService>();
     metricsService.getMeter.mockReturnValue(mock());
@@ -260,8 +393,25 @@ describe(ClosedDeploymentsReconcilerService.name, () => {
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);
 
-    const service = new ClosedDeploymentsReconcilerService(deploymentSettingRepository, deploymentRepository, metricsService, createLogger);
+    const service = new ClosedDeploymentsReconcilerService(
+      deploymentSettingRepository,
+      deploymentRepository,
+      jobQueueService,
+      deploymentConfig,
+      metricsService,
+      createLogger
+    );
 
-    return { service, deploymentSettingRepository, deploymentRepository, metricsService, countersByName, logger, createLogger };
+    return {
+      service,
+      deploymentSettingRepository,
+      deploymentRepository,
+      jobQueueService,
+      deploymentConfig,
+      metricsService,
+      countersByName,
+      logger,
+      createLogger
+    };
   }
 });

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
@@ -83,9 +83,7 @@ export class ClosedDeploymentsReconcilerService {
     let consecutiveFailures = 0;
 
     try {
-      const pendingCompensationKeys = dryRun
-        ? new Set<string>()
-        : await this.jobQueueService.findPendingSingletonKeys(DeleteUnbackedDeploymentSetting[JOB_NAME]);
+      const pendingCompensationKeys = await this.#readPendingCompensationKeys();
       const unbackedBefore = subMinutes(new Date(), this.deploymentConfig.get("UNBACKED_DEPLOYMENT_SETTING_GRACE_IN_MIN"));
 
       for await (const batch of this.deploymentSettingRepository.findOpenDeploymentsIteratively({ batchSize: BATCH_SIZE })) {
@@ -153,12 +151,28 @@ export class ClosedDeploymentsReconcilerService {
       await this.deploymentSettingRepository.markAsClosed(idsToClose);
     }
 
-    const compensated = dryRun ? unbacked.length : await this.#compensate(unbacked, pendingCompensationKeys);
+    const compensated = dryRun
+      ? unbacked.filter(deployment => !pendingCompensationKeys.has(unbackedDeploymentSettingKeyFor(deployment))).length
+      : await this.#compensate(unbacked, pendingCompensationKeys);
 
     return { closed: idsToClose.length, confirmedOpen, withoutChainState, compensated };
   }
 
-  /** Skips a row whose compensation is already waiting, so the hourly run cannot stack jobs behind one the create path or an earlier run enqueued. */
+  /** A snapshot only spares the queue inserts its exclusive policy would refuse anyway, so a queue it cannot read must not cost the run its close detection. */
+  async #readPendingCompensationKeys(): Promise<Set<string>> {
+    try {
+      return await this.jobQueueService.findPendingSingletonKeys(DeleteUnbackedDeploymentSetting[JOB_NAME]);
+    } catch (error) {
+      this.#logger.error({ event: "CLOSED_DEPLOYMENTS_RECONCILE_PENDING_COMPENSATIONS_UNREADABLE", error });
+      return new Set();
+    }
+  }
+
+  /**
+   * Skips a row whose compensation is already waiting, so the hourly run cannot stack jobs behind one the create
+   * path or an earlier run enqueued, and gives up on the rest of the batch rather than raising, since the closes
+   * beside them are already committed and an unreachable queue would otherwise log a line per row.
+   */
   async #compensate(unbacked: OpenDeployment[], pendingCompensationKeys: Set<string>): Promise<number> {
     let compensated = 0;
 
@@ -167,14 +181,19 @@ export class ClosedDeploymentsReconcilerService {
 
       if (pendingCompensationKeys.has(singletonKey)) continue;
 
-      const jobId = await this.jobQueueService.enqueue(
-        new DeleteUnbackedDeploymentSetting({ deploymentSettingId: deployment.id, owner: deployment.address, dseq: deployment.dseq }),
-        { singletonKey, priority: BACKLOG_COMPENSATION_PRIORITY, ...unbackedDeploymentSettingRetryOptions(this.deploymentConfig) }
-      );
+      try {
+        const jobId = await this.jobQueueService.enqueue(
+          new DeleteUnbackedDeploymentSetting({ deploymentSettingId: deployment.id, owner: deployment.address, dseq: deployment.dseq }),
+          { singletonKey, priority: BACKLOG_COMPENSATION_PRIORITY, ...unbackedDeploymentSettingRetryOptions(this.deploymentConfig) }
+        );
 
-      if (jobId) {
-        pendingCompensationKeys.add(singletonKey);
-        compensated++;
+        if (jobId) {
+          pendingCompensationKeys.add(singletonKey);
+          compensated++;
+        }
+      } catch (error) {
+        this.#logger.error({ event: "CLOSED_DEPLOYMENTS_RECONCILE_COMPENSATION_ENQUEUE_FAILED", deploymentSettingId: deployment.id, compensated, error });
+        break;
       }
     }
 

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
@@ -168,11 +168,7 @@ export class ClosedDeploymentsReconcilerService {
     }
   }
 
-  /**
-   * Skips a row whose compensation is already waiting, so the hourly run cannot stack jobs behind one the create
-   * path or an earlier run enqueued, and gives up on the rest of the batch rather than raising, since the closes
-   * beside them are already committed and an unreachable queue would otherwise log a line per row.
-   */
+  /** A failed enqueue ends the batch rather than raising: its closes are already committed, and an unreachable queue would otherwise log a line per row. */
   async #compensate(unbacked: OpenDeployment[], pendingCompensationKeys: Set<string>): Promise<number> {
     let compensated = 0;
 

--- a/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
+++ b/apps/api/src/deployment/services/closed-deployments-reconciler/closed-deployments-reconciler.service.ts
@@ -1,20 +1,30 @@
 import type { Counter } from "@opentelemetry/api";
+import { subMinutes } from "date-fns";
 import { inject, singleton } from "tsyringe";
 
-import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, JOB_NAME, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { MetricsService } from "@src/core/services/metrics/metrics.service";
 import type { DryRunOptions } from "@src/core/types/console";
 import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { DeploymentSettingRepository, type OpenDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import {
+  DeleteUnbackedDeploymentSetting,
+  unbackedDeploymentSettingKeyFor,
+  unbackedDeploymentSettingRetryOptions
+} from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 
 const BATCH_SIZE = 1000;
 /** Bounds what an unreachable chain database can cost the funding sweep that shares this command's hour. */
 const MAX_CONSECUTIVE_BATCH_FAILURES = 3;
+/** Below pg-boss's default of 0, so a backlog of old records never delays the compensation a create just enqueued. */
+const BACKLOG_COMPENSATION_PRIORITY = -1;
 
 type BatchOutcome = {
   closed: number;
   confirmedOpen: number;
   withoutChainState: number;
+  compensated: number;
 };
 
 type ReconcileTally = BatchOutcome & {
@@ -37,10 +47,13 @@ export class ClosedDeploymentsReconcilerService {
   readonly #rowsClosed: Counter;
   readonly #rowsConfirmedOpen: Counter;
   readonly #rowsWithoutChainState: Counter;
+  readonly #rowsCompensated: Counter;
 
   constructor(
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly deploymentRepository: DeploymentRepository,
+    private readonly jobQueueService: JobQueueService,
+    private readonly deploymentConfig: DeploymentConfigService,
     metricsService: MetricsService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
@@ -54,28 +67,37 @@ export class ClosedDeploymentsReconcilerService {
       description: "Deployment records left open because the chain still holds their deployment open"
     });
     this.#rowsWithoutChainState = metricsService.createCounter(meter, "closed_deployments_reconcile_rows_without_chain_state_total", {
-      description: "Deployment records left alone because the indexer holds no deployment for them"
+      description: "Deployment records left alone because the indexer holds no deployment for them yet"
+    });
+    this.#rowsCompensated = metricsService.createCounter(meter, "closed_deployments_reconcile_rows_compensated_total", {
+      description: "Deployment records handed to the unbacked-setting compensation because the indexer never saw their deployment"
     });
   }
 
-  /** Only safe because the indexer lags in one direction: it can miss a close it has not caught up to, never invent one. */
+  /** Only safe because the indexer lags in one direction: it can miss a close it has not caught up to, never invent one; a record it never saw is handed to the compensation, which asks the chain itself before deleting. */
   async reconcileClosedDeployments({ dryRun }: DryRunOptions): Promise<void> {
-    const tally: ReconcileTally = { scanned: 0, closed: 0, confirmedOpen: 0, withoutChainState: 0, failedBatches: 0 };
+    const tally: ReconcileTally = { scanned: 0, closed: 0, confirmedOpen: 0, withoutChainState: 0, compensated: 0, failedBatches: 0 };
 
     this.#logger.info({ event: "CLOSED_DEPLOYMENTS_RECONCILE_START", batchSize: BATCH_SIZE, dryRun });
 
     let consecutiveFailures = 0;
 
     try {
+      const pendingCompensationKeys = dryRun
+        ? new Set<string>()
+        : await this.jobQueueService.findPendingSingletonKeys(DeleteUnbackedDeploymentSetting[JOB_NAME]);
+      const unbackedBefore = subMinutes(new Date(), this.deploymentConfig.get("UNBACKED_DEPLOYMENT_SETTING_GRACE_IN_MIN"));
+
       for await (const batch of this.deploymentSettingRepository.findOpenDeploymentsIteratively({ batchSize: BATCH_SIZE })) {
         tally.scanned += batch.length;
 
         try {
-          const outcome = await this.#reconcileBatch(batch, dryRun);
+          const outcome = await this.#reconcileBatch(batch, { dryRun, pendingCompensationKeys, unbackedBefore });
 
           tally.closed += outcome.closed;
           tally.confirmedOpen += outcome.confirmedOpen;
           tally.withoutChainState += outcome.withoutChainState;
+          tally.compensated += outcome.compensated;
 
           if (!dryRun) {
             this.#recordOutcome(outcome);
@@ -101,11 +123,15 @@ export class ClosedDeploymentsReconcilerService {
     this.#logger.info({ event: "CLOSED_DEPLOYMENTS_RECONCILE_END", ...tally, dryRun });
   }
 
-  async #reconcileBatch(batch: OpenDeployment[], dryRun: boolean): Promise<BatchOutcome> {
+  async #reconcileBatch(
+    batch: OpenDeployment[],
+    { dryRun, pendingCompensationKeys, unbackedBefore }: { dryRun: boolean; pendingCompensationKeys: Set<string>; unbackedBefore: Date }
+  ): Promise<BatchOutcome> {
     const closureStates = await this.deploymentRepository.findClosureStates(batch.map(({ address, dseq }) => ({ owner: address, dseq: normalizeDseq(dseq) })));
     const closedByKey = new Map(closureStates.map(state => [closureKey(state), state.isClosed]));
 
     const idsToClose: string[] = [];
+    const unbacked: OpenDeployment[] = [];
     let confirmedOpen = 0;
     let withoutChainState = 0;
 
@@ -116,6 +142,8 @@ export class ClosedDeploymentsReconcilerService {
         idsToClose.push(deployment.id);
       } else if (isClosedOnChain === false) {
         confirmedOpen++;
+      } else if (deployment.createdAt < unbackedBefore) {
+        unbacked.push(deployment);
       } else {
         withoutChainState++;
       }
@@ -125,13 +153,39 @@ export class ClosedDeploymentsReconcilerService {
       await this.deploymentSettingRepository.markAsClosed(idsToClose);
     }
 
-    return { closed: idsToClose.length, confirmedOpen, withoutChainState };
+    const compensated = dryRun ? unbacked.length : await this.#compensate(unbacked, pendingCompensationKeys);
+
+    return { closed: idsToClose.length, confirmedOpen, withoutChainState, compensated };
+  }
+
+  /** Skips a row whose compensation is already waiting, so the hourly run cannot stack jobs behind one the create path or an earlier run enqueued. */
+  async #compensate(unbacked: OpenDeployment[], pendingCompensationKeys: Set<string>): Promise<number> {
+    let compensated = 0;
+
+    for (const deployment of unbacked) {
+      const singletonKey = unbackedDeploymentSettingKeyFor(deployment);
+
+      if (pendingCompensationKeys.has(singletonKey)) continue;
+
+      const jobId = await this.jobQueueService.enqueue(
+        new DeleteUnbackedDeploymentSetting({ deploymentSettingId: deployment.id, owner: deployment.address, dseq: deployment.dseq }),
+        { singletonKey, priority: BACKLOG_COMPENSATION_PRIORITY, ...unbackedDeploymentSettingRetryOptions(this.deploymentConfig) }
+      );
+
+      if (jobId) {
+        pendingCompensationKeys.add(singletonKey);
+        compensated++;
+      }
+    }
+
+    return compensated;
   }
 
   /** Credited per batch and only after its write landed, so a run that dies part way still reports what it converged. */
-  #recordOutcome({ closed, confirmedOpen, withoutChainState }: BatchOutcome): void {
+  #recordOutcome({ closed, confirmedOpen, withoutChainState, compensated }: BatchOutcome): void {
     this.#rowsClosed.add(closed);
     this.#rowsConfirmedOpen.add(confirmedOpen);
     this.#rowsWithoutChainState.add(withoutChainState);
+    this.#rowsCompensated.add(compensated);
   }
 }

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
@@ -1,7 +1,8 @@
 import { inject, singleton } from "tsyringe";
 
-import { type CreateLogger, type Job, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, type EnqueueOptions, type Job, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, LOGGER_FACTORY } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import { DeploymentPresenceService } from "@src/deployment/services/deployment-presence/deployment-presence.service";
 
 /**
@@ -31,9 +32,24 @@ export function unbackedDeploymentSettingKeyFor({ userId, dseq }: { userId: stri
   return `deleteUnbackedDeploymentSetting.${userId}.${dseq}`;
 }
 
+/** Shared by every enqueuer of the compensation, so a row found unbacked later retries on the same horizon as one found at create. */
+export function unbackedDeploymentSettingRetryOptions(
+  config: DeploymentConfigService
+): Required<Pick<EnqueueOptions, "retryLimit" | "retryBackoff" | "retryDelay" | "retryDelayMax">> {
+  return {
+    retryLimit: config.get("UNBACKED_DEPLOYMENT_SETTING_RETRY_LIMIT"),
+    retryBackoff: true,
+    retryDelay: config.get("UNBACKED_DEPLOYMENT_SETTING_RETRY_DELAY_IN_SEC"),
+    retryDelayMax: config.get("UNBACKED_DEPLOYMENT_SETTING_RETRY_DELAY_MAX_IN_MIN") * 60
+  };
+}
+
 @singleton()
 export class DeleteUnbackedDeploymentSettingHandler implements JobHandler<DeleteUnbackedDeploymentSetting> {
   public readonly accepts = DeleteUnbackedDeploymentSetting;
+
+  /** One compensation per row across queued, retrying and running; pg-boss's `singleton` only caps the running ones and would let the hourly reconcile queue a second behind the create path's. */
+  public readonly policy = "exclusive";
 
   private readonly logger: ReturnType<CreateLogger>;
 

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -1,4 +1,3 @@
-import { ForbiddenError } from "@casl/ability";
 import { faker } from "@faker-js/faker";
 import { PostgresError } from "postgres";
 import { describe, expect, it } from "vitest";
@@ -19,64 +18,32 @@ import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(DeploymentSettingService.name, () => {
-  describe("findOrCreateByUserIdAndDseq", () => {
-    it("returns existing setting when found", async () => {
-      const { service, deploymentSettingRepository, userWalletRepository } = setup();
+  describe("findByUserIdAndDseq", () => {
+    it("returns the stored setting", async () => {
+      const { service, deploymentSettingRepository } = setup();
       const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
       const existing = createDeploymentSettingsOutput(params);
 
       deploymentSettingRepository.accessibleBy.mockReturnValue(deploymentSettingRepository);
       deploymentSettingRepository.findOneBy.mockResolvedValue(existing);
 
-      const result = await service.findOrCreateByUserIdAndDseq(params);
+      const result = await service.findByUserIdAndDseq(params);
 
+      expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(expect.anything(), "read");
       expect(result).toEqual(expect.objectContaining({ userId: params.userId, dseq: params.dseq }));
-      expect(userWalletRepository.findOneByUserId).not.toHaveBeenCalled();
-      expect(deploymentSettingRepository.create).not.toHaveBeenCalled();
     });
 
-    it("leaves auto top-up to the repository default rather than deciding it from the wallet", async () => {
-      const { service, deploymentSettingRepository, userWalletRepository } = setup();
-      const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
-      const created = createDeploymentSettingsOutput({ ...params, autoTopUpEnabled: true });
-
-      deploymentSettingRepository.accessibleBy.mockReturnValue(deploymentSettingRepository);
-      deploymentSettingRepository.findOneBy.mockResolvedValue(undefined);
-      deploymentSettingRepository.create.mockResolvedValue(created);
-
-      const result = await service.findOrCreateByUserIdAndDseq(params);
-
-      expect(deploymentSettingRepository.create).toHaveBeenCalledWith(params);
-      expect(userWalletRepository.findOneByUserId).not.toHaveBeenCalled();
-      expect(result).toEqual(expect.objectContaining({ autoTopUpEnabled: true }));
-    });
-
-    it("schedules no wallet reload for a deployment whose owner asked for nothing", async () => {
-      const { service, deploymentSettingRepository, walletReloadJobService } = setup();
+    it("returns undefined and writes no row when nothing is stored for the deployment", async () => {
+      const { service, deploymentSettingRepository } = setup();
       const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
 
       deploymentSettingRepository.accessibleBy.mockReturnValue(deploymentSettingRepository);
       deploymentSettingRepository.findOneBy.mockResolvedValue(undefined);
-      deploymentSettingRepository.create.mockResolvedValue(createDeploymentSettingsOutput({ ...params, autoTopUpEnabled: true }));
 
-      await service.findOrCreateByUserIdAndDseq(params);
-
-      expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
-    });
-
-    it("returns undefined on ForbiddenError", async () => {
-      const { service, deploymentSettingRepository, userWalletRepository } = setup();
-      const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
-
-      deploymentSettingRepository.accessibleBy.mockReturnValue(deploymentSettingRepository);
-      deploymentSettingRepository.findOneBy.mockResolvedValue(undefined);
-      userWalletRepository.findOneByUserId.mockResolvedValue(undefined);
-      const forbiddenError = Object.create(ForbiddenError.prototype);
-      deploymentSettingRepository.create.mockRejectedValue(forbiddenError);
-
-      const result = await service.findOrCreateByUserIdAndDseq(params);
+      const result = await service.findByUserIdAndDseq(params);
 
       expect(result).toBeUndefined();
+      expect(deploymentSettingRepository.create).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -50,30 +50,11 @@ export class DeploymentSettingService {
     private readonly domainEvents: DomainEventsService
   ) {}
 
-  async findOrCreateByUserIdAndDseq(params: FindDeploymentSettingParams): Promise<DeploymentSettingWithEstimatedTopUpAmount | undefined> {
+  /** A read persists nothing: a row written for whatever dseq a client asks about is backed by no deployment, and nothing can ever close it. */
+  async findByUserIdAndDseq(params: FindDeploymentSettingParams): Promise<DeploymentSettingWithEstimatedTopUpAmount | undefined> {
     const setting = await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "read").findOneBy(params);
 
-    if (setting) {
-      return this.withEstimatedTopUpAmount(setting);
-    }
-
-    try {
-      return await this.createWithDefaults(params);
-    } catch (error) {
-      if (error instanceof ForbiddenError) {
-        return undefined;
-      }
-      throw error;
-    }
-  }
-
-  /**
-   * Creates a settings row on the repository's defaults, recording no choice by the user. Deployment
-   * create uses this: the row exists from the start without scheduling a wallet reload the user never
-   * asked for, which is what makes creating a row cheap enough to do for every deployment.
-   */
-  async createWithDefaults(params: FindDeploymentSettingParams): Promise<DeploymentSettingWithEstimatedTopUpAmount> {
-    return await this.withEstimatedTopUpAmount(await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "create").create(params));
+    return setting && (await this.withEstimatedTopUpAmount(setting));
   }
 
   /**
@@ -105,7 +86,7 @@ export class DeploymentSettingService {
   }
 
   /**
-   * A row can appear between the read and the write: a settings read creates one lazily, and a second
+   * A row can appear between the read and the write: deployment create records one, and a second
    * request for the same deployment takes the same no-row-yet branch. The (dseq, userId) unique catches
    * whichever insert loses, and re-reading lets the request run again as an update, landing where it
    * would have had it arrived a moment later instead of surfacing the driver error as a 500. One retry

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -680,6 +680,30 @@ describe(DeploymentWriterService.name, () => {
       );
     });
 
+    it("goes on with the create when the queue refused the compensation because one is already waiting for the row", async () => {
+      const { service, signerService, logger } = setup({ compensationEnqueued: false, compensationAlreadyWaiting: true });
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 })).resolves.toMatchObject({ dseq: "1748400000000" });
+
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "UNBACKED_DEPLOYMENT_SETTING_COMPENSATION_ALREADY_WAITING", dseq: "1748400000000" })
+      );
+    });
+
+    it("asks about the waiting compensation under the key the create would have enqueued", async () => {
+      const { service, jobQueueService } = setup({ compensationEnqueued: false, compensationAlreadyWaiting: true });
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(jobQueueService.hasPendingSingleton).toHaveBeenCalledWith({
+        name: DeleteUnbackedDeploymentSetting[JOB_NAME],
+        singletonKey: "deleteUnbackedDeploymentSetting.user-1.1748400000000"
+      });
+    });
+
     it("refuses the create when the queue accepted no compensation", async () => {
       const { service } = setup({ compensationEnqueued: false });
 
@@ -1854,6 +1878,7 @@ describe(DeploymentWriterService.name, () => {
     defaultDeposit?: number;
     transactionRuns?: boolean;
     compensationEnqueued?: boolean;
+    compensationAlreadyWaiting?: boolean;
     manifestVersion?: Uint8Array;
     received?: SdlSecrets;
     sealedSecrets?: string | null;
@@ -1883,6 +1908,7 @@ describe(DeploymentWriterService.name, () => {
     txService.transaction.mockImplementation(async cb => (input?.transactionRuns === false ? (undefined as never) : await cb()));
     const jobQueueService = mock<JobQueueService>();
     jobQueueService.enqueue.mockResolvedValue(input?.compensationEnqueued === false ? null : COMPENSATION_JOB_ID);
+    jobQueueService.hasPendingSingleton.mockResolvedValue(input?.compensationAlreadyWaiting ?? false);
 
     const sdlSecretsService = mock<SdlSecretsService>();
     /** Real rather than doubled, because what every stored-sdl assertion below measures is the document this produces. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -41,6 +41,7 @@ const REGISTRY_USERNAME = faker.string.alphanumeric(10);
 const REGISTRY_PASSWORD = faker.internet.password();
 const DEPLOYMENT_SETTING_ID = faker.string.uuid();
 const GRACE_IN_MIN = 60;
+const SIGNER_REQUEST_TIMEOUT_MS = 180_000;
 const RETRY_LIMIT = 47;
 const RETRY_DELAY_MAX_IN_MIN = 30;
 const RETRY_DELAY_IN_SEC = 30;
@@ -692,19 +693,20 @@ describe(DeploymentWriterService.name, () => {
       );
     });
 
-    it("asks about the waiting compensation under the key the create would have enqueued", async () => {
+    it("asks for a compensation still waiting under the key the create would have enqueued, and not due before the signer could have given up", async () => {
       const { service, jobQueueService } = setup({ compensationEnqueued: false, compensationAlreadyWaiting: true });
       vi.spyOn(Date, "now").mockReturnValue(1748400000000);
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
 
-      expect(jobQueueService.hasPendingSingleton).toHaveBeenCalledWith({
+      expect(jobQueueService.hasWaitingSingleton).toHaveBeenCalledWith({
         name: DeleteUnbackedDeploymentSetting[JOB_NAME],
-        singletonKey: "deleteUnbackedDeploymentSetting.user-1.1748400000000"
+        singletonKey: "deleteUnbackedDeploymentSetting.user-1.1748400000000",
+        notDueBefore: new Date(1748400000000 + SIGNER_REQUEST_TIMEOUT_MS)
       });
     });
 
-    it("refuses the create when the queue accepted no compensation", async () => {
+    it("refuses the create when the queue accepted no compensation and none is still waiting for the row", async () => {
       const { service } = setup({ compensationEnqueued: false });
 
       await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 })).rejects.toThrow(/without a compensation/);
@@ -1887,7 +1889,8 @@ describe(DeploymentWriterService.name, () => {
     const rpcMessageService = mock<RpcMessageService>();
     const sdlService = mock<SdlService>();
     const billingConfig: MockProxy<BillingConfigService> = mockConfigService<BillingConfigService>({
-      DEPLOYMENT_GRANT_DENOM: "uakt"
+      DEPLOYMENT_GRANT_DENOM: "uakt",
+      TX_SIGNER_REQUEST_TIMEOUT_MS: SIGNER_REQUEST_TIMEOUT_MS
     });
     const providerService = mock<ProviderService>();
     const deploymentReaderService = mock<DeploymentReaderService>();
@@ -1908,7 +1911,7 @@ describe(DeploymentWriterService.name, () => {
     txService.transaction.mockImplementation(async cb => (input?.transactionRuns === false ? (undefined as never) : await cb()));
     const jobQueueService = mock<JobQueueService>();
     jobQueueService.enqueue.mockResolvedValue(input?.compensationEnqueued === false ? null : COMPENSATION_JOB_ID);
-    jobQueueService.hasPendingSingleton.mockResolvedValue(input?.compensationAlreadyWaiting ?? false);
+    jobQueueService.hasWaitingSingleton.mockResolvedValue(input?.compensationAlreadyWaiting ?? false);
 
     const sdlSecretsService = mock<SdlSecretsService>();
     /** Real rather than doubled, because what every stored-sdl assertion below measures is the document this produces. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -165,12 +165,7 @@ export class DeploymentWriterService {
     });
   }
 
-  /**
-   * A retry of a create on the same dseq upserts the same row, and the queue's exclusive policy refuses a second job
-   * for its key, so the compensation the abandoned attempt left behind is the one this row needs, provided it cannot
-   * run before the signer has given up: one that judges the row before this broadcast lands finds no deployment and
-   * deletes it, and `cancelCreatedBy` cannot call off a job a worker already holds.
-   */
+  /** A retry inherits the compensation its failed predecessor left only while that job cannot run before the signer gives up: one that judges the row first finds no deployment and deletes it, and `cancelCreatedBy` cannot call off a job a worker holds. */
   private async compensationIsStillWaiting(singletonKey: string): Promise<boolean> {
     return await this.jobQueueService.hasWaitingSingleton({
       name: DeleteUnbackedDeploymentSetting[JOB_NAME],

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -144,19 +144,33 @@ export class DeploymentWriterService {
   }): Promise<void> {
     const { owner, ...definition } = input;
 
+    const singletonKey = unbackedDeploymentSettingKeyFor(input);
+
     await this.txService.transaction(async () => {
       const deploymentSettingId = await this.recordDefinition(definition);
 
       const compensationId = await this.jobQueueService.enqueue(new DeleteUnbackedDeploymentSetting({ deploymentSettingId, owner, dseq: input.dseq }), {
-        singletonKey: unbackedDeploymentSettingKeyFor(input),
+        singletonKey,
         startAfter: addMinutes(new Date(), this.deploymentConfig.get("UNBACKED_DEPLOYMENT_SETTING_GRACE_IN_MIN")).toISOString(),
         ...unbackedDeploymentSettingRetryOptions(this.deploymentConfig)
       });
 
-      if (!compensationId) {
+      if (compensationId) return;
+
+      if (!(await this.compensationIsAlreadyWaiting(singletonKey))) {
         throw new Error(`Refusing to record deployment setting ${deploymentSettingId} without a compensation: the queue accepted no job`);
       }
+
+      this.logger.info({ event: "UNBACKED_DEPLOYMENT_SETTING_COMPENSATION_ALREADY_WAITING", deploymentSettingId, owner, dseq: input.dseq });
     });
+  }
+
+  /**
+   * A retry of a create on the same dseq upserts the same row, and the queue's exclusive policy refuses a second
+   * job for its key, so the compensation the abandoned attempt left behind is already the one this row needs.
+   */
+  private async compensationIsAlreadyWaiting(singletonKey: string): Promise<boolean> {
+    return await this.jobQueueService.hasPendingSingleton({ name: DeleteUnbackedDeploymentSetting[JOB_NAME], singletonKey });
   }
 
   /** A failure must stay logged rather than raised: the create already succeeded, and an uncancelled compensation still asks the chain before deleting. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -157,7 +157,7 @@ export class DeploymentWriterService {
 
       if (compensationId) return;
 
-      if (!(await this.compensationIsAlreadyWaiting(singletonKey))) {
+      if (!(await this.compensationIsStillWaiting(singletonKey))) {
         throw new Error(`Refusing to record deployment setting ${deploymentSettingId} without a compensation: the queue accepted no job`);
       }
 
@@ -166,11 +166,17 @@ export class DeploymentWriterService {
   }
 
   /**
-   * A retry of a create on the same dseq upserts the same row, and the queue's exclusive policy refuses a second
-   * job for its key, so the compensation the abandoned attempt left behind is already the one this row needs.
+   * A retry of a create on the same dseq upserts the same row, and the queue's exclusive policy refuses a second job
+   * for its key, so the compensation the abandoned attempt left behind is the one this row needs, provided it cannot
+   * run before the signer has given up: one that judges the row before this broadcast lands finds no deployment and
+   * deletes it, and `cancelCreatedBy` cannot call off a job a worker already holds.
    */
-  private async compensationIsAlreadyWaiting(singletonKey: string): Promise<boolean> {
-    return await this.jobQueueService.hasPendingSingleton({ name: DeleteUnbackedDeploymentSetting[JOB_NAME], singletonKey });
+  private async compensationIsStillWaiting(singletonKey: string): Promise<boolean> {
+    return await this.jobQueueService.hasWaitingSingleton({
+      name: DeleteUnbackedDeploymentSetting[JOB_NAME],
+      singletonKey,
+      notDueBefore: new Date(Date.now() + this.billingConfig.get("TX_SIGNER_REQUEST_TIMEOUT_MS"))
+    });
   }
 
   /** A failure must stay logged rather than raised: the create already succeeded, and an uncancelled compensation still asks the chain before deleting. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -24,7 +24,8 @@ import {
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import {
   DeleteUnbackedDeploymentSetting,
-  unbackedDeploymentSettingKeyFor
+  unbackedDeploymentSettingKeyFor,
+  unbackedDeploymentSettingRetryOptions
 } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlPatchService } from "@src/deployment/services/sdl-patch/sdl-patch.service";
@@ -149,10 +150,7 @@ export class DeploymentWriterService {
       const compensationId = await this.jobQueueService.enqueue(new DeleteUnbackedDeploymentSetting({ deploymentSettingId, owner, dseq: input.dseq }), {
         singletonKey: unbackedDeploymentSettingKeyFor(input),
         startAfter: addMinutes(new Date(), this.deploymentConfig.get("UNBACKED_DEPLOYMENT_SETTING_GRACE_IN_MIN")).toISOString(),
-        retryLimit: this.deploymentConfig.get("UNBACKED_DEPLOYMENT_SETTING_RETRY_LIMIT"),
-        retryBackoff: true,
-        retryDelay: this.deploymentConfig.get("UNBACKED_DEPLOYMENT_SETTING_RETRY_DELAY_IN_SEC"),
-        retryDelayMax: this.deploymentConfig.get("UNBACKED_DEPLOYMENT_SETTING_RETRY_DELAY_MAX_IN_MIN") * 60
+        ...unbackedDeploymentSettingRetryOptions(this.deploymentConfig)
       });
 
       if (!compensationId) {

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -36,7 +36,7 @@ describe("Deployment Settings", () => {
       expect(response.status).toBe(401);
     });
 
-    it("returns a new deployment setting if not found", async () => {
+    it("returns 404 and stores nothing when no setting exists for the deployment", async () => {
       const { token, user } = await setup();
       const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
 
@@ -46,23 +46,8 @@ describe("Deployment Settings", () => {
         }
       });
 
-      expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({
-        data: {
-          id: expect.any(String),
-          userId: user.id,
-          dseq,
-          autoTopUpEnabled: true,
-          sdl: null,
-          createdAt: expect.any(String),
-          updatedAt: expect.any(String),
-          estimatedTopUpAmount: expect.any(Number),
-          topUpFrequencyMs: expect.any(Number),
-          runtimeLimitHours: null,
-          runtimeEndsAt: null,
-          closed: false
-        }
-      });
+      expect(response.status).toBe(404);
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toBeUndefined();
     });
 
     it("hands back none of what the console remembers the deployment by", async () => {
@@ -84,20 +69,6 @@ describe("Deployment Settings", () => {
       expect(data).not.toHaveProperty("manifestVersion");
       expect(data).not.toHaveProperty("sealedSecrets");
       expect(body).not.toContain(sealedSecrets);
-    });
-
-    it("enables auto top-up on a lazily created row without consulting the owner's wallet", async () => {
-      const { token, user } = await setup({ hasManagedWallet: false });
-      const dseq = faker.number.int({ min: 1, max: 1000000 }).toString();
-
-      const response = await app.request(`/v1/deployment-settings/${user.id}/${dseq}`, {
-        headers: {
-          authorization: `Bearer ${token}`
-        }
-      });
-
-      expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ data: expect.objectContaining({ autoTopUpEnabled: true }) });
     });
 
     it("returns 404 when accessing other user's deployment settings", async () => {
@@ -555,18 +526,17 @@ describe("Deployment Settings", () => {
     });
   }
 
-  async function setup(input: { hasManagedWallet?: boolean } = {}) {
+  async function setup() {
     const user = await userRepository.create({ userId: faker.string.uuid() });
     const walletAddress = createAkashAddress();
     const token = faker.string.alphanumeric(40);
 
     const wallet = createUserWallet({ userId: user.id, address: walletAddress });
-    const resolvedWallet = input.hasManagedWallet === false ? undefined : wallet;
 
     vi.spyOn(userAuthTokenService, "getValidUserId").mockResolvedValue(user.userId);
     vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(userWalletRepository);
-    vi.spyOn(userWalletRepository, "findFirst").mockResolvedValue(resolvedWallet);
-    vi.spyOn(userWalletRepository, "findOneByUserId").mockResolvedValue(resolvedWallet);
+    vi.spyOn(userWalletRepository, "findFirst").mockResolvedValue(wallet);
+    vi.spyOn(userWalletRepository, "findOneByUserId").mockResolvedValue(wallet);
     vi.spyOn(leaseRepository, "findOneByDseqAndOwner").mockResolvedValue(createDrainingDeployment());
 
     return { user, token, wallet };


### PR DESCRIPTION
## Why

Fixes CON-923

After #3806, #3807 and #3808 drained the closable backlog, about 16,700 deployment settings rows still claim to be open against roughly 391 open leases. Sampling them against the chain shows they are not stale, they are orphans: the chain returns `Deployment not found` for them while still returning the same owners' closed deployments, so the deployments never existed. They split cleanly on whether the row carries an SDL:

- **Rows with an SDL (about 9,100)** were written by the eager pre-broadcast record introduced in #3662 during the ~27 hours before its compensation (#3686) reached production. Their `created_at` stops six minutes after that rollout. Historical.
- **Rows without an SDL (about 7,500, 2025-02 onward)** were written by the settings **read**: `GET /v{1,2}/deployment-settings/...` persisted a defaults row for whatever dseq a client asked about, with no check that the deployment existed. Still live before this PR.

Two things found along the way. The per-row `singletonKey` on the compensation queue deduplicated nothing, because the queue was created with the `standard` policy and pg-boss refuses to change a policy through its API. And pg-boss's `singleton` policy only caps *running* jobs per key, so declaring it would not have fixed that either.

## What

- A settings read no longer persists a row. It returns 404 when nothing is stored, which the frontend query already treats as "no setting" (no retry, data undefined).
- The hourly reconcile hands a record the indexer never saw, once it is older than the create grace, to the existing `DeleteUnbackedDeploymentSetting` compensation instead of leaving it alone. The compensation asks the chain at a pinned height before deleting, so a lagging indexer cannot cost a live row. Rows whose compensation is already pending are skipped, and backlog jobs run below the priority of a create's own. This drains both populations without a manual cleanup and keeps doing so for any future producer.
- `DeleteUnbackedDeploymentSettingHandler` declares the `exclusive` policy (one job per key across queued, retrying and running), and `JobQueueService` rewrites the live policy of an unpartitioned queue at startup, since the shared job table already carries every policy's unique index. Partitioned queues keep the existing warning.

Metrics: `closed_deployments_reconcile_rows_without_chain_state_total` now counts only rows still inside the grace; the new `closed_deployments_reconcile_rows_compensated_total` counts what was handed to the compensation.

Rollout note: the first hourly run after deploy enqueues on the order of 16k compensation jobs. With two workers and a 2s poll that is a few hours of chain lookups, each a latest-block read plus one pinned deployment query.

Not in this PR: `RecordDeploymentSettingHandler` also declares `singleton` while its comment describes `short`/`exclusive` semantics. Its handler is idempotent so a duplicate is harmless, and it is left alone here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Behavior Changes**
  - Deployment-setting GET requests now only retrieve existing settings; missing settings return 404 without creating records.
  - Open deployment results now include the associated user and creation time.
  - Live trial deployments can be identified within a configurable age window.

- **Bug Fixes**
  - Queue policies now converge where supported, helping prevent duplicate singleton jobs.
  - Waiting singleton checks exclude active or not-yet-due jobs.
  - Reconciliation queues compensation jobs for sufficiently old deployments missing chain state, avoids duplicates, respects grace periods, and applies configured retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->