### PR TITLE
test(dx): assert the absences these worker tests were only implying

### DIFF
--- a/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
+++ b/apps/api/src/app/services/auto-recharge-succeeded/auto-recharge-succeeded.handler.integration.ts
@@ -31,6 +31,8 @@ describe("recharge and bonus notices", () => {
 
       await rechargeSucceeded({ amountCents: 2500 });
 
+      expect(sentNotifications()).toHaveLength(1);
+
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);
       expect(sent.body).toMatchObject({
@@ -64,6 +66,8 @@ describe("recharge and bonus notices", () => {
       const { userId, bonusGranted, sentNotifications } = await setup();
 
       await bonusGranted({ bonusAmountCents: 1000, paidAmountCents: 5000 });
+
+      expect(sentNotifications()).toHaveLength(1);
 
       const [sent] = sentNotifications();
       expect(sent.userId).toBe(userId);

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.integration.ts
@@ -25,10 +25,11 @@ describe(EnableDeploymentAlertHandler.name, () => {
   });
 
   it("enables the closed alert on the owner's existing channel", async () => {
-    const { userId, walletAddress, dseq, enableAlert, upsertedAlerts } = await setup();
+    const { userId, walletAddress, dseq, enableAlert, createdChannels, upsertedAlerts } = await setup();
 
     await enableAlert();
 
+    expect(createdChannels()).toHaveLength(0);
     expect(upsertedAlerts()).toEqual([
       {
         dseq,

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.integration.ts
@@ -63,11 +63,11 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   });
 
   it("says nothing about a lease that is not the first", async () => {
-    const { leaseCreated, sentNotifications } = await setup({ isFirstLease: false });
+    const { leaseCreated, findCongratulationJobs } = await setup({ isFirstLease: false });
 
     await leaseCreated();
 
-    expect(sentNotifications()).toHaveLength(0);
+    expect(await findCongratulationJobs()).toHaveLength(0);
   });
 
   it("schedules nothing for a wallet that has left the trial", async () => {
@@ -126,6 +126,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
       findCloseJob: () => findJobBySingletonKey(CloseTrialDeployment[JOB_NAME], `closeTrialDeployment.${dseq}.${wallet.id}`),
       findWarningJob: () => findJobBySingletonKey(NotificationJob[JOB_NAME], `notification.beforeCloseTrialDeployment.${dseq}.${wallet.id}`),
       awaitCongratulations: () => expectJobCompleted(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
+      findCongratulationJobs: () => findJobRows(NotificationJob[JOB_NAME], { singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}` }),
       leaseCreated: async () => {
         await enqueue(
           new TrialDeploymentLeaseCreated({


### PR DESCRIPTION
## Why

Part of CON-952. **Stacked** — base is `test/billing-reload-check-charge-claim` (#3862).

Collects the review feedback left across the stack (#3849, #3850, #3855) into one place, because each finding is a test in an already-reviewed PR that asserts an absence weakly enough to keep passing once the behaviour it names breaks.

- **#3849** — `expect(sentNotifications()).toHaveLength(0)` runs immediately after the domain-event job completes. The congratulation `NotificationJob` can be queued or still running at that moment, so Nock has simply not recorded the POST yet. A handler that congratulated every lease would pass.
- **#3850** — both positive paths do `const [sent] = sentNotifications()` with no length check, so a handler firing the notification twice (pg-boss delivers at least once) is invisible.
- **#3855** — the existing-channel case asserts only `upsertedAlerts()`. Both branches converge on the same `CHANNEL_ID`, so a handler that POSTed `/notification-channels/default` unconditionally would produce a byte-identical upsert.

## What

Three assertions, one per finding:

- `trial-deployment-lease-created` — asserts no `notification.trialFirstDeploymentLeaseCreated.${walletId}` job row exists, instead of no notification having been sent. The row is written transactionally by the domain-event job we already waited on, so there is nothing left to race.
- `auto-recharge-succeeded` — `toHaveLength(1)` before destructuring, in both the recharge and the bonus case.
- `enable-deployment-alert` — `expect(createdChannels()).toHaveLength(0)` in the existing-channel case.

### Verification

- `npm run test:integration` for the three files — 15 tests pass
- Mutation check on the one that changed meaning: forcing `if (payload.isFirstLease)` to `if (true)` in `trial-deployment-lease-created.handler.ts` now fails `says nothing about a lease that is not the first`, which the old assertion let through
- `npm run lint -- --quiet` — clean
- `npx tsc --noEmit` — unchanged from this stack's base

🤖 Generated with [Claude Code](https://claude.com/claude-code)
