### PR TITLE
test(deployment): stop the top-up sweep tests re-reading each other's rows

### DIFF
--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import nock from "nock";
 import { container } from "tsyringe";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -46,9 +46,10 @@ function depositedAmounts(executeDerivedTx: { mock: { calls: unknown[][] } }): n
  * when the business rules themselves change.
  */
 describe(TopUpManagedDeploymentsService.name, () => {
-  afterEach(() => {
+  afterEach(async () => {
     vi.restoreAllMocks();
     nock.cleanAll();
+    await removeOwners();
   });
 
   describe("topUpDeployments", () => {
@@ -576,6 +577,12 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(executeDerivedTx).toHaveBeenCalledTimes(2);
     });
   });
+
+  /** The sweep reads every owner in the database, so an owner one test leaves behind becomes a later test's input. */
+  async function removeOwners() {
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    await db.execute(sql`TRUNCATE TABLE ${resolveTable("Users")} CASCADE`);
+  }
 
   function createActiveLease(owner: string, dseq: string) {
     return createLeaseApiResponse({

--- a/apps/api/test/setup-integration-tests.ts
+++ b/apps/api/test/setup-integration-tests.ts
@@ -1,10 +1,14 @@
 import "reflect-metadata";
 
+import nock from "nock";
 import { container } from "tsyringe";
 import { afterAll, afterEach, beforeAll, beforeEach, expect } from "vitest";
 
 import MemoryCacheEngine from "@src/caching/memoryCacheEngine";
 import { TestDatabaseService } from "./services/test-database.service";
+
+nock.disableNetConnect();
+nock.enableNetConnect(/^(localhost|127\.0\.0\.1|\[::1\])(:|$)/);
 
 const testPath = expect.getState().testPath;
 const dbService = new TestDatabaseService(testPath!);


### PR DESCRIPTION
## Why

`top-up-managed-deployments.service.integration.ts` took **136.8s** for 18 tests, and the per-test durations gave away why: they grew by a near-constant ~1.6s a test (1.7s → 3.3s → 5.1s → … → 14.5s). The file is quadratic, not slow.

`topUpDeployments` sweeps every owner in the database. Nothing was truncating between tests, so each test re-processed the owners seeded by every test before it. Two flat points in the series confirm the mechanism — the two tests that leave their settings `closed` or `autoTopUpEnabled = false` are filtered out by `findAutoTopUpDeployments` and add no cost to their successors.

Each stale owner cost real time because the two chain reads for its address matched no `nock` interceptor (`nock.cleanAll()` had removed the previous test's, and each test only mocks its own owner). With net connect enabled those requests went to the real network, where `REST_API_NODE_URL=https://api.non-existing.akash.network` bought a DNS failure on each of the three retry attempts in `createFetchAdapter`. `findLeases` then swallowed the error via its database fallback, so the tests stayed green and the cost showed up only on the clock.

## What

- Truncate owners in `afterEach` of the integration file, so each test sweeps only what it seeded. This is the change that removes the quadratic.
- `nock.disableNetConnect()` for the whole `integration` project, with loopback still allowed so the docker-compose services (mock-oauth2, KMS mock) keep working. An unmocked external call now fails immediately instead of resolving DNS three times.

**Result: 136.8s → 13.2s, 18/18 passing, every test flat at ~400ms** (the two ~2s outliers are connection warmup, at positions 1 and 4).

Verified locally against a real database. Two notes for reviewers:

- The default `hookTimeout` of 20s is unrelated but worth knowing about: `beforeAll` → `dbService.setup()` now times out locally once enough test databases have leaked (each interrupted run abandons two). I had to pass `--hookTimeout=180000` to get a run at all. Not addressed here.
- One run emitted `CREDITS_LOW_CHECK_SCHEDULE_FAILED` / `LATE_ANCHOR_CLOSE_JOB_SCHEDULE_FAILED` error logs. A baseline run without these changes showed zero, and a later run with them also showed zero, so it looks non-deterministic rather than introduced here. Tests pass either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
