### PR TITLE
test(billing): cover the jobs a started trial schedules

### DIFF
--- a/apps/api/src/app/services/trial-started/trial-started.handler.integration.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.integration.ts
@@ -1,0 +1,109 @@
+import "@src/app/providers/jobs.provider";
+
+import { faker } from "@faker-js/faker";
+import { addDays, subDays } from "date-fns";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TrialStarted } from "@src/billing/events/trial-started";
+import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { JOB_NAME } from "@src/core";
+import { DOMAIN_EVENT_NAME } from "@src/core/services/domain-events/domain-events.service";
+import { NOTIFICATIONS_CONFIG } from "@src/notifications/providers/notifications-config.provider";
+import { NotificationHandler, NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
+import { UserRepository } from "@src/user/repositories";
+import { TrialStartedHandler } from "./trial-started.handler";
+
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const NOTIFICATION_PATH = "/internal/v1/jobs/notification";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(TrialStartedHandler), container.resolve(NotificationHandler)]);
+
+describe(TrialStartedHandler.name, () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("schedules the whole trial email sequence off the day the user was created", async () => {
+    const { userId, trialEndsAt, expirationDays, handle, findNotificationJobs } = await setup();
+
+    await handle();
+
+    const scheduled = await findNotificationJobs(userId);
+    expect(scheduled).toEqual([
+      { singleton_key: `notification.beforeTrialEnds.${userId}.${expirationDays - 7}`, startAfter: subDays(trialEndsAt, 7) },
+      { singleton_key: `notification.beforeTrialEnds.${userId}.${expirationDays - 1}`, startAfter: subDays(trialEndsAt, 1) },
+      { singleton_key: `notification.trialEnded.${userId}`, startAfter: trialEndsAt },
+      { singleton_key: `notification.afterTrialEnds.${userId}.${expirationDays + 7}`, startAfter: addDays(trialEndsAt, 7) }
+    ]);
+  });
+
+  it("sends the welcome email straight away", async () => {
+    const { handle, sentNotifications } = await setup();
+
+    await handle();
+
+    expect(sentNotifications()).toHaveLength(1);
+  });
+
+  it("still schedules the sequence for a user with no email to welcome", async () => {
+    const { userId, handle, findNotificationJobs, sentNotifications } = await setup({ email: null });
+
+    await handle();
+
+    expect(sentNotifications()).toHaveLength(0);
+    expect(await findNotificationJobs(userId)).toHaveLength(4);
+  });
+
+  it("schedules nothing for a user who no longer exists", async () => {
+    const { handle, findNotificationJobs } = await setup();
+    const strangerId = faker.string.uuid();
+
+    await handle(strangerId);
+
+    expect(await findNotificationJobs(strangerId)).toHaveLength(0);
+  });
+
+  async function setup(input: { email?: string | null } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const billingConfig = container.resolve(BillingConfigService);
+    const expirationDays = billingConfig.get("TRIAL_ALLOWANCE_EXPIRATION_DAYS");
+    const notificationsBaseUrl = container.resolve(NOTIFICATIONS_CONFIG).NOTIFICATIONS_API_BASE_URL as string;
+
+    const email = input.email === undefined ? faker.internet.email() : input.email;
+    const user = await container.resolve(UserRepository).create({ email });
+
+    const sent: unknown[] = [];
+    nock(notificationsBaseUrl)
+      .persist()
+      .post(NOTIFICATION_PATH)
+      .reply(function reply(this: nock.ReplyFnContext, _uri, body) {
+        sent.push(body);
+
+        return [201, {}];
+      });
+
+    async function findNotificationJobs(userId: string) {
+      const rows = await findJobRows(NotificationJob[JOB_NAME], { singletonKeyLike: `%.${userId}%` });
+
+      return rows
+        .map(row => ({ singleton_key: row.singleton_key, startAfter: new Date(row.start_after) }))
+        .sort((a, b) => a.startAfter.getTime() - b.startAfter.getTime());
+    }
+
+    return {
+      userId: user.id,
+      expirationDays,
+      trialEndsAt: addDays(user.createdAt!, expirationDays),
+      sentNotifications: () => sent,
+      findNotificationJobs,
+      handle: async (userId: string = user.id) => {
+        await enqueue(new TrialStarted({ userId }));
+        await startWorkers();
+        await expectJobCompleted(TrialStarted[DOMAIN_EVENT_NAME], { data: { userId } });
+      }
+    };
+  }
+});

--- a/apps/api/test/services/job-queue-harness.ts
+++ b/apps/api/test/services/job-queue-harness.ts
@@ -30,6 +30,7 @@ export interface JobRow<TData = Record<string, unknown>> {
 interface JobSelector {
   singletonKey?: string;
   singletonKeyLike?: string;
+  data?: Record<string, string>;
 }
 
 function db() {
@@ -68,11 +69,18 @@ export function useJobWorkers(resolveHandlers: () => JobHandler<Job>[]) {
   };
 }
 
-function selectorFilter({ singletonKey, singletonKeyLike }: JobSelector) {
-  if (singletonKey) return sql`and singleton_key = ${singletonKey}`;
-  if (singletonKeyLike) return sql`and singleton_key like ${singletonKeyLike}`;
+/** A payload selector, because a domain event published without a singleton key has no other way to name one job among many. */
+function selectorFilter({ singletonKey, singletonKeyLike, data }: JobSelector) {
+  let filter = sql``;
 
-  return sql``;
+  if (singletonKey) filter = sql`${filter} and singleton_key = ${singletonKey}`;
+  else if (singletonKeyLike) filter = sql`${filter} and singleton_key like ${singletonKeyLike}`;
+
+  for (const [key, value] of Object.entries(data ?? {})) {
+    filter = sql`${filter} and data->>${key} = ${value}`;
+  }
+
+  return filter;
 }
 
 export async function findJobRows<TData = Record<string, unknown>>(jobName: string, selector: JobSelector = {}): Promise<JobRow<TData>[]> {


### PR DESCRIPTION
## Why

Part of CON-952.

`TrialStartedHandler` schedules the entire trial email sequence — two reminders, the expiry notice, and a follow-up — off `user.createdAt` read from the database. The two `beforeTrialEnds` reminders use the **same template and the same payload**; the only thing that makes them two jobs rather than one is their singleton key:

```ts
singletonKey: `notification.beforeTrialEnds.${user.id}.${TRIAL_ALLOWANCE_EXPIRATION_DAYS - 7}`
singletonKey: `notification.beforeTrialEnds.${user.id}.${TRIAL_ALLOWANCE_EXPIRATION_DAYS - 1}`
```

Give them one key and pg-boss silently keeps a single reminder. The unit spec asserts against a mocked queue, so it cannot see that — nor that the schedule is anchored to a real `created_at` timestamp.

## What

Publishes the real `TrialStarted` event, runs it through a real worker, and asserts the four resulting job rows **as a timeline** (sorted by `start_after`, since the handler enqueues them in a `Promise.all` and `created_on` order is nondeterministic).

Verified by mutation — collapsing the two reminder keys into one fails the schedule test.

Also covers that a user with no email still gets the sequence scheduled (only the immediate welcome is conditional on an address), and that a vanished user gets nothing.

### Harness change

Adds a **payload selector** to `findJobRows`/`expectJobCompleted`:

```ts
expectJobCompleted(TrialStarted[DOMAIN_EVENT_NAME], { data: { userId } })
```

`TrialStarted` is published with no options, so its `singleton_key` is NULL and there was no way to name one job among several in the same file. Rather than add a singleton key the test invents and production doesn't use, the selector matches on `data->>'userId'`. Most remaining domain events (`AutoRechargeSucceeded`, `FirstPurchaseBonusGranted`, `TrialDeploymentLeaseCreated`) are published keyless too, so this unblocks them as well.

### Verification

- `npm run test:integration` for this file, plus the two suites on `main` that use the restructured `selectorFilter` (`delete-unbacked-deployment-setting`, `deployment-writer`) — all pass
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 42 errors, unchanged from the `main` baseline

A full-suite run is not currently meaningful on this machine: ~112 leaked test databases from interrupted runs have the data volume at 79%, and every integration file intermittently fails in `beforeAll` with `Hook timed out in 20000ms`. Verified per-file instead; CI runs against a fresh database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for trial-started notification scheduling, including expiration timing and immediate welcome-email delivery.
  - Verified behavior when users lack an email address or do not exist.
  - Improved test validation for queued jobs by supporting filtering based on job payload values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->