### PR TITLE
test(billing): cover the jobs a trial lease schedules

### DIFF
--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
@@ -1,0 +1,127 @@
+import "@src/app/providers/jobs.provider";
+
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AutoRechargeSucceeded } from "@src/billing/events/auto-recharge-succeeded";
+import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { DOMAIN_EVENT_NAME } from "@src/core/services/domain-events/domain-events.service";
+import { FirstPurchaseBonusGrantedHandler } from "../first-purchase-bonus-granted/first-purchase-bonus-granted.handler";
+import { AutoRechargeSucceededHandler } from "./auto-recharge-succeeded.handler";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+import { interceptNotifications } from "@test/services/notifications-intercept";
+
+const BALANCE_USD = 42.5;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(AutoRechargeSucceededHandler), container.resolve(FirstPurchaseBonusGrantedHandler)]);
+
+describe("recharge and bonus notices", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  describe(AutoRechargeSucceededHandler.name, () => {
+    it("tells the owner what was charged and what the balance now is", async () => {
+      const { userId, rechargeSucceeded, sentNotifications } = await setup();
+
+      await rechargeSucceeded({ amountCents: 2500 });
+
+      const [sent] = sentNotifications();
+      expect(sent.userId).toBe(userId);
+      expect(sent.body).toMatchObject({
+        notificationId: "autoRechargeSucceeded.pi_test_recharge",
+        payload: {
+          summary: "Your Akash account was recharged $25.00",
+          description: expect.stringContaining("balance is now <strong>$42.50</strong>")
+        }
+      });
+    });
+
+    it("says nothing to a user with no email", async () => {
+      const { rechargeSucceeded, sentNotifications } = await setup({ email: null });
+
+      await rechargeSucceeded({ amountCents: 2500 });
+
+      expect(sentNotifications()).toHaveLength(0);
+    });
+
+    it("says nothing when the wallet has no address to read a balance for", async () => {
+      const { rechargeSucceeded, sentNotifications } = await setup({ address: null });
+
+      await rechargeSucceeded({ amountCents: 2500 });
+
+      expect(sentNotifications()).toHaveLength(0);
+    });
+  });
+
+  describe(FirstPurchaseBonusGrantedHandler.name, () => {
+    it("tells the owner what bonus the purchase earned", async () => {
+      const { userId, bonusGranted, sentNotifications } = await setup();
+
+      await bonusGranted({ bonusAmountCents: 1000, paidAmountCents: 5000 });
+
+      const [sent] = sentNotifications();
+      expect(sent.userId).toBe(userId);
+      expect(sent.body).toMatchObject({
+        notificationId: `firstPurchaseBonusGranted.${userId}`,
+        payload: {
+          summary: "You earned $10.00 in bonus credits",
+          description: expect.stringContaining("first purchase of $50.00")
+        }
+      });
+    });
+
+    it("says nothing to a user with no email", async () => {
+      const { bonusGranted, sentNotifications } = await setup({ email: null });
+
+      await bonusGranted({ bonusAmountCents: 1000, paidAmountCents: 5000 });
+
+      expect(sentNotifications()).toHaveLength(0);
+    });
+
+    it("says nothing to a user who no longer exists", async () => {
+      const { bonusGrantedFor, sentNotifications } = await setup();
+
+      await bonusGrantedFor("00000000-0000-0000-0000-000000000000", { bonusAmountCents: 1000, paidAmountCents: 5000 });
+
+      expect(sentNotifications()).toHaveLength(0);
+    });
+  });
+
+  async function setup(input: { email?: string | null; address?: string | null } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const email = input.email === undefined ? "recharge@example.com" : input.email;
+    const { user } = await seedUserWithWallet({
+      ...(input.address === null ? { address: null } : {}),
+      user: { email }
+    });
+
+    vi.spyOn(container.resolve(BalancesService), "getDeploymentBalanceInFiat").mockResolvedValue(BALANCE_USD);
+    const sentNotifications = interceptNotifications();
+
+    return {
+      userId: user.id,
+      sentNotifications,
+      rechargeSucceeded: async (amounts: { amountCents: number }) => {
+        await enqueue(new AutoRechargeSucceeded({ userId: user.id, transactionId: "pi_test_recharge", ...amounts }));
+        await startWorkers();
+        await expectJobCompleted(AutoRechargeSucceeded[DOMAIN_EVENT_NAME], { data: { userId: user.id } });
+      },
+      bonusGranted: async (amounts: { bonusAmountCents: number; paidAmountCents: number }) => {
+        await enqueue(new FirstPurchaseBonusGranted({ userId: user.id, ...amounts }));
+        await startWorkers();
+        await expectJobCompleted(FirstPurchaseBonusGranted[DOMAIN_EVENT_NAME], { data: { userId: user.id } });
+      },
+      bonusGrantedFor: async (userId: string, amounts: { bonusAmountCents: number; paidAmountCents: number }) => {
+        await enqueue(new FirstPurchaseBonusGranted({ userId, ...amounts }));
+        await startWorkers();
+        await expectJobCompleted(FirstPurchaseBonusGranted[DOMAIN_EVENT_NAME], { data: { userId } });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
@@ -31,6 +31,8 @@ describe("recharge and bonus notices", () => {
 
       await rechargeSucceeded({ amountCents: 2500 });
 
+      expect(sentNotifications()).toHaveLength(1);
+
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);
       expect(sent.body).toMatchObject({
@@ -64,6 +66,8 @@ describe("recharge and bonus notices", () => {
       const { userId, bonusGranted, sentNotifications } = await setup();
 
       await bonusGranted({ bonusAmountCents: 1000, paidAmountCents: 5000 });
+
+      expect(sentNotifications()).toHaveLength(1);
 
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);

--- a/apps/api/src/app/services/close-expired-deployment/close-expired-deployment.handler.integration.ts
+++ b/apps/api/src/app/services/close-expired-deployment/close-expired-deployment.handler.integration.ts
@@ -1,0 +1,139 @@
+import "@src/app/providers/jobs.provider";
+
+import { addHours, minutesToMilliseconds } from "date-fns";
+import { eq } from "drizzle-orm";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+import { CloseExpiredDeploymentCommand } from "@src/deployment/commands/close-expired-deployment.command";
+import { DeploymentCloseJobService } from "@src/deployment/services/deployment-close-job/deployment-close-job.service";
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import { CloseExpiredDeploymentHandler } from "./close-expired-deployment.handler";
+
+import { seedDeploymentSetting } from "@test/seeders/db/deployment-setting.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const RETRY_DELAY_IN_MS = minutesToMilliseconds(15);
+const UNSETTLEABLE_ESCROW = "negative decimal coin amount";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(CloseExpiredDeploymentHandler)]);
+
+describe(CloseExpiredDeploymentHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("closes a deployment whose runtime limit has passed and records it closed", async () => {
+    const { dseq, closeExpired, close, findSetting } = await setup();
+
+    await closeExpired();
+
+    expect(close).toHaveBeenCalledWith(expect.objectContaining({ address: expect.any(String) }), dseq);
+    expect((await findSetting()).closed).toBe(true);
+  });
+
+  it("reschedules itself for a deadline that has since moved out", async () => {
+    const { runtimeEndsAt, closeExpired, close, findPendingCloseJob } = await setup({ runtimeEndsAt: addHours(new Date(), 5) });
+
+    await closeExpired();
+
+    expect(close).not.toHaveBeenCalled();
+    expect(new Date((await findPendingCloseJob()).start_after)).toEqual(runtimeEndsAt);
+  });
+
+  it("does nothing for a setting whose runtime limit was removed", async () => {
+    const { closeExpired, close, findPendingCloseJob } = await setup({ runtimeEndsAt: null });
+
+    await closeExpired();
+
+    expect(close).not.toHaveBeenCalled();
+    expect(await findPendingCloseJob()).toBeUndefined();
+  });
+
+  it("does nothing for a setting already closed", async () => {
+    const { closeExpired, close, findSetting } = await setup({ closed: true });
+
+    await closeExpired();
+
+    expect(close).not.toHaveBeenCalled();
+    expect((await findSetting()).closed).toBe(true);
+  });
+
+  it("leaves the setting open and tries again later while the dry run flag is on", async () => {
+    const { closeExpired, close, findSetting, findPendingCloseJob } = await setup({ dryRun: "true" });
+
+    await closeExpired();
+
+    expect(close).not.toHaveBeenCalled();
+    expect((await findSetting()).closed).toBe(false);
+    expect(Date.parse((await findPendingCloseJob()).start_after)).toBeGreaterThan(Date.now() + RETRY_DELAY_IN_MS * 0.8);
+  });
+
+  it("leaves the setting open and tries again later when the escrow cannot be settled", async () => {
+    const { closeExpired, close, findSetting, findPendingCloseJob } = await setup();
+    close.mockRejectedValue(new Error(`failed to execute message: ${UNSETTLEABLE_ESCROW}`));
+
+    await closeExpired();
+
+    expect((await findSetting()).closed).toBe(false);
+    expect(await findPendingCloseJob()).toBeDefined();
+  });
+
+  it("tries again later when the wallet has no address to close from", async () => {
+    const { closeExpired, close, findSetting, findPendingCloseJob } = await setup({ address: null });
+
+    await closeExpired();
+
+    expect(close).not.toHaveBeenCalled();
+    expect((await findSetting()).closed).toBe(false);
+    expect(await findPendingCloseJob()).toBeDefined();
+  });
+
+  async function setup(input: { runtimeEndsAt?: Date | null; closed?: boolean; address?: string | null; dryRun?: "true" | "false" } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const deploymentSettingsTable = resolveTable("DeploymentSettings");
+
+    const { user } = await seedUserWithWallet({ ...(input.address === null ? { address: null } : {}) });
+    const runtimeEndsAt = input.runtimeEndsAt === undefined ? new Date(Date.now() - 60_000) : input.runtimeEndsAt;
+    const setting = await seedDeploymentSetting({
+      userId: user.id,
+      runtimeLimitHours: 1,
+      runtimeEndsAt,
+      closed: input.closed ?? false
+    });
+
+    const deploymentConfig = container.resolve(DeploymentConfigService);
+    const readConfig = deploymentConfig.get.bind(deploymentConfig);
+    vi.spyOn(deploymentConfig, "get").mockImplementation((key =>
+      key === "CLOSE_EXPIRED_DEPLOYMENTS_DRY_RUN" ? input.dryRun ?? "false" : readConfig(key)) as typeof deploymentConfig.get);
+
+    const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(true);
+    const singletonKey = DeploymentCloseJobService.singletonKey(setting.id);
+
+    return {
+      dseq: setting.dseq,
+      runtimeEndsAt: runtimeEndsAt as Date,
+      close,
+      findSetting: async () => {
+        const [row] = await db.select().from(deploymentSettingsTable).where(eq(deploymentSettingsTable.id, setting.id));
+
+        return row;
+      },
+      findPendingCloseJob: async () => {
+        const [row] = await findJobRows(CloseExpiredDeploymentCommand[JOB_NAME], { singletonKey, state: "created" });
+
+        return row;
+      },
+      closeExpired: async () => {
+        await enqueue(new CloseExpiredDeploymentCommand({ deploymentSettingId: setting.id, userId: user.id, dseq: setting.dseq }), { singletonKey });
+        await startWorkers();
+        await expectJobCompleted(CloseExpiredDeploymentCommand[JOB_NAME], { singletonKey, state: "completed" });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.integration.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.integration.ts
@@ -1,0 +1,108 @@
+import "@src/app/providers/jobs.provider";
+
+import { DeploymentHttpService } from "@akashnetwork/http-sdk";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { JOB_NAME } from "@src/core";
+import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import { NotificationHandler, NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
+import { CloseTrialDeployment, CloseTrialDeploymentHandler } from "./close-trial-deployment.handler";
+
+import { createDseq } from "@test/seeders/db/deployment-setting.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+import { interceptNotifications } from "@test/services/notifications-intercept";
+
+const UNSETTLEABLE_ESCROW = "negative decimal coin amount";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(CloseTrialDeploymentHandler), container.resolve(NotificationHandler)]);
+
+describe(CloseTrialDeploymentHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("closes an active trial deployment and tells the owner", async () => {
+    const { walletId, dseq, closeTrialDeployment, awaitClosedNotice, close, sentNotifications } = await setup();
+
+    await closeTrialDeployment();
+    await awaitClosedNotice();
+
+    expect(close).toHaveBeenCalledWith(expect.objectContaining({ id: walletId }), dseq);
+    expect(sentNotifications()).toHaveLength(1);
+  });
+
+  it("leaves a wallet that has left the trial alone", async () => {
+    const { closeTrialDeployment, close, sentNotifications } = await setup({ isTrialing: false });
+
+    await closeTrialDeployment();
+
+    expect(close).not.toHaveBeenCalled();
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  it("leaves a wallet with no address alone", async () => {
+    const { closeTrialDeployment, close } = await setup({ address: null });
+
+    await closeTrialDeployment();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("leaves a deployment the chain no longer reports as active alone", async () => {
+    const { closeTrialDeployment, close } = await setup({ deploymentState: "closed" });
+
+    await closeTrialDeployment();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it("tells the owner nothing when the escrow cannot be settled yet", async () => {
+    const { closeTrialDeployment, close, findClosedNotice } = await setup();
+    close.mockRejectedValue(new Error(`failed to execute message: ${UNSETTLEABLE_ESCROW}`));
+
+    await closeTrialDeployment();
+
+    expect(await findClosedNotice()).toBeUndefined();
+  });
+
+  async function setup(input: { isTrialing?: boolean; address?: string | null; deploymentState?: string } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const { wallet } = await seedUserWithWallet({
+      isTrialing: input.isTrialing ?? true,
+      ...(input.address === null ? { address: null } : {}),
+      user: { email: "close-trial@example.com" }
+    });
+    const dseq = createDseq();
+    const closedNoticeKey = `notification.trialDeploymentClosed.${dseq}.${wallet.id}`;
+
+    vi.spyOn(container.resolve(DeploymentHttpService), "findByOwnerAndDseq").mockResolvedValue(
+      createDeploymentInfoSeed({ owner: wallet.address ?? undefined, dseq, state: input.deploymentState ?? "active" })
+    );
+
+    const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(true);
+    const sentNotifications = interceptNotifications();
+
+    return {
+      walletId: wallet.id,
+      dseq,
+      close,
+      sentNotifications,
+      awaitClosedNotice: () => expectJobCompleted(NotificationJob[JOB_NAME], { singletonKey: closedNoticeKey }),
+      findClosedNotice: async () => {
+        const [row] = await findJobRows(NotificationJob[JOB_NAME], { singletonKey: closedNoticeKey });
+
+        return row;
+      },
+      closeTrialDeployment: async () => {
+        await enqueue(new CloseTrialDeployment({ walletId: wallet.id, dseq }), { singletonKey: `closeTrialDeployment.${dseq}.${wallet.id}` });
+        await startWorkers();
+        await expectJobCompleted(CloseTrialDeployment[JOB_NAME], { singletonKey: `closeTrialDeployment.${dseq}.${wallet.id}` });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.integration.ts
+++ b/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.integration.ts
@@ -1,19 +1,30 @@
+import "@src/app/providers/jobs.provider";
+
 import { faker } from "@faker-js/faker";
+import nock from "nock";
 import { container } from "tsyringe";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { CHAIN_DB } from "@src/chain";
-import { JobQueueService } from "@src/core";
+import { JOB_NAME, JobQueueService } from "@src/core";
+import { CloseUnreachableProviderDeploymentCommand } from "@src/deployment/commands/close-unreachable-provider-deployment.command";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { ProviderOutagesHttpService } from "@src/deployment/services/provider-outages-http/provider-outages-http.service";
+import { UnreachableProviderDeploymentsCloserService } from "@src/deployment/services/unreachable-provider-deployments-closer/unreachable-provider-deployments-closer.service";
+import { NotificationHandler, NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 import { UserRepository } from "@src/user/repositories";
 import { CloseUnreachableProviderDeploymentHandler } from "./close-unreachable-provider-deployment.handler";
 
 import { createAkashAddress, createDeployment, createDeploymentGroup, createLease, createProvider } from "@test/seeders";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+import { interceptNotifications } from "@test/services/notifications-intercept";
 
 const DOWN_SINCE = "2026-07-24T00:00:00.000Z";
+const UNSETTLEABLE_ESCROW = "negative decimal coin amount";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(CloseUnreachableProviderDeploymentHandler), container.resolve(NotificationHandler)]);
 
 describe(CloseUnreachableProviderDeploymentHandler.name, () => {
   beforeAll(async () => {
@@ -22,54 +33,75 @@ describe(CloseUnreachableProviderDeploymentHandler.name, () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    nock.cleanAll();
   });
 
   it("closes a still fully dark deployment, records it and tells the owner", async () => {
-    const { handler, close, enqueue, deploymentSettingRepository, deployment, user } = await setup();
+    const { closeUnreachable, awaitClosedNotice, close, findSetting, sentNotifications, deployment } = await setup();
 
-    await handler.handle({ owner: deployment.owner, dseq: deployment.dseq, version: 1 });
+    await closeUnreachable();
+    await awaitClosedNotice();
 
     expect(close).toHaveBeenCalledWith(expect.objectContaining({ address: deployment.owner }), deployment.dseq);
-    expect(enqueue).toHaveBeenCalledTimes(1);
-    const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq });
-    expect(setting?.closed).toBe(true);
+    expect((await findSetting())?.closed).toBe(true);
+    expect(sentNotifications()).toHaveLength(1);
+  });
+
+  it("records nothing when the email it must queue alongside cannot be queued", async () => {
+    const { dispatchCloseUnreachable, awaitCloseRetrying, findSetting, failNoticeEnqueue } = await setup();
+    failNoticeEnqueue();
+
+    await dispatchCloseUnreachable();
+    await awaitCloseRetrying();
+
+    expect(await findSetting()).toBeUndefined();
   });
 
   it("closes nothing once one of the deployment's providers answers again", async () => {
-    const { handler, close, enqueue, deploymentSettingRepository, deployment, user } = await setup({ alsoOnHealthyProvider: true });
+    const { closeUnreachable, close, findSetting, findClosedNotice } = await setup({ alsoOnHealthyProvider: true });
 
-    await handler.handle({ owner: deployment.owner, dseq: deployment.dseq, version: 1 });
+    await closeUnreachable();
 
     expect(close).not.toHaveBeenCalled();
-    expect(enqueue).not.toHaveBeenCalled();
-    expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq })).toBeUndefined();
+    expect(await findSetting()).toBeUndefined();
+    expect(await findClosedNotice()).toBeUndefined();
   });
 
   it("closes nothing when the deployment has no active lease left", async () => {
-    const { handler, close, deployment } = await setup({ leaseAlreadyClosed: true });
+    const { closeUnreachable, close } = await setup({ leaseAlreadyClosed: true });
 
-    await handler.handle({ owner: deployment.owner, dseq: deployment.dseq, version: 1 });
+    await closeUnreachable();
 
     expect(close).not.toHaveBeenCalled();
   });
 
   it("still tells the owner when the close had already landed on chain", async () => {
-    const { handler, enqueue, deploymentSettingRepository, deployment, user } = await setup({ alreadyClosedOnChain: true });
+    const { closeUnreachable, awaitClosedNotice, findSetting } = await setup({ alreadyClosedOnChain: true });
 
-    await handler.handle({ owner: deployment.owner, dseq: deployment.dseq, version: 1 });
+    await closeUnreachable();
+    await awaitClosedNotice();
 
-    expect(enqueue).toHaveBeenCalledTimes(1);
-    const setting = await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq });
-    expect(setting?.closed).toBe(true);
+    expect((await findSetting())?.closed).toBe(true);
+  });
+
+  it("records nothing and tries again later when the escrow cannot be settled", async () => {
+    const { closeUnreachable, close, findSetting, findClosedNotice, findPendingCloseJob } = await setup();
+    close.mockRejectedValue(new Error(`failed to execute message: ${UNSETTLEABLE_ESCROW}`));
+
+    await closeUnreachable();
+
+    expect(await findSetting()).toBeUndefined();
+    expect(await findClosedNotice()).toBeUndefined();
+    expect(await findPendingCloseJob()).toBeDefined();
   });
 
   async function setup(input: { alsoOnHealthyProvider?: boolean; leaseAlreadyClosed?: boolean; alreadyClosedOnChain?: boolean } = {}) {
-    const userRepository = container.resolve(UserRepository);
+    const { enqueue, startWorkers } = await jobWorkers();
     const userWalletRepository = container.resolve(UserWalletRepository);
     const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
 
     const owner = createAkashAddress();
-    const user = await userRepository.create({ userId: faker.string.uuid(), email: "owner@example.com" });
+    const user = await container.resolve(UserRepository).create({ userId: faker.string.uuid(), email: "owner@example.com" });
     const { wallet } = await userWalletRepository.getOrCreate({ userId: user.id });
     await userWalletRepository.updateById(wallet.id, { address: owner });
 
@@ -87,15 +119,43 @@ describe(CloseUnreachableProviderDeploymentHandler.name, () => {
     ]);
 
     const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(!input.alreadyClosedOnChain);
-    const enqueue = vi.spyOn(container.resolve(JobQueueService), "enqueue").mockResolvedValue("job-id");
+    const sentNotifications = interceptNotifications();
+    const commandKey = UnreachableProviderDeploymentsCloserService.singletonKey({ owner, dseq: deployment.dseq });
+    const noticeKey = `notification.providerUnreachableClosed.${deployment.dseq}.${wallet.id}`;
 
     return {
-      handler: container.resolve(CloseUnreachableProviderDeploymentHandler),
-      deploymentSettingRepository,
-      close,
-      enqueue,
       deployment,
-      user
+      close,
+      sentNotifications,
+      findSetting: () => deploymentSettingRepository.findOneBy({ userId: user.id, dseq: deployment.dseq }),
+      findClosedNotice: async () => (await findJobRows(NotificationJob[JOB_NAME], { singletonKey: noticeKey }))[0],
+      findPendingCloseJob: async () =>
+        (await findJobRows(CloseUnreachableProviderDeploymentCommand[JOB_NAME], { singletonKey: commandKey, state: "created" }))[0],
+      awaitClosedNotice: () => expectJobCompleted(NotificationJob[JOB_NAME], { singletonKey: noticeKey }),
+      failNoticeEnqueue: () => {
+        const jobQueue = container.resolve(JobQueueService);
+        const passThrough = jobQueue.enqueue.bind(jobQueue);
+        vi.spyOn(jobQueue, "enqueue").mockImplementation((job, options) =>
+          job.name === NotificationJob[JOB_NAME] ? Promise.reject(new Error("queue unavailable")) : passThrough(job, options)
+        );
+      },
+      awaitCloseRetrying: () =>
+        vi.waitFor(
+          async () => {
+            const [row] = await findJobRows(CloseUnreachableProviderDeploymentCommand[JOB_NAME], { singletonKey: commandKey });
+            expect(row?.state).toBe("retry");
+          },
+          { timeout: 20_000, interval: 250 }
+        ),
+      dispatchCloseUnreachable: async () => {
+        await enqueue(new CloseUnreachableProviderDeploymentCommand({ owner, dseq: deployment.dseq }), { singletonKey: commandKey });
+        await startWorkers();
+      },
+      closeUnreachable: async () => {
+        await enqueue(new CloseUnreachableProviderDeploymentCommand({ owner, dseq: deployment.dseq }), { singletonKey: commandKey });
+        await startWorkers();
+        await expectJobCompleted(CloseUnreachableProviderDeploymentCommand[JOB_NAME], { singletonKey: commandKey, state: "completed" });
+      }
     };
   }
 });

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
@@ -1,0 +1,117 @@
+import "@src/app/providers/jobs.provider";
+
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
+import { JOB_NAME } from "@src/core";
+import { NOTIFICATIONS_CONFIG } from "@src/notifications/providers/notifications-config.provider";
+import { EnableDeploymentAlertHandler } from "./enable-deployment-alert.handler";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { createDseq } from "@test/seeders/db/deployment-setting.seeder";
+import { seedUser } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+
+const CHANNELS_PATH = "/v1/notification-channels";
+const CHANNEL_ID = "channel-1";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(EnableDeploymentAlertHandler)]);
+
+describe(EnableDeploymentAlertHandler.name, () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("enables the closed alert on the owner's existing channel", async () => {
+    const { userId, walletAddress, dseq, enableAlert, upsertedAlerts } = await setup();
+
+    await enableAlert();
+
+    expect(upsertedAlerts()).toEqual([
+      {
+        dseq,
+        userId,
+        ownerAddress: walletAddress,
+        body: { data: { alerts: { deploymentClosed: { notificationChannelId: CHANNEL_ID, enabled: true } } } }
+      }
+    ]);
+  });
+
+  it("creates a channel first for an owner who has none", async () => {
+    const { enableAlert, createdChannels, upsertedAlerts } = await setup({ hasChannel: false });
+
+    await enableAlert();
+
+    expect(createdChannels()).toHaveLength(1);
+    expect(upsertedAlerts()).toHaveLength(1);
+  });
+
+  it("enables nothing for a user with no email to notify", async () => {
+    const { enableAlert, upsertedAlerts } = await setup({ email: null });
+
+    await enableAlert();
+
+    expect(upsertedAlerts()).toHaveLength(0);
+  });
+
+  async function setup(input: { email?: string | null; hasChannel?: boolean } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const baseUrl = container.resolve(NOTIFICATIONS_CONFIG).NOTIFICATIONS_API_BASE_URL as string;
+
+    const email = input.email === undefined ? "alerts@example.com" : input.email;
+    const user = await seedUser({ email });
+    const walletAddress = createAkashAddress();
+    const dseq = createDseq();
+
+    const createdChannels: unknown[] = [];
+    const upserted: { dseq: string; userId: string | undefined; ownerAddress: string | undefined; body: unknown }[] = [];
+    let channels = input.hasChannel === false ? [] : [{ id: CHANNEL_ID }];
+
+    nock(baseUrl)
+      .persist()
+      .get(CHANNELS_PATH)
+      .query(true)
+      .reply(() => [200, { data: channels }]);
+
+    nock(baseUrl)
+      .persist()
+      .post(`${CHANNELS_PATH}/default`)
+      .reply(function reply(this: nock.ReplyFnContext, _uri, body) {
+        createdChannels.push(body);
+        channels = [{ id: CHANNEL_ID }];
+
+        return [201, { data: { id: CHANNEL_ID } }];
+      });
+
+    nock(baseUrl)
+      .persist()
+      .post(`/v1/deployment-alerts/${dseq}`)
+      .reply(function reply(this: nock.ReplyFnContext, _uri, body) {
+        upserted.push({
+          dseq,
+          userId: this.req.headers["x-user-id"] as string,
+          ownerAddress: this.req.headers["x-owner-address"] as string,
+          body
+        });
+
+        return [200, { data: {} }];
+      });
+
+    return {
+      userId: user.id,
+      walletAddress,
+      dseq,
+      createdChannels: () => createdChannels,
+      upsertedAlerts: () => upserted,
+      enableAlert: async () => {
+        await enqueue(new EnableDeploymentAlertCommand({ userId: user.id, walletAddress, dseq }), {
+          singletonKey: `enableDeploymentAlert.${user.id}.${dseq}`
+        });
+        await startWorkers();
+        await expectJobCompleted(EnableDeploymentAlertCommand[JOB_NAME], { singletonKey: `enableDeploymentAlert.${user.id}.${dseq}` });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
@@ -25,10 +25,11 @@ describe(EnableDeploymentAlertHandler.name, () => {
   });
 
   it("enables the closed alert on the owner's existing channel", async () => {
-    const { userId, walletAddress, dseq, enableAlert, upsertedAlerts } = await setup();
+    const { userId, walletAddress, dseq, enableAlert, createdChannels, upsertedAlerts } = await setup();
 
     await enableAlert();
 
+    expect(createdChannels()).toHaveLength(0);
     expect(upsertedAlerts()).toEqual([
       {
         dseq,

--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.integration.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.integration.ts
@@ -1,0 +1,90 @@
+import "@src/app/providers/jobs.provider";
+
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.command";
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { WalletCreditsLowCheckHandler } from "@src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler";
+import { JOB_NAME } from "@src/core";
+import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import { FundDeploymentHandler } from "./fund-deployment.handler";
+
+import { createDseq } from "@test/seeders/db/deployment-setting.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(FundDeploymentHandler), container.resolve(WalletCreditsLowCheckHandler)]);
+
+describe(FundDeploymentHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("still schedules the credits low check when funding is skipped for a closed deployment", async () => {
+    const { fundDeployment, findCreditsLowCheck } = await setup({ lease: "closed" });
+
+    await fundDeployment();
+
+    expect(await findCreditsLowCheck()).toBeDefined();
+  });
+
+  it("still schedules the credits low check when the lease is not visible on chain yet", async () => {
+    const { dispatchFundDeployment, awaitFundingRetrying, findCreditsLowCheck } = await setup({ lease: "missing" });
+
+    await dispatchFundDeployment();
+    await awaitFundingRetrying();
+
+    expect(await findCreditsLowCheck()).toBeDefined();
+  });
+
+  it("schedules no credits low check for a wallet whose auto reload is on", async () => {
+    const { fundDeployment, findCreditsLowCheck } = await setup({ lease: "closed", autoReload: true });
+
+    await fundDeployment();
+
+    expect(await findCreditsLowCheck()).toBeUndefined();
+  });
+
+  async function setup(input: { lease: "closed" | "missing"; autoReload?: boolean }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const { user, wallet, address } = await seedUserWithWallet();
+    const dseq = createDseq();
+
+    await seedWalletSetting({
+      userId: user.id,
+      walletId: wallet.id,
+      autoReloadEnabled: input.autoReload ?? false
+    });
+
+    vi.spyOn(container.resolve(DrainingDeploymentService), "findLeases").mockResolvedValue(
+      input.lease === "closed" ? [createDrainingDeployment({ dseq: Number(dseq), isClosed: true })] : []
+    );
+    vi.spyOn(container.resolve(WalletCreditsLowCheckHandler), "handle").mockResolvedValue();
+
+    const fundingKey = `fundDeployment.${wallet.id}.${dseq}`;
+
+    return {
+      findCreditsLowCheck: async () => (await findJobRows(WalletCreditsLowCheck[JOB_NAME], { singletonKey: `${WalletCreditsLowCheck.name}.${user.id}` }))[0],
+      dispatchFundDeployment: async () => {
+        await enqueue(new FundDeploymentCommand({ walletId: wallet.id, address, dseq }), { singletonKey: fundingKey });
+        await startWorkers();
+      },
+      awaitFundingRetrying: () =>
+        vi.waitFor(
+          async () => {
+            const [row] = await findJobRows(FundDeploymentCommand[JOB_NAME], { singletonKey: fundingKey });
+            expect(row?.state).toBe("retry");
+          },
+          { timeout: 20_000, interval: 250 }
+        ),
+      fundDeployment: async () => {
+        await enqueue(new FundDeploymentCommand({ walletId: wallet.id, address, dseq }), { singletonKey: fundingKey });
+        await startWorkers();
+        await expectJobCompleted(FundDeploymentCommand[JOB_NAME], { singletonKey: fundingKey });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.integration.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.integration.ts
@@ -1,0 +1,95 @@
+import "@src/app/providers/jobs.provider";
+
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { WalletCreditsLowCheckHandler } from "@src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler";
+import { JOB_NAME } from "@src/core";
+import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
+import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import { FundDrainingDeploymentsHandler } from "./fund-draining-deployments.handler";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const LATEST_BLOCK_PATH = "/cosmos/base/tendermint/v1beta1/blocks/latest";
+const CURRENT_HEIGHT = "28343549";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(FundDrainingDeploymentsHandler), container.resolve(WalletCreditsLowCheckHandler)]);
+
+describe(FundDrainingDeploymentsHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("still schedules the credits low check when the owner has nothing draining", async () => {
+    const { fundDraining, findCreditsLowCheck } = await setup();
+
+    await fundDraining();
+
+    expect(await findCreditsLowCheck()).toBeDefined();
+  });
+
+  it("still schedules the credits low check when the top up cannot run at all", async () => {
+    const { dispatchFundDraining, awaitFundingRetrying, findCreditsLowCheck } = await setup({ topUpUnavailable: true });
+
+    await dispatchFundDraining();
+    await awaitFundingRetrying();
+
+    expect(await findCreditsLowCheck()).toBeDefined();
+  });
+
+  it("schedules no credits low check for a wallet whose auto reload is on", async () => {
+    const { fundDraining, findCreditsLowCheck } = await setup({ autoReload: true });
+
+    await fundDraining();
+
+    expect(await findCreditsLowCheck()).toBeUndefined();
+  });
+
+  async function setup(input: { topUpUnavailable?: boolean; autoReload?: boolean } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const { user, wallet, address } = await seedUserWithWallet();
+
+    await seedWalletSetting({ userId: user.id, walletId: wallet.id, autoReloadEnabled: input.autoReload ?? false });
+
+    nock(container.resolve(CoreConfigService).get("REST_API_NODE_URL"))
+      .persist()
+      .get(LATEST_BLOCK_PATH)
+      .query(true)
+      .reply(200, { block_id: {}, block: { header: { height: CURRENT_HEIGHT, time: new Date().toISOString(), chain_id: "akashnet-2" } } });
+
+    const findDraining = vi.spyOn(container.resolve(DrainingDeploymentService), "findDrainingDeploymentsForOwner");
+    if (input.topUpUnavailable) findDraining.mockRejectedValue(new Error("indexer unavailable"));
+    else findDraining.mockResolvedValue([]);
+    vi.spyOn(container.resolve(WalletCreditsLowCheckHandler), "handle").mockResolvedValue();
+
+    const fundingKey = `fundDrainingDeployments.${wallet.id}`;
+
+    return {
+      findCreditsLowCheck: async () => (await findJobRows(WalletCreditsLowCheck[JOB_NAME], { singletonKey: `${WalletCreditsLowCheck.name}.${user.id}` }))[0],
+      dispatchFundDraining: async () => {
+        await enqueue(new FundDrainingDeploymentsCommand({ walletId: wallet.id, address }), { singletonKey: fundingKey });
+        await startWorkers();
+      },
+      awaitFundingRetrying: () =>
+        vi.waitFor(
+          async () => {
+            const [row] = await findJobRows(FundDrainingDeploymentsCommand[JOB_NAME], { singletonKey: fundingKey });
+            expect(row?.state).toBe("retry");
+          },
+          { timeout: 20_000, interval: 250 }
+        ),
+      fundDraining: async () => {
+        await enqueue(new FundDrainingDeploymentsCommand({ walletId: wallet.id, address }), { singletonKey: fundingKey });
+        await startWorkers();
+        await expectJobCompleted(FundDrainingDeploymentsCommand[JOB_NAME], { singletonKey: fundingKey });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
@@ -1,0 +1,143 @@
+import "@src/app/providers/jobs.provider";
+
+import { addHours } from "date-fns";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TrialDeploymentLeaseCreated } from "@src/billing/events/trial-deployment-lease-created";
+import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { JOB_NAME } from "@src/core";
+import { DOMAIN_EVENT_NAME } from "@src/core/services/domain-events/domain-events.service";
+import { NOTIFICATIONS_CONFIG } from "@src/notifications/providers/notifications-config.provider";
+import { NotificationHandler, NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
+import { CloseTrialDeployment, CloseTrialDeploymentHandler } from "../close-trial-deployment/close-trial-deployment.handler";
+import { TrialDeploymentLeaseCreatedHandler } from "./trial-deployment-lease-created.handler";
+
+import { createDseq } from "@test/seeders/db/deployment-setting.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const NOTIFICATION_PATH = "/internal/v1/jobs/notification";
+
+const jobWorkers = useJobWorkers(() => [
+  container.resolve(TrialDeploymentLeaseCreatedHandler),
+  container.resolve(NotificationHandler),
+  container.resolve(CloseTrialDeploymentHandler)
+]);
+
+describe(TrialDeploymentLeaseCreatedHandler.name, () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("schedules the close for the end of the trial deployment's life", async () => {
+    const { walletId, dseq, leaseCreatedAt, lifetimeHours, leaseCreated, findCloseJob } = await setup();
+
+    await leaseCreated();
+
+    expect(await findCloseJob()).toMatchObject({
+      singleton_key: `closeTrialDeployment.${dseq}.${walletId}`,
+      startAfter: addHours(leaseCreatedAt, lifetimeHours)
+    });
+  });
+
+  it("warns the owner an hour before that close", async () => {
+    const { walletId, dseq, leaseCreatedAt, lifetimeHours, leaseCreated, findWarningJob } = await setup();
+
+    await leaseCreated();
+
+    expect(await findWarningJob()).toMatchObject({
+      singleton_key: `notification.beforeCloseTrialDeployment.${dseq}.${walletId}`,
+      startAfter: addHours(leaseCreatedAt, lifetimeHours - 1)
+    });
+  });
+
+  it("congratulates the owner on a first lease straight away", async () => {
+    const { leaseCreated, awaitCongratulations, sentNotifications } = await setup({ isFirstLease: true });
+
+    await leaseCreated();
+    await awaitCongratulations();
+
+    expect(sentNotifications()).toHaveLength(1);
+  });
+
+  it("says nothing about a lease that is not the first", async () => {
+    const { leaseCreated, sentNotifications } = await setup({ isFirstLease: false });
+
+    await leaseCreated();
+
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  it("schedules nothing for a wallet that has left the trial", async () => {
+    const { leaseCreated, findCloseJob, findWarningJob } = await setup({ isTrialing: false });
+
+    await leaseCreated();
+
+    expect(await findCloseJob()).toBeUndefined();
+    expect(await findWarningJob()).toBeUndefined();
+  });
+
+  it("schedules nothing for a wallet with no address to close against", async () => {
+    const { leaseCreated, findCloseJob, findWarningJob } = await setup({ address: null });
+
+    await leaseCreated();
+
+    expect(await findCloseJob()).toBeUndefined();
+    expect(await findWarningJob()).toBeUndefined();
+  });
+
+  async function setup(input: { isTrialing?: boolean; isFirstLease?: boolean; address?: string | null } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const lifetimeHours = container.resolve(BillingConfigService).get("TRIAL_DEPLOYMENT_CLEANUP_HOURS");
+    const notificationsBaseUrl = container.resolve(NOTIFICATIONS_CONFIG).NOTIFICATIONS_API_BASE_URL as string;
+
+    const { wallet } = await seedUserWithWallet({
+      isTrialing: input.isTrialing ?? true,
+      ...(input.address === null ? { address: null } : {}),
+      user: { email: "trial-lease@example.com" }
+    });
+    const dseq = createDseq();
+    const leaseCreatedAt = new Date();
+
+    const sent: unknown[] = [];
+    nock(notificationsBaseUrl)
+      .persist()
+      .post(NOTIFICATION_PATH)
+      .reply(function reply(this: nock.ReplyFnContext, _uri, body) {
+        sent.push(body);
+
+        return [204];
+      });
+
+    async function findJobBySingletonKey(jobName: string, singletonKey: string) {
+      const [row] = await findJobRows(jobName, { singletonKey });
+
+      return row && { singleton_key: row.singleton_key, startAfter: new Date(row.start_after) };
+    }
+
+    return {
+      walletId: wallet.id,
+      dseq,
+      leaseCreatedAt,
+      lifetimeHours,
+      sentNotifications: () => sent,
+      findCloseJob: () => findJobBySingletonKey(CloseTrialDeployment[JOB_NAME], `closeTrialDeployment.${dseq}.${wallet.id}`),
+      findWarningJob: () => findJobBySingletonKey(NotificationJob[JOB_NAME], `notification.beforeCloseTrialDeployment.${dseq}.${wallet.id}`),
+      awaitCongratulations: () => expectJobCompleted(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
+      leaseCreated: async () => {
+        await enqueue(
+          new TrialDeploymentLeaseCreated({
+            walletId: wallet.id,
+            dseq,
+            createdAt: leaseCreatedAt.toISOString(),
+            isFirstLease: input.isFirstLease ?? false
+          })
+        );
+        await startWorkers();
+        await expectJobCompleted(TrialDeploymentLeaseCreated[DOMAIN_EVENT_NAME], { data: { dseq } });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
@@ -63,11 +63,11 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   });
 
   it("says nothing about a lease that is not the first", async () => {
-    const { leaseCreated, sentNotifications } = await setup({ isFirstLease: false });
+    const { leaseCreated, findCongratulationJobs } = await setup({ isFirstLease: false });
 
     await leaseCreated();
 
-    expect(sentNotifications()).toHaveLength(0);
+    expect(await findCongratulationJobs()).toHaveLength(0);
   });
 
   it("schedules nothing for a wallet that has left the trial", async () => {
@@ -126,6 +126,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
       findCloseJob: () => findJobBySingletonKey(CloseTrialDeployment[JOB_NAME], `closeTrialDeployment.${dseq}.${wallet.id}`),
       findWarningJob: () => findJobBySingletonKey(NotificationJob[JOB_NAME], `notification.beforeCloseTrialDeployment.${dseq}.${wallet.id}`),
       awaitCongratulations: () => expectJobCompleted(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
+      findCongratulationJobs: () => findJobRows(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
       leaseCreated: async () => {
         await enqueue(
           new TrialDeploymentLeaseCreated({

--- a/apps/api/src/billing/services/activate-trial/activate-trial.handler.integration.ts
+++ b/apps/api/src/billing/services/activate-trial/activate-trial.handler.integration.ts
@@ -1,0 +1,120 @@
+import "@src/app/providers/jobs.provider";
+
+import { eq } from "drizzle-orm";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TrialStartedHandler } from "@src/app/services/trial-started/trial-started.handler";
+import { ActivateTrial } from "@src/billing/events/activate-trial";
+import { TrialStarted } from "@src/billing/events/trial-started";
+import { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+import { DOMAIN_EVENT_NAME } from "@src/core/services/domain-events/domain-events.service";
+import { ActivateTrialHandler } from "./activate-trial.handler";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { seedUser } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const DEPLOYMENT_LIMIT = 7_000_000;
+const FEE_LIMIT = 3_000_000;
+
+/** The allowance columns are numeric(20, 2), so what the chain granted comes back scaled. */
+const STORED_DEPLOYMENT_LIMIT = "7000000.00";
+const STORED_FEE_LIMIT = "3000000.00";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(ActivateTrialHandler), container.resolve(TrialStartedHandler)]);
+
+describe(ActivateTrialHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("activates the wallet with the trial limits the chain granted", async () => {
+    const { activateTrial, findWallet } = await setup();
+
+    await activateTrial();
+
+    expect(await findWallet()).toMatchObject({
+      activatedAt: expect.any(Date),
+      deploymentAllowance: STORED_DEPLOYMENT_LIMIT,
+      feeAllowance: STORED_FEE_LIMIT
+    });
+  });
+
+  it("announces the started trial so its email sequence gets scheduled", async () => {
+    const { userId, activateTrial, findTrialStartedEvents } = await setup();
+
+    await activateTrial();
+
+    expect(await findTrialStartedEvents()).toHaveLength(1);
+    expect((await findTrialStartedEvents())[0].data).toMatchObject({ userId });
+  });
+
+  it("announces nothing the second time for a wallet already activated", async () => {
+    const { activateTrial, findTrialStartedEvents } = await setup();
+
+    await activateTrial();
+    await activateTrial({ again: true });
+
+    expect(await findTrialStartedEvents()).toHaveLength(1);
+  });
+
+  it("activates nothing for a user whose email is not verified", async () => {
+    const { dispatchActivateTrial, awaitActivationRetrying, findWallet, findTrialStartedEvents } = await setup({ emailVerified: false });
+
+    await dispatchActivateTrial();
+    await awaitActivationRetrying();
+
+    expect(await findWallet()).toBeUndefined();
+    expect(await findTrialStartedEvents()).toHaveLength(0);
+  });
+
+  async function setup(input: { emailVerified?: boolean } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const userWalletsTable = resolveTable("UserWallets");
+
+    const user = await seedUser({ email: "trial@example.com", emailVerified: input.emailVerified ?? true });
+    const address = createAkashAddress();
+
+    const walletManager = container.resolve(ManagedUserWalletService);
+    vi.spyOn(walletManager, "createWallet").mockResolvedValue({ address });
+    vi.spyOn(walletManager, "createAndAuthorizeTrialSpending").mockResolvedValue({
+      address,
+      limits: { deployment: DEPLOYMENT_LIMIT, fees: FEE_LIMIT }
+    });
+    vi.spyOn(container.resolve(TrialStartedHandler), "handle").mockResolvedValue();
+
+    const activationKey = `activateTrial.${user.id}`;
+
+    return {
+      userId: user.id,
+      findWallet: async () => {
+        const [row] = await db.select().from(userWalletsTable).where(eq(userWalletsTable.userId, user.id));
+
+        return row;
+      },
+      findTrialStartedEvents: () => findJobRows<{ userId: string }>(TrialStarted[DOMAIN_EVENT_NAME], { data: { userId: user.id } }),
+      dispatchActivateTrial: async () => {
+        await enqueue(new ActivateTrial({ userId: user.id }), { singletonKey: activationKey });
+        await startWorkers();
+      },
+      awaitActivationRetrying: () =>
+        vi.waitFor(
+          async () => {
+            const [row] = await findJobRows(ActivateTrial[JOB_NAME], { singletonKey: activationKey });
+            expect(row?.state).toBe("retry");
+          },
+          { timeout: 20_000, interval: 250 }
+        ),
+      activateTrial: async (options: { again?: boolean } = {}) => {
+        const key = options.again ? `${activationKey}.again` : activationKey;
+        await enqueue(new ActivateTrial({ userId: user.id }), { singletonKey: key });
+        await startWorkers();
+        await expectJobCompleted(ActivateTrial[JOB_NAME], { singletonKey: key });
+      }
+    };
+  }
+});

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.integration.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.integration.ts
@@ -1,0 +1,132 @@
+import "@src/app/providers/jobs.provider";
+
+import { faker } from "@faker-js/faker";
+import { eq } from "drizzle-orm";
+import type Stripe from "stripe";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
+import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import { WalletBalanceReloadCheckHandler } from "@src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+
+const STRIPE_CUSTOMER_ID = "cus_test_reload";
+const THRESHOLD_CENTS = 2_000;
+const RELOAD_AMOUNT_CENTS = 5_000;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(WalletBalanceReloadCheckHandler)]);
+
+describe(WalletBalanceReloadCheckHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("charges the default payment method once the balance falls below the threshold", async () => {
+    const { checkBalance, createPaymentIntent, findWalletSetting, paymentMethodId } = await setup({ balanceUsd: 1 });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_method: paymentMethodId, customer: STRIPE_CUSTOMER_ID, confirm: true, offSession: true })
+    );
+    expect((await findWalletSetting()).lastAutoChargeAt).toBeInstanceOf(Date);
+  });
+
+  it("charges nothing while the balance still covers the threshold", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 100 });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing for a wallet paused after repeated declines", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, autoReloadPausedAt: new Date() });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing a second time inside the cooldown the first charge claimed", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, lastAutoChargeAt: new Date() });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing for a wallet whose auto reload is off", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, autoReloadEnabled: false });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  async function setup(input: { balanceUsd: number; autoReloadEnabled?: boolean; autoReloadPausedAt?: Date; lastAutoChargeAt?: Date }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const walletSettingTable = resolveTable("WalletSetting");
+
+    const { user, wallet } = await seedUserWithWallet({
+      isTrialing: false,
+      activatedAt: new Date(),
+      user: { email: "reload@example.com", stripeCustomerId: STRIPE_CUSTOMER_ID }
+    });
+
+    const walletSetting = await seedWalletSetting({
+      userId: user.id,
+      walletId: wallet.id,
+      autoReloadEnabled: input.autoReloadEnabled ?? true,
+      autoReloadMode: "threshold",
+      autoReloadThreshold: THRESHOLD_CENTS,
+      autoReloadAmount: RELOAD_AMOUNT_CENTS,
+      autoReloadPausedAt: input.autoReloadPausedAt ?? null,
+      lastAutoChargeAt: input.lastAutoChargeAt ?? null
+    });
+
+    const paymentMethodId = `pm_${faker.string.alphanumeric(12)}`;
+    await db.insert(resolveTable("PaymentMethods")).values({
+      userId: user.id,
+      paymentMethodId,
+      fingerprint: `fp_${faker.string.alphanumeric(12)}`,
+      isDefault: true,
+      isValidated: true
+    });
+
+    vi.spyOn(container.resolve<Stripe>(STRIPE_CLIENT).paymentMethods, "retrieve").mockResolvedValue(
+      mock<Stripe.Response<Stripe.PaymentMethod>>({ id: paymentMethodId, customer: STRIPE_CUSTOMER_ID })
+    );
+    vi.spyOn(container.resolve(BalancesService), "getDeploymentBalanceInFiat").mockResolvedValue(input.balanceUsd);
+    const createPaymentIntent = vi
+      .spyOn(container.resolve(StripeTransactionService), "createPaymentIntent")
+      .mockResolvedValue({ success: true, transactionId: "tx_test", paymentIntentId: "pi_test", transactionStatus: "succeeded" });
+
+    const checkKey = `${WalletBalanceReloadCheck.name}.${user.id}`;
+
+    return {
+      paymentMethodId,
+      createPaymentIntent,
+      findWalletSetting: async () => {
+        const [row] = await db.select().from(walletSettingTable).where(eq(walletSettingTable.id, walletSetting.id));
+
+        return row;
+      },
+      checkBalance: async () => {
+        await enqueue(new WalletBalanceReloadCheck({ userId: user.id, triggeredByDeployment: true }), { singletonKey: checkKey });
+        await startWorkers();
+        await expectJobCompleted(WalletBalanceReloadCheck[JOB_NAME], { singletonKey: checkKey, state: "completed" });
+      }
+    };
+  }
+});

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.integration.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.integration.ts
@@ -1,0 +1,191 @@
+import "@src/app/providers/jobs.provider";
+
+import { subMinutes } from "date-fns";
+import { eq } from "drizzle-orm";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { WalletCreditsLowCheckHandler } from "@src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+import { interceptNotifications } from "@test/services/notifications-intercept";
+
+/** Longer than CREDITS_LOW_CONFIRM_WINDOW_MIN, so a streak stamped this long ago counts as confirmed. */
+const PAST_THE_CONFIRM_WINDOW_IN_MIN = 45;
+
+/** Longer than CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN, so a recovery stamped this long ago counts as held. */
+const PAST_THE_RECOVERY_WINDOW_IN_MIN = 24 * 60 * 3;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(WalletCreditsLowCheckHandler)]);
+
+describe(WalletCreditsLowCheckHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("opens the low window on a first low reading without emailing", async () => {
+    const { checkCredits, findWallet, sentNotifications } = await setup({ balanceUsd: 1, weeklyCostUsd: 20 });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowSince: expect.any(Date), creditsLowNotifiedAt: null });
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  it("stays quiet while the low reading is still inside the confirm window", async () => {
+    const { checkCredits, sentNotifications } = await setup({ balanceUsd: 1, weeklyCostUsd: 20, creditsLowSince: new Date() });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  it("emails once the low streak has held past the confirm window", async () => {
+    const { checkCredits, findWallet, sentNotifications } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN)
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(1);
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: expect.any(Date), creditsLowSince: null, creditsSufficientSince: null });
+  });
+
+  it("emails nothing a second time for a wallet already notified, and ends its recovery streak", async () => {
+    const { checkCredits, findWallet, sentNotifications } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN),
+      creditsLowNotifiedAt: new Date(),
+      creditsSufficientSince: subMinutes(new Date(), 5)
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+    expect(await findWallet()).toMatchObject({ creditsSufficientSince: null });
+  });
+
+  it("emails nothing for a wallet whose auto reload is on", async () => {
+    const { checkCredits, sentNotifications, findWallet } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN),
+      autoReload: true
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null });
+  });
+
+  it("clears the notice at once when there is nothing left to top up", async () => {
+    const { checkCredits, findWallet } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 0,
+      hasAutoTopUpSettings: false,
+      creditsLowNotifiedAt: new Date()
+    });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null });
+  });
+
+  it("opens the recovery window on a balance that covers the week again", async () => {
+    const { checkCredits, findWallet } = await setup({ balanceUsd: 50, weeklyCostUsd: 20, creditsLowNotifiedAt: new Date() });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsSufficientSince: expect.any(Date), creditsLowNotifiedAt: expect.any(Date) });
+  });
+
+  it("clears the notice once the recovery has held past its window", async () => {
+    const { checkCredits, findWallet } = await setup({
+      balanceUsd: 50,
+      weeklyCostUsd: 20,
+      creditsLowNotifiedAt: new Date(),
+      creditsSufficientSince: subMinutes(new Date(), PAST_THE_RECOVERY_WINDOW_IN_MIN)
+    });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null });
+  });
+
+  it("emails nothing for a wallet still on trial", async () => {
+    const { checkCredits, sentNotifications } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN),
+      isTrialing: true
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  async function setup(input: {
+    balanceUsd: number;
+    weeklyCostUsd: number;
+    creditsLowSince?: Date;
+    creditsLowNotifiedAt?: Date;
+    creditsSufficientSince?: Date;
+    autoReload?: boolean;
+    isTrialing?: boolean;
+    hasAutoTopUpSettings?: boolean;
+  }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const userWalletsTable = resolveTable("UserWallets");
+
+    const { user, wallet, address } = await seedUserWithWallet({
+      isTrialing: input.isTrialing ?? false,
+      activatedAt: new Date(),
+      creditsLowSince: input.creditsLowSince ?? null,
+      creditsLowNotifiedAt: input.creditsLowNotifiedAt ?? null,
+      creditsSufficientSince: input.creditsSufficientSince ?? null,
+      user: { email: "credits-low@example.com" }
+    });
+
+    await seedWalletSetting({ userId: user.id, walletId: wallet.id, autoReloadEnabled: input.autoReload ?? false });
+
+    vi.spyOn(container.resolve(BalancesService), "getDeploymentBalanceInFiat").mockResolvedValue(input.balanceUsd);
+    vi.spyOn(container.resolve(DrainingDeploymentService), "calculateWeeklyCoverageForAddress").mockResolvedValue({
+      weeklyCostUsd: input.weeklyCostUsd,
+      cumulativeDailyCostsUsd: [1, 5, 10, 15, 20, 25, 30],
+      hasAutoTopUpSettings: input.hasAutoTopUpSettings ?? true
+    });
+
+    const sentNotifications = interceptNotifications();
+    const checkKey = `${WalletCreditsLowCheck.name}.${user.id}`;
+
+    return {
+      address,
+      sentNotifications,
+      findWallet: async () => {
+        const [row] = await db.select().from(userWalletsTable).where(eq(userWalletsTable.id, wallet.id));
+
+        return row;
+      },
+      checkCredits: async () => {
+        await enqueue(new WalletCreditsLowCheck({ userId: user.id }), { singletonKey: checkKey });
+        await startWorkers();
+        await expectJobCompleted(WalletCreditsLowCheck[JOB_NAME], { singletonKey: checkKey });
+      }
+    };
+  }
+});

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.integration.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.integration.ts
@@ -1,0 +1,122 @@
+import "@src/app/providers/jobs.provider";
+
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { JOB_NAME } from "@src/core";
+import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { type ProbeReport, TrialWorkloadProbeService } from "@src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service";
+import { ProbeTrialDeployment, probeTrialDeploymentKeyFor } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { ProbeTrialDeploymentHandler } from "./probe-trial-deployment.handler";
+
+import { createDseq } from "@test/seeders/db/deployment-setting.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const MAX_ATTEMPTS = 30;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(ProbeTrialDeploymentHandler)]);
+
+describe(ProbeTrialDeploymentHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("records a detection for a workload the probe judges abusive", async () => {
+    const { dseq, probeDeployment, findDetections } = await setup({ verdict: "hard" });
+
+    await probeDeployment();
+
+    expect(await findDetections()).toMatchObject([{ dseq, verdict: "hard", probeStatus: "probed" }]);
+  });
+
+  it("stops probing once the verdict is hard", async () => {
+    const { probeDeployment, findNextProbe } = await setup({ verdict: "hard" });
+
+    await probeDeployment();
+
+    expect(await findNextProbe()).toBeUndefined();
+  });
+
+  it("probes again for a workload that still looks clean", async () => {
+    const { probeDeployment, findNextProbe } = await setup({ verdict: "clean" });
+
+    await probeDeployment();
+
+    expect((await findNextProbe())?.data).toMatchObject({ attempt: 2 });
+  });
+
+  it("stops probing at the attempt cap", async () => {
+    const { probeDeployment, findNextProbe } = await setup({ verdict: "clean", attempt: MAX_ATTEMPTS });
+
+    await probeDeployment();
+
+    expect(await findNextProbe()).toBeUndefined();
+  });
+
+  it("probes nothing for a wallet that has left the trial", async () => {
+    const { probeDeployment, findDetections, probe } = await setup({ verdict: "hard", isTrialing: false });
+
+    await probeDeployment();
+
+    expect(probe).not.toHaveBeenCalled();
+    expect(await findDetections()).toHaveLength(0);
+  });
+
+  it("records nothing more for a deployment already judged abusive", async () => {
+    const { probeDeployment, findDetections, probe, seedExistingDetection } = await setup({ verdict: "hard" });
+    await seedExistingDetection();
+
+    await probeDeployment();
+
+    expect(probe).not.toHaveBeenCalled();
+    expect(await findDetections()).toHaveLength(1);
+  });
+
+  async function setup(input: { verdict: ProbeReport["verdict"]; attempt?: number; isTrialing?: boolean }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const detectionRepository = container.resolve(WorkloadAbuseDetectionRepository);
+    const { user, wallet, address } = await seedUserWithWallet({ isTrialing: input.isTrialing ?? true });
+    const dseq = createDseq();
+
+    const config = container.resolve(WorkloadAbuseConfigService);
+    const readConfig = config.get.bind(config);
+    vi.spyOn(config, "get").mockImplementation((key => (key === "WORKLOAD_ABUSE_PROBE_ENABLED" ? true : readConfig(key))) as typeof config.get);
+
+    const probe = vi.spyOn(container.resolve(TrialWorkloadProbeService), "probe").mockResolvedValue({
+      verdict: input.verdict,
+      probeStatus: "probed",
+      signals: [],
+      excerpt: "denied",
+      leases: []
+    });
+
+    const probeKey = probeTrialDeploymentKeyFor({ walletId: wallet.id, dseq });
+
+    return {
+      dseq,
+      probe,
+      findDetections: () => detectionRepository.find({ walletId: wallet.id, dseq }),
+      seedExistingDetection: () =>
+        detectionRepository.create({
+          userId: user.id,
+          walletId: wallet.id,
+          dseq,
+          provider: address,
+          verdict: "hard",
+          probeStatus: "probed",
+          signals: [],
+          evidenceExcerpt: "denied"
+        }),
+      findNextProbe: async () => (await findJobRows<{ attempt: number }>(ProbeTrialDeployment[JOB_NAME], { singletonKey: probeKey, state: "created" }))[0],
+      probeDeployment: async () => {
+        await enqueue(new ProbeTrialDeployment({ walletId: wallet.id, dseq, attempt: input.attempt ?? 1, leaseCreatedAt: new Date().toISOString() }), {
+          singletonKey: probeKey
+        });
+        await startWorkers();
+        await expectJobCompleted(ProbeTrialDeployment[JOB_NAME], { singletonKey: probeKey, state: "completed" });
+      }
+    };
+  }
+});

--- a/apps/api/test/seeders/db/wallet-setting.seeder.ts
+++ b/apps/api/test/seeders/db/wallet-setting.seeder.ts
@@ -1,0 +1,13 @@
+import { container } from "tsyringe";
+
+import type { ApiPgDatabase, ApiPgTables } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+
+type WalletSettingInsert = ApiPgTables["WalletSetting"]["$inferInsert"];
+
+export async function seedWalletSetting(overrides: Partial<WalletSettingInsert> & Pick<WalletSettingInsert, "userId" | "walletId">) {
+  const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+  const [setting] = await db.insert(resolveTable("WalletSetting")).values(overrides).returning();
+
+  return setting;
+}

--- a/apps/api/test/services/job-queue-harness.ts
+++ b/apps/api/test/services/job-queue-harness.ts
@@ -31,6 +31,7 @@ interface JobSelector {
   singletonKey?: string;
   singletonKeyLike?: string;
   data?: Record<string, string>;
+  state?: string;
 }
 
 function db() {
@@ -70,8 +71,10 @@ export function useJobWorkers(resolveHandlers: () => JobHandler<Job>[]) {
 }
 
 /** A payload selector, because a domain event published without a singleton key has no other way to name one job among many. */
-function selectorFilter({ singletonKey, singletonKeyLike, data }: JobSelector) {
+function selectorFilter({ singletonKey, singletonKeyLike, data, state }: JobSelector) {
   let filter = sql``;
+
+  if (state) filter = sql`${filter} and state = ${state}`;
 
   if (singletonKey) filter = sql`${filter} and singleton_key = ${singletonKey}`;
   else if (singletonKeyLike) filter = sql`${filter} and singleton_key like ${singletonKeyLike}`;

--- a/apps/api/test/services/notifications-intercept.ts
+++ b/apps/api/test/services/notifications-intercept.ts
@@ -1,0 +1,27 @@
+import nock from "nock";
+import { container } from "tsyringe";
+
+import { NOTIFICATIONS_CONFIG } from "@src/notifications/providers/notifications-config.provider";
+
+const NOTIFICATION_PATH = "/internal/v1/jobs/notification";
+
+export interface SentNotification {
+  userId: string | undefined;
+  body: Record<string, unknown>;
+}
+
+/** Replies 204 because that is the only status the internal endpoint declares. */
+export function interceptNotifications() {
+  const sent: SentNotification[] = [];
+
+  nock(container.resolve(NOTIFICATIONS_CONFIG).NOTIFICATIONS_API_BASE_URL as string)
+    .persist()
+    .post(NOTIFICATION_PATH)
+    .reply(function reply(this: nock.ReplyFnContext, _uri, body) {
+      sent.push({ userId: this.req.headers["x-user-id"] as string, body: body as Record<string, unknown> });
+
+      return [204];
+    });
+
+  return () => sent;
+}


### PR DESCRIPTION
## Why

Part of CON-952. **First PR of a stack** — base is `main`; each following PR is based on the one before it.

Every decision `TrialDeploymentLeaseCreatedHandler` makes comes off the wallet row it reads unscoped: whether the wallet is still trialing, whether it has an address, and the schedule derived from the lease creation time. A mocked repository answers all three however the test asks it to, so none of them were covered.

## What

Publishes the real `TrialDeploymentLeaseCreated` event, runs it through a real worker, and asserts:

- the close job lands at `leaseCreatedAt + TRIAL_DEPLOYMENT_CLEANUP_HOURS`, keyed per deployment and wallet
- its warning notification lands an hour earlier
- a first lease gets an immediate congratulation, a subsequent lease gets nothing
- a wallet that has left the trial, or has no address, gets nothing scheduled

Verified by mutation — dropping the `isTrialing` guard fails `schedules nothing for a wallet that has left the trial` (`expected { …(2) } to be undefined`).

### Two traps worth recording

**Fixed dates in the past make delayed jobs fire immediately.** My first version anchored the lease to a hardcoded `2026-03-01`, so `startAfter` for the warning and close computed to the past and pg-boss delivered them at once — earlier tests' notifications then arrived during a later test and the count assertion saw 3 instead of 1. Anchoring to `new Date()` keeps the derived schedule in the future, which is what production sees.

**A notification the handler enqueues is not sent by the time the handler's own job completes.** `expectJobCompleted` on the event returns before the `NotificationJob` it queued has been worked, so the assertion has to wait on that job too.

Neither is visible with a mocked queue, and both will bite the remaining handlers in this stack.

### Verification

Stacked PRs get neither CI nor CodeRabbit (`all-ci.yml` filters base to `main`/`main-sdk-next`, `.coderabbit.yaml` sets `base_branches: ["main"]`), so this is local only:

- `npm run test:integration` for this file — 6 tests pass
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 42 errors, unchanged from the `main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for trial deployment lifecycle events, including scheduling, closing, and notifications.
  * Verified recharge, first-purchase, low-balance, and auto-reload notification scenarios.
  * Covered deployment funding, draining, expiration, unreachable providers, and alert setup.
  * Verified trial activation, abuse probing, and retry behavior under common failure conditions.
  * Added coverage for wallets without email or blockchain addresses, inactive trials, and other ineligible scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->