### PR TITLE
fix(deployment): fix the trial workload probe defects found in review

### DIFF
--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
@@ -225,6 +225,23 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
     expect(probeJobService.scheduleInitial).toHaveBeenCalledWith({ walletId: wallet.id, dseq: "test-dseq", leaseCreatedAt: deploymentCreatedAt });
   });
 
+  it("keeps the rest of the lease-created work when the probe cannot be scheduled", async () => {
+    const wallet = createUserWallet({ isTrialing: true });
+    const { handler, probeJobService, jobQueueService, logger } = setup({ findWalletById: vi.fn().mockResolvedValue(wallet) });
+    probeJobService.scheduleInitial.mockRejectedValue(new Error("queue unavailable"));
+
+    await handler.handle({ walletId: wallet.id, dseq: "test-dseq", createdAt: new Date().toISOString(), version: 1, isFirstLease: true });
+
+    expect(jobQueueService.enqueue).toHaveBeenCalledTimes(3);
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ template: "trialFirstDeploymentLeaseCreated" }) }),
+      expect.anything()
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_SCHEDULE_FAILED", walletId: wallet.id, dseq: "test-dseq", error: expect.any(Error) })
+    );
+  });
+
   it("declares no permissions for its execution", () => {
     const { handler } = setup();
 

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
@@ -97,7 +97,7 @@ export class TrialDeploymentLeaseCreatedHandler implements JobHandler<TrialDeplo
         startAfter: addHours(deploymentCreatedAt, trialDeploymentLifetime).toISOString()
       }
     );
-    await this.probeJobService.scheduleInitial({ walletId: wallet.id, dseq: payload.dseq, leaseCreatedAt: deploymentCreatedAt });
+    await this.#scheduleWorkloadProbe({ walletId: wallet.id, dseq: payload.dseq, leaseCreatedAt: deploymentCreatedAt });
 
     if (payload.isFirstLease) {
       await this.jobQueueService.enqueue(
@@ -114,6 +114,21 @@ export class TrialDeploymentLeaseCreatedHandler implements JobHandler<TrialDeplo
           singletonKey: `notification.trialFirstDeploymentLeaseCreated.${wallet.id}`
         }
       );
+    }
+  }
+
+  /** The probe is a backstopped extra, so failing to schedule it must not fail or retry the close and notification work queued above. */
+  async #scheduleWorkloadProbe(target: { walletId: number; dseq: string; leaseCreatedAt: Date }): Promise<void> {
+    try {
+      await this.probeJobService.scheduleInitial(target);
+    } catch (error) {
+      this.logger.error({
+        event: "TRIAL_WORKLOAD_PROBE_SCHEDULE_FAILED",
+        domainEvent: TrialDeploymentLeaseCreated[DOMAIN_EVENT_NAME],
+        walletId: target.walletId,
+        dseq: target.dseq,
+        error
+      });
     }
   }
 }

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from "vitest";
 import { AbilityService } from "@src/auth/services/ability/ability.service";
 import type { ApiPgDatabase } from "@src/core";
 import { POSTGRES_DB, resolveTable } from "@src/core";
+import { TxService } from "@src/core/services/tx/tx.service";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import type { UserOutput } from "@src/user/repositories";
@@ -799,7 +800,7 @@ describe(DeploymentSettingRepository.name, () => {
 
   describe("findLiveTrialDeployments", () => {
     it("returns open trial deployments created inside the window with their wallet id", async () => {
-      const { deploymentSettingRepository, trialUser, trialWallet, createSetting, db, deploymentSettingsTable } = await setup();
+      const { deploymentSettingRepository, user, trialUser, trialWallet, createSetting, db, deploymentSettingsTable } = await setup();
       const liveDseq = faker.number.int({ min: 100000, max: 999999 }).toString();
       await db.insert(deploymentSettingsTable).values({ userId: trialUser.id, dseq: liveDseq, autoTopUpEnabled: true });
       await db.insert(deploymentSettingsTable).values({ userId: trialUser.id, dseq: `1`, autoTopUpEnabled: true, closed: true });
@@ -812,7 +813,28 @@ describe(DeploymentSettingRepository.name, () => {
 
       const ofTrialUser = deployments.filter(deployment => deployment.userId === trialUser.id);
       expect(ofTrialUser).toEqual([{ userId: trialUser.id, dseq: liveDseq, walletId: trialWallet.walletId, createdAt: expect.any(Date) }]);
-      expect(deployments.some(deployment => deployment.userId !== trialUser.id && deployment.walletId === undefined)).toBe(false);
+      expect(deployments.map(deployment => deployment.userId)).not.toContain(user.id);
+    });
+
+    it("selects the same deployments whatever the session time zone", async () => {
+      const { deploymentSettingRepository, trialUser, deploymentSettingsTable } = await setup();
+      const txService = container.resolve(TxService);
+      const insideWindowDseq = faker.number.int({ min: 100000, max: 999999 }).toString();
+      const outsideWindowDseq = faker.number.int({ min: 100000, max: 999999 }).toString();
+
+      const dseqs = await txService.transaction(async () => {
+        const tx = txService.getPgTx()!;
+        await tx.execute(sql`set local time zone 'Asia/Tokyo'`);
+        await tx.insert(deploymentSettingsTable).values([
+          { userId: trialUser.id, dseq: insideWindowDseq, autoTopUpEnabled: true, createdAt: sql`now() - interval '25 hours'` },
+          { userId: trialUser.id, dseq: outsideWindowDseq, autoTopUpEnabled: true, createdAt: sql`now() - interval '27 hours'` }
+        ]);
+
+        return (await deploymentSettingRepository.findLiveTrialDeployments({ maxAgeHours: 26 })).map(deployment => deployment.dseq);
+      });
+
+      expect(dseqs).toContain(insideWindowDseq);
+      expect(dseqs).not.toContain(outsideWindowDseq);
     });
 
     it("leaves the deployments of a wallet locked for abuse out of the sweep", async () => {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -188,7 +188,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   /** `closed` is Console bookkeeping that drifts from the chain, so these are candidates the probe job re-checks on chain. */
   async findLiveTrialDeployments({ maxAgeHours }: { maxAgeHours: number }): Promise<LiveTrialDeployment[]> {
     const hours = Math.max(1, Math.trunc(maxAgeHours));
-    const deployments = await this.pg
+    const deployments = await this.cursor
       .select({
         userId: this.table.userId,
         dseq: this.table.dseq,
@@ -203,7 +203,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
           eq(UserWallets.isTrialing, true),
           isNotNull(UserWallets.address),
           isNull(UserWallets.abuseLockedAt),
-          gt(this.table.createdAt, sql`(now() at time zone 'utc') - make_interval(hours => ${sql.raw(String(hours))})`)
+          gt(this.table.createdAt, sql`now() - make_interval(hours => ${sql.raw(String(hours))})`)
         )
       )
       .orderBy(desc(this.table.createdAt));

--- a/apps/api/src/workload-abuse/config/env.config.spec.ts
+++ b/apps/api/src/workload-abuse/config/env.config.spec.ts
@@ -37,8 +37,13 @@ describe("workload abuse env config", () => {
     expect(() => envSchema.parse({ WORKLOAD_ABUSE_SIGNATURES: document })).toThrow(/invalid pattern for hard\/broken/);
   });
 
-  it("parses the initial delay list and rejects negative entries", () => {
+  it("parses the initial delay list and rejects negative or blank entries", () => {
     expect(envSchema.parse({ WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: "2, 10" }).WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN).toEqual([2, 10]);
     expect(() => envSchema.parse({ WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: "2,-1" })).toThrow(/non-negative integers/);
+    expect(() => envSchema.parse({ WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: "1,,2" })).toThrow(/non-negative integers/);
+  });
+
+  it("falls back to the default schedule when the initial delay setting is blank", () => {
+    expect(envSchema.parse({ WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: " " }).WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN).toEqual([5, 20, 60]);
   });
 });

--- a/apps/api/src/workload-abuse/config/env.config.ts
+++ b/apps/api/src/workload-abuse/config/env.config.ts
@@ -52,15 +52,21 @@ function parseJson(raw: string): unknown {
   }
 }
 
-function parseMinutesList(raw: string, ctx: z.RefinementCtx): number[] {
-  const values = raw.split(",").map(value => Number(value.trim()));
+const DEFAULT_PROBE_INITIAL_DELAYS_MIN = "5,20,60";
 
-  if (values.length === 0 || values.some(value => !Number.isInteger(value) || value < 0)) {
+function parseMinutesList(raw: string, ctx: z.RefinementCtx): number[] {
+  const entries = raw.split(",").map(entry => entry.trim());
+
+  if (entries.some(entry => !/^\d+$/.test(entry))) {
     ctx.addIssue({ code: z.ZodIssueCode.custom, message: "must be a comma-separated list of non-negative integers" });
     return z.NEVER;
   }
 
-  return values;
+  return entries.map(Number);
+}
+
+function blankToUndefined(value: unknown): unknown {
+  return typeof value === "string" && value.trim() === "" ? undefined : value;
 }
 
 export const envSchema = z.object({
@@ -71,7 +77,7 @@ export const envSchema = z.object({
   WORKLOAD_ABUSE_SIGNATURES: z.string().default("{}").transform(compileSignatures),
   /** `detect` records hard verdicts without acting on them, so a rollout can be compared against manual review first. */
   WORKLOAD_ABUSE_ENFORCEMENT_MODE: z.enum(["detect", "enforce"]).default("detect"),
-  WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: z.string().default("5,20,60").transform(parseMinutesList),
+  WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: z.preprocess(blankToUndefined, z.string().default(DEFAULT_PROBE_INITIAL_DELAYS_MIN).transform(parseMinutesList)),
   WORKLOAD_ABUSE_PROBE_INTERVAL_MIN: z.number({ coerce: true }).int().positive().default(60),
   WORKLOAD_ABUSE_PROBE_JITTER_MIN: z.number({ coerce: true }).int().nonnegative().default(10),
   /** Trial deployments close after a day on their own, so this only bounds a deployment that close missed. */

--- a/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.spec.ts
@@ -149,7 +149,30 @@ describe(ProviderStreamService.name, () => {
     socket.emitShellBytes([100, ...Buffer.from("ignored")]);
     const result = await pending;
 
-    expect(result).toMatchObject({ status: "output_capped", frames: [{ payload: "123456" }] });
+    expect(result).toMatchObject({ status: "output_capped", frames: [{ payload: "12345" }] });
+  });
+
+  it("counts the cap in UTF-8 bytes and never keeps more than it", async () => {
+    const { service, socket } = setup();
+
+    const pending = service.collect({ ...INPUT, maxBytes: 5 });
+    socket.emit("open");
+    socket.emitShellBytes([100, ...Buffer.from("ééé")]);
+    const result = await pending;
+
+    expect(result).toMatchObject({ status: "output_capped", frames: [{ payload: "éé" }] });
+  });
+
+  it("reports a connection error when the socket closes without the proxy announcing completion", async () => {
+    const { service, socket } = setup();
+
+    const pending = service.collect(INPUT);
+    socket.emit("open");
+    socket.emitShellBytes([100, ...Buffer.from("partial")]);
+    socket.emit("close", { code: 1006 });
+    const result = await pending;
+
+    expect(result).toMatchObject({ status: "connection_error", closeCode: 1006, frames: [{ stream: "stdout", payload: "partial" }] });
   });
 
   it("reports a connection error when the socket never opens", async () => {

--- a/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.spec.ts
@@ -152,6 +152,38 @@ describe(ProviderStreamService.name, () => {
     expect(result).toMatchObject({ status: "output_capped", frames: [{ payload: "12345" }] });
   });
 
+  it("counts the cap across frames and truncates the one that crosses it", async () => {
+    const { service, socket } = setup();
+
+    const pending = service.collect({ ...INPUT, maxBytes: 5 });
+    socket.emit("open");
+    socket.emitShellBytes([100, ...Buffer.from("12")]);
+    socket.emitShellBytes([100, ...Buffer.from("3456")]);
+    socket.emitShellBytes([102, ...Buffer.from('{"exit_code":0}')]);
+    const result = await pending;
+
+    expect(result).toEqual({
+      status: "output_capped",
+      exitCode: undefined,
+      frames: [
+        { kind: "shell", stream: "stdout", payload: "12" },
+        { kind: "shell", stream: "stdout", payload: "345" }
+      ]
+    });
+  });
+
+  it("keeps a result frame that exactly fills the cap and still reports its exit code", async () => {
+    const { service, socket } = setup();
+    const payload = '{"exit_code":7}';
+
+    const pending = service.collect({ ...INPUT, maxBytes: Buffer.byteLength(payload) });
+    socket.emit("open");
+    socket.emitShellBytes([102, ...Buffer.from(payload)]);
+    const result = await pending;
+
+    expect(result).toEqual({ status: "completed", exitCode: 7, frames: [{ kind: "shell", stream: "result", payload }] });
+  });
+
   it("counts the cap in UTF-8 bytes and never keeps more than it", async () => {
     const { service, socket } = setup();
 

--- a/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.ts
+++ b/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.ts
@@ -1,3 +1,4 @@
+import { StringDecoder } from "node:string_decoder";
 import { inject, singleton } from "tsyringe";
 
 import { decodeProviderFrame, parseShellExit, type ProviderFrame } from "@src/workload-abuse/lib/provider-frame/provider-frame";
@@ -51,7 +52,6 @@ export class ProviderStreamService {
       const frames: CollectedFrame[] = [];
       let collectedBytes = 0;
       let exitCode: number | undefined;
-      let opened = false;
       let settled = false;
       let idleTimer: NodeJS.Timeout | undefined;
 
@@ -75,7 +75,6 @@ export class ProviderStreamService {
       };
 
       socket.addEventListener("open", () => {
-        opened = true;
         socket.send(
           JSON.stringify({
             type: "websocket",
@@ -105,8 +104,16 @@ export class ProviderStreamService {
           return finish(status, { closeCode: frame.code, closeReason: frame.reason });
         }
 
+        const payloadBytes = Buffer.byteLength(frame.payload, "utf8");
+        const remainingBytes = input.maxBytes - collectedBytes;
+
+        if (payloadBytes > remainingBytes) {
+          frames.push({ ...frame, payload: truncateToUtf8Bytes(frame.payload, remainingBytes) });
+          return finish("output_capped");
+        }
+
         frames.push(frame);
-        collectedBytes += frame.payload.length;
+        collectedBytes += payloadBytes;
 
         if (frame.kind === "shell" && frame.stream === "result") {
           exitCode = parseShellExit(frame.payload)?.exitCode;
@@ -116,10 +123,15 @@ export class ProviderStreamService {
         if (collectedBytes >= input.maxBytes) finish("output_capped");
       });
 
-      socket.addEventListener("close", () => finish(opened ? "completed" : "connection_error"));
+      socket.addEventListener("close", event => finish("connection_error", { closeCode: event.code, closeReason: event.reason }));
       socket.addEventListener("error", () => finish("connection_error"));
     });
   }
+}
+
+/** `write` without `end` never emits a partial character, so the kept text stays within the byte budget. */
+function truncateToUtf8Bytes(text: string, maxBytes: number): string {
+  return new StringDecoder("utf8").write(Buffer.from(text, "utf8").subarray(0, maxBytes));
 }
 
 function toText(data: unknown): string | undefined {

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
@@ -1,5 +1,5 @@
 import { addMinutes, subHours } from "date-fns";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { CreateLogger, JobQueueService } from "@src/core";
@@ -14,6 +14,10 @@ const LEASE_CREATED_AT = new Date("2026-01-01T12:00:00.000Z");
 const TARGET = { walletId: 42, dseq: "1000001" };
 
 describe(TrialWorkloadProbeJobService.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("scheduleInitial", () => {
     it("enqueues nothing while probing is disabled", async () => {
       const { service, jobQueueService } = setup({ enabled: false });
@@ -74,6 +78,16 @@ describe(TrialWorkloadProbeJobService.name, () => {
 
       expect(startAfter.getTime()).toBeGreaterThanOrEqual(addMinutes(now, 50).getTime());
       expect(startAfter.getTime()).toBeLessThanOrEqual(addMinutes(now, 70).getTime());
+    });
+
+    it("never reschedules at or before now when the jitter reaches the interval", () => {
+      const { service } = setup({ intervalMin: 10, jitterMin: 60 });
+      const now = new Date("2026-09-06T15:00:00.000Z");
+      vi.spyOn(Math, "random").mockReturnValue(0);
+
+      const startAfter = service.startAfterFor({ attempt: 4, leaseCreatedAt: LEASE_CREATED_AT.toISOString() }, now);
+
+      expect(startAfter).toEqual(addMinutes(now, 1));
     });
   });
 
@@ -166,6 +180,8 @@ describe(TrialWorkloadProbeJobService.name, () => {
     pendingKeys?: string[];
     detected?: Array<{ walletId: number; dseq: string }>;
     now?: Date;
+    intervalMin?: number;
+    jitterMin?: number;
   }) {
     if (input.now) vi.useFakeTimers({ now: input.now, toFake: ["Date"] });
     else vi.useRealTimers();
@@ -180,8 +196,8 @@ describe(TrialWorkloadProbeJobService.name, () => {
     const config = mockConfigService<WorkloadAbuseConfigService>({
       WORKLOAD_ABUSE_PROBE_ENABLED: input.enabled ?? true,
       WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN: [5, 20, 60],
-      WORKLOAD_ABUSE_PROBE_INTERVAL_MIN: 60,
-      WORKLOAD_ABUSE_PROBE_JITTER_MIN: 10,
+      WORKLOAD_ABUSE_PROBE_INTERVAL_MIN: input.intervalMin ?? 60,
+      WORKLOAD_ABUSE_PROBE_JITTER_MIN: input.jitterMin ?? 10,
       WORKLOAD_ABUSE_RECONCILE_MAX_AGE_HOURS: 26
     });
     const logger = mock<ReturnType<CreateLogger>>();

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
@@ -24,6 +24,9 @@ export class ProbeTrialDeployment implements Job {
 
 export type ProbeTrialDeploymentTarget = { walletId: number; dseq: string };
 
+/** A jittered reschedule must land strictly after now whatever the jitter and interval settings are, or pg-boss can archive it before a worker sees it. */
+const MIN_RESCHEDULE_DELAY_MIN = 1;
+
 export function probeTrialDeploymentKeyFor({ walletId, dseq }: ProbeTrialDeploymentTarget): string {
   return `probeTrialDeployment.${walletId}.${dseq}`;
 }
@@ -133,7 +136,7 @@ export class TrialWorkloadProbeJobService {
     const jitter = this.config.get("WORKLOAD_ABUSE_PROBE_JITTER_MIN");
     const offset = (Math.random() * 2 - 1) * jitter;
 
-    return addMinutes(now, this.config.get("WORKLOAD_ABUSE_PROBE_INTERVAL_MIN") + offset);
+    return addMinutes(now, Math.max(this.config.get("WORKLOAD_ABUSE_PROBE_INTERVAL_MIN") + offset, MIN_RESCHEDULE_DELAY_MIN));
   }
 
   async #schedule(data: ProbeTrialDeployment["data"], startAfter = this.startAfterFor(data)): Promise<string | null> {


### PR DESCRIPTION
## Why

Fixes CON-950

The trial workload probe (#3819) shipped detection-only and off by default. Review found seven defects that decide whether a finding gets recorded at all. Fixing them while the feature is still dark means the detection data can be trusted from the day the probe is switched on.

## What

Evidence collection

- The output cap is checked before a frame is kept, and counted in UTF-8 bytes. A frame that does not fit is cut on a character boundary and the probe ends as `output_capped`, so a probe never holds more than the configured limit.
- A socket that closes without the proxy's `closed` message is recorded as `connection_error` instead of `completed`. The proxy always sends that message before it closes, so the bare `close` event only fires on a transport failure, and the truncated evidence no longer looks like a complete, clean probe.

Scheduling

- A blank `WORKLOAD_ABUSE_PROBE_INITIAL_DELAYS_MIN` falls back to the default `5,20,60` instead of parsing as one zero-minute delay. A blank entry inside a list (`1,,2`) fails validation at startup instead of being read as zero.
- The jittered reschedule has a floor of one minute after now, so it cannot land at or before the current time when the jitter is set at or above the interval.
- When the probe cannot be scheduled, the handler logs `TRIAL_WORKLOAD_PROBE_SCHEDULE_FAILED` and carries on, instead of failing the lease-created job after its close and notification work was already queued.

Data selection

- The reconcile sweep compares `created_at` against `now()` rather than `now() at time zone 'utc'`. The column stores the session-local wall clock, so the old comparison picked the wrong window on any non-UTC session. The query now runs on the transaction cursor, which is what lets the integration test pin a Tokyo session and show the window stays the same.

Tests

- The non-trial exclusion assertion in the sweep test compared against a `walletId` the inner join can never leave undefined. It now checks that the non-trial user's deployment is absent.
- I reverted each fix in turn and confirmed its test fails without it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Probe-processing failures no longer prevent follow-up notifications and deployment closure.
  * Improved handling of workload-abuse probe schedules, including blank or invalid configuration values and minimum rescheduling delays.
  * Stream output now respects byte limits without breaking UTF-8 characters.
  * Unexpected stream disconnections are consistently reported as connection errors.
  * Live trial deployment filtering remains accurate across time zones and excludes regular deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->