### PR TITLE
test(notifications): cover the notification queue end to end

### DIFF
--- a/apps/api/src/notifications/services/notification-handler/notification.handler.integration.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.integration.ts
@@ -1,0 +1,103 @@
+import "@src/app/providers/jobs.provider";
+
+import { faker } from "@faker-js/faker";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { JOB_NAME } from "@src/core";
+import { NOTIFICATIONS_CONFIG } from "@src/notifications/providers/notifications-config.provider";
+import { NotificationHandler, NotificationJob } from "./notification.handler";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { seedUser, seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+
+const NOTIFICATION_PATH = "/internal/v1/jobs/notification";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(NotificationHandler)]);
+
+describe(NotificationHandler.name, () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("sends the notification a user still on trial earns", async () => {
+    const { userId, dseq, notificationId, notify, sentNotifications } = await setup({ isTrialing: true });
+
+    await notify();
+
+    const [sent] = sentNotifications();
+    expect(sent.userId).toBe(userId);
+    expect(sent.body).toMatchObject({ notificationId });
+    expect(JSON.stringify(sent.body)).toContain(dseq);
+  });
+
+  it("sends the notification to a user who has no wallet yet", async () => {
+    const { notify, sentNotifications } = await setup({ withWallet: false });
+
+    await notify();
+
+    expect(sentNotifications()).toHaveLength(1);
+  });
+
+  it("skips a user whose wallet has left the trial", async () => {
+    const { notify, sentNotifications } = await setup({ isTrialing: false });
+
+    await notify();
+
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  it("skips a user with no email to send to", async () => {
+    const { notify, sentNotifications } = await setup({ isTrialing: true, email: null });
+
+    await notify();
+
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  async function setup(input: { isTrialing?: boolean; withWallet?: boolean; email?: string | null } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const notificationsBaseUrl = container.resolve(NOTIFICATIONS_CONFIG).NOTIFICATIONS_API_BASE_URL as string;
+
+    const email = input.email === undefined ? faker.internet.email() : input.email;
+    const user =
+      input.withWallet === false ? await seedUser({ email }) : (await seedUserWithWallet({ isTrialing: input.isTrialing ?? true, user: { email } })).user;
+
+    const dseq = faker.string.numeric(6);
+    const owner = createAkashAddress();
+    const notificationId = `trialFirstDeploymentLeaseCreated.${owner}`;
+
+    const sent: { userId: string | undefined; body: Record<string, unknown> }[] = [];
+    nock(notificationsBaseUrl)
+      .persist()
+      .post(NOTIFICATION_PATH)
+      .reply(function reply(this: nock.ReplyFnContext, _uri, body) {
+        sent.push({ userId: this.req.headers["x-user-id"] as string, body: body as Record<string, unknown> });
+
+        return [201, {}];
+      });
+
+    return {
+      userId: user.id,
+      dseq,
+      owner,
+      notificationId,
+      sentNotifications: () => sent,
+      notify: async () => {
+        await enqueue(
+          new NotificationJob({
+            template: "trialFirstDeploymentLeaseCreated",
+            userId: user.id,
+            conditions: { trial: true },
+            vars: { dseq, owner }
+          }),
+          { singletonKey: notificationId }
+        );
+        await startWorkers();
+        await expectJobCompleted(NotificationJob[JOB_NAME], { singletonKey: notificationId });
+      }
+    };
+  }
+});

--- a/apps/api/test/seeders/db/user-with-wallet.seeder.ts
+++ b/apps/api/test/seeders/db/user-with-wallet.seeder.ts
@@ -2,14 +2,18 @@ import { container } from "tsyringe";
 
 import type { ApiPgDatabase, ApiPgTables } from "@src/core";
 import { POSTGRES_DB, resolveTable } from "@src/core";
-import { UserRepository } from "@src/user/repositories";
+import { type UserInput, UserRepository } from "@src/user/repositories";
 import { createAkashAddress } from "../akash-address.seeder";
 
 type UserWalletInsert = ApiPgTables["UserWallets"]["$inferInsert"];
 
-export async function seedUserWithWallet(overrides: Omit<Partial<UserWalletInsert>, "userId"> = {}) {
+export async function seedUser(overrides: UserInput = {}) {
+  return await container.resolve(UserRepository).create(overrides);
+}
+
+export async function seedUserWithWallet({ user: userOverrides, ...overrides }: Omit<Partial<UserWalletInsert>, "userId"> & { user?: UserInput } = {}) {
   const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
-  const user = await container.resolve(UserRepository).create({});
+  const user = await seedUser(userOverrides);
   const [wallet] = await db
     .insert(resolveTable("UserWallets"))
     .values({


### PR DESCRIPTION
## Why

Part of CON-952.

`NotificationHandler` is the terminal queue six other handlers feed into, and its decision to send or skip is made against a **real user row**:

```ts
if (payload.conditions && !guard<UserOutput>(payload.conditions)(user)) return;
```

Production calls it with `conditions: { trial: true }` — but `trial` is not a column. `UserRepository.findById` derives it by joining `user_wallets` and defaulting to `true` when the user has no wallet yet:

```ts
trial: result.userWallets?.isTrialing ?? true
```

A mocked repository returns whatever `trial` the test asked for, so neither the join nor the default was covered. Break either and a paying user starts receiving trial email while every existing test stays green.

## What

Runs the handler through a real worker against a real database, covering the four paths: on-trial sends, no-wallet-yet sends (the `?? true` default), left-the-trial skips, and no-email skips.

Both DB-derived behaviours are verified by mutation:

| Mutation | Failing test |
|---|---|
| drop the `conditions` guard | `skips a user whose wallet has left the trial` — `expected [ { …(2) } ] to have a length of +0 but got 1` |
| `?? true` → `?? false` | `sends the notification to a user who has no wallet yet` — `expected [] to have a length of 1 but got +0` |

Asserts on the request that actually reaches the notifications API (`POST /internal/v1/jobs/notification`, intercepted with `nock`) rather than spying on `NotificationService`. That keeps the real service — retry policy and default-channel fallback included — in the path, and covers the rendered template body and the `x-user-id` header as a side benefit.

### Notes for the reviewer

- The template is `trialFirstDeploymentLeaseCreated` with concrete vars, chosen because production pairs it with `conditions: { trial: true }` and because it needs no `RESOLVED_MARKER` — so no data resolver fires and the test needs no chain or balance faking.
- `import "@src/app/providers/jobs.provider"` is a side-effect import for DI registration only; `startJobQueues()` is never called. The `DATA_RESOLVER` classes register when their modules load, which is how bootstrap does it, and `NotificationDataResolverService` cannot be constructed without them.
- `seedUserWithWallet` grows a `user` override so a seeded user can have an email. Existing callers pass no arguments and are unaffected.

### Verification

- `npm run test:integration` — this file passes, full suite green
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 42 errors, unchanged from the `main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
