### PR TITLE
test(billing): cover the auto reload charge and its rate limit

### DIFF
--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
@@ -31,6 +31,8 @@ describe("recharge and bonus notices", () => {
 
       await rechargeSucceeded({ amountCents: 2500 });
 
+      expect(sentNotifications()).toHaveLength(1);
+
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);
       expect(sent.body).toMatchObject({
@@ -64,6 +66,8 @@ describe("recharge and bonus notices", () => {
       const { userId, bonusGranted, sentNotifications } = await setup();
 
       await bonusGranted({ bonusAmountCents: 1000, paidAmountCents: 5000 });
+
+      expect(sentNotifications()).toHaveLength(1);
 
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
@@ -25,10 +25,11 @@ describe(EnableDeploymentAlertHandler.name, () => {
   });
 
   it("enables the closed alert on the owner's existing channel", async () => {
-    const { userId, walletAddress, dseq, enableAlert, upsertedAlerts } = await setup();
+    const { userId, walletAddress, dseq, enableAlert, createdChannels, upsertedAlerts } = await setup();
 
     await enableAlert();
 
+    expect(createdChannels()).toHaveLength(0);
     expect(upsertedAlerts()).toEqual([
       {
         dseq,

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
@@ -63,11 +63,11 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   });
 
   it("says nothing about a lease that is not the first", async () => {
-    const { leaseCreated, sentNotifications } = await setup({ isFirstLease: false });
+    const { leaseCreated, findCongratulationJobs } = await setup({ isFirstLease: false });
 
     await leaseCreated();
 
-    expect(sentNotifications()).toHaveLength(0);
+    expect(await findCongratulationJobs()).toHaveLength(0);
   });
 
   it("schedules nothing for a wallet that has left the trial", async () => {
@@ -126,6 +126,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
       findCloseJob: () => findJobBySingletonKey(CloseTrialDeployment[JOB_NAME], `closeTrialDeployment.${dseq}.${wallet.id}`),
       findWarningJob: () => findJobBySingletonKey(NotificationJob[JOB_NAME], `notification.beforeCloseTrialDeployment.${dseq}.${wallet.id}`),
       awaitCongratulations: () => expectJobCompleted(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
+      findCongratulationJobs: () => findJobRows(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
       leaseCreated: async () => {
         await enqueue(
           new TrialDeploymentLeaseCreated({

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.integration.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.integration.ts
@@ -1,0 +1,132 @@
+import "@src/app/providers/jobs.provider";
+
+import { faker } from "@faker-js/faker";
+import { eq } from "drizzle-orm";
+import type Stripe from "stripe";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
+import { STRIPE_CLIENT } from "@src/billing/providers/stripe-client.provider";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
+import { WalletBalanceReloadCheckHandler } from "@src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler";
+import type { ApiPgDatabase } from "@src/core";
+import { JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
+
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { seedWalletSetting } from "@test/seeders/db/wallet-setting.seeder";
+import { expectJobCompleted, useJobWorkers } from "@test/services/job-queue-harness";
+
+const STRIPE_CUSTOMER_ID = "cus_test_reload";
+const THRESHOLD_CENTS = 2_000;
+const RELOAD_AMOUNT_CENTS = 5_000;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(WalletBalanceReloadCheckHandler)]);
+
+describe(WalletBalanceReloadCheckHandler.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("charges the default payment method once the balance falls below the threshold", async () => {
+    const { checkBalance, createPaymentIntent, findWalletSetting, paymentMethodId } = await setup({ balanceUsd: 1 });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).toHaveBeenCalledWith(
+      expect.objectContaining({ payment_method: paymentMethodId, customer: STRIPE_CUSTOMER_ID, confirm: true, offSession: true })
+    );
+    expect((await findWalletSetting()).lastAutoChargeAt).toBeInstanceOf(Date);
+  });
+
+  it("charges nothing while the balance still covers the threshold", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 100 });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing for a wallet paused after repeated declines", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, autoReloadPausedAt: new Date() });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing a second time inside the cooldown the first charge claimed", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, lastAutoChargeAt: new Date() });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  it("charges nothing for a wallet whose auto reload is off", async () => {
+    const { checkBalance, createPaymentIntent } = await setup({ balanceUsd: 1, autoReloadEnabled: false });
+
+    await checkBalance();
+
+    expect(createPaymentIntent).not.toHaveBeenCalled();
+  });
+
+  async function setup(input: { balanceUsd: number; autoReloadEnabled?: boolean; autoReloadPausedAt?: Date; lastAutoChargeAt?: Date }) {
+    const { enqueue, startWorkers } = await jobWorkers();
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const walletSettingTable = resolveTable("WalletSetting");
+
+    const { user, wallet } = await seedUserWithWallet({
+      isTrialing: false,
+      activatedAt: new Date(),
+      user: { email: "reload@example.com", stripeCustomerId: STRIPE_CUSTOMER_ID }
+    });
+
+    const walletSetting = await seedWalletSetting({
+      userId: user.id,
+      walletId: wallet.id,
+      autoReloadEnabled: input.autoReloadEnabled ?? true,
+      autoReloadMode: "threshold",
+      autoReloadThreshold: THRESHOLD_CENTS,
+      autoReloadAmount: RELOAD_AMOUNT_CENTS,
+      autoReloadPausedAt: input.autoReloadPausedAt ?? null,
+      lastAutoChargeAt: input.lastAutoChargeAt ?? null
+    });
+
+    const paymentMethodId = `pm_${faker.string.alphanumeric(12)}`;
+    await db.insert(resolveTable("PaymentMethods")).values({
+      userId: user.id,
+      paymentMethodId,
+      fingerprint: `fp_${faker.string.alphanumeric(12)}`,
+      isDefault: true,
+      isValidated: true
+    });
+
+    vi.spyOn(container.resolve<Stripe>(STRIPE_CLIENT).paymentMethods, "retrieve").mockResolvedValue(
+      mock<Stripe.Response<Stripe.PaymentMethod>>({ id: paymentMethodId, customer: STRIPE_CUSTOMER_ID })
+    );
+    vi.spyOn(container.resolve(BalancesService), "getDeploymentBalanceInFiat").mockResolvedValue(input.balanceUsd);
+    const createPaymentIntent = vi
+      .spyOn(container.resolve(StripeTransactionService), "createPaymentIntent")
+      .mockResolvedValue({ success: true, transactionId: "tx_test", paymentIntentId: "pi_test", transactionStatus: "succeeded" });
+
+    const checkKey = `${WalletBalanceReloadCheck.name}.${user.id}`;
+
+    return {
+      paymentMethodId,
+      createPaymentIntent,
+      findWalletSetting: async () => {
+        const [row] = await db.select().from(walletSettingTable).where(eq(walletSettingTable.id, walletSetting.id));
+
+        return row;
+      },
+      checkBalance: async () => {
+        await enqueue(new WalletBalanceReloadCheck({ userId: user.id, triggeredByDeployment: true }), { singletonKey: checkKey });
+        await startWorkers();
+        await expectJobCompleted(WalletBalanceReloadCheck[JOB_NAME], { singletonKey: checkKey, state: "completed" });
+      }
+    };
+  }
+});


### PR DESCRIPTION
## Why

Part of CON-952 — **the handler this issue was written about**. **Stacked** — base is `test/billing-credits-low-latch-and-email` (#3861).

`WalletBalanceReloadCheckHandler` is the one place in the codebase that already works around the empty worker ability, by hand-building its own inline:

```ts
const paymentMethod = await this.paymentMethodService.getDefaultPaymentMethod(
  user,
  createMongoAbility([{ action: "read", subject: "PaymentMethod" }])
);
```

Someone hit this in production and patched it locally. **Nothing held that workaround in place.** Swap it back for the worker's `createMongoAbility()` and the read throws:

```
ForbiddenError: Cannot execute "read" on "PaymentMethod"
  at DrizzleAbility.toDrizzleWhereClause (src/lib/drizzle-ability/drizzle-ability.ts:50)
  at PaymentMethodRepository.accessibleBy (src/billing/repositories/payment-method/payment-method.repository.ts:24)
  at PaymentMethodService.getDefaultPaymentMethod (src/billing/services/payment-method/payment-method.service.ts:175)
  at WalletBalanceReloadCheckHandler.#getDefaultPaymentMethod (…:176)
```

And in production that failure is **silent**: `#collectResources` returns `Err(DEFAULT_PAYMENT_METHOD_NOT_FOUND)`, `handle` sets `success = true`, the job completes. Auto top-up simply stops charging that user and the queue reports everything fine.

## What

Five cases through a real worker: the card is charged once the balance drops below the threshold and `lastAutoChargeAt` is stamped; nothing is charged when the balance still covers it, when the wallet is paused after declines, inside the cooldown the previous charge claimed, or when auto reload is off.

Crucially the payment method is read **through the real ability-scoped repository** against a seeded `payment_methods` row — only Stripe's `paymentMethods.retrieve` is faked. So the workaround is what the test depends on, which is what makes the mutation above fail rather than pass.

`triggeredByDeployment` is set on the charge case, because the no-active-deployments guard otherwise skips it — that flag exists for exactly this situation and it is the honest way to reach the charge path without seeding indexer state.

### Verification

Stacked, so no CI and no CodeRabbit — local only:

- `npm run test:integration` for this file — 5 tests pass
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — 42 errors, matching the `main` baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
