### PR TITLE
docs(dx): require integration coverage for job handlers

### DIFF
--- a/.claude/skills/console-tests/SKILL.md
+++ b/.claude/skills/console-tests/SKILL.md
@@ -14,7 +14,7 @@ Choose the lowest-effective test level:
 | Level | When to use in this repo | Mocking strategy |
 |-------|-------------------------|-----------------|
 | **Unit** (default) | Components, hooks, services, utilities | All deps mocked via DI (`mock<T>()`) — never `vi.mock()` |
-| **Integration** | Services with heavy DB logic or Repository patterns | Real DB fixtures; mock only 3rd-party calls |
+| **Integration** | Services with heavy DB logic or Repository patterns; **required for every pg-boss job handler** | Real DB fixtures; mock only 3rd-party calls |
 | **Functional** | Black-box HTTP endpoint verification | `nock` for external calls only; never mock internal services |
 | **E2E** | Post-deployment verification (beta/prod) | No mocks; happy path only; Playwright with semantic locators |
 
@@ -205,6 +205,27 @@ Key points:
 - Use function-based seeders (not class-based)
 - Use `@faker-js/faker` for randomized data in seeders
 - Seeder accepts `Partial<T>` overrides with sensible defaults
+
+## Background Job Handlers (apps/api)
+
+A pg-boss job handler needs an **integration** test (`*.handler.integration.ts`), not a unit spec. A unit spec cannot cover it, because the two ways a job fails in production are both invisible to mocks:
+
+- the worker installs a fake system user and an **empty** CASL ability, so any ability-scoped repository call throws `ForbiddenError` — the job then dies after its retries with no user-facing error
+- a query that matches no rows reports success while doing nothing
+
+Mocked repositories consult no ability and return whatever the test told them to, so they cannot produce either outcome.
+
+Rules:
+
+- Run the handler through the real worker — `useJobWorkers` + `startWorkers`, never `handler.handle(payload)` alone. Calling `handle` directly bypasses the worker context and tests an execution environment that does not exist in production.
+- Assert on **end state** (rows, job rows), never on `expect(repo.method).toHaveBeenCalled()`. A write that matched zero rows satisfies the spy and fails the row read.
+- Wait with `expectJobCompleted(jobName)` rather than only waiting on a side effect, so a refused job reports its cause instead of timing out opaquely.
+- Fake collaborators at the tsyringe boundary with `vi.spyOn(container.resolve(X), "m")`, or with `nock` for HTTP. `test:ci-setup` starts only the database and the mock OAuth2 server, so anything reaching notifications, provider-proxy, the tx signer, or KMS must be faked or the test dies on `ECONNREFUSED`.
+- Keep the existing unit spec. Integration coverage supersedes it as the guarantee, but removing specs is separate work with its own coverage argument.
+
+The shared helpers live in `apps/api/test/services/job-queue-harness.ts` and the DB seeders in `apps/api/test/seeders/db/`. `apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.integration.ts` is the reference example.
+
+An exception is fair for a handler that touches no table and makes no ability-scoped call — a pure pass-through to another service. Such a test asserts a spy was called after a queue round trip, which tests the harness rather than the handler. Say so rather than writing it.
 
 ## API Functional Tests
 


### PR DESCRIPTION
## Why

Part of CON-952.

A unit spec cannot cover a pg-boss job handler. The worker installs a fake system user and an **empty** CASL ability, so the two ways a job fails in production are both invisible to mocked repositories: refused by the ability layer (dies after its retries, no user-facing error), or writing zero rows while reporting success.

This is not hypothetical drift. While CON-952 was in progress, #3819 landed an 18th handler (`probe-trial-deployment`) with a unit spec only. Writing the rule down is what stops the backfill from being permanent.

## What

Adds a *Background Job Handlers* section to the `console-tests` skill, and marks integration coverage as required for job handlers in the test-level table.

The four mechanics it states, each of which cost real debugging to learn:

- run the handler through the real worker, never `handler.handle(payload)` alone — calling `handle` directly tests an execution environment that does not exist in production
- assert on end state, never on `expect(repo.method).toHaveBeenCalled()` — a write that matched zero rows satisfies the spy and fails the row read
- wait with `expectJobCompleted`, so a refused job reports its cause instead of timing out opaquely
- fake collaborators at the tsyringe boundary or with `nock`, because `test:ci-setup` starts only the database and the mock OAuth2 server — anything reaching notifications, provider-proxy, the tx signer, or KMS dies on `ECONNREFUSED`

It also records the one fair exception: a handler that touches no table and makes no ability-scoped call cannot exhibit either failure mode, so a test there asserts a spy was called after a queue round trip, which tests the harness rather than the handler. Better to say so than to write it.

Depends on #3839 (merged), which added the harness this references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
