### PR TITLE
test(dx): share the job worker bootstrap across integration suites

### DIFF
--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
@@ -8,7 +8,11 @@ import type { ApiPgDatabase } from "@src/core";
 import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
 import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
 import { UserRepository } from "@src/user/repositories";
-import { DeleteUnbackedDeploymentSetting, DeleteUnbackedDeploymentSettingHandler } from "./delete-unbacked-deployment-setting.handler";
+import {
+  DeleteUnbackedDeploymentSetting,
+  DeleteUnbackedDeploymentSettingHandler,
+  unbackedDeploymentSettingKeyFor
+} from "./delete-unbacked-deployment-setting.handler";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { seedDeploymentSetting } from "@test/seeders/db/deployment-setting.seeder";
@@ -59,13 +63,13 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
   });
 
   it("deletes a setting no deployment backs, run the way a worker runs it", async () => {
-    const { settingId, answerChainWith, enqueueCompensation, startWorkers, findSetting } = await setup();
+    const { settingId, answerChainWith, enqueueCompensation, startWorkers, findSetting, compensationKey } = await setup();
     answerChainWith(ABSENT_FROM_CHAIN);
 
     await enqueueCompensation();
     await startWorkers();
 
-    await expectJobCompleted(DeleteUnbackedDeploymentSetting[JOB_NAME]);
+    await expectJobCompleted(DeleteUnbackedDeploymentSetting[JOB_NAME], { singletonKey: compensationKey });
     expect(await findSetting(settingId)).toBeUndefined();
   });
 
@@ -162,6 +166,7 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     const user = await container.resolve(UserRepository).create({});
     const setting = await seedDeploymentSetting({ userId: user.id, sdl: 'version: "2.0"', manifestVersion: "BAUG" });
     const dseq = setting.dseq;
+    const compensationKey = unbackedDeploymentSettingKeyFor({ userId: user.id, dseq });
 
     answerLatestBlockWith(addMinutes(new Date(setting.createdAt ?? new Date()), input.chainMinutesAhead ?? CHAIN_MINUTES_AHEAD));
 
@@ -227,7 +232,9 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
       failLatestBlock,
       pinnedHeights,
       findSetting,
-      enqueueCompensation: () => enqueue(new DeleteUnbackedDeploymentSetting({ deploymentSettingId: setting.id, owner, dseq })),
+      compensationKey,
+      enqueueCompensation: () =>
+        enqueue(new DeleteUnbackedDeploymentSetting({ deploymentSettingId: setting.id, owner, dseq }), { singletonKey: compensationKey }),
       startWorkers
     };
   }

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts
@@ -1,17 +1,18 @@
-import { faker } from "@faker-js/faker";
 import { addMinutes } from "date-fns";
 import { eq } from "drizzle-orm";
 import nock from "nock";
 import { container } from "tsyringe";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { ApiPgDatabase } from "@src/core";
-import { JobQueueService, POSTGRES_DB, resolveTable } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
 import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
 import { UserRepository } from "@src/user/repositories";
 import { DeleteUnbackedDeploymentSetting, DeleteUnbackedDeploymentSettingHandler } from "./delete-unbacked-deployment-setting.handler";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { seedDeploymentSetting } from "@test/seeders/db/deployment-setting.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
 
 const DEPLOYMENT_INFO_PATH = "/akash/deployment/v1beta4/deployments/info";
 const LATEST_BLOCK_PATH = "/cosmos/base/tendermint/v1beta1/blocks/latest";
@@ -45,20 +46,7 @@ function presentOnChain(owner: string, dseq: string) {
   };
 }
 
-let jobQueueReady: Promise<JobQueueService> | undefined;
-
-/** pg-boss owns its own schema and creates it on start, so the queue this suite uses is bootstrapped once per file. */
-function bootstrapJobQueue() {
-  jobQueueReady ??= (async () => {
-    const jobQueue = container.resolve(JobQueueService);
-    await jobQueue.setup();
-    await jobQueue.registerHandlers([container.resolve(DeleteUnbackedDeploymentSettingHandler)]);
-
-    return jobQueue;
-  })();
-
-  return jobQueueReady;
-}
+const jobWorkers = useJobWorkers(() => [container.resolve(DeleteUnbackedDeploymentSettingHandler)]);
 
 /**
  * Covers the compensation against a real database and a real chain response, because both halves of its decision
@@ -70,15 +58,6 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     nock.cleanAll();
   });
 
-  /**
-   * A worker left running outlives the interceptors: the compensation it retried becomes due a minute later
-   * with nock torn down, and issues a real request to `REST_API_NODE_URL` — egress from CI to a third-party
-   * mainnet endpoint, and a flake that only shows up on a slow run.
-   */
-  afterAll(async () => {
-    if (jobQueueReady) await (await jobQueueReady).dispose();
-  });
-
   it("deletes a setting no deployment backs, run the way a worker runs it", async () => {
     const { settingId, answerChainWith, enqueueCompensation, startWorkers, findSetting } = await setup();
     answerChainWith(ABSENT_FROM_CHAIN);
@@ -86,7 +65,8 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     await enqueueCompensation();
     await startWorkers();
 
-    await vi.waitFor(async () => expect(await findSetting(settingId)).toBeUndefined(), { timeout: 20_000, interval: 250 });
+    await expectJobCompleted(DeleteUnbackedDeploymentSetting[JOB_NAME]);
+    expect(await findSetting(settingId)).toBeUndefined();
   });
 
   it("keeps a setting the chain does have a deployment for", async () => {
@@ -176,15 +156,12 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
     const deploymentSettingsTable = resolveTable("DeploymentSettings");
     const restApiNodeUrl = container.resolve(CoreConfigService).get("REST_API_NODE_URL");
-    const jobQueue = await bootstrapJobQueue();
+    const { enqueue, startWorkers } = await jobWorkers();
 
     const owner = createAkashAddress();
-    const dseq = faker.number.int({ min: 100000, max: 999999 }).toString();
     const user = await container.resolve(UserRepository).create({});
-    const [setting] = await db
-      .insert(deploymentSettingsTable)
-      .values({ userId: user.id, dseq, autoTopUpEnabled: true, sdl: 'version: "2.0"', manifestVersion: "BAUG" })
-      .returning();
+    const setting = await seedDeploymentSetting({ userId: user.id, sdl: 'version: "2.0"', manifestVersion: "BAUG" });
+    const dseq = setting.dseq;
 
     answerLatestBlockWith(addMinutes(new Date(setting.createdAt ?? new Date()), input.chainMinutesAhead ?? CHAIN_MINUTES_AHEAD));
 
@@ -250,8 +227,8 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
       failLatestBlock,
       pinnedHeights,
       findSetting,
-      enqueueCompensation: () => jobQueue.enqueue(new DeleteUnbackedDeploymentSetting({ deploymentSettingId: setting.id, owner, dseq })),
-      startWorkers: () => jobQueue.startWorkers({ concurrency: 1, pollingIntervalSeconds: 0.5 })
+      enqueueCompensation: () => enqueue(new DeleteUnbackedDeploymentSetting({ deploymentSettingId: setting.id, owner, dseq })),
+      startWorkers
     };
   }
 });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.integration.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.integration.ts
@@ -57,7 +57,7 @@ const jobWorkers = useJobWorkers(() => [container.resolve(DeleteUnbackedDeployme
 
 type CompensationPayload = { deploymentSettingId: string; owner: string; dseq: string; version: number };
 
-type CompensationRow = JobRow<CompensationPayload>;
+type CompensationRow = JobRow<CompensationPayload> & { singleton_key: string };
 
 describe(DeploymentWriterService.name, () => {
   afterEach(() => {
@@ -184,7 +184,9 @@ describe(DeploymentWriterService.name, () => {
   }
 
   async function findCompensations(userId: string): Promise<CompensationRow[]> {
-    return await findJobRows<CompensationPayload>(DeleteUnbackedDeploymentSetting[JOB_NAME], { singletonKeyLike: `%.${userId}.%` });
+    const rows = await findJobRows<CompensationPayload>(DeleteUnbackedDeploymentSetting[JOB_NAME], { singletonKeyLike: `%.${userId}.%` });
+
+    return rows as CompensationRow[];
   }
 
   async function setup() {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.integration.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.integration.ts
@@ -2,22 +2,20 @@ import { minutesToMilliseconds, secondsToMilliseconds } from "date-fns";
 import { eq, sql } from "drizzle-orm";
 import nock from "nock";
 import { container } from "tsyringe";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { AbilityService } from "@src/auth/services/ability/ability.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { ApiPgDatabase } from "@src/core";
-import { JOB_NAME, JobQueueService, POSTGRES_DB, resolveTable, TxService } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable, TxService } from "@src/core";
 import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
-import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
 import {
   DeleteUnbackedDeploymentSetting,
   DeleteUnbackedDeploymentSettingHandler
 } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
-import { UserRepository } from "@src/user/repositories";
 import { DeploymentWriterService } from "./deployment-writer.service";
 
-import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { findJobRows, type JobRow, makeJobDue, runAsUser, useJobWorkers } from "@test/services/job-queue-harness";
 
 const SDL = `version: "2.0"
 services:
@@ -55,39 +53,16 @@ const RETRY_LIMIT = 47;
 const RETRY_DELAY_IN_SECONDS = 30;
 const RETRY_DELAY_MAX_IN_SECONDS = 30 * 60;
 
-let jobQueueReady: Promise<JobQueueService> | undefined;
+const jobWorkers = useJobWorkers(() => [container.resolve(DeleteUnbackedDeploymentSettingHandler)]);
 
-function bootstrapJobQueue() {
-  jobQueueReady ??= (async () => {
-    const jobQueue = container.resolve(JobQueueService);
-    await jobQueue.setup();
-    await jobQueue.registerHandlers([container.resolve(DeleteUnbackedDeploymentSettingHandler)]);
+type CompensationPayload = { deploymentSettingId: string; owner: string; dseq: string; version: number };
 
-    return jobQueue;
-  })();
-
-  return jobQueueReady;
-}
-
-type CompensationRow = {
-  state: string;
-  singleton_key: string;
-  data: { deploymentSettingId: string; owner: string; dseq: string; version: number };
-  retry_limit: number;
-  retry_backoff: boolean;
-  retry_delay: number;
-  retry_delay_max: number | null;
-  start_after: string;
-};
+type CompensationRow = JobRow<CompensationPayload>;
 
 describe(DeploymentWriterService.name, () => {
   afterEach(() => {
     vi.restoreAllMocks();
     nock.cleanAll();
-  });
-
-  afterAll(async () => {
-    if (jobQueueReady) await (await jobQueueReady).dispose();
   });
 
   it("enqueues a compensation for the setting it records", async () => {
@@ -209,34 +184,21 @@ describe(DeploymentWriterService.name, () => {
   }
 
   async function findCompensations(userId: string): Promise<CompensationRow[]> {
-    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
-    const rows = await db.execute<CompensationRow>(
-      sql`select state, singleton_key, data, retry_limit, retry_backoff, retry_delay, retry_delay_max, start_after
-          from ${jobTable()}
-          where name = ${DeleteUnbackedDeploymentSetting[JOB_NAME]} and singleton_key like ${`%.${userId}.%`}`
-    );
-
-    return rows as unknown as CompensationRow[];
+    return await findJobRows<CompensationPayload>(DeleteUnbackedDeploymentSetting[JOB_NAME], { singletonKeyLike: `%.${userId}.%` });
   }
 
   async function setup() {
     const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
     const txService = container.resolve(TxService);
-    const userRepository = container.resolve(UserRepository);
     const deploymentSettingsTable = resolveTable("DeploymentSettings");
-    const userWalletsTable = resolveTable("UserWallets");
 
-    const jobQueue = await bootstrapJobQueue();
+    const { startWorkers } = await jobWorkers();
 
     const broadcast = vi
       .spyOn(container.resolve(ManagedSignerService), "executeDerivedDecodedTxByUserId")
       .mockResolvedValue({ code: 0, transactionHash: "tx-hash", hash: "tx-hash", rawLog: "" });
 
-    const user = await userRepository.create({});
-    await db
-      .insert(userWalletsTable)
-      .values({ userId: user.id, address: createAkashAddress(), deploymentAllowance: "10000000", feeAllowance: "5000000", isTrialing: false })
-      .returning();
+    const { user } = await seedUserWithWallet();
 
     async function findCompensation(userId: string, dseq: string) {
       const rows = await findCompensations(userId);
@@ -280,7 +242,7 @@ describe(DeploymentWriterService.name, () => {
 
     async function makeCompensationDue(userId: string) {
       const [compensation] = await findCompensations(userId);
-      await db.execute(sql`update ${jobTable()} set start_after = now() where singleton_key = ${compensation.singleton_key}`);
+      await makeJobDue(DeleteUnbackedDeploymentSetting[JOB_NAME], { singletonKey: compensation.singleton_key });
 
       return { dseq: compensation.data.dseq };
     }
@@ -294,16 +256,9 @@ describe(DeploymentWriterService.name, () => {
     }
 
     const writer = container.resolve(DeploymentWriterService);
-    const executionContextService = container.resolve(ExecutionContextService);
-    const ability = container.resolve(AbilityService).getAbilityFor("REGULAR_USER", user);
 
     async function createDeployment() {
-      return await executionContextService.runWithContext(async () => {
-        executionContextService.set("CURRENT_USER", user);
-        executionContextService.set("ABILITY", ability);
-
-        return await writer.create({ userId: user.id, sdl: SDL, deposit: 5 });
-      });
+      return await runAsUser(user, () => writer.create({ userId: user.id, sdl: SDL, deposit: 5 }));
     }
 
     return {
@@ -318,7 +273,7 @@ describe(DeploymentWriterService.name, () => {
       findCompensationTransactionId,
       makeCompensationDue,
       failEveryChainQuery,
-      startWorkers: () => jobQueue.startWorkers({ concurrency: 1, pollingIntervalSeconds: 0.5 }),
+      startWorkers,
       countSettings,
       countCompensations
     };

--- a/apps/api/test/seeders/db/deployment-setting.seeder.ts
+++ b/apps/api/test/seeders/db/deployment-setting.seeder.ts
@@ -1,0 +1,21 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+
+import type { ApiPgDatabase, ApiPgTables } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+
+type DeploymentSettingInsert = ApiPgTables["DeploymentSettings"]["$inferInsert"];
+
+export async function seedDeploymentSetting(overrides: Partial<DeploymentSettingInsert> & Pick<DeploymentSettingInsert, "userId">) {
+  const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+  const [setting] = await db
+    .insert(resolveTable("DeploymentSettings"))
+    .values({
+      dseq: faker.number.int({ min: 100000, max: 999999 }).toString(),
+      autoTopUpEnabled: true,
+      ...overrides
+    })
+    .returning();
+
+  return setting;
+}

--- a/apps/api/test/seeders/db/user-with-wallet.seeder.ts
+++ b/apps/api/test/seeders/db/user-with-wallet.seeder.ts
@@ -1,0 +1,26 @@
+import { container } from "tsyringe";
+
+import type { ApiPgDatabase, ApiPgTables } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+import { UserRepository } from "@src/user/repositories";
+import { createAkashAddress } from "../akash-address.seeder";
+
+type UserWalletInsert = ApiPgTables["UserWallets"]["$inferInsert"];
+
+export async function seedUserWithWallet(overrides: Omit<Partial<UserWalletInsert>, "userId"> = {}) {
+  const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+  const user = await container.resolve(UserRepository).create({});
+  const [wallet] = await db
+    .insert(resolveTable("UserWallets"))
+    .values({
+      userId: user.id,
+      address: createAkashAddress(),
+      deploymentAllowance: "10000000",
+      feeAllowance: "5000000",
+      isTrialing: false,
+      ...overrides
+    })
+    .returning();
+
+  return { user, wallet, address: wallet.address as string };
+}

--- a/apps/api/test/seeders/index.ts
+++ b/apps/api/test/seeders/index.ts
@@ -18,3 +18,5 @@ export * from "./validator.seeder";
 export * from "./stripe-test-data.seeder";
 export * from "./stripe-transaction-test.seeder";
 export * from "./user-test.seeder";
+export * from "./db/deployment-setting.seeder";
+export * from "./db/user-with-wallet.seeder";

--- a/apps/api/test/services/job-queue-harness.ts
+++ b/apps/api/test/services/job-queue-harness.ts
@@ -22,9 +22,14 @@ export interface JobRow<TData = Record<string, unknown>> {
   retry_backoff: boolean;
   retry_delay: number;
   retry_delay_max: number | null;
-  singleton_key: string;
+  singleton_key: string | null;
   data: TData;
   start_after: string;
+}
+
+interface JobSelector {
+  singletonKey?: string;
+  singletonKeyLike?: string;
 }
 
 function db() {
@@ -62,12 +67,18 @@ export function useJobWorkers(resolveHandlers: () => JobHandler<Job>[]) {
   };
 }
 
-export async function findJobRows<TData = Record<string, unknown>>(jobName: string, options: { singletonKeyLike?: string } = {}): Promise<JobRow<TData>[]> {
-  const singletonKeyFilter = options.singletonKeyLike ? sql`and singleton_key like ${options.singletonKeyLike}` : sql``;
+function selectorFilter({ singletonKey, singletonKeyLike }: JobSelector) {
+  if (singletonKey) return sql`and singleton_key = ${singletonKey}`;
+  if (singletonKeyLike) return sql`and singleton_key like ${singletonKeyLike}`;
+
+  return sql``;
+}
+
+export async function findJobRows<TData = Record<string, unknown>>(jobName: string, selector: JobSelector = {}): Promise<JobRow<TData>[]> {
   const rows = await db().execute(
     sql`select state, output, retry_count, retry_limit, retry_backoff, retry_delay, retry_delay_max, singleton_key, data, start_after::text
         from ${jobTable()}
-        where name = ${jobName} ${singletonKeyFilter}
+        where name = ${jobName} ${selectorFilter(selector)}
         order by created_on`
   );
 
@@ -85,12 +96,17 @@ function describeFailure(output: unknown) {
 }
 
 /** Reports what a job recorded, because pg-boss reschedules a throwing handler silently and a side-effect wait alone times out with no cause. */
-export async function expectJobCompleted(jobName: string, options: { timeout?: number; singletonKeyLike?: string } = {}): Promise<JobRow> {
+export async function expectJobCompleted(jobName: string, options: JobSelector & { timeout?: number } = {}): Promise<JobRow> {
   return await vi.waitFor(
     async () => {
-      const [row] = await findJobRows(jobName, options);
+      const rows = await findJobRows(jobName, options);
 
-      if (!row) throw new Error(`No "${jobName}" job was enqueued`);
+      if (rows.length === 0) throw new Error(`No "${jobName}" job was enqueued`);
+      if (rows.length > 1) {
+        throw new Error(`${rows.length} "${jobName}" jobs match, so this cannot tell which one to report on. Narrow it with singletonKey or singletonKeyLike.`);
+      }
+
+      const [row] = rows;
       if (row.state === "completed") return row;
 
       throw new Error(`Job "${jobName}" is ${row.state} instead of completed. It recorded:\n${describeFailure(row.output)}`);
@@ -99,10 +115,8 @@ export async function expectJobCompleted(jobName: string, options: { timeout?: n
   );
 }
 
-export async function makeJobDue(jobName: string, options: { singletonKey?: string } = {}): Promise<void> {
-  const singletonKeyFilter = options.singletonKey ? sql`and singleton_key = ${options.singletonKey}` : sql``;
-
-  await db().execute(sql`update ${jobTable()} set start_after = now() where name = ${jobName} ${singletonKeyFilter}`);
+export async function makeJobDue(jobName: string, selector: JobSelector = {}): Promise<void> {
+  await db().execute(sql`update ${jobTable()} set start_after = now() where name = ${jobName} ${selectorFilter(selector)}`);
 }
 
 /** Lets a fixture be built through the ability-scoped services a request uses, which the worker's own empty ability would refuse. */

--- a/apps/api/test/services/job-queue-harness.ts
+++ b/apps/api/test/services/job-queue-harness.ts
@@ -1,0 +1,119 @@
+import { sql } from "drizzle-orm";
+import { container } from "tsyringe";
+import { afterAll, vi } from "vitest";
+
+import { AbilityService } from "@src/auth/services/ability/ability.service";
+import type { ApiPgDatabase } from "@src/core";
+import { type EnqueueOptions, type Job, type JobHandler, JobQueueService, POSTGRES_DB } from "@src/core";
+import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import type { UserOutput } from "@src/user/repositories";
+
+const WORKER_OPTIONS = { concurrency: 1, pollingIntervalSeconds: 0.5 };
+
+const SETTLE_TIMEOUT_IN_MS = 20_000;
+const SETTLE_INTERVAL_IN_MS = 250;
+
+export interface JobRow<TData = Record<string, unknown>> {
+  state: string;
+  output: unknown;
+  retry_count: number;
+  retry_limit: number;
+  retry_backoff: boolean;
+  retry_delay: number;
+  retry_delay_max: number | null;
+  singleton_key: string;
+  data: TData;
+  start_after: string;
+}
+
+function db() {
+  return container.resolve<ApiPgDatabase>(POSTGRES_DB);
+}
+
+function jobTable() {
+  return sql`${sql.identifier(container.resolve(CoreConfigService).get("POSTGRES_BACKGROUND_JOBS_SCHEMA"))}.job`;
+}
+
+/** Disposes on teardown because a worker left running outlives a test's interceptors and then calls the real chain. */
+export function useJobWorkers(resolveHandlers: () => JobHandler<Job>[]) {
+  let ready: Promise<JobQueueService> | undefined;
+
+  afterAll(async () => {
+    if (ready) await (await ready).dispose();
+  });
+
+  return async function jobWorkers() {
+    ready ??= (async () => {
+      const jobQueue = container.resolve(JobQueueService);
+      await jobQueue.setup();
+      await jobQueue.registerHandlers(resolveHandlers());
+
+      return jobQueue;
+    })();
+
+    const jobQueue = await ready;
+
+    return {
+      jobQueue,
+      enqueue: (job: Job, options?: EnqueueOptions) => jobQueue.enqueue(job, options),
+      startWorkers: () => jobQueue.startWorkers(WORKER_OPTIONS)
+    };
+  };
+}
+
+export async function findJobRows<TData = Record<string, unknown>>(jobName: string, options: { singletonKeyLike?: string } = {}): Promise<JobRow<TData>[]> {
+  const singletonKeyFilter = options.singletonKeyLike ? sql`and singleton_key like ${options.singletonKeyLike}` : sql``;
+  const rows = await db().execute(
+    sql`select state, output, retry_count, retry_limit, retry_backoff, retry_delay, retry_delay_max, singleton_key, data, start_after::text
+        from ${jobTable()}
+        where name = ${jobName} ${singletonKeyFilter}
+        order by created_on`
+  );
+
+  return rows as unknown as JobRow<TData>[];
+}
+
+function describeFailure(output: unknown) {
+  if (output && typeof output === "object" && "message" in output) {
+    const { message, stack } = output as { message?: unknown; stack?: unknown };
+
+    return typeof stack === "string" ? stack : String(message);
+  }
+
+  return JSON.stringify(output);
+}
+
+/** Reports what a job recorded, because pg-boss reschedules a throwing handler silently and a side-effect wait alone times out with no cause. */
+export async function expectJobCompleted(jobName: string, options: { timeout?: number; singletonKeyLike?: string } = {}): Promise<JobRow> {
+  return await vi.waitFor(
+    async () => {
+      const [row] = await findJobRows(jobName, options);
+
+      if (!row) throw new Error(`No "${jobName}" job was enqueued`);
+      if (row.state === "completed") return row;
+
+      throw new Error(`Job "${jobName}" is ${row.state} instead of completed. It recorded:\n${describeFailure(row.output)}`);
+    },
+    { timeout: options.timeout ?? SETTLE_TIMEOUT_IN_MS, interval: SETTLE_INTERVAL_IN_MS }
+  );
+}
+
+export async function makeJobDue(jobName: string, options: { singletonKey?: string } = {}): Promise<void> {
+  const singletonKeyFilter = options.singletonKey ? sql`and singleton_key = ${options.singletonKey}` : sql``;
+
+  await db().execute(sql`update ${jobTable()} set start_after = now() where name = ${jobName} ${singletonKeyFilter}`);
+}
+
+/** Lets a fixture be built through the ability-scoped services a request uses, which the worker's own empty ability would refuse. */
+export async function runAsUser<T>(user: UserOutput, cb: () => Promise<T>): Promise<T> {
+  const executionContextService = container.resolve(ExecutionContextService);
+  const ability = container.resolve(AbilityService).getAbilityFor("REGULAR_USER", user);
+
+  return await executionContextService.runWithContext(async () => {
+    executionContextService.set("CURRENT_USER", user);
+    executionContextService.set("ABILITY", ability);
+
+    return await cb();
+  });
+}

--- a/apps/api/test/services/job-queue-harness.ts
+++ b/apps/api/test/services/job-queue-harness.ts
@@ -43,6 +43,7 @@ function jobTable() {
 /** Disposes on teardown because a worker left running outlives a test's interceptors and then calls the real chain. */
 export function useJobWorkers(resolveHandlers: () => JobHandler<Job>[]) {
   let ready: Promise<JobQueueService> | undefined;
+  let started: Promise<void> | undefined;
 
   afterAll(async () => {
     if (ready) await (await ready).dispose();
@@ -62,7 +63,7 @@ export function useJobWorkers(resolveHandlers: () => JobHandler<Job>[]) {
     return {
       jobQueue,
       enqueue: (job: Job, options?: EnqueueOptions) => jobQueue.enqueue(job, options),
-      startWorkers: () => jobQueue.startWorkers(WORKER_OPTIONS)
+      startWorkers: () => (started ??= jobQueue.startWorkers(WORKER_OPTIONS))
     };
   };
 }


### PR DESCRIPTION
## Why

Part of CON-952.

Background job handlers run inside a pg-boss worker that installs a fake system user and an **empty** CASL ability. Their current coverage is unit specs with mocked repositories, so neither failure mode that setup can produce is observable: a handler the ability layer refuses, and a handler whose query silently matches no rows.

Covering all 17 handlers needs a shared bootstrap first, because the three integration suites that already reach the worker had each grown their own copy of it — and none of them can report *why* a job failed. Both worker-path tests wait on a side effect, so a refused handler times out after 20s with nothing but `expect(received).toBeUndefined()`.

## What

Adds `apps/api/test/services/job-queue-harness.ts`, collecting what the existing suites had duplicated:

- `useJobWorkers(handlers)` — the per-file pg-boss bootstrap plus its teardown. Handlers resolve lazily so registration happens at run time, not collection time.
- `findJobRows(name, { singletonKeyLike })` — one typed reader over the background-jobs `job` table, replacing two hand-rolled `select`s.
- `makeJobDue(name, { singletonKey })` — brings a delayed job forward.
- `runAsUser(user, cb)` — builds fixtures through ability-scoped services, which the worker's own empty ability would refuse.

And adds the capability none of them had:

- `expectJobCompleted(name)` — fails with what the job *recorded* instead of a bare timeout.

Verified against a handler that makes an ability-scoped call under the worker's empty ability. Before, that test timed out at 20s with no cause. Now it fails with:

```
Job "abilityScopedScratch" is retry instead of completed. It recorded:
ForbiddenError: Cannot execute "sign" on "UserWallet"
    at DrizzleAbility.toDrizzleWhereClause (src/lib/drizzle-ability/drizzle-ability.ts:50:20)
    at new DrizzleAbility (src/lib/drizzle-ability/drizzle-ability.ts:30:41)
    at UserWalletRepository.withAbility (src/core/repositories/base.repository.ts:49:20)
    ...
```

That diagnosis is what makes the remaining handler PRs worth writing rather than 16 opaque timeouts.

Also adds the first two DB-writing seeders (`seedUserWithWallet`, `seedDeploymentSetting`). Every existing seeder in `test/seeders/` is an in-memory factory for unit specs, so the integration suites had been retyping these inserts.

### Notes for the reviewer

- **Two of the three bootstrap copies converge here.** `src/core/services/job-queue/job-queue.service.integration.ts` keeps its own, because it constructs and registers its *own* `PgBoss` instance in order to inspect queue rows. Folding that in would mean adding a `pgBoss` escape hatch to the harness for exactly one caller.
- `JobRow` carries the retry columns because `deployment-writer.service.integration.ts` asserts on them today; it is generic over `data` so callers keep their payload typing.
- No behaviour change to any handler — `src/**` edits are test files only.

### Verification

- `npm run test:integration` — both refactored suites pass (`delete-unbacked-deployment-setting`: 10 tests; `deployment-writer`: full suite)
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 42 errors, identical to the `origin/main` baseline measured on this worktree (this app has never typechecked clean); sorted error lists diff empty, so zero introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability with shared worker setup and uniquely scoped job-completion checks.
  * Added deterministic controls for job timing, status verification, querying, and user-scoped scenarios.
  * Enhanced job matching to support exact and pattern-based identifiers, including jobs without identifiers.

* **Test Data**
  * Added reusable seeders for deployment settings and users with wallets.
  * Added generated defaults and support for customizing seeded test data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->