### PR TITLE
test(dx): stop the mutation gate scoring log call arguments

### DIFF
--- a/script/mutation-report.mjs
+++ b/script/mutation-report.mjs
@@ -11,12 +11,14 @@ if (!reportPath) {
 
 const MAX_SURVIVOR_ROWS = 50;
 const KILLED = ["Killed", "Timeout"];
-const UNREACHED = ["NoCoverage", "Ignored", "CompileError", "RuntimeError"];
+const UNREACHED = ["NoCoverage", "CompileError", "RuntimeError"];
+const UNSCORED = ["Ignored", ...UNREACHED];
 
 const mutants = readMutants(reportPath);
 const killed = mutants.filter(({ status }) => KILLED.includes(status));
-const survived = mutants.filter(({ status }) => !KILLED.includes(status) && !UNREACHED.includes(status));
+const survived = mutants.filter(({ status }) => !KILLED.includes(status) && !UNSCORED.includes(status));
 const unreached = mutants.filter(({ status }) => UNREACHED.includes(status));
+const ignored = mutants.filter(({ status }) => status === "Ignored");
 const reached = killed.length + survived.length;
 /** Scored over reached mutants only: an untested file has nothing to say about test quality, and coverage is measured elsewhere. */
 const score = reached === 0 ? null : (killed.length / reached) * 100;
@@ -59,11 +61,19 @@ function summary() {
     lines.push("", `${unreached.length} mutant(s) were never reached by a unit test and do not count towards the score: ${fileList(unreached)}.`);
   }
 
+  if (ignored.length > 0) {
+    lines.push("", `${ignored.length} mutant(s) were ignored and do not count towards the score: ${reasonList(ignored)}.`);
+  }
+
   if (survived.length > 0 && reproduceCommand) {
     lines.push("", "Reproduce with:", "", "```", reproduceCommand, "```");
   }
 
   return `${lines.join("\n")}\n`;
+}
+
+function reasonList(mutants) {
+  return [...new Set(mutants.map(({ statusReason }) => statusReason ?? "no reason given"))].join("; ");
 }
 
 function fileList(mutants) {

--- a/script/stryker-observability-ignorer.mjs
+++ b/script/stryker-observability-ignorer.mjs
@@ -1,0 +1,37 @@
+/** An Ignore plugin rather than `// Stryker disable` comments, so no source file has to carry an annotation for the gate's benefit. */
+const IGNORE_REASON = "Ignored because it sits inside an observability call, whose arguments no unit test asserts on";
+
+const LOG_LEVELS = new Set(["trace", "debug", "info", "warn", "error", "fatal", "verbose", "log"]);
+const LOGGER_WORDS = new Set(["log", "logger", "logging", "console"]);
+const CALL_NODES = new Set(["CallExpression", "OptionalCallExpression"]);
+const MEMBER_NODES = new Set(["MemberExpression", "OptionalMemberExpression"]);
+
+export const strykerPlugins = [{ kind: "Ignore", name: "observability", value: { shouldIgnore } }];
+
+/** Stryker enters every node and ignoring one ignores its whole subtree, so judging the call itself covers its arguments. */
+function shouldIgnore(path) {
+  return isObservabilityCall(path.node) ? IGNORE_REASON : undefined;
+}
+
+function isObservabilityCall(node) {
+  if (!CALL_NODES.has(node.type) || !MEMBER_NODES.has(node.callee.type)) return false;
+
+  return LOG_LEVELS.has(propertyName(node.callee)) && namesALogger(receiverName(node.callee.object));
+}
+
+function propertyName({ property, computed }) {
+  if (property.type === "StringLiteral") return property.value;
+
+  return !computed && property.type === "Identifier" ? property.name : "";
+}
+
+function receiverName(object) {
+  if (object.type === "Identifier") return object.name;
+
+  return MEMBER_NODES.has(object.type) ? propertyName(object) : "";
+}
+
+/** A whole word has to name the logger: `Math.log(x)` and a `catalog.error(...)` are calls whose arguments a test does assert on. */
+function namesALogger(name) {
+  return name.split(/[^A-Za-z0-9]+|(?<=[a-z0-9])(?=[A-Z])/).some(word => LOGGER_WORDS.has(word.toLowerCase()));
+}

--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -5,6 +5,7 @@
  */
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const number = (name, fallback) => Number(process.env[name] ?? fallback);
 const breakThreshold = process.env.STRYKER_BREAK ? number("STRYKER_BREAK", 0) : null;
@@ -12,8 +13,14 @@ const breakThreshold = process.env.STRYKER_BREAK ? number("STRYKER_BREAK", 0) : 
 /** Relative on purpose: an absolute path would point vitest at the real workspace instead of Stryker's mutated copy. */
 const unitOnlyConfigFile = ["vitest.mutation.config.ts", "vitest.mutation.config.mts"].find(name => existsSync(join(process.cwd(), name)));
 
+/** Absolute because Stryker resolves a relative plugin path against the workspace it runs from, not against this file. */
+const observabilityIgnorer = fileURLToPath(new URL("script/stryker-observability-ignorer.mjs", import.meta.url));
+
 export default {
   testRunner: "vitest",
+  plugins: ["@stryker-mutator/*", observabilityIgnorer],
+  /** A mutant inside a log call can only survive: the arguments are not part of the behaviour a unit test asserts on. */
+  ignorers: ["observability"],
   vitest: {
     /** Off by default: vitest's related-file detection fails on some suites, and Stryker treats that as zero tests. */
     related: process.env.STRYKER_VITEST_RELATED === "true",


### PR DESCRIPTION
## Why

Ref CON-864.

`93ca389ed` made mutation testing a gate on every PR (`MUTATION_MIN_SCORE: 80`). It has a structural hole: **a change whose only mutatable line is an observability call cannot reach 80% however good its tests are.**

Evidence — PR #3823, job `101880996995`, scored **0.00** on exactly two survived mutants, both on one line:

```
[Survived] StringLiteral  src/deployment/services/deployment-writer/deployment-writer.service.ts:306:31
-  this.logger.warn({ event: "DEPRECATED_UPDATE_DEPLOYMENT_ENDPOINT_USED", userId, dseq });
+  this.logger.warn({ event: "", userId, dseq });

[Survived] ObjectLiteral  src/deployment/services/deployment-writer/deployment-writer.service.ts:306:22
+  this.logger.warn({});
```

That was the whole mutatable diff, so the score was 0/2. Neither mutant is killable: no unit test in this repo asserts on a log payload, and one that did would pin wording rather than behaviour. The gate was measuring something tests are not supposed to cover.

## What

Stryker's own Ignore plugin API is built for this — its schema documents it as "you can use this to ignore all `console.debug()` statements from being mutated" — and an ignored mutant is *already* excluded from the score by `script/mutation-report.mjs` (`Ignored` was in its unscored list from day one). So the whole fix is one plugin plus two config lines:

- `script/stryker-observability-ignorer.mjs` — an `Ignore` plugin that returns an ignore reason for a call whose **method is a log level** (`trace|debug|info|warn|error|fatal|verbose|log`) **and** whose receiver has a whole word naming a logger (`log`, `logger`, `logging`, `console`). Ignoring the call node ignores its subtree, so its arguments go with it.
- `stryker.config.mjs` — loads the plugin by absolute path (a relative one would resolve against the app directory Stryker runs from) and enables `ignorers: ["observability"]`.
- `script/mutation-report.mjs` — the step summary lumped `Ignored` in with "never reached by a unit test", which is now untrue; ignored mutants get their own line with the reason, so a shrunken denominator is always visible in the job summary.

No source file gains an annotation: `// Stryker disable` comments would have violated `clean-code-over-comments.md`, which is why the plugin route was taken over the comment route.

### The gate still fails a real regression

The plugin only ever answers for a logger call node; every other node is untouched, so nothing outside a log call changes. Verified by running the plugin over parsed ASTs of representative code and recording which nodes end up inside an ignored subtree:

| case | outcome |
| --- | --- |
| `this.logger.warn({ event: "DEPRECATED_...", userId, dseq })` (the #3823 line) | both mutants **ignored** — gate passes |
| `if (count > 10) { this.logger.warn({ event: "TOO_MANY" }); }` | the `>` and `10` mutants **still mutated**; only the log payload ignored |
| `return bid.amount * 1.05 > 100 ? { tier: "high" } : { tier: "low" }` | **all** mutants still mutated |
| `Math.log(x * 2 + 1)` | **still mutated** — `Math` has no logger word |
| `catalog.error({ code: "E_NOT_FOUND" }, 3)` | **still mutated** — `catalog` is one word, not `…log` |

Known, accepted tradeoff: a computation smuggled into a log argument (`logger.info({ total: items.length + 1 })`) is ignored with it. Log arguments are not where behaviour belongs, and the alternative is a per-argument rule that would re-import the false failures this removes.

### Alternatives rejected

- **Exclude `StringLiteral` globally** — kills real signal (a wrong `errorCode`, a wrong SQL fragment), and would not even have saved #3823, whose `ObjectLiteral` mutant survived too.
- **Exclude `ObjectLiteral` globally** — mutating a real config object to `{}` is exactly the kind of thing worth catching.
- **File-glob exclusions for routers / `http-schemas`** — over-excludes: the `.max(64)` and `.min(1)` mutants in schemas are among the most valuable ones the gate produces.
- **Skip the whole run when every changed range is observability-only** (in `script/mutation-targets.mjs`) — cheaper, and it fits the script's existing `skip` outcomes, but it is coarser: it works on line ranges, so `if (count > 10) this.logger.warn(...)` on one line would drop the `>` mutant with the log, and a diff mixing a log line with real code gets no relief at all. The ignorer is per-node, so it is strictly narrower.
- **`// Stryker disable` comments** — per-file annotations in application code, forbidden by `clean-code-over-comments.md`.

`MUTATION_MIN_SCORE` stays at 80 and `MAX_MUTATION_RANGES` at 200; no label, and no app code, is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mutation reports now distinguish ignored mutants from unreached mutants and show separate counts with status reasons.
  * Mutation testing automatically excludes mutations within logging calls while continuing to evaluate other calls normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->