### PR TITLE
test(deployment): cover releasing funding claims for a reverted tx

### DIFF
--- a/apps/api/src/deployment/services/reconcile-managed-tx/reconcile-managed-tx.handler.integration.ts
+++ b/apps/api/src/deployment/services/reconcile-managed-tx/reconcile-managed-tx.handler.integration.ts
@@ -1,0 +1,106 @@
+import { faker } from "@faker-js/faker";
+import { eq } from "drizzle-orm";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { type LandedTx, TxPresenceService } from "@src/chain/services/tx-presence/tx-presence.service";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { UserRepository } from "@src/user/repositories";
+import { ReconcileManagedTx, ReconcileManagedTxHandler } from "./reconcile-managed-tx.handler";
+import { ReconcileManagedTxJobService } from "./reconcile-managed-tx-job.service";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { seedDeploymentSetting } from "@test/seeders/db/deployment-setting.seeder";
+import { expectJobCompleted, makeJobDue, useJobWorkers } from "@test/services/job-queue-harness";
+
+const FUNDING_COOLDOWN_IN_MINUTES = 30;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(ReconcileManagedTxHandler)]);
+
+describe(ReconcileManagedTxHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("releases the funding claims a reverted transaction left held", async () => {
+    const { answerChainWith, reconcile, findLastFundedAt } = await setup();
+    answerChainWith({ code: 11, rawLog: "insufficient funds" });
+
+    await reconcile();
+
+    expect(await findLastFundedAt()).toBeNull();
+  });
+
+  it("keeps the funding claims a landed transaction earned", async () => {
+    const { answerChainWith, reconcile, findLastFundedAt, heldSince } = await setup();
+    answerChainWith({ code: 0 });
+
+    await reconcile();
+
+    expect(await findLastFundedAt()).toEqual(heldSince);
+  });
+
+  it("keeps the funding claims while the transaction is not seen", async () => {
+    const { answerChainAbsent, reconcile, findLastFundedAt, heldSince } = await setup();
+    answerChainAbsent();
+
+    await reconcile();
+
+    expect(await findLastFundedAt()).toEqual(heldSince);
+  });
+
+  it("keeps a claim another pass has since re-taken", async () => {
+    const { answerChainWith, reconcile, findLastFundedAt, reclaimAt } = await setup();
+    answerChainWith({ code: 11, rawLog: "insufficient funds" });
+    const retakenAt = await reclaimAt();
+
+    await reconcile();
+
+    expect(await findLastFundedAt()).toEqual(retakenAt);
+  });
+
+  async function setup() {
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const deploymentSettingsTable = resolveTable("DeploymentSettings");
+    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+    const { startWorkers } = await jobWorkers();
+
+    const txHash = faker.string.hexadecimal({ length: 64, prefix: "" }).toUpperCase();
+    const owner = createAkashAddress();
+    const user = await container.resolve(UserRepository).create({});
+    const setting = await seedDeploymentSetting({ userId: user.id });
+    const [claim] = await deploymentSettingRepository.claimForFunding([setting.id], FUNDING_COOLDOWN_IN_MINUTES);
+    const findTx = vi.spyOn(container.resolve(TxPresenceService), "findTx");
+
+    async function findLastFundedAt() {
+      const [row] = await db.select().from(deploymentSettingsTable).where(eq(deploymentSettingsTable.id, setting.id));
+
+      return row.lastFundedAt;
+    }
+
+    async function reclaimAt() {
+      const retakenAt = new Date(Date.now() - 1000);
+      await db.update(deploymentSettingsTable).set({ lastFundedAt: retakenAt }).where(eq(deploymentSettingsTable.id, setting.id));
+
+      return retakenAt;
+    }
+
+    const singletonKey = ReconcileManagedTxJobService.singletonKey(txHash);
+
+    return {
+      heldSince: await findLastFundedAt(),
+      reclaimAt,
+      findLastFundedAt,
+      answerChainWith: (tx: Partial<LandedTx>) => findTx.mockResolvedValue({ hash: txHash, code: 0, height: 1, rawLog: "", ...tx }),
+      answerChainAbsent: () => findTx.mockResolvedValue(null),
+      reconcile: async () => {
+        await container.resolve(ReconcileManagedTxJobService).schedule({ txHash, owner, claims: [claim] });
+        await makeJobDue(ReconcileManagedTx[JOB_NAME], { singletonKey });
+        await startWorkers();
+        await expectJobCompleted(ReconcileManagedTx[JOB_NAME], { singletonKey });
+      }
+    };
+  }
+});


### PR DESCRIPTION
## Why

Part of CON-952.

`releaseFundingClaim` is a compare-and-set: it clears `last_funded_at` only where the column still equals the exact marker the claim wrote. That marker is produced as `last_funded_at::text` from a **timezone-less** `timestamp` column, makes a round trip through pg-boss JSON, and comes back as `${claim.claimedAt}::timestamp`.

A mocked repository cannot get that comparison wrong on the handler's behalf, so the guard was untested — **drop it from the WHERE clause and every existing test stays green**, while in production a claim another pass had already re-taken would be cleared, letting a second deposit through.

## What

Covers the handler through a real worker against a real database, for all four outcomes: reverted releases, landed holds, not-seen holds, and a re-taken claim holds.

It goes through the real machinery rather than hand-rolling it — `ReconcileManagedTxJobService.schedule()` for the enqueue (so the singleton key and the delay are the production ones), `makeJobDue` to bring the delayed job forward, and a real `claimForFunding` to produce the marker in its true format.

Verified by mutation — dropping the marker from the WHERE clause fails exactly the test meant to catch it:

```
× keeps a claim another pass has since re-taken
AssertionError: expected null to deeply equal 2026-09-07T22:24:39.689Z
```

`TxPresenceService.findTx` is spied at the tsyringe boundary rather than nocked: its own spec already covers the SDK decoding, and what is untested here is the database write.

### Note for whoever writes the next handler test

The first version of this failed with a two-hour offset, and the assertion was at fault, not the code: `claimedAt` is a timezone-less string, so `new Date(claimedAt)` parses it as **local** time while the driver reads the column back as UTC. Assert against the value read from the database, not a reparse of the marker. Several remaining handlers compare timestamp markers the same way.

### Verification

- `npm run test:integration` — this file passes, full integration suite green
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 42 errors, unchanged from the `main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
