### PR TITLE
test(alert): cover auto enabling the deployment closed alert

### DIFF
--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
@@ -31,6 +31,8 @@ describe("recharge and bonus notices", () => {
 
       await rechargeSucceeded({ amountCents: 2500 });
 
+      expect(sentNotifications()).toHaveLength(1);
+
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);
       expect(sent.body).toMatchObject({
@@ -64,6 +66,8 @@ describe("recharge and bonus notices", () => {
       const { userId, bonusGranted, sentNotifications } = await setup();
 
       await bonusGranted({ bonusAmountCents: 1000, paidAmountCents: 5000 });
+
+      expect(sentNotifications()).toHaveLength(1);
 
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
@@ -1,0 +1,117 @@
+import "@src/app/providers/jobs.provider";
+
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
+import { JOB_NAME } from "@src/core";
+import { NOTIFICATIONS_CONFIG } from "@src/notifications/providers/notifications-config.provider";
+import { EnableDeploymentAlertHandler } from "./enable-deployment-alert.handler";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { createDseq } from "@test/seeders/db/deployment-setting.seeder";
+import { seedUser } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+
+const CHANNELS_PATH = "/v1/notification-channels";
+const CHANNEL_ID = "channel-1";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(EnableDeploymentAlertHandler)]);
+
+describe(EnableDeploymentAlertHandler.name, () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("enables the closed alert on the owner's existing channel", async () => {
+    const { userId, walletAddress, dseq, enableAlert, upsertedAlerts } = await setup();
+
+    await enableAlert();
+
+    expect(upsertedAlerts()).toEqual([
+      {
+        dseq,
+        userId,
+        ownerAddress: walletAddress,
+        body: { data: { alerts: { deploymentClosed: { notificationChannelId: CHANNEL_ID, enabled: true } } } }
+      }
+    ]);
+  });
+
+  it("creates a channel first for an owner who has none", async () => {
+    const { enableAlert, createdChannels, upsertedAlerts } = await setup({ hasChannel: false });
+
+    await enableAlert();
+
+    expect(createdChannels()).toHaveLength(1);
+    expect(upsertedAlerts()).toHaveLength(1);
+  });
+
+  it("enables nothing for a user with no email to notify", async () => {
+    const { enableAlert, upsertedAlerts } = await setup({ email: null });
+
+    await enableAlert();
+
+    expect(upsertedAlerts()).toHaveLength(0);
+  });
+
+  async function setup(input: { email?: string | null; hasChannel?: boolean } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const baseUrl = container.resolve(NOTIFICATIONS_CONFIG).NOTIFICATIONS_API_BASE_URL as string;
+
+    const email = input.email === undefined ? "alerts@example.com" : input.email;
+    const user = await seedUser({ email });
+    const walletAddress = createAkashAddress();
+    const dseq = createDseq();
+
+    const createdChannels: unknown[] = [];
+    const upserted: { dseq: string; userId: string | undefined; ownerAddress: string | undefined; body: unknown }[] = [];
+    let channels = input.hasChannel === false ? [] : [{ id: CHANNEL_ID }];
+
+    nock(baseUrl)
+      .persist()
+      .get(CHANNELS_PATH)
+      .query(true)
+      .reply(() => [200, { data: channels }]);
+
+    nock(baseUrl)
+      .persist()
+      .post(`${CHANNELS_PATH}/default`)
+      .reply(function reply(this: nock.ReplyFnContext, _uri, body) {
+        createdChannels.push(body);
+        channels = [{ id: CHANNEL_ID }];
+
+        return [201, { data: { id: CHANNEL_ID } }];
+      });
+
+    nock(baseUrl)
+      .persist()
+      .post(`/v1/deployment-alerts/${dseq}`)
+      .reply(function reply(this: nock.ReplyFnContext, _uri, body) {
+        upserted.push({
+          dseq,
+          userId: this.req.headers["x-user-id"] as string,
+          ownerAddress: this.req.headers["x-owner-address"] as string,
+          body
+        });
+
+        return [200, { data: {} }];
+      });
+
+    return {
+      userId: user.id,
+      walletAddress,
+      dseq,
+      createdChannels: () => createdChannels,
+      upsertedAlerts: () => upserted,
+      enableAlert: async () => {
+        await enqueue(new EnableDeploymentAlertCommand({ userId: user.id, walletAddress, dseq }), {
+          singletonKey: `enableDeploymentAlert.${user.id}.${dseq}`
+        });
+        await startWorkers();
+        await expectJobCompleted(EnableDeploymentAlertCommand[JOB_NAME], { singletonKey: `enableDeploymentAlert.${user.id}.${dseq}` });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
@@ -25,10 +25,11 @@ describe(EnableDeploymentAlertHandler.name, () => {
   });
 
   it("enables the closed alert on the owner's existing channel", async () => {
-    const { userId, walletAddress, dseq, enableAlert, upsertedAlerts } = await setup();
+    const { userId, walletAddress, dseq, enableAlert, createdChannels, upsertedAlerts } = await setup();
 
     await enableAlert();
 
+    expect(createdChannels()).toHaveLength(0);
     expect(upsertedAlerts()).toEqual([
       {
         dseq,

--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.integration.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.integration.ts
@@ -1,0 +1,90 @@
+import "@src/app/providers/jobs.provider";
+
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.command";
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { WalletCreditsLowCheckHandler } from "@src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler";
+import { JOB_NAME } from "@src/core";
+import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import { FundDeploymentHandler } from "./fund-deployment.handler";
+
+import { createDseq } from "@test/seeders/db/deployment-setting.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(FundDeploymentHandler), container.resolve(WalletCreditsLowCheckHandler)]);
+
+describe(FundDeploymentHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("still schedules the credits low check when funding is skipped for a closed deployment", async () => {
+    const { fundDeployment, findCreditsLowCheck } = await setup({ lease: "closed" });
+
+    await fundDeployment();
+
+    expect(await findCreditsLowCheck()).toBeDefined();
+  });
+
+  it("still schedules the credits low check when the lease is not visible on chain yet", async () => {
+    const { dispatchFundDeployment, awaitFundingRetrying, findCreditsLowCheck } = await setup({ lease: "missing" });
+
+    await dispatchFundDeployment();
+    await awaitFundingRetrying();
+
+    expect(await findCreditsLowCheck()).toBeDefined();
+  });
+
+  it("schedules no credits low check for a wallet whose auto reload is on", async () => {
+    const { fundDeployment, findCreditsLowCheck } = await setup({ lease: "closed", autoReload: true });
+
+    await fundDeployment();
+
+    expect(await findCreditsLowCheck()).toBeUndefined();
+  });
+
+  async function setup(input: { lease: "closed" | "missing"; autoReload?: boolean }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const { user, wallet, address } = await seedUserWithWallet();
+    const dseq = createDseq();
+
+    await seedWalletSetting({
+      userId: user.id,
+      walletId: wallet.id,
+      autoReloadEnabled: input.autoReload ?? false
+    });
+
+    vi.spyOn(container.resolve(DrainingDeploymentService), "findLeases").mockResolvedValue(
+      input.lease === "closed" ? [createDrainingDeployment({ dseq: Number(dseq), isClosed: true })] : []
+    );
+    vi.spyOn(container.resolve(WalletCreditsLowCheckHandler), "handle").mockResolvedValue();
+
+    const fundingKey = `fundDeployment.${wallet.id}.${dseq}`;
+
+    return {
+      findCreditsLowCheck: async () => (await findJobRows(WalletCreditsLowCheck[JOB_NAME], { singletonKey: `${WalletCreditsLowCheck.name}.${user.id}` }))[0],
+      dispatchFundDeployment: async () => {
+        await enqueue(new FundDeploymentCommand({ walletId: wallet.id, address, dseq }), { singletonKey: fundingKey });
+        await startWorkers();
+      },
+      awaitFundingRetrying: () =>
+        vi.waitFor(
+          async () => {
+            const [row] = await findJobRows(FundDeploymentCommand[JOB_NAME], { singletonKey: fundingKey });
+            expect(row?.state).toBe("retry");
+          },
+          { timeout: 20_000, interval: 250 }
+        ),
+      fundDeployment: async () => {
+        await enqueue(new FundDeploymentCommand({ walletId: wallet.id, address, dseq }), { singletonKey: fundingKey });
+        await startWorkers();
+        await expectJobCompleted(FundDeploymentCommand[JOB_NAME], { singletonKey: fundingKey });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.integration.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.integration.ts
@@ -1,0 +1,95 @@
+import "@src/app/providers/jobs.provider";
+
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { WalletCreditsLowCheckHandler } from "@src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler";
+import { JOB_NAME } from "@src/core";
+import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
+import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import { FundDrainingDeploymentsHandler } from "./fund-draining-deployments.handler";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const LATEST_BLOCK_PATH = "/cosmos/base/tendermint/v1beta1/blocks/latest";
+const CURRENT_HEIGHT = "28343549";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(FundDrainingDeploymentsHandler), container.resolve(WalletCreditsLowCheckHandler)]);
+
+describe(FundDrainingDeploymentsHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("still schedules the credits low check when the owner has nothing draining", async () => {
+    const { fundDraining, findCreditsLowCheck } = await setup();
+
+    await fundDraining();
+
+    expect(await findCreditsLowCheck()).toBeDefined();
+  });
+
+  it("still schedules the credits low check when the top up cannot run at all", async () => {
+    const { dispatchFundDraining, awaitFundingRetrying, findCreditsLowCheck } = await setup({ topUpUnavailable: true });
+
+    await dispatchFundDraining();
+    await awaitFundingRetrying();
+
+    expect(await findCreditsLowCheck()).toBeDefined();
+  });
+
+  it("schedules no credits low check for a wallet whose auto reload is on", async () => {
+    const { fundDraining, findCreditsLowCheck } = await setup({ autoReload: true });
+
+    await fundDraining();
+
+    expect(await findCreditsLowCheck()).toBeUndefined();
+  });
+
+  async function setup(input: { topUpUnavailable?: boolean; autoReload?: boolean } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const { user, wallet, address } = await seedUserWithWallet();
+
+    await seedWalletSetting({ userId: user.id, walletId: wallet.id, autoReloadEnabled: input.autoReload ?? false });
+
+    nock(container.resolve(CoreConfigService).get("REST_API_NODE_URL"))
+      .persist()
+      .get(LATEST_BLOCK_PATH)
+      .query(true)
+      .reply(200, { block_id: {}, block: { header: { height: CURRENT_HEIGHT, time: new Date().toISOString(), chain_id: "akashnet-2" } } });
+
+    const findDraining = vi.spyOn(container.resolve(DrainingDeploymentService), "findDrainingDeploymentsForOwner");
+    if (input.topUpUnavailable) findDraining.mockRejectedValue(new Error("indexer unavailable"));
+    else findDraining.mockResolvedValue([]);
+    vi.spyOn(container.resolve(WalletCreditsLowCheckHandler), "handle").mockResolvedValue();
+
+    const fundingKey = `fundDrainingDeployments.${wallet.id}`;
+
+    return {
+      findCreditsLowCheck: async () => (await findJobRows(WalletCreditsLowCheck[JOB_NAME], { singletonKey: `${WalletCreditsLowCheck.name}.${user.id}` }))[0],
+      dispatchFundDraining: async () => {
+        await enqueue(new FundDrainingDeploymentsCommand({ walletId: wallet.id, address }), { singletonKey: fundingKey });
+        await startWorkers();
+      },
+      awaitFundingRetrying: () =>
+        vi.waitFor(
+          async () => {
+            const [row] = await findJobRows(FundDrainingDeploymentsCommand[JOB_NAME], { singletonKey: fundingKey });
+            expect(row?.state).toBe("retry");
+          },
+          { timeout: 20_000, interval: 250 }
+        ),
+      fundDraining: async () => {
+        await enqueue(new FundDrainingDeploymentsCommand({ walletId: wallet.id, address }), { singletonKey: fundingKey });
+        await startWorkers();
+        await expectJobCompleted(FundDrainingDeploymentsCommand[JOB_NAME], { singletonKey: fundingKey });
+      }
+    };
+  }
+});

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
@@ -63,11 +63,11 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   });
 
   it("says nothing about a lease that is not the first", async () => {
-    const { leaseCreated, sentNotifications } = await setup({ isFirstLease: false });
+    const { leaseCreated, findCongratulationJobs } = await setup({ isFirstLease: false });
 
     await leaseCreated();
 
-    expect(sentNotifications()).toHaveLength(0);
+    expect(await findCongratulationJobs()).toHaveLength(0);
   });
 
   it("schedules nothing for a wallet that has left the trial", async () => {
@@ -126,6 +126,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
       findCloseJob: () => findJobBySingletonKey(CloseTrialDeployment[JOB_NAME], `closeTrialDeployment.${dseq}.${wallet.id}`),
       findWarningJob: () => findJobBySingletonKey(NotificationJob[JOB_NAME], `notification.beforeCloseTrialDeployment.${dseq}.${wallet.id}`),
       awaitCongratulations: () => expectJobCompleted(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
+      findCongratulationJobs: () => findJobRows(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
       leaseCreated: async () => {
         await enqueue(
           new TrialDeploymentLeaseCreated({

--- a/apps/api/src/billing/services/activate-trial/activate-trial.handler.integration.ts
+++ b/apps/api/src/billing/services/activate-trial/activate-trial.handler.integration.ts
@@ -1,0 +1,120 @@
+import "@src/app/providers/jobs.provider";
+
+import { eq } from "drizzle-orm";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { TrialStartedHandler } from "@src/app/services/trial-started/trial-started.handler";
+import { ActivateTrial } from "@src/billing/events/activate-trial";
+import { TrialStarted } from "@src/billing/events/trial-started";
+import { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+import { DOMAIN_EVENT_NAME } from "@src/core/services/domain-events/domain-events.service";
+import { ActivateTrialHandler } from "./activate-trial.handler";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { seedUser } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const DEPLOYMENT_LIMIT = 7_000_000;
+const FEE_LIMIT = 3_000_000;
+
+/** The allowance columns are numeric(20, 2), so what the chain granted comes back scaled. */
+const STORED_DEPLOYMENT_LIMIT = "7000000.00";
+const STORED_FEE_LIMIT = "3000000.00";
+
+const jobWorkers = useJobWorkers(() => [container.resolve(ActivateTrialHandler), container.resolve(TrialStartedHandler)]);
+
+describe(ActivateTrialHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("activates the wallet with the trial limits the chain granted", async () => {
+    const { activateTrial, findWallet } = await setup();
+
+    await activateTrial();
+
+    expect(await findWallet()).toMatchObject({
+      activatedAt: expect.any(Date),
+      deploymentAllowance: STORED_DEPLOYMENT_LIMIT,
+      feeAllowance: STORED_FEE_LIMIT
+    });
+  });
+
+  it("announces the started trial so its email sequence gets scheduled", async () => {
+    const { userId, activateTrial, findTrialStartedEvents } = await setup();
+
+    await activateTrial();
+
+    expect(await findTrialStartedEvents()).toHaveLength(1);
+    expect((await findTrialStartedEvents())[0].data).toMatchObject({ userId });
+  });
+
+  it("announces nothing the second time for a wallet already activated", async () => {
+    const { activateTrial, findTrialStartedEvents } = await setup();
+
+    await activateTrial();
+    await activateTrial({ again: true });
+
+    expect(await findTrialStartedEvents()).toHaveLength(1);
+  });
+
+  it("activates nothing for a user whose email is not verified", async () => {
+    const { dispatchActivateTrial, awaitActivationRetrying, findWallet, findTrialStartedEvents } = await setup({ emailVerified: false });
+
+    await dispatchActivateTrial();
+    await awaitActivationRetrying();
+
+    expect(await findWallet()).toBeUndefined();
+    expect(await findTrialStartedEvents()).toHaveLength(0);
+  });
+
+  async function setup(input: { emailVerified?: boolean } = {}) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const userWalletsTable = resolveTable("UserWallets");
+
+    const user = await seedUser({ email: "trial@example.com", emailVerified: input.emailVerified ?? true });
+    const address = createAkashAddress();
+
+    const walletManager = container.resolve(ManagedUserWalletService);
+    vi.spyOn(walletManager, "createWallet").mockResolvedValue({ address });
+    vi.spyOn(walletManager, "createAndAuthorizeTrialSpending").mockResolvedValue({
+      address,
+      limits: { deployment: DEPLOYMENT_LIMIT, fees: FEE_LIMIT }
+    });
+    vi.spyOn(container.resolve(TrialStartedHandler), "handle").mockResolvedValue();
+
+    const activationKey = `activateTrial.${user.id}`;
+
+    return {
+      userId: user.id,
+      findWallet: async () => {
+        const [row] = await db.select().from(userWalletsTable).where(eq(userWalletsTable.userId, user.id));
+
+        return row;
+      },
+      findTrialStartedEvents: () => findJobRows<{ userId: string }>(TrialStarted[DOMAIN_EVENT_NAME], { data: { userId: user.id } }),
+      dispatchActivateTrial: async () => {
+        await enqueue(new ActivateTrial({ userId: user.id }), { singletonKey: activationKey });
+        await startWorkers();
+      },
+      awaitActivationRetrying: () =>
+        vi.waitFor(
+          async () => {
+            const [row] = await findJobRows(ActivateTrial[JOB_NAME], { singletonKey: activationKey });
+            expect(row?.state).toBe("retry");
+          },
+          { timeout: 20_000, interval: 250 }
+        ),
+      activateTrial: async (options: { again?: boolean } = {}) => {
+        const key = options.again ? `${activationKey}.again` : activationKey;
+        await enqueue(new ActivateTrial({ userId: user.id }), { singletonKey: key });
+        await startWorkers();
+        await expectJobCompleted(ActivateTrial[JOB_NAME], { singletonKey: key });
+      }
+    };
+  }
+});

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.integration.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.integration.ts
@@ -1,0 +1,132 @@
+import "@src/app/providers/jobs.provider";
+
+import { faker } from "@faker-js/faker";
+import { eq } from "drizzle-orm";
+import type Stripe from "stripe";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
+import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import { WalletBalanceReloadCheckHandler } from "@src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+
+const STRIPE_CUSTOMER_ID = "cus_test_reload";
+const THRESHOLD_CENTS = 2_000;
+const RELOAD_AMOUNT_CENTS = 5_000;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(WalletBalanceReloadCheckHandler)]);
+
+describe(WalletBalanceReloadCheckHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("charges the default payment method once the balance falls below the threshold", async () => {
+    const { checkBalance, createPaymentIntent, findWalletSetting, paymentMethodId } = await setup({ balanceUsd: 1 });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_method: paymentMethodId, customer: STRIPE_CUSTOMER_ID, confirm: true, offSession: true })
+    );
+    expect((await findWalletSetting()).lastAutoChargeAt).toBeInstanceOf(Date);
+  });
+
+  it("charges nothing while the balance still covers the threshold", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 100 });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing for a wallet paused after repeated declines", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, autoReloadPausedAt: new Date() });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing a second time inside the cooldown the first charge claimed", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, lastAutoChargeAt: new Date() });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing for a wallet whose auto reload is off", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, autoReloadEnabled: false });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  async function setup(input: { balanceUsd: number; autoReloadEnabled?: boolean; autoReloadPausedAt?: Date; lastAutoChargeAt?: Date }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const walletSettingTable = resolveTable("WalletSetting");
+
+    const { user, wallet } = await seedUserWithWallet({
+      isTrialing: false,
+      activatedAt: new Date(),
+      user: { email: "reload@example.com", stripeCustomerId: STRIPE_CUSTOMER_ID }
+    });
+
+    const walletSetting = await seedWalletSetting({
+      userId: user.id,
+      walletId: wallet.id,
+      autoReloadEnabled: input.autoReloadEnabled ?? true,
+      autoReloadMode: "threshold",
+      autoReloadThreshold: THRESHOLD_CENTS,
+      autoReloadAmount: RELOAD_AMOUNT_CENTS,
+      autoReloadPausedAt: input.autoReloadPausedAt ?? null,
+      lastAutoChargeAt: input.lastAutoChargeAt ?? null
+    });
+
+    const paymentMethodId = `pm_${faker.string.alphanumeric(12)}`;
+    await db.insert(resolveTable("PaymentMethods")).values({
+      userId: user.id,
+      paymentMethodId,
+      fingerprint: `fp_${faker.string.alphanumeric(12)}`,
+      isDefault: true,
+      isValidated: true
+    });
+
+    vi.spyOn(container.resolve<Stripe>(STRIPE_CLIENT).paymentMethods, "retrieve").mockResolvedValue(
+      mock<Stripe.Response<Stripe.PaymentMethod>>({ id: paymentMethodId, customer: STRIPE_CUSTOMER_ID })
+    );
+    vi.spyOn(container.resolve(BalancesService), "getDeploymentBalanceInFiat").mockResolvedValue(input.balanceUsd);
+    const createPaymentIntent = vi
+      .spyOn(container.resolve(StripeTransactionService), "createPaymentIntent")
+      .mockResolvedValue({ success: true, transactionId: "tx_test", paymentIntentId: "pi_test", transactionStatus: "succeeded" });
+
+    const checkKey = `${WalletBalanceReloadCheck.name}.${user.id}`;
+
+    return {
+      paymentMethodId,
+      createPaymentIntent,
+      findWalletSetting: async () => {
+        const [row] = await db.select().from(walletSettingTable).where(eq(walletSettingTable.id, walletSetting.id));
+
+        return row;
+      },
+      checkBalance: async () => {
+        await enqueue(new WalletBalanceReloadCheck({ userId: user.id, triggeredByDeployment: true }), { singletonKey: checkKey });
+        await startWorkers();
+        await expectJobCompleted(WalletBalanceReloadCheck[JOB_NAME], { singletonKey: checkKey, state: "completed" });
+      }
+    };
+  }
+});

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.integration.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.integration.ts
@@ -1,0 +1,191 @@
+import "@src/app/providers/jobs.provider";
+
+import { subMinutes } from "date-fns";
+import { eq } from "drizzle-orm";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { WalletCreditsLowCheckHandler } from "@src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+import { interceptNotifications } from "@test/services/notifications-intercept";
+
+/** Longer than CREDITS_LOW_CONFIRM_WINDOW_MIN, so a streak stamped this long ago counts as confirmed. */
+const PAST_THE_CONFIRM_WINDOW_IN_MIN = 45;
+
+/** Longer than CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN, so a recovery stamped this long ago counts as held. */
+const PAST_THE_RECOVERY_WINDOW_IN_MIN = 24 * 60 * 3;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(WalletCreditsLowCheckHandler)]);
+
+describe(WalletCreditsLowCheckHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("opens the low window on a first low reading without emailing", async () => {
+    const { checkCredits, findWallet, sentNotifications } = await setup({ balanceUsd: 1, weeklyCostUsd: 20 });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowSince: expect.any(Date), creditsLowNotifiedAt: null });
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  it("stays quiet while the low reading is still inside the confirm window", async () => {
+    const { checkCredits, sentNotifications } = await setup({ balanceUsd: 1, weeklyCostUsd: 20, creditsLowSince: new Date() });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  it("emails once the low streak has held past the confirm window", async () => {
+    const { checkCredits, findWallet, sentNotifications } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN)
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(1);
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: expect.any(Date), creditsLowSince: null, creditsSufficientSince: null });
+  });
+
+  it("emails nothing a second time for a wallet already notified, and ends its recovery streak", async () => {
+    const { checkCredits, findWallet, sentNotifications } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN),
+      creditsLowNotifiedAt: new Date(),
+      creditsSufficientSince: subMinutes(new Date(), 5)
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+    expect(await findWallet()).toMatchObject({ creditsSufficientSince: null });
+  });
+
+  it("emails nothing for a wallet whose auto reload is on", async () => {
+    const { checkCredits, sentNotifications, findWallet } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN),
+      autoReload: true
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null });
+  });
+
+  it("clears the notice at once when there is nothing left to top up", async () => {
+    const { checkCredits, findWallet } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 0,
+      hasAutoTopUpSettings: false,
+      creditsLowNotifiedAt: new Date()
+    });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null });
+  });
+
+  it("opens the recovery window on a balance that covers the week again", async () => {
+    const { checkCredits, findWallet } = await setup({ balanceUsd: 50, weeklyCostUsd: 20, creditsLowNotifiedAt: new Date() });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsSufficientSince: expect.any(Date), creditsLowNotifiedAt: expect.any(Date) });
+  });
+
+  it("clears the notice once the recovery has held past its window", async () => {
+    const { checkCredits, findWallet } = await setup({
+      balanceUsd: 50,
+      weeklyCostUsd: 20,
+      creditsLowNotifiedAt: new Date(),
+      creditsSufficientSince: subMinutes(new Date(), PAST_THE_RECOVERY_WINDOW_IN_MIN)
+    });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null });
+  });
+
+  it("emails nothing for a wallet still on trial", async () => {
+    const { checkCredits, sentNotifications } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN),
+      isTrialing: true
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  async function setup(input: {
+    balanceUsd: number;
+    weeklyCostUsd: number;
+    creditsLowSince?: Date;
+    creditsLowNotifiedAt?: Date;
+    creditsSufficientSince?: Date;
+    autoReload?: boolean;
+    isTrialing?: boolean;
+    hasAutoTopUpSettings?: boolean;
+  }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const userWalletsTable = resolveTable("UserWallets");
+
+    const { user, wallet, address } = await seedUserWithWallet({
+      isTrialing: input.isTrialing ?? false,
+      activatedAt: new Date(),
+      creditsLowSince: input.creditsLowSince ?? null,
+      creditsLowNotifiedAt: input.creditsLowNotifiedAt ?? null,
+      creditsSufficientSince: input.creditsSufficientSince ?? null,
+      user: { email: "credits-low@example.com" }
+    });
+
+    await seedWalletSetting({ userId: user.id, walletId: wallet.id, autoReloadEnabled: input.autoReload ?? false });
+
+    vi.spyOn(container.resolve(BalancesService), "getDeploymentBalanceInFiat").mockResolvedValue(input.balanceUsd);
+    vi.spyOn(container.resolve(DrainingDeploymentService), "calculateWeeklyCoverageForAddress").mockResolvedValue({
+      weeklyCostUsd: input.weeklyCostUsd,
+      cumulativeDailyCostsUsd: [1, 5, 10, 15, 20, 25, 30],
+      hasAutoTopUpSettings: input.hasAutoTopUpSettings ?? true
+    });
+
+    const sentNotifications = interceptNotifications();
+    const checkKey = `${WalletCreditsLowCheck.name}.${user.id}`;
+
+    return {
+      address,
+      sentNotifications,
+      findWallet: async () => {
+        const [row] = await db.select().from(userWalletsTable).where(eq(userWalletsTable.id, wallet.id));
+
+        return row;
+      },
+      checkCredits: async () => {
+        await enqueue(new WalletCreditsLowCheck({ userId: user.id }), { singletonKey: checkKey });
+        await startWorkers();
+        await expectJobCompleted(WalletCreditsLowCheck[JOB_NAME], { singletonKey: checkKey });
+      }
+    };
+  }
+});

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.integration.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.integration.ts
@@ -1,0 +1,122 @@
+import "@src/app/providers/jobs.provider";
+
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { JOB_NAME } from "@src/core";
+import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { type ProbeReport, TrialWorkloadProbeService } from "@src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service";
+import { ProbeTrialDeployment, probeTrialDeploymentKeyFor } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { ProbeTrialDeploymentHandler } from "./probe-trial-deployment.handler";
+
+import { createDseq } from "@test/seeders/db/deployment-setting.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { expectJobCompleted, findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const MAX_ATTEMPTS = 30;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(ProbeTrialDeploymentHandler)]);
+
+describe(ProbeTrialDeploymentHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("records a detection for a workload the probe judges abusive", async () => {
+    const { dseq, probeDeployment, findDetections } = await setup({ verdict: "hard" });
+
+    await probeDeployment();
+
+    expect(await findDetections()).toMatchObject([{ dseq, verdict: "hard", probeStatus: "probed" }]);
+  });
+
+  it("stops probing once the verdict is hard", async () => {
+    const { probeDeployment, findNextProbe } = await setup({ verdict: "hard" });
+
+    await probeDeployment();
+
+    expect(await findNextProbe()).toBeUndefined();
+  });
+
+  it("probes again for a workload that still looks clean", async () => {
+    const { probeDeployment, findNextProbe } = await setup({ verdict: "clean" });
+
+    await probeDeployment();
+
+    expect((await findNextProbe())?.data).toMatchObject({ attempt: 2 });
+  });
+
+  it("stops probing at the attempt cap", async () => {
+    const { probeDeployment, findNextProbe } = await setup({ verdict: "clean", attempt: MAX_ATTEMPTS });
+
+    await probeDeployment();
+
+    expect(await findNextProbe()).toBeUndefined();
+  });
+
+  it("probes nothing for a wallet that has left the trial", async () => {
+    const { probeDeployment, findDetections, probe } = await setup({ verdict: "hard", isTrialing: false });
+
+    await probeDeployment();
+
+    expect(probe).not.toHaveBeenCalled();
+    expect(await findDetections()).toHaveLength(0);
+  });
+
+  it("records nothing more for a deployment already judged abusive", async () => {
+    const { probeDeployment, findDetections, probe, seedExistingDetection } = await setup({ verdict: "hard" });
+    await seedExistingDetection();
+
+    await probeDeployment();
+
+    expect(probe).not.toHaveBeenCalled();
+    expect(await findDetections()).toHaveLength(1);
+  });
+
+  async function setup(input: { verdict: ProbeReport["verdict"]; attempt?: number; isTrialing?: boolean }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const detectionRepository = container.resolve(WorkloadAbuseDetectionRepository);
+    const { user, wallet, address } = await seedUserWithWallet({ isTrialing: input.isTrialing ?? true });
+    const dseq = createDseq();
+
+    const config = container.resolve(WorkloadAbuseConfigService);
+    const readConfig = config.get.bind(config);
+    vi.spyOn(config, "get").mockImplementation((key => (key === "WORKLOAD_ABUSE_PROBE_ENABLED" ? true : readConfig(key))) as typeof config.get);
+
+    const probe = vi.spyOn(container.resolve(TrialWorkloadProbeService), "probe").mockResolvedValue({
+      verdict: input.verdict,
+      probeStatus: "probed",
+      signals: [],
+      excerpt: "denied",
+      leases: []
+    });
+
+    const probeKey = probeTrialDeploymentKeyFor({ walletId: wallet.id, dseq });
+
+    return {
+      dseq,
+      probe,
+      findDetections: () => detectionRepository.find({ walletId: wallet.id, dseq }),
+      seedExistingDetection: () =>
+        detectionRepository.create({
+          userId: user.id,
+          walletId: wallet.id,
+          dseq,
+          provider: address,
+          verdict: "hard",
+          probeStatus: "probed",
+          signals: [],
+          evidenceExcerpt: "denied"
+        }),
+      findNextProbe: async () => (await findJobRows<{ attempt: number }>(ProbeTrialDeployment[JOB_NAME], { singletonKey: probeKey, state: "created" }))[0],
+      probeDeployment: async () => {
+        await enqueue(new ProbeTrialDeployment({ walletId: wallet.id, dseq, attempt: input.attempt ?? 1, leaseCreatedAt: new Date().toISOString() }), {
+          singletonKey: probeKey
+        });
+        await startWorkers();
+        await expectJobCompleted(ProbeTrialDeployment[JOB_NAME], { singletonKey: probeKey, state: "completed" });
+      }
+    };
+  }
+});

--- a/apps/api/test/seeders/db/wallet-setting.seeder.ts
+++ b/apps/api/test/seeders/db/wallet-setting.seeder.ts
@@ -1,0 +1,13 @@
+import { container } from "tsyringe";
+
+import type { ApiPgDatabase, ApiPgTables } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+
+type WalletSettingInsert = ApiPgTables["WalletSetting"]["$inferInsert"];
+
+export async function seedWalletSetting(overrides: Partial<WalletSettingInsert> & Pick<WalletSettingInsert, "userId" | "walletId">) {
+  const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+  const [setting] = await db.insert(resolveTable("WalletSetting")).values(overrides).returning();
+
+  return setting;
+}


### PR DESCRIPTION
## Why

Part of CON-952. **Stacked** — base is `test/deployment-unreachable-close-on-harness` (#3854).

I had this one down as not worth covering — a 32-line pass-through to `NotificationService`, no table touched, so neither failure mode could reach it. **That was wrong.** The service behind it does the work:

```ts
const user = await this.userRepository.findById(input.userId);
if (!user?.email) return;
```

An unscoped user read and a silent skip, both of which the worker's empty ability and a real row decide. The handler is thin; what it delegates to is not.

## What

Runs the command through a real worker and asserts the requests that reach the notifications API:

- an owner with an existing channel gets the closed alert upserted on it, with the right `x-user-id` and `x-owner-address` headers
- an owner with no channel gets one created first, then the alert
- a user with no email gets nothing at all

Verified by mutation — dropping the `user?.email` skip fails `enables nothing for a user with no email to notify`.

### Verification

Stacked, so no CI and no CodeRabbit — local only:

- `npm run test:integration` for this file — 3 tests pass
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 42 errors, matching the `main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
