### PR TITLE
feat(auth): require job handlers to declare their execution permissions

### DIFF
--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.spec.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.spec.ts
@@ -77,6 +77,12 @@ describe(AutoRechargeSucceededHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: AutoRechargeSucceededHandler.name });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup({ user: null });
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input: {
     user: ReturnType<typeof createUser> | null;
     wallet?: ReturnType<typeof createUserWallet>;

--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.ts
@@ -4,7 +4,7 @@ import { AutoRechargeSucceeded } from "@src/billing/events/auto-recharge-succeed
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { type CreateLogger, EventPayload, JobHandler, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, EventPayload, JobHandler, type JobPermissions, LOGGER_FACTORY } from "@src/core";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { autoRechargeSucceededNotification } from "@src/notifications/services/notification-templates/auto-recharge-succeeded-notification";
 import { UserRepository } from "@src/user/repositories";
@@ -26,6 +26,10 @@ export class AutoRechargeSucceededHandler implements JobHandler<AutoRechargeSucc
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: AutoRechargeSucceededHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: EventPayload<AutoRechargeSucceeded>): Promise<void> {

--- a/apps/api/src/app/services/close-expired-deployment/close-expired-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-expired-deployment/close-expired-deployment.handler.spec.ts
@@ -133,6 +133,12 @@ describe(CloseExpiredDeploymentHandler.name, () => {
     });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function expectRetriedLater(deploymentCloseJobService: ReturnType<typeof setup>["deploymentCloseJobService"], setting: DeploymentSettingsOutput) {
     expect(deploymentCloseJobService.schedule).toHaveBeenCalledWith(
       { deploymentSettingId: setting.id, userId: setting.userId, dseq: setting.dseq },

--- a/apps/api/src/app/services/close-expired-deployment/close-expired-deployment.handler.ts
+++ b/apps/api/src/app/services/close-expired-deployment/close-expired-deployment.handler.ts
@@ -3,7 +3,7 @@ import { inject, singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
-import { type CreateLogger, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, type JobHandler, type JobPayload, type JobPermissions, LOGGER_FACTORY } from "@src/core";
 import { CloseExpiredDeploymentCommand } from "@src/deployment/commands/close-expired-deployment.command";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { type CloseExpiredDeploymentTarget, DeploymentCloseJobService } from "@src/deployment/services/deployment-close-job/deployment-close-job.service";
@@ -52,6 +52,10 @@ export class CloseExpiredDeploymentHandler implements JobHandler<CloseExpiredDep
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: CloseExpiredDeploymentHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: JobPayload<CloseExpiredDeploymentCommand>): Promise<void> {

--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
@@ -291,6 +291,12 @@ describe(CloseTrialDeploymentHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: CloseTrialDeploymentHandler.name });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input?: {
     findWalletById?: UserWalletRepository["findById"];
     enqueueJob?: JobQueueService["enqueue"];

--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.ts
@@ -4,7 +4,7 @@ import { inject, singleton } from "tsyringe";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
-import { type CreateLogger, Job, JOB_NAME, JobHandler, JobPayload, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, Job, JOB_NAME, JobHandler, JobPayload, type JobPermissions, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
@@ -40,6 +40,10 @@ export class CloseTrialDeploymentHandler implements JobHandler<CloseTrialDeploym
     private readonly chainErrorService: ChainErrorService
   ) {
     this.logger = createLogger({ context: CloseTrialDeploymentHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: JobPayload<CloseTrialDeployment>): Promise<void> {

--- a/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.spec.ts
@@ -138,6 +138,12 @@ describe(CloseUnreachableProviderDeploymentHandler.name, () => {
     await expect(handler.handle(aPayload())).rejects.toThrow("connection terminated");
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function aPayload(): JobPayload<CloseUnreachableProviderDeploymentCommand> {
     return { owner: OWNER, dseq: DSEQ, version: 1 };
   }

--- a/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.ts
+++ b/apps/api/src/app/services/close-unreachable-provider-deployment/close-unreachable-provider-deployment.handler.ts
@@ -3,7 +3,7 @@ import { inject, singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
-import { type CreateLogger, type JobHandler, type JobPayload, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, type JobHandler, type JobPayload, type JobPermissions, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { TxService } from "@src/core/services/tx/tx.service";
 import { CloseUnreachableProviderDeploymentCommand } from "@src/deployment/commands/close-unreachable-provider-deployment.command";
 import type { DarkDeployment } from "@src/deployment/lib/dark-deployment/dark-deployment";
@@ -43,6 +43,10 @@ export class CloseUnreachableProviderDeploymentHandler implements JobHandler<Clo
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: CloseUnreachableProviderDeploymentHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: JobPayload<CloseUnreachableProviderDeploymentCommand>): Promise<void> {

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.spec.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.spec.ts
@@ -33,6 +33,12 @@ describe(EnableDeploymentAlertHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: EnableDeploymentAlertHandler.name });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(params?: { notificationService?: Partial<NotificationService>; logger?: Partial<ReturnType<CreateLogger>> }) {
     const notificationService = mock<NotificationService>({
       autoEnableDeploymentAlert: vi.fn().mockResolvedValue(undefined),

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.ts
@@ -1,7 +1,7 @@
 import { inject, singleton } from "tsyringe";
 
 import { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
-import type { JobHandler, JobPayload } from "@src/core";
+import type { JobHandler, JobPayload, JobPermissions } from "@src/core";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 
@@ -18,6 +18,10 @@ export class EnableDeploymentAlertHandler implements JobHandler<EnableDeployment
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: EnableDeploymentAlertHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: JobPayload<EnableDeploymentAlertCommand>): Promise<void> {

--- a/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.spec.ts
+++ b/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.spec.ts
@@ -51,6 +51,12 @@ describe(FirstPurchaseBonusGrantedHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: FirstPurchaseBonusGrantedHandler.name });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input?: { findUserById?: UserRepository["findById"] }) {
     const mocks = {
       notificationService: mock<NotificationService>({

--- a/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.ts
+++ b/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.ts
@@ -1,7 +1,7 @@
 import { inject, singleton } from "tsyringe";
 
 import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
-import { type CreateLogger, EventPayload, JobHandler, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, EventPayload, JobHandler, type JobPermissions, LOGGER_FACTORY } from "@src/core";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { firstPurchaseBonusGrantedNotification } from "@src/notifications/services/notification-templates/first-purchase-bonus-granted-notification";
 import { UserRepository } from "@src/user/repositories";
@@ -20,6 +20,10 @@ export class FirstPurchaseBonusGrantedHandler implements JobHandler<FirstPurchas
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: FirstPurchaseBonusGrantedHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: EventPayload<FirstPurchaseBonusGranted>): Promise<void> {

--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.spec.ts
@@ -49,6 +49,12 @@ describe(FundDeploymentHandler.name, () => {
     expect(instrumentation.recordJobSucceeded).not.toHaveBeenCalled();
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(params?: { initialDeploymentFundingService?: Partial<InitialDeploymentFundingService> }) {
     const initialDeploymentFundingService = mock<InitialDeploymentFundingService>({
       fundOnLeaseStarted: vi.fn().mockResolvedValue(undefined),

--- a/apps/api/src/app/services/fund-deployment/fund-deployment.handler.ts
+++ b/apps/api/src/app/services/fund-deployment/fund-deployment.handler.ts
@@ -1,7 +1,7 @@
 import { inject, singleton } from "tsyringe";
 
 import { FundDeploymentCommand } from "@src/billing/commands/fund-deployment.command";
-import type { JobHandler, JobPayload } from "@src/core";
+import type { JobHandler, JobPayload, JobPermissions } from "@src/core";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { InitialDeploymentFundingService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding.service";
 import { InitialDeploymentFundingInstrumentationService } from "@src/deployment/services/initial-deployment-funding/initial-deployment-funding-instrumentation.service";
@@ -20,6 +20,10 @@ export class FundDeploymentHandler implements JobHandler<FundDeploymentCommand> 
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: FundDeploymentHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: JobPayload<FundDeploymentCommand>): Promise<void> {

--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.spec.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.spec.ts
@@ -45,6 +45,12 @@ describe(FundDrainingDeploymentsHandler.name, () => {
     expect(handler.policy).toBe("singleton");
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(params?: { topUpManagedDeploymentsService?: Partial<TopUpManagedDeploymentsService> }) {
     const topUpManagedDeploymentsService = mock<TopUpManagedDeploymentsService>({
       topUpDrainingDeploymentsForOwner: vi.fn().mockResolvedValue(undefined),

--- a/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.ts
+++ b/apps/api/src/app/services/fund-draining-deployments/fund-draining-deployments.handler.ts
@@ -1,7 +1,7 @@
 import { inject, singleton } from "tsyringe";
 
 import { FundDrainingDeploymentsCommand } from "@src/billing/commands/fund-draining-deployments.command";
-import type { JobHandler, JobPayload } from "@src/core";
+import type { JobHandler, JobPayload, JobPermissions } from "@src/core";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { FundDrainingDeploymentsInstrumentationService } from "@src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service";
 import { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
@@ -27,6 +27,10 @@ export class FundDrainingDeploymentsHandler implements JobHandler<FundDrainingDe
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: FundDrainingDeploymentsHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: JobPayload<FundDrainingDeploymentsCommand>): Promise<void> {

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
@@ -225,6 +225,12 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
     expect(probeJobService.scheduleInitial).toHaveBeenCalledWith({ walletId: wallet.id, dseq: "test-dseq", leaseCreatedAt: deploymentCreatedAt });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input?: {
     findWalletById?: UserWalletRepository["findById"];
     enqueueJob?: JobQueueService["enqueue"];

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
@@ -4,7 +4,7 @@ import { inject, singleton } from "tsyringe";
 import { TrialDeploymentLeaseCreated } from "@src/billing/events/trial-deployment-lease-created";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { type CreateLogger, DOMAIN_EVENT_NAME, EventPayload, JobHandler, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, DOMAIN_EVENT_NAME, EventPayload, JobHandler, type JobPermissions, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 import { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
@@ -26,6 +26,10 @@ export class TrialDeploymentLeaseCreatedHandler implements JobHandler<TrialDeplo
     private readonly probeJobService: TrialWorkloadProbeJobService
   ) {
     this.logger = createLogger({ context: TrialDeploymentLeaseCreatedHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: EventPayload<TrialDeploymentLeaseCreated>): Promise<void> {

--- a/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
@@ -223,6 +223,12 @@ describe(TrialStartedHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: TrialStartedHandler.name });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input?: {
     findUserById?: UserRepository["findById"];
     createNotification?: NotificationService["createNotification"];

--- a/apps/api/src/app/services/trial-started/trial-started.handler.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.ts
@@ -3,7 +3,7 @@ import { inject, singleton } from "tsyringe";
 
 import { TrialStarted } from "@src/billing/events/trial-started";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { type CreateLogger, EventPayload, JobHandler, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, EventPayload, JobHandler, type JobPermissions, JobQueueService, LOGGER_FACTORY } from "@src/core";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
@@ -26,6 +26,10 @@ export class TrialStartedHandler implements JobHandler<TrialStarted> {
     private readonly billingConfig: BillingConfigService
   ) {
     this.logger = createLogger({ context: TrialStartedHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: EventPayload<TrialStarted>): Promise<void> {

--- a/apps/api/src/billing/services/activate-trial/activate-trial.handler.spec.ts
+++ b/apps/api/src/billing/services/activate-trial/activate-trial.handler.spec.ts
@@ -38,6 +38,12 @@ describe(ActivateTrialHandler.name, () => {
     });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input?: { activationError?: Error }) {
     const walletInitializer = mock<WalletInitializerService>();
     if (input?.activationError) {

--- a/apps/api/src/billing/services/activate-trial/activate-trial.handler.ts
+++ b/apps/api/src/billing/services/activate-trial/activate-trial.handler.ts
@@ -3,7 +3,7 @@ import { singleton } from "tsyringe";
 import { ActivateTrial } from "@src/billing/events/activate-trial";
 import { TrialActivationInstrumentationService } from "@src/billing/services/activate-trial/trial-activation-instrumentation.service";
 import { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
-import { JobHandler, JobPayload } from "@src/core";
+import { JobHandler, JobPayload, type JobPermissions } from "@src/core";
 
 @singleton()
 export class ActivateTrialHandler implements JobHandler<ActivateTrial> {
@@ -17,6 +17,10 @@ export class ActivateTrialHandler implements JobHandler<ActivateTrial> {
     private readonly walletInitializer: WalletInitializerService,
     private readonly instrumentation: TrialActivationInstrumentationService
   ) {}
+
+  requiresPermission(): JobPermissions {
+    return [];
+  }
 
   async handle(payload: JobPayload<ActivateTrial>): Promise<void> {
     const startTime = Date.now();

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -868,6 +868,12 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function declinedCardError(declineCode: string) {
     return new Stripe.errors.StripeCardError({
       type: "card_error",

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -16,7 +16,7 @@ import { BalancesService } from "@src/billing/services/balances/balances.service
 import { type PaymentMethod, PaymentMethodService } from "@src/billing/services/payment-method/payment-method.service";
 import { AUTO_RECHARGE_METADATA_KEY, StripeTransactionService } from "@src/billing/services/stripe-transaction/stripe-transaction.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
-import { JobHandler, JobMeta, JobPayload } from "@src/core";
+import { JobHandler, JobMeta, JobPayload, type JobPermissions } from "@src/core";
 import type { Require } from "@src/core/types/require.type";
 import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
@@ -77,6 +77,10 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     private readonly instrumentationService: WalletBalanceReloadCheckInstrumentationService,
     private readonly autoReloadPauseService: AutoReloadPauseService
   ) {}
+
+  requiresPermission(): JobPermissions {
+    return [];
+  }
 
   async handle(payload: JobPayload<WalletBalanceReloadCheck>, job: JobMeta): Promise<void> {
     const startTime = Date.now();

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -391,6 +391,12 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: WalletCreditsLowCheckHandler.name });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input?: {
     autoReloadEnabled?: boolean;
     autoReloadPausedAt?: Date;

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -5,7 +5,7 @@ import { isAutoReloadActive } from "@src/billing/lib/auto-reload/auto-reload";
 import { isWalletInitialized, type UserWalletOutput, UserWalletRepository, WalletSettingRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { type CreateLogger, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, type JobHandler, type JobPayload, type JobPermissions, LOGGER_FACTORY } from "@src/core";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { creditsRunningLowNotification } from "@src/notifications/services/notification-templates/credits-running-low-notification";
@@ -43,6 +43,10 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: WalletCreditsLowCheckHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: JobPayload<WalletCreditsLowCheck>): Promise<void> {

--- a/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
@@ -169,7 +169,12 @@ describe(JobQueueService.name, () => {
 
     return {
       jobQueue,
-      handler: { accepts: ScopedJob, policy, handle: input.handle ?? vi.fn().mockResolvedValue(undefined) } satisfies JobHandler<Job>,
+      handler: {
+        accepts: ScopedJob,
+        policy,
+        requiresPermission: () => [],
+        handle: input.handle ?? vi.fn().mockResolvedValue(undefined)
+      } satisfies JobHandler<Job>,
       enqueue: (options?: EnqueueOptions) => jobQueue.enqueue(new ScopedJob(), options),
       createLegacyQueue: () =>
         pgBoss.createQueue(queueName, { retryLimit: RETRY_LIMIT, retryBackoff: true, retryDelayMax: RETRY_DELAY_MAX_IN_SECONDS, policy }),

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -1,14 +1,15 @@
+import { type MongoAbility, subject } from "@casl/ability";
 import { faker } from "@faker-js/faker";
 import type { Job as PgBossJob, PgBoss, QueueResult, WorkHandler } from "pg-boss";
 import type { Sql } from "postgres";
-import { describe, expect, it, vi } from "vitest";
-import { mock, mockDeep } from "vitest-mock-extended";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { mock, mockDeep, type MockProxy } from "vitest-mock-extended";
 
 import type { CreateLogger } from "@src/core/providers/logging.provider";
 import type { CoreConfigService } from "../core-config/core-config.service";
 import type { ExecutionContextService } from "../execution-context/execution-context.service";
 import type { TxService } from "../tx/tx.service";
-import { type EnqueueOptions, type Job, JOB_NAME, type JobHandler, JobQueueService } from "./job-queue.service";
+import { type EnqueueOptions, type Job, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, JobQueueService } from "./job-queue.service";
 
 describe(JobQueueService.name, () => {
   describe("registerHandlers", () => {
@@ -440,6 +441,82 @@ describe(JobQueueService.name, () => {
       expect(handleFn).toHaveBeenCalledWith({ message: "Job 1", userId: "user-1" }, { id: job.id });
     });
 
+    it("installs the permissions the handler declares for its execution", async () => {
+      const { service, pgBoss, executionContextService } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new ReadPaymentMethodTestHandler(vi.fn().mockResolvedValue(undefined))]);
+      await service.startWorkers({ concurrency: 1 });
+
+      const ability = installedAbility(executionContextService);
+      expect(ability.can("read", "PaymentMethod")).toBe(true);
+      expect(ability.can("update", "PaymentMethod")).toBe(false);
+    });
+
+    it("installs an ability without rules when the handler declares no permissions", async () => {
+      const { service, pgBoss, executionContextService } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockResolvedValue(undefined))]);
+      await service.startWorkers({ concurrency: 1 });
+
+      const ability = installedAbility(executionContextService);
+      expect(abilityInstallations(executionContextService)).toHaveLength(1);
+      expect(ability.rules).toEqual([]);
+      expect(ability.can("read", "PaymentMethod")).toBe(false);
+    });
+
+    it("declares the permissions from the payload the handler is given", async () => {
+      const { service, pgBoss } = setup();
+      const handler = new ReadOwnPaymentMethodTestHandler(vi.fn().mockResolvedValue(undefined));
+      const requiresPermission = vi.spyOn(handler, "requiresPermission");
+      const job = deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([handler]);
+      await service.startWorkers({ concurrency: 1 });
+
+      expect(requiresPermission).toHaveBeenCalledWith(job.data);
+    });
+
+    it("keeps the conditions the handler declares for the job at hand", async () => {
+      const { service, pgBoss, executionContextService } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new ReadOwnPaymentMethodTestHandler(vi.fn().mockResolvedValue(undefined))]);
+      await service.startWorkers({ concurrency: 1 });
+
+      const ability = installedAbility(executionContextService);
+      expect(ability.can("read", subject("PaymentMethod", { userId: "user-1" }))).toBe(true);
+      expect(ability.can("read", subject("PaymentMethod", { userId: "user-2" }))).toBe(false);
+    });
+
+    it("installs the declared permissions before running the handler", async () => {
+      const { service, pgBoss, executionContextService } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+      const handle = vi.fn(async () => {
+        expect(installedAbility(executionContextService).can("read", "PaymentMethod")).toBe(true);
+      });
+
+      await service.registerHandlers([new ReadPaymentMethodTestHandler(handle)]);
+      await service.startWorkers({ concurrency: 1 });
+
+      expect(handle).toHaveBeenCalledTimes(1);
+    });
+
+    it("fails the job when the handler cannot declare its permissions", async () => {
+      const error = new Error("Permissions unavailable");
+      const { service, pgBoss, logger } = setup();
+      const handle = vi.fn().mockResolvedValue(undefined);
+      const job = deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new UndeclarablePermissionTestHandler(handle, error)]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      expect(result.status).toBe("rejected");
+      expect(logger.error).toHaveBeenCalledWith({ event: "JOB_FAILED", jobId: job.id, error });
+      expect(handle).not.toHaveBeenCalled();
+    });
+
     it("uses default options when none provided", async () => {
       const handleFn = vi.fn().mockResolvedValue(undefined);
       const handler = new TestHandler(handleFn);
@@ -521,6 +598,10 @@ describe(JobQueueService.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: JobQueueService.name });
   });
 
+  it("obliges every handler to declare the permissions its execution needs", () => {
+    expectTypeOf<JobHandler<TestJob>["requiresPermission"]>().toBeFunction();
+  });
+
   function setup(input?: { pgBoss?: PgBoss; postgresDbUri?: string; queues?: QueueResult[] }) {
     const mocks = {
       logger: mock<ReturnType<CreateLogger>>(),
@@ -577,12 +658,50 @@ describe(JobQueueService.name, () => {
   class TestHandler implements JobHandler<TestJob> {
     readonly accepts = TestJob;
     constructor(public readonly handle: JobHandler<TestJob>["handle"]) {}
+
+    requiresPermission(): JobPermissions {
+      return [];
+    }
   }
 
   class SingletonTestHandler implements JobHandler<TestJob> {
     readonly accepts = TestJob;
     readonly policy = "singleton" as const;
     constructor(public readonly handle: JobHandler<TestJob>["handle"]) {}
+
+    requiresPermission(): JobPermissions {
+      return [];
+    }
+  }
+
+  class ReadPaymentMethodTestHandler implements JobHandler<TestJob> {
+    readonly accepts = TestJob;
+    constructor(public readonly handle: JobHandler<TestJob>["handle"]) {}
+
+    requiresPermission(): JobPermissions {
+      return [{ action: "read", subject: "PaymentMethod" }];
+    }
+  }
+
+  class ReadOwnPaymentMethodTestHandler implements JobHandler<TestJob> {
+    readonly accepts = TestJob;
+    constructor(public readonly handle: JobHandler<TestJob>["handle"]) {}
+
+    requiresPermission(payload: JobPayload<TestJob>): JobPermissions {
+      return [{ action: "read", subject: "PaymentMethod", conditions: { userId: payload.userId } }];
+    }
+  }
+
+  class UndeclarablePermissionTestHandler implements JobHandler<TestJob> {
+    readonly accepts = TestJob;
+    constructor(
+      public readonly handle: JobHandler<TestJob>["handle"],
+      private readonly error: Error
+    ) {}
+
+    requiresPermission(): JobPermissions {
+      throw this.error;
+    }
   }
 
   class AnotherTestJob implements Job {
@@ -596,6 +715,30 @@ describe(JobQueueService.name, () => {
   class AnotherTestHandler implements JobHandler<AnotherTestJob> {
     readonly accepts = AnotherTestJob;
     constructor(public readonly handle: JobHandler<AnotherTestJob>["handle"]) {}
+
+    requiresPermission(): JobPermissions {
+      return [];
+    }
+  }
+
+  function deliverOneJob(pgBoss: PgBoss, data: Record<string, unknown>) {
+    const job = { id: "1", data };
+    vi.spyOn(pgBoss, "work").mockImplementation(async (queueName: string, options: unknown, processFn: WorkHandler<unknown>) => {
+      await processFn([job as PgBossJob<unknown>]);
+      return "work-id";
+    });
+
+    return job;
+  }
+
+  function abilityInstallations(executionContextService: MockProxy<ExecutionContextService>) {
+    return vi.mocked(executionContextService.set).mock.calls.filter(([key]) => key === "ABILITY");
+  }
+
+  function installedAbility(executionContextService: MockProxy<ExecutionContextService>) {
+    const [installation] = abilityInstallations(executionContextService);
+
+    return installation[1] as MongoAbility;
   }
 
   function liveQueue(overrides?: Partial<QueueResult>) {

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -1,4 +1,4 @@
-import { createMongoAbility, MongoAbility } from "@casl/ability";
+import { createMongoAbility, type MongoAbility, type RawRuleOf } from "@casl/ability";
 import { context, propagation, SpanStatusCode, trace } from "@opentelemetry/api";
 import {
   Job as PgBossJob,
@@ -321,12 +321,12 @@ export class JobQueueService implements Disposable {
                 username: "___bg_job_user___",
                 trial: false
               });
-              this.executionContextService.set("ABILITY", createMongoAbility<MongoAbility>());
               this.logger.info({
                 event: "JOB_STARTED",
                 jobId: job.id
               });
               try {
+                this.executionContextService.set("ABILITY", createMongoAbility<MongoAbility>(handler.requiresPermission(job.data)));
                 await handler.handle(job.data, { id: job.id });
                 this.logger.info({
                   event: "JOB_DONE",
@@ -421,10 +421,14 @@ export type JobType<T extends Job> = {
 
 export type JobMeta = Pick<PgBossJob, "id">;
 
+export type JobPermissions = RawRuleOf<MongoAbility>[];
+
 export interface JobHandler<T extends Job> {
   accepts: JobType<T>;
   concurrency?: ProcessOptions["concurrency"];
   policy?: PgBossQueue["policy"];
+  /** Declared rules gate rather than filter: `accessibleBy` refuses outright any action its rules omit, so a declaration covers everything the handler's services ask for. */
+  requiresPermission(payload: JobPayload<T>): JobPermissions;
   handle(payload: JobPayload<T>, job?: JobMeta): Promise<void>;
 }
 

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.spec.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.spec.ts
@@ -131,6 +131,12 @@ describe(DeleteUnbackedDeploymentSettingHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: DeleteUnbackedDeploymentSettingHandler.name });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup({});
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input: { isOnChain?: boolean; chainLookupRejectsWith?: unknown; settingExists?: boolean; storedDseq?: string; recordedAt?: Date | null }) {
     const deploymentSettingId = faker.string.uuid();
     const recordedAt = input.recordedAt === undefined ? RECORDED_AT : input.recordedAt;

--- a/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler.ts
@@ -1,6 +1,6 @@
 import { inject, singleton } from "tsyringe";
 
-import { type CreateLogger, type Job, JOB_NAME, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, type Job, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, LOGGER_FACTORY } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeploymentPresenceService } from "@src/deployment/services/deployment-presence/deployment-presence.service";
 
@@ -43,6 +43,10 @@ export class DeleteUnbackedDeploymentSettingHandler implements JobHandler<Delete
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: DeleteUnbackedDeploymentSettingHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   /**

--- a/apps/api/src/deployment/services/reconcile-managed-tx/reconcile-managed-tx.handler.spec.ts
+++ b/apps/api/src/deployment/services/reconcile-managed-tx/reconcile-managed-tx.handler.spec.ts
@@ -48,6 +48,12 @@ describe(ReconcileManagedTxHandler.name, () => {
     expect(deploymentSettingRepository.releaseFundingClaim).not.toHaveBeenCalled();
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function claims(): FundingClaim[] {
     return [{ id: "setting-1", claimedAt: "2026-09-04 12:00:00.123456" }];
   }

--- a/apps/api/src/deployment/services/reconcile-managed-tx/reconcile-managed-tx.handler.ts
+++ b/apps/api/src/deployment/services/reconcile-managed-tx/reconcile-managed-tx.handler.ts
@@ -1,7 +1,7 @@
 import { singleton } from "tsyringe";
 
 import { TxPresenceService } from "@src/chain/services/tx-presence/tx-presence.service";
-import { type Job, JOB_NAME, type JobHandler, type JobPayload } from "@src/core";
+import { type Job, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions } from "@src/core";
 import { DeploymentSettingRepository, type FundingClaim } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
 import { ReconcileManagedTxInstrumentationService } from "./reconcile-managed-tx-instrumentation.service";
@@ -33,6 +33,10 @@ export class ReconcileManagedTxHandler implements JobHandler<ReconcileManagedTx>
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly instrumentation: ReconcileManagedTxInstrumentationService
   ) {}
+
+  requiresPermission(): JobPermissions {
+    return [];
+  }
 
   /** Only a chain-confirmed revert releases the claims, because absence over a pooled endpoint can be a lagging member rather than a tx that never landed. */
   async handle(payload: JobPayload<ReconcileManagedTx>): Promise<void> {

--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.spec.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.spec.ts
@@ -49,6 +49,12 @@ describe(RecordDeploymentSettingHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: RecordDeploymentSettingHandler.name });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup({});
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input: { wasMissing?: boolean; writeRejectsWith?: unknown }) {
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.createDefaultIfMissing.mockImplementation(async () => {

--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
@@ -1,6 +1,6 @@
 import { inject, singleton } from "tsyringe";
 
-import { type CreateLogger, type Job, JOB_NAME, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, type Job, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, LOGGER_FACTORY } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 
 /** Records a deployment created through the transaction endpoint, which bypasses the deployment API and so leaves the funding sweep with no row to find. */
@@ -36,6 +36,10 @@ export class RecordDeploymentSettingHandler implements JobHandler<RecordDeployme
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: RecordDeploymentSettingHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   /** Unscoped because job execution runs under an empty ability, which a scoped read would throw on before any SQL ran. */

--- a/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
@@ -304,6 +304,12 @@ describe(NotificationHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: NotificationHandler.name });
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup();
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input?: {
     findUserById?: UserRepository["findById"];
     createNotification?: NotificationService["createNotification"];

--- a/apps/api/src/notifications/services/notification-handler/notification.handler.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.ts
@@ -2,7 +2,7 @@ import { guard, MongoQuery } from "@ucast/mongo2js";
 import { inject, singleton } from "tsyringe";
 
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
-import { Job, JOB_NAME, JobHandler, JobPayload } from "@src/core/services/job-queue/job-queue.service";
+import { Job, JOB_NAME, JobHandler, JobPayload, type JobPermissions } from "@src/core/services/job-queue/job-queue.service";
 import {
   IsResolved,
   NotificationDataResolverService,
@@ -62,6 +62,10 @@ export class NotificationHandler implements JobHandler<NotificationJob> {
     private readonly notificationDataResolver: NotificationDataResolverService
   ) {
     this.logger = createLogger({ context: NotificationHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle<T extends keyof NotificationTemplates>(payload: JobPayload<NotificationJob<T>>): Promise<void> {

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
@@ -131,6 +131,12 @@ describe(ProbeTrialDeploymentHandler.name, () => {
     );
   });
 
+  it("declares no permissions for its execution", () => {
+    const { handler } = setup({});
+
+    expect(handler.requiresPermission()).toEqual([]);
+  });
+
   function setup(input: {
     enabled?: boolean;
     wallet?: ReturnType<typeof createUserWallet> | null;

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
@@ -1,7 +1,7 @@
 import { inject, singleton } from "tsyringe";
 
 import { isWalletInitialized, UserWalletRepository } from "@src/billing/repositories";
-import { type CreateLogger, JOB_NAME, type JobHandler, type JobPayload, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, LOGGER_FACTORY } from "@src/core";
 import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
 import { type ProbeReport, TrialWorkloadProbeService } from "@src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service";
 import { ProbeTrialDeployment, TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
@@ -30,6 +30,10 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: ProbeTrialDeploymentHandler.name });
+  }
+
+  requiresPermission(): JobPermissions {
+    return [];
   }
 
   async handle(payload: JobPayload<ProbeTrialDeployment>): Promise<void> {

--- a/apps/api/test/setup-integration-tests.ts
+++ b/apps/api/test/setup-integration-tests.ts
@@ -16,7 +16,7 @@ const dbService = new TestDatabaseService(testPath!);
 beforeAll(async () => {
   MemoryCacheEngine.clearAllCaches();
   await dbService.setup();
-}, 20_000);
+});
 
 afterAll(async () => {
   try {
@@ -26,7 +26,7 @@ afterAll(async () => {
   }
   await dbService.teardown();
   MemoryCacheEngine.clearAllCaches();
-}, 20_000);
+});
 
 beforeEach(() => {
   MemoryCacheEngine.clearAllCaches();

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
           include: ["src/**/*.integration.ts"],
           setupFiles: ["./test/setup-integration-env.ts", "./test/setup-integration-tests.ts"],
           testTimeout: 60_000,
-          hookTimeout: 30_000
+          hookTimeout: 60_000
         }
       },
       {


### PR DESCRIPTION
## Why

Fixes CON-951

Every background job in `apps/api` runs under a hardcoded zero-rule ability. `JobQueueService.startWorkers` fabricates a `___bg_job_user___` and then sets `ABILITY` to `createMongoAbility<MongoAbility>()` for every job, whatever that job goes on to touch. A handler therefore has no way to say what it is allowed to reach, and nothing at the type or test level catches a handler that quietly leans on unscoped repository access — the failure only shows up in production.

This PR adds the mechanism a handler needs to declare that, without changing what any job is allowed to do today.

## What

**The contract.** `JobHandler<T>` gains a **required** member `requiresPermission(payload: JobPayload<T>): JobPermissions`, where `JobPermissions` is a new exported alias for `RawRuleOf<MongoAbility>[]`. Handlers return raw CASL rules rather than an ability, which keeps `createMongoAbility` in exactly one place, makes "no permissions" literally `[]`, and keeps handlers away from `AbilityService.getAbilityFor`, whose `${user.id}` templates would silently bind to the fabricated background-job user.

**The queue.** `startWorkers` replaces the hardcoded empty ability with `createMongoAbility<MongoAbility>(handler.requiresPermission(job.data))`. The call sits inside the existing per-job `try`/`catch`, so a declaration that throws is logged as `JOB_FAILED` and rethrown for pg-boss to retry, with `handle` never invoked — a broken declaration fails its job, not the worker. The payload is passed in so a handler can scope a rule to the job at hand (`conditions: { userId: payload.userId }`); handlers that do not care omit the parameter.

**The handlers.** All 18 registered handlers implement the member as `return []`, and the queue's own integration-test handler fixture was updated for the required member. **Runtime behaviour is identical to before**: no handler declares a non-empty rule set, so every job still runs under the zero-rule ability it has today.

**Deviation from the issue text.** The issue describes the method as optional, falling back to an empty ability when unspecified. It is required here instead: the contract is only useful if it cannot be forgotten, and an optional member means a new handler silently inherits blanket-empty permissions rather than stating them. The outcome the issue's sentence protects is preserved exactly — all 18 handlers declare `[]`.

**Tests.** `job-queue.service.spec.ts` gains behavioural coverage for the declared ability reaching the execution context, an empty declaration meaning no permissions, the payload being handed to the declaration, payload-scoped conditions, the install-before-`handle` ordering, and a throwing declaration surfacing as `JOB_FAILED`; plus an `expectTypeOf` assertion that the member is required. Each of the 18 handler specs asserts its own declaration is empty — this also kills the array mutant CI's changed-line mutation testing generates for every `return []`.

### Also in this PR — an unrelated test-infrastructure fix

Flagged explicitly because it is out of CON-951's scope and a reviewer should judge it on its own merits, not as a side effect of the permissions contract:

- `apps/api/test/setup-integration-tests.ts` — the shared integration `beforeAll`/`afterAll` hard-coded a 20s budget for themselves, *below* the `hookTimeout` the integration project configures. The per-hook override is removed so both hooks use the project budget.
- `apps/api/vitest.config.ts` — the integration project's `hookTimeout` goes from 30s to 60s, matching its `testTimeout`.

The bootstrap that hook runs creates and migrates **two** databases per suite, and Postgres serialises `CREATE DATABASE`, so its wall time grows with how many suites bootstrap at once. Measured across the integration project, `CREATE DATABASE` dominates at ~1.35s per suite (~50s total) against ~0.6s for migrations. On a loaded machine the bootstrap outran the 20s and a suite died before a single test ran. The trade-off: an integration suite whose database bootstrap genuinely hangs now burns 60s per file before reporting instead of 20s. No assertion or test body was changed.

### Out of scope

- **No handler declares a non-empty rule set yet.** This PR ships the mechanism; narrowing individual handlers to the rules they actually need is a follow-up, and doing it per handler needs care — several reach the database through unscoped repository calls on purpose, so a partial rule set would make `DrizzleAbility` throw where nothing throws today.
- **The CLI entry point.** `apps/api/src/app/console.ts` installs the same hardcoded empty ability for `cli-user` against the same services. Same class of risk, different entry point, not addressed here.

### Verification

`apps/api`: `npm test`, `npm run lint -- --quiet` and `npx tsc --noEmit` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background jobs can now declare and enforce the permissions required for each task, including permissions based on job data.
  * Jobs that require no permissions continue to run without additional authorization rules.

* **Bug Fixes**
  * Improved consistency and reliability when validating permissions before background job execution.

* **Tests**
  * Expanded coverage for permission handling, conditional rules, execution ordering, and declaration failures.
  * Increased integration-test hook time limits to improve test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->