### PR TITLE
test(dx): stop the mutation gate scoring the removal of a log call

### DIFF
--- a/script/stryker-observability-ignorer.mjs
+++ b/script/stryker-observability-ignorer.mjs
@@ -8,9 +8,18 @@ const MEMBER_NODES = new Set(["MemberExpression", "OptionalMemberExpression"]);
 
 export const strykerPlugins = [{ kind: "Ignore", name: "observability", value: { shouldIgnore } }];
 
-/** Stryker enters every node and ignoring one ignores its whole subtree, so judging the call itself covers its arguments. */
+/** Stryker enters every node and ignoring one ignores its whole subtree, so judging a node covers everything under it. */
 function shouldIgnore(path) {
-  return isObservabilityCall(path.node) ? IGNORE_REASON : undefined;
+  return isObservabilityStatement(path.node) || isObservabilityCall(path.node) ? IGNORE_REASON : undefined;
+}
+
+/** Deleting a whole log call is a mutant on the statement wrapping it, an ancestor the call's own ignore is entered too late to reach. */
+function isObservabilityStatement(node) {
+  return node.type === "ExpressionStatement" && isObservabilityCall(withoutAwait(node.expression));
+}
+
+function withoutAwait(expression) {
+  return expression.type === "AwaitExpression" ? expression.argument : expression;
 }
 
 function isObservabilityCall(node) {


### PR DESCRIPTION
## Why

Refs CON-864.

#3844 was supposed to stop the mutation gate scoring observability calls. It did not finish the job: **#3823 still fails, and it now fails on a mutant #3844 itself brought into existence.**

Evidence — run `34171534766`, job `101892665333`, head `cc2c0e4a5`, score **0.00** on a single survivor:

```
[Survived] CallExpression
src/deployment/services/deployment-writer/deployment-writer.service.ts:306:5
-       this.logger.warn({ event: "DEPRECATED_UPDATE_DEPLOYMENT_ENDPOINT_USED", userId, dseq });
+       ;
```

The ignorer answers for the **call** node. Stryker's `CallExpression` mutator (`empty-expression-mutator`) does not always mutate the call: for a statement-level call it emits its mutant on the **`ExpressionStatement` wrapping it**. `IgnorerBookkeeper` sets the active ignore on *enter* and traversal is parent-first, so the statement is entered — and mutated — before the call is ever judged. The ignore begins one node too late.

That also explains why this survivor is new. `empty-expression-mutator` declares `filter: mutantsInScope => mutantsInScope.length === 1`, and `mutantsInScope` counts only *non-ignored* mutants in the subtree. Before #3844 the line carried three mutants, so the deletion mutant was filtered away and only the `StringLiteral` and `ObjectLiteral` survived. #3844 ignored those two, the count fell to one, the filter began to keep the deletion mutant — and the score stayed 0.00 with a different mutant's name on it.

## What

`shouldIgnore` now also answers for an `ExpressionStatement` whose expression is an observability call (through an `await`, if there is one). A statement that does nothing but log has nothing else beneath it, so ignoring the statement ignores exactly the call and its arguments and nothing more.

### The gate still fails a real regression

Verified by running the changed plugin through Stryker's own `transformBabel` + `MutantCollector` — its real traversal, real mutators, real `IgnorerBookkeeper` — and recording which mutants come back ignored. #3844's table still holds:

| case | before | after |
| --- | --- | --- |
| `this.logger.warn({ event: "DEPRECATED_…", userId, dseq })` (the #3823 line) | `CallExpression -> ;` **mutated** | **ignored** — gate passes |
| `if (count > 10) { this.logger.warn({ event: "TOO_MANY" }); }` | `>` and `10` mutated | `>` and `10` **still mutated**; only the log ignored |
| `return bid.amount * 1.05 > 100 ? { tier: "high" } : { tier: "low" }` | all 10 mutated | **all 10 still mutated** |
| `Math.log(x * 2 + 1)` | mutated | **still mutated** |
| `catalog.error({ code: "E_NOT_FOUND" }, 3)` | mutated | **still mutated** |
| `takenNames.add(name);` (a non-log statement call) | `CallExpression -> ;` mutated | **still mutated** |

The last row is the one that matters most: this does not blanket-ignore call deletion. A deleted `Set.add` is still scored; only a deleted *log* is not.

### What this does not fix

Three other PRs fail CI on the mutation gate, and I checked each rather than assuming this covers them:

- **#3823** — 3 mutants, all observability. Goes green.
- **#3829** — 16 survivors, of which 3 are this bug. Removing them moves 75.76% to 79.37%, still under 80. It needs one more of its 13 genuine survivors killed; that is a test problem, not a gate problem.
- **#3826** — 2 survivors, `takenNames.add(name)` deletion and `suffix++ -> suffix--`. Neither is observability. Unaffected.
- **#3831** — not a mutation failure at all. Its `validate` job fails on a functional test (`test/functional/deployment-patch.spec.ts:149`, expected 200 got 400). Unaffected.

Their `security-scan` failures are all mirrors of the CI conclusion ("Blocked: Upstream CI conclusion is 'failure'"), not independent findings.

One adjacent case is left mutated on purpose: `BlockStatement -> {}` on a block whose only statement is a log call. It did not arise in any of the four runs, and widening the ignorer to whole blocks trades a real class of signal (an emptied block *is* removed behaviour) for a case with no evidence behind it. Worth revisiting if it ever shows up.

`MUTATION_MIN_SCORE` stays at 80. No label, and no app code, is involved.
