### PR TITLE
test(billing): cover the credits low latch and its email

### DIFF
--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
@@ -31,6 +31,8 @@ describe("recharge and bonus notices", () => {
 
       await rechargeSucceeded({ amountCents: 2500 });
 
+      expect(sentNotifications()).toHaveLength(1);
+
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);
       expect(sent.body).toMatchObject({
@@ -64,6 +66,8 @@ describe("recharge and bonus notices", () => {
       const { userId, bonusGranted, sentNotifications } = await setup();
 
       await bonusGranted({ bonusAmountCents: 1000, paidAmountCents: 5000 });
+
+      expect(sentNotifications()).toHaveLength(1);
 
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
@@ -25,10 +25,11 @@ describe(EnableDeploymentAlertHandler.name, () => {
   });
 
   it("enables the closed alert on the owner's existing channel", async () => {
-    const { userId, walletAddress, dseq, enableAlert, upsertedAlerts } = await setup();
+    const { userId, walletAddress, dseq, enableAlert, createdChannels, upsertedAlerts } = await setup();
 
     await enableAlert();
 
+    expect(createdChannels()).toHaveLength(0);
     expect(upsertedAlerts()).toEqual([
       {
         dseq,

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
@@ -63,11 +63,11 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   });
 
   it("says nothing about a lease that is not the first", async () => {
-    const { leaseCreated, sentNotifications } = await setup({ isFirstLease: false });
+    const { leaseCreated, findCongratulationJobs } = await setup({ isFirstLease: false });
 
     await leaseCreated();
 
-    expect(sentNotifications()).toHaveLength(0);
+    expect(await findCongratulationJobs()).toHaveLength(0);
   });
 
   it("schedules nothing for a wallet that has left the trial", async () => {
@@ -126,6 +126,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
       findCloseJob: () => findJobBySingletonKey(CloseTrialDeployment[JOB_NAME], `closeTrialDeployment.${dseq}.${wallet.id}`),
       findWarningJob: () => findJobBySingletonKey(NotificationJob[JOB_NAME], `notification.beforeCloseTrialDeployment.${dseq}.${wallet.id}`),
       awaitCongratulations: () => expectJobCompleted(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
+      findCongratulationJobs: () => findJobRows(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
       leaseCreated: async () => {
         await enqueue(
           new TrialDeploymentLeaseCreated({

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.integration.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.integration.ts
@@ -1,0 +1,132 @@
+import "@src/app/providers/jobs.provider";
+
+import { faker } from "@faker-js/faker";
+import { eq } from "drizzle-orm";
+import type Stripe from "stripe";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
+import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import { WalletBalanceReloadCheckHandler } from "@src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+
+const STRIPE_CUSTOMER_ID = "cus_test_reload";
+const THRESHOLD_CENTS = 2_000;
+const RELOAD_AMOUNT_CENTS = 5_000;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(WalletBalanceReloadCheckHandler)]);
+
+describe(WalletBalanceReloadCheckHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("charges the default payment method once the balance falls below the threshold", async () => {
+    const { checkBalance, createPaymentIntent, findWalletSetting, paymentMethodId } = await setup({ balanceUsd: 1 });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_method: paymentMethodId, customer: STRIPE_CUSTOMER_ID, confirm: true, offSession: true })
+    );
+    expect((await findWalletSetting()).lastAutoChargeAt).toBeInstanceOf(Date);
+  });
+
+  it("charges nothing while the balance still covers the threshold", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 100 });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing for a wallet paused after repeated declines", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, autoReloadPausedAt: new Date() });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing a second time inside the cooldown the first charge claimed", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, lastAutoChargeAt: new Date() });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing for a wallet whose auto reload is off", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, autoReloadEnabled: false });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  async function setup(input: { balanceUsd: number; autoReloadEnabled?: boolean; autoReloadPausedAt?: Date; lastAutoChargeAt?: Date }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const walletSettingTable = resolveTable("WalletSetting");
+
+    const { user, wallet } = await seedUserWithWallet({
+      isTrialing: false,
+      activatedAt: new Date(),
+      user: { email: "reload@example.com", stripeCustomerId: STRIPE_CUSTOMER_ID }
+    });
+
+    const walletSetting = await seedWalletSetting({
+      userId: user.id,
+      walletId: wallet.id,
+      autoReloadEnabled: input.autoReloadEnabled ?? true,
+      autoReloadMode: "threshold",
+      autoReloadThreshold: THRESHOLD_CENTS,
+      autoReloadAmount: RELOAD_AMOUNT_CENTS,
+      autoReloadPausedAt: input.autoReloadPausedAt ?? null,
+      lastAutoChargeAt: input.lastAutoChargeAt ?? null
+    });
+
+    const paymentMethodId = `pm_${faker.string.alphanumeric(12)}`;
+    await db.insert(resolveTable("PaymentMethods")).values({
+      userId: user.id,
+      paymentMethodId,
+      fingerprint: `fp_${faker.string.alphanumeric(12)}`,
+      isDefault: true,
+      isValidated: true
+    });
+
+    vi.spyOn(container.resolve<Stripe>(STRIPE_CLIENT).paymentMethods, "retrieve").mockResolvedValue(
+      mock<Stripe.Response<Stripe.PaymentMethod>>({ id: paymentMethodId, customer: STRIPE_CUSTOMER_ID })
+    );
+    vi.spyOn(container.resolve(BalancesService), "getDeploymentBalanceInFiat").mockResolvedValue(input.balanceUsd);
+    const createPaymentIntent = vi
+      .spyOn(container.resolve(StripeTransactionService), "createPaymentIntent")
+      .mockResolvedValue({ success: true, transactionId: "tx_test", paymentIntentId: "pi_test", transactionStatus: "succeeded" });
+
+    const checkKey = `${WalletBalanceReloadCheck.name}.${user.id}`;
+
+    return {
+      paymentMethodId,
+      createPaymentIntent,
+      findWalletSetting: async () => {
+        const [row] = await db.select().from(walletSettingTable).where(eq(walletSettingTable.id, walletSetting.id));
+
+        return row;
+      },
+      checkBalance: async () => {
+        await enqueue(new WalletBalanceReloadCheck({ userId: user.id, triggeredByDeployment: true }), { singletonKey: checkKey });
+        await startWorkers();
+        await expectJobCompleted(WalletBalanceReloadCheck[JOB_NAME], { singletonKey: checkKey, state: "completed" });
+      }
+    };
+  }
+});

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.integration.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.integration.ts
@@ -1,0 +1,191 @@
+import "@src/app/providers/jobs.provider";
+
+import { subMinutes } from "date-fns";
+import { eq } from "drizzle-orm";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WalletCreditsLowCheck } from "@src/billing/events/wallet-credits-low-check";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { WalletCreditsLowCheckHandler } from "@src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+import { interceptNotifications } from "@test/services/notifications-intercept";
+
+/** Longer than CREDITS_LOW_CONFIRM_WINDOW_MIN, so a streak stamped this long ago counts as confirmed. */
+const PAST_THE_CONFIRM_WINDOW_IN_MIN = 45;
+
+/** Longer than CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN, so a recovery stamped this long ago counts as held. */
+const PAST_THE_RECOVERY_WINDOW_IN_MIN = 24 * 60 * 3;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(WalletCreditsLowCheckHandler)]);
+
+describe(WalletCreditsLowCheckHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("opens the low window on a first low reading without emailing", async () => {
+    const { checkCredits, findWallet, sentNotifications } = await setup({ balanceUsd: 1, weeklyCostUsd: 20 });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowSince: expect.any(Date), creditsLowNotifiedAt: null });
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  it("stays quiet while the low reading is still inside the confirm window", async () => {
+    const { checkCredits, sentNotifications } = await setup({ balanceUsd: 1, weeklyCostUsd: 20, creditsLowSince: new Date() });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  it("emails once the low streak has held past the confirm window", async () => {
+    const { checkCredits, findWallet, sentNotifications } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN)
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(1);
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: expect.any(Date), creditsLowSince: null, creditsSufficientSince: null });
+  });
+
+  it("emails nothing a second time for a wallet already notified, and ends its recovery streak", async () => {
+    const { checkCredits, findWallet, sentNotifications } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN),
+      creditsLowNotifiedAt: new Date(),
+      creditsSufficientSince: subMinutes(new Date(), 5)
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+    expect(await findWallet()).toMatchObject({ creditsSufficientSince: null });
+  });
+
+  it("emails nothing for a wallet whose auto reload is on", async () => {
+    const { checkCredits, sentNotifications, findWallet } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN),
+      autoReload: true
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null });
+  });
+
+  it("clears the notice at once when there is nothing left to top up", async () => {
+    const { checkCredits, findWallet } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 0,
+      hasAutoTopUpSettings: false,
+      creditsLowNotifiedAt: new Date()
+    });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null });
+  });
+
+  it("opens the recovery window on a balance that covers the week again", async () => {
+    const { checkCredits, findWallet } = await setup({ balanceUsd: 50, weeklyCostUsd: 20, creditsLowNotifiedAt: new Date() });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsSufficientSince: expect.any(Date), creditsLowNotifiedAt: expect.any(Date) });
+  });
+
+  it("clears the notice once the recovery has held past its window", async () => {
+    const { checkCredits, findWallet } = await setup({
+      balanceUsd: 50,
+      weeklyCostUsd: 20,
+      creditsLowNotifiedAt: new Date(),
+      creditsSufficientSince: subMinutes(new Date(), PAST_THE_RECOVERY_WINDOW_IN_MIN)
+    });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null });
+  });
+
+  it("emails nothing for a wallet still on trial", async () => {
+    const { checkCredits, sentNotifications } = await setup({
+      balanceUsd: 1,
+      weeklyCostUsd: 20,
+      creditsLowSince: subMinutes(new Date(), PAST_THE_CONFIRM_WINDOW_IN_MIN),
+      isTrialing: true
+    });
+
+    await checkCredits();
+
+    expect(sentNotifications()).toHaveLength(0);
+  });
+
+  async function setup(input: {
+    balanceUsd: number;
+    weeklyCostUsd: number;
+    creditsLowSince?: Date;
+    creditsLowNotifiedAt?: Date;
+    creditsSufficientSince?: Date;
+    autoReload?: boolean;
+    isTrialing?: boolean;
+    hasAutoTopUpSettings?: boolean;
+  }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const userWalletsTable = resolveTable("UserWallets");
+
+    const { user, wallet, address } = await seedUserWithWallet({
+      isTrialing: input.isTrialing ?? false,
+      activatedAt: new Date(),
+      creditsLowSince: input.creditsLowSince ?? null,
+      creditsLowNotifiedAt: input.creditsLowNotifiedAt ?? null,
+      creditsSufficientSince: input.creditsSufficientSince ?? null,
+      user: { email: "credits-low@example.com" }
+    });
+
+    await seedWalletSetting({ userId: user.id, walletId: wallet.id, autoReloadEnabled: input.autoReload ?? false });
+
+    vi.spyOn(container.resolve(BalancesService), "getDeploymentBalanceInFiat").mockResolvedValue(input.balanceUsd);
+    vi.spyOn(container.resolve(DrainingDeploymentService), "calculateWeeklyCoverageForAddress").mockResolvedValue({
+      weeklyCostUsd: input.weeklyCostUsd,
+      cumulativeDailyCostsUsd: [1, 5, 10, 15, 20, 25, 30],
+      hasAutoTopUpSettings: input.hasAutoTopUpSettings ?? true
+    });
+
+    const sentNotifications = interceptNotifications();
+    const checkKey = `${WalletCreditsLowCheck.name}.${user.id}`;
+
+    return {
+      address,
+      sentNotifications,
+      findWallet: async () => {
+        const [row] = await db.select().from(userWalletsTable).where(eq(userWalletsTable.id, wallet.id));
+
+        return row;
+      },
+      checkCredits: async () => {
+        await enqueue(new WalletCreditsLowCheck({ userId: user.id }), { singletonKey: checkKey });
+        await startWorkers();
+        await expectJobCompleted(WalletCreditsLowCheck[JOB_NAME], { singletonKey: checkKey });
+      }
+    };
+  }
+});


