### PR TITLE
test(deployment): cover recording a deployment setting through a worker

### DIFF
--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.integration.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.integration.ts
@@ -1,0 +1,63 @@
+import { eq } from "drizzle-orm";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+import { UserRepository } from "@src/user/repositories";
+import { RecordDeploymentSetting, RecordDeploymentSettingHandler, recordDeploymentSettingKeyFor } from "./record-deployment-setting.handler";
+
+import { createDseq, seedDeploymentSetting } from "@test/seeders/db/deployment-setting.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(RecordDeploymentSettingHandler)]);
+
+describe(RecordDeploymentSettingHandler.name, () => {
+  it("records a setting with auto top up on for a deployment that has none", async () => {
+    const { userId, dseq, jobKey, enqueueRecord, startWorkers, findSettings } = await setup();
+
+    await enqueueRecord();
+    await startWorkers();
+    await expectJobCompleted(RecordDeploymentSetting[JOB_NAME], { singletonKey: jobKey });
+
+    const settings = await findSettings();
+
+    expect(settings).toHaveLength(1);
+    expect(settings[0]).toMatchObject({ userId, dseq, autoTopUpEnabled: true, closed: false });
+  });
+
+  it("leaves the auto top up choice a user already made alone", async () => {
+    const { jobKey, enqueueRecord, startWorkers, findSettings, seedExistingSetting } = await setup();
+    await seedExistingSetting({ autoTopUpEnabled: false, runtimeLimitHours: 12 });
+
+    await enqueueRecord();
+    await startWorkers();
+    await expectJobCompleted(RecordDeploymentSetting[JOB_NAME], { singletonKey: jobKey });
+
+    const settings = await findSettings();
+
+    expect(settings).toHaveLength(1);
+    expect(settings[0]).toMatchObject({ autoTopUpEnabled: false, runtimeLimitHours: 12 });
+  });
+
+  async function setup() {
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const deploymentSettingsTable = resolveTable("DeploymentSettings");
+    const { enqueue, startWorkers } = await jobWorkers();
+
+    const user = await container.resolve(UserRepository).create({});
+    const dseq = createDseq();
+
+    return {
+      userId: user.id,
+      dseq,
+      jobKey: recordDeploymentSettingKeyFor({ userId: user.id, dseq }),
+      seedExistingSetting: (overrides: { autoTopUpEnabled?: boolean; runtimeLimitHours?: number }) =>
+        seedDeploymentSetting({ userId: user.id, dseq, ...overrides }),
+      enqueueRecord: () =>
+        enqueue(new RecordDeploymentSetting({ userId: user.id, dseq }), { singletonKey: recordDeploymentSettingKeyFor({ userId: user.id, dseq }) }),
+      startWorkers,
+      findSettings: () => db.select().from(deploymentSettingsTable).where(eq(deploymentSettingsTable.userId, user.id))
+    };
+  }
+});

--- a/apps/api/test/seeders/db/deployment-setting.seeder.ts
+++ b/apps/api/test/seeders/db/deployment-setting.seeder.ts
@@ -6,12 +6,16 @@ import { POSTGRES_DB, resolveTable } from "@src/core";
 
 type DeploymentSettingInsert = ApiPgTables["DeploymentSettings"]["$inferInsert"];
 
+export function createDseq() {
+  return faker.number.int({ min: 100000, max: 999999 }).toString();
+}
+
 export async function seedDeploymentSetting(overrides: Partial<DeploymentSettingInsert> & Pick<DeploymentSettingInsert, "userId">) {
   const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
   const [setting] = await db
     .insert(resolveTable("DeploymentSettings"))
     .values({
-      dseq: faker.number.int({ min: 100000, max: 999999 }).toString(),
+      dseq: createDseq(),
       autoTopUpEnabled: true,
       ...overrides
     })


### PR DESCRIPTION
## Why

Part of CON-952.

`RecordDeploymentSettingHandler` carries this comment on `handle`:

> Unscoped because job execution runs under an empty ability, which a scoped read would throw on before any SQL ran.

Nothing held it to that, and its unit spec cannot: a mocked repository consults no ability and writes no row. If someone "tidied" that call into an `accessibleBy` read, every existing test would stay green and the job would die in production after its retries, silently leaving the funding sweep with no row to find.

## What

Runs the handler through a real worker against a real database, and pins the behaviour a mock cannot get wrong on the repository's behalf.

The second test is the one worth reading: `createDefaultIfMissing` is an `onConflictDoNothing` insert, so a late job must **not** re-enable auto top-up on a deployment whose owner turned it off. Verified by mutation — swapping `onConflictDoNothing` for `onConflictDoUpdate` fails it:

```
× leaves the auto top up choice a user already made alone
AssertionError: expected { …(15) } to match object { autoTopUpEnabled: false, …(1) }
```

Adds `createDseq` to the deployment-setting seeder, since the dseq is needed before the row exists (it keys the job).

### Verification

- `npm run test:integration` — this file passes, and the full integration suite is green
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 42 errors, unchanged from the `main` baseline (this app has never typechecked clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