### PR DESCRIPTION
## Why

Part of CON-952. **Stacked** — base is `test/network-probe-trial-deployment-worker` (#3860).

`WalletCreditsLowCheckHandler` is a latch written across three `user_wallets` columns — `creditsLowSince`, `creditsLowNotifiedAt`, `creditsSufficientSince` — and read back by two SQL window queries (`isCreditsLowConfirmed`, `clearCreditsLowNotifiedIfRecoveryConfirmed`). Its own comment states why the latch exists:

> Mirrors the recovery latch on the sending side: a lone low reading only opens the window, so one misread cannot send an email by itself.

A mocked repository stubs those queries to a boolean — i.e. it supplies the very verdict the handler exists to compute. Both failure directions matter: a broken latch either spams "your credits are low" on every misread, or never sends it at all.

## What

Nine cases through a real worker against real rows, covering **both** directions rather than only the sending side:

- a first low reading opens the window and emails nothing
- a reading still inside the confirm window stays quiet
- a streak held past the window emails once and stamps `creditsLowNotifiedAt`, clearing both streak columns
- an already-notified wallet emails nothing and has its recovery streak ended
- auto reload on, or still trialing → nothing
- nothing left to top up → the notice clears at once
- a balance that covers the week again opens the recovery window, keeping the notice
- a recovery held past its window clears the notice

Verified by mutation:

| Mutation | Failing test |
|---|---|
| drop the low-streak confirmation | `opens the low window…` and `stays quiet while…` |
| drop the already-notified guard | `emails nothing a second time…` |
| drop the immediate unlatch | `clears the notice at once when there is nothing left to top up` |

### One test I had to strengthen

`emails nothing a second time for a wallet already notified` initially passed **with the guard removed** — because `isCreditsLowConfirmed`'s SQL also requires `creditsLowNotifiedAt IS NULL`, so the outcome is doubly defended and the assertion could not tell the difference. I extended it to assert the guard's own side effect (`#endRecoveryStreak` clearing `creditsSufficientSince`), and it now fails when the guard goes.

Worth stating plainly: a green mutation run is the only thing that distinguishes a test with teeth from one that merely agrees with the code.

### Deviation from the plan

The estimate for this issue wanted this split into two PRs (low-streak, then recovery). Both halves came to nine tests in ~200 lines, and splitting a single latch across two PRs would have meant reviewing half a state machine — so it is one PR, still `size: S`.

### Verification

Stacked, so no CI and no CodeRabbit — local only:

- `npm run test:integration` for this file — 9 tests pass
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 42 errors, matching the `main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
