### PR TITLE
feat(deployment): resolve a deployment's definition api-first

### DIFF
--- a/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.spec.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.spec.tsx
@@ -101,7 +101,6 @@ describe(LocalNoteManager.name, () => {
     const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => ({
       getDeploymentName,
       changeDeploymentName: vi.fn(),
-      getDeploymentData: vi.fn().mockReturnValue(null),
       favoriteProviders: [],
       updateFavoriteProviders: vi.fn(),
       selectedDeploymentDseq: dseq,

--- a/apps/deploy-web/src/components/LocalNoteManager/useLocalNotes.ts
+++ b/apps/deploy-web/src/components/LocalNoteManager/useLocalNotes.ts
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import { useAtom } from "jotai";
 
 import { useServices } from "@src/context/ServicesProvider";
-import type { LocalDeploymentData } from "@src/services/deployment-storage/deployment-storage.service";
 import { settingsIdAtom } from "@src/store/settingsStore";
 import { getProviderLocalData, updateProviderLocalData } from "@src/utils/providerUtils";
 import { localNoteStore } from "./localNoteStore";
@@ -11,7 +10,6 @@ import { localNoteStore } from "./localNoteStore";
 export type LocalNotesContextType = {
   getDeploymentName: (dseq: string | number | null) => string | null;
   changeDeploymentName: (dseq: string | number) => void;
-  getDeploymentData: (dseq: string | number) => Partial<LocalDeploymentData> | null;
   favoriteProviders: string[];
   updateFavoriteProviders: (newFavorites: string[]) => void;
   selectedDeploymentDseq: string | number | null;
@@ -32,14 +30,6 @@ export function useLocalNotes(): LocalNotesContextType {
     [deploymentLocalStorage, settingsId]
   );
 
-  const getDeploymentData = useCallback(
-    (dseq: string | number) => {
-      const localData = deploymentLocalStorage.get(settingsId, dseq);
-      return localData ?? null;
-    },
-    [deploymentLocalStorage, settingsId]
-  );
-
   const changeDeploymentName = useCallback(
     (dseq: string | number) => {
       selectDeployment(dseq);
@@ -55,7 +45,7 @@ export function useLocalNotes(): LocalNotesContextType {
     [setFavoriteProviders]
   );
 
-  return { getDeploymentName, changeDeploymentName, getDeploymentData, favoriteProviders, updateFavoriteProviders, selectedDeploymentDseq, selectDeployment };
+  return { getDeploymentName, changeDeploymentName, favoriteProviders, updateFavoriteProviders, selectedDeploymentDseq, selectDeployment };
 }
 
 export function useInitFavoriteProviders() {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { DEPENDENCIES, DeploymentDetail } from "./DeploymentDetail";
@@ -102,16 +103,22 @@ describe("DeploymentDetail", () => {
     expect(screen.queryByTestId("deployment-detail-skeleton")).not.toBeInTheDocument();
   });
 
+  it("holds the page skeleton until the definition resolves, so placements never render with no services", () => {
+    setup({ definition: { sdl: undefined, source: "resolving" } });
+
+    expect(screen.getByTestId("deployment-detail-skeleton")).toBeInTheDocument();
+  });
+
   it("redirects an in-progress deployment with no lease to the configure flow", () => {
     const { router } = setup({ leases: [] });
 
     expect(router.replace).toHaveBeenCalledWith(expect.stringContaining("configure"));
   });
 
-  it("offers redeploy on the Update tab when a manifest is stored locally", () => {
+  it("offers redeploy on the Update tab when a definition resolves", () => {
     const { redeploy, analyticsService, ManifestUpdate } = setup({
       tab: "UPDATE",
-      storedDeployment: { manifest: "version: '2.0'", name: "My Storefront" }
+      definition: { sdl: "version: '2.0'", name: "My Storefront", source: "api" }
     });
 
     ManifestUpdate.mock.calls[0][0].onRedeploy?.();
@@ -120,10 +127,22 @@ describe("DeploymentDetail", () => {
     expect(analyticsService.track).toHaveBeenCalledWith("redeploy_btn_clk", "Amplitude");
   });
 
-  it("withholds redeploy from the Update tab when no manifest is stored locally", () => {
-    const { ManifestUpdate } = setup({ tab: "UPDATE", storedDeployment: null });
+  it("withholds redeploy from the Update tab when neither source holds a definition", () => {
+    const { ManifestUpdate } = setup({ tab: "UPDATE", definition: { sdl: undefined, source: "absent" } });
 
     expect(ManifestUpdate.mock.calls[0][0].onRedeploy).toBeUndefined();
+  });
+
+  it("seeds the configure draft from the api definition when redirecting a lease-less deployment", () => {
+    const { router } = setup({ leases: [], definition: { sdl: "version: '2.0' # from-the-api", source: "api" } });
+
+    expect(router.replace).toHaveBeenCalledWith(expect.stringContaining("draftId"));
+  });
+
+  it("does not redirect a lease-less deployment until the definition resolves", () => {
+    const { router } = setup({ leases: [], definition: { sdl: undefined, source: "resolving" } });
+
+    expect(router.replace).not.toHaveBeenCalled();
   });
 
   function isRenderedBefore(earlier: Element, later: Element) {
@@ -138,7 +157,7 @@ describe("DeploymentDetail", () => {
     error?: Error | null;
     tab?: string;
     leaseState?: string;
-    storedDeployment?: { manifest?: string; name?: string } | null;
+    definition?: Partial<DeploymentDefinition>;
   }) {
     const deployment = input && "deployment" in input ? input.deployment : mock<DeploymentDto>({ dseq: "1786440078202", state: "active", groups: [] });
     const leases = input && "leases" in input ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: input?.leaseState ?? "active" })];
@@ -149,9 +168,6 @@ describe("DeploymentDetail", () => {
 
     const useServices: typeof DEPENDENCIES.useServices = () =>
       mock<ReturnType<typeof DEPENDENCIES.useServices>>({
-        deploymentLocalStorage: mock<ReturnType<typeof DEPENDENCIES.useServices>["deploymentLocalStorage"]>({
-          get: () => input?.storedDeployment ?? null
-        }),
         sdlAnalyzer: mock<ReturnType<typeof DEPENDENCIES.useServices>["sdlAnalyzer"]>({ hasCiCdImage: () => false }),
         analyticsService
       });
@@ -172,6 +188,8 @@ describe("DeploymentDetail", () => {
       mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: providers, isFetching: false });
     const redeploy = vi.fn();
     const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
+    const definition: DeploymentDefinition = { sdl: "version: '2.0'", name: undefined, source: "local", ...input?.definition };
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
 
     const DeploymentDetailHeader = vi.fn(() => <div>detail-header</div>);
     const ReclamationBanner = vi.fn(() => <div>reclamation-banner</div>);
@@ -195,6 +213,7 @@ describe("DeploymentDetail", () => {
           useRouter,
           useSearchParams,
           useRedeploy,
+          useDeploymentDefinition,
           useDeploymentDetail,
           useDeploymentLeaseList,
           useProviderList,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -107,6 +107,8 @@ describe("DeploymentDetail", () => {
     setup({ definition: { sdl: undefined, source: "resolving" } });
 
     expect(screen.getByTestId("deployment-detail-skeleton")).toBeInTheDocument();
+    expect(screen.queryByText("detail-header")).not.toBeInTheDocument();
+    expect(screen.queryByText("placements")).not.toBeInTheDocument();
   });
 
   it("redirects an in-progress deployment with no lease to the configure flow", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -135,10 +135,22 @@ describe("DeploymentDetail", () => {
     expect(ManifestUpdate.mock.calls[0][0].onRedeploy).toBeUndefined();
   });
 
+  it("withholds redeploy from the Update tab when the definition is absent despite an inspection-only api sdl", () => {
+    const { ManifestUpdate } = setup({ tab: "UPDATE", definition: { sdl: "version: '2.0' # not-self-contained", source: "absent" } });
+
+    expect(ManifestUpdate.mock.calls[0][0].onRedeploy).toBeUndefined();
+  });
+
   it("seeds the configure draft from the api definition when redirecting a lease-less deployment", () => {
     const { router } = setup({ leases: [], definition: { sdl: "version: '2.0' # from-the-api", source: "api" } });
 
     expect(router.replace).toHaveBeenCalledWith(expect.stringContaining("draftId"));
+  });
+
+  it("redirects a lease-less deployment without a draft when the definition is absent despite an inspection-only api sdl", () => {
+    const { router } = setup({ leases: [], definition: { sdl: "version: '2.0' # not-self-contained", source: "absent" } });
+
+    expect(router.replace).toHaveBeenCalledWith(expect.not.stringContaining("draftId"));
   });
 
   it("does not redirect a lease-less deployment until the definition resolves", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -103,12 +103,22 @@ describe("DeploymentDetail", () => {
     expect(screen.queryByTestId("deployment-detail-skeleton")).not.toBeInTheDocument();
   });
 
-  it("holds the page skeleton until the definition resolves, so placements never render with no services", () => {
+  it("holds only the placements until the definition resolves, so they never render with no services", () => {
     setup({ definition: { sdl: undefined, source: "resolving" } });
 
-    expect(screen.getByTestId("deployment-detail-skeleton")).toBeInTheDocument();
-    expect(screen.queryByText("detail-header")).not.toBeInTheDocument();
+    expect(screen.getByTestId("deployment-placements-skeleton")).toBeInTheDocument();
     expect(screen.queryByText("placements")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("deployment-detail-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByText("detail-header")).toBeInTheDocument();
+    expect(screen.getByRole("tablist")).toBeInTheDocument();
+  });
+
+  it("renders a tab that does not read the definition without waiting for it", () => {
+    setup({ tab: "LOGS", definition: { sdl: undefined, source: "resolving" } });
+
+    expect(screen.getByText("logs")).toBeInTheDocument();
+    expect(screen.queryByTestId("deployment-detail-skeleton")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("deployment-placements-skeleton")).not.toBeInTheDocument();
   });
 
   it("redirects an in-progress deployment with no lease to the configure flow", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -98,9 +98,9 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
   const deploymentManifest = definition.sdl || "";
   const isActive = deployment?.state === "active" && !!leases?.some(isLeaseLive);
   const isDeploymentNotFound = !!deploymentError && (deploymentError as any).response?.data?.message?.includes("Deployment not found") && !isLoadingDeployment;
-  /** The definition feeds the service counts and the placement cards, so showing the page before it lands renders "0 services" and then corrects itself. */
-  const showsPageSkeleton =
-    !isDeploymentNotFound && !deploymentError && !isLeasesError && (!deployment || !isLeasesLoaded || definition.source === "resolving");
+  const showsPageSkeleton = !isDeploymentNotFound && !deploymentError && !isLeasesError && (!deployment || !isLeasesLoaded);
+  /** The placement cards read their services off the definition, so rendering them before it lands shows "0 services" and then corrects itself. */
+  const showsPlacementsSkeleton = definition.source === "resolving";
 
   useEffect(() => {
     if (deployment) {
@@ -196,15 +196,18 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
 
             <div className="flex-1 bg-muted py-6">
               <div className={PAGE_BAND}>
-                {activeTab === "DETAILS" && (
-                  <d.DeploymentPlacements
-                    leases={leases || []}
-                    providers={providers || []}
-                    deploymentManifest={deploymentManifest}
-                    dseq={dseq}
-                    onClosed={loadDeploymentDetail}
-                  />
-                )}
+                {activeTab === "DETAILS" &&
+                  (showsPlacementsSkeleton ? (
+                    <Skeleton className="h-64 w-full rounded-xl" data-testid="deployment-placements-skeleton" />
+                  ) : (
+                    <d.DeploymentPlacements
+                      leases={leases || []}
+                      providers={providers || []}
+                      deploymentManifest={deploymentManifest}
+                      dseq={dseq}
+                      onClosed={loadDeploymentDetail}
+                    />
+                  ))}
 
                 {activeTab === "LOGS" && (isActive ? <d.DeploymentLogs leases={leases} selectedLogsMode="logs" /> : <TabInactiveState />)}
                 {activeTab === "EVENTS" && (isActive ? <d.DeploymentLogs leases={leases} selectedLogsMode="events" /> : <TabInactiveState />)}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -11,6 +11,7 @@ import { NextSeo } from "next-seo";
 import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
@@ -33,6 +34,7 @@ export const DEPENDENCIES = {
   useRouter,
   useSearchParams,
   useRedeploy,
+  useDeploymentDefinition,
   useDeploymentDetail,
   useDeploymentLeaseList,
   useProviderList,
@@ -69,7 +71,7 @@ export interface DeploymentDetailProps {
 }
 
 export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies: d = DEPENDENCIES }) => {
-  const { deploymentLocalStorage, sdlAnalyzer, analyticsService } = d.useServices();
+  const { sdlAnalyzer, analyticsService } = d.useServices();
   const router = d.useRouter();
   const searchParams = d.useSearchParams();
   const { address } = d.useWallet();
@@ -92,11 +94,13 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
   });
   const { data: providers, isFetching: isLoadingProviders, refetch: getProviders } = d.useProviderList();
 
-  const storedDeployment = deployment ? deploymentLocalStorage.get(address, dseq) : null;
-  const deploymentManifest = storedDeployment?.manifest || "";
+  const definition = d.useDeploymentDefinition(dseq);
+  const deploymentManifest = definition.sdl || "";
   const isActive = deployment?.state === "active" && !!leases?.some(isLeaseLive);
   const isDeploymentNotFound = !!deploymentError && (deploymentError as any).response?.data?.message?.includes("Deployment not found") && !isLoadingDeployment;
-  const showsPageSkeleton = !isDeploymentNotFound && !deploymentError && !isLeasesError && (!deployment || !isLeasesLoaded);
+  /** The definition feeds the service counts and the placement cards, so showing the page before it lands renders "0 services" and then corrects itself. */
+  const showsPageSkeleton =
+    !isDeploymentNotFound && !deploymentError && !isLeasesError && (!deployment || !isLeasesLoaded || definition.source === "resolving");
 
   useEffect(() => {
     if (deployment) {
@@ -107,13 +111,14 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
 
   useEffect(
     function redirectWhenInProgressWithoutLease() {
+      if (definition.source === "resolving") return;
+
       if (leases && deployment?.state === "active" && leases.length === 0 && !deployment.groups?.some(g => g.state === "paused")) {
-        const localData = deploymentLocalStorage.get(address, dseq);
-        const draftId = localData?.manifest ? createConfigureDraft(localData.manifest, localData.name) : undefined;
+        const draftId = definition.sdl ? createConfigureDraft(definition.sdl, definition.name) : undefined;
         router.replace(UrlService.configureDeployment({ dseq, draftId }));
       }
     },
-    [address, deployment?.state, deployment?.groups, deploymentLocalStorage, dseq, leases, router]
+    [deployment?.state, deployment?.groups, definition.source, definition.sdl, definition.name, dseq, leases, router]
   );
 
   const tabQuery = searchParams?.get("tab");
@@ -130,8 +135,8 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
     }
   }
 
-  function redeployFromStoredManifest() {
-    redeploy({ sdl: storedDeployment?.manifest, name: storedDeployment?.name });
+  function redeployFromResolvedDefinition() {
+    redeploy({ sdl: definition.sdl, name: definition.name });
     analyticsService.track("redeploy_btn_clk", "Amplitude");
   }
 
@@ -211,7 +216,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
                     onManifestChange={setEditedManifest}
                     isRemoteDeploy={isRemoteDeploy}
                     deployment={deployment}
-                    onRedeploy={storedDeployment?.manifest ? redeployFromStoredManifest : undefined}
+                    onRedeploy={definition.sdl ? redeployFromResolvedDefinition : undefined}
                     closeManifestEditor={() => {
                       changeTab("DETAILS");
                       loadDeploymentDetail();

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -11,7 +11,7 @@ import { NextSeo } from "next-seo";
 import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
@@ -114,7 +114,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
       if (definition.source === "resolving") return;
 
       if (leases && deployment?.state === "active" && leases.length === 0 && !deployment.groups?.some(g => g.state === "paused")) {
-        const draftId = definition.sdl ? createConfigureDraft(definition.sdl, definition.name) : undefined;
+        const draftId = isUsableDeploymentDefinition(definition) ? createConfigureDraft(definition.sdl, definition.name) : undefined;
         router.replace(UrlService.configureDeployment({ dseq, draftId }));
       }
     },
@@ -216,7 +216,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
                     onManifestChange={setEditedManifest}
                     isRemoteDeploy={isRemoteDeploy}
                     deployment={deployment}
-                    onRedeploy={definition.sdl ? redeployFromResolvedDefinition : undefined}
+                    onRedeploy={isUsableDeploymentDefinition(definition) ? redeployFromResolvedDefinition : undefined}
                     closeManifestEditor={() => {
                       changeTab("DETAILS");
                       loadDeploymentDetail();

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -171,7 +171,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
 
       {showsPageSkeleton && <DeploymentDetailSkeleton />}
 
-      {deployment && isLeasesLoaded && (
+      {!showsPageSkeleton && deployment && isLeasesLoaded && (
         <>
           <div className={PAGE_BAND}>
             <d.DeploymentDetailHeader deployment={deployment} leases={leases} providers={providers || []} />

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -3,6 +3,7 @@ import yaml from "js-yaml";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { DeploymentDto, DeploymentGroup, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { DEPENDENCIES, DeploymentDetailHeader } from "./DeploymentDetailHeader";
@@ -14,7 +15,7 @@ import { MockComponents } from "@tests/unit/mocks";
 describe(DeploymentDetailHeader.name, () => {
   it("counts the services of every placement, not just the one whose status is loaded", () => {
     setup({
-      storedManifest: yaml.dump({
+      definitionSdl: yaml.dump({
         services: { web: {}, api: {}, worker: {} },
         deployment: { web: { "dcloud-us": {} }, api: { "dcloud-us": {} }, worker: { "dcloud-eu": {} } }
       }),
@@ -26,7 +27,7 @@ describe(DeploymentDetailHeader.name, () => {
 
   it("falls back to the placement count when no manifest is stored locally", () => {
     setup({
-      storedManifest: null,
+      definitionSdl: null,
       leases: [buildLeaseInPlacement("1", "dcloud-us"), buildLeaseInPlacement("2", "dcloud-eu"), buildLeaseInPlacement("3", "dcloud-ap")]
     });
 
@@ -223,7 +224,7 @@ describe(DeploymentDetailHeader.name, () => {
   });
 
   it("keeps redeploy off the header now that it lives on the update tab", () => {
-    setup({ storedManifest: "version: '2.0'" });
+    setup({ definitionSdl: "version: '2.0'" });
 
     expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
   });
@@ -267,12 +268,19 @@ describe(DeploymentDetailHeader.name, () => {
     });
   }
 
+  it("holds a skeleton for the service count until the definition resolves", () => {
+    setup({ definitionSource: "resolving" });
+
+    expect(screen.getByTestId("services-count-skeleton")).toBeInTheDocument();
+  });
+
   function setup(input: {
     runtimeLimitHours?: number | null;
     runtimeEndsAt?: string | null;
     name?: string | null;
     isTrialing?: boolean;
-    storedManifest?: string | null;
+    definitionSdl?: string | null;
+    definitionSource?: DeploymentDefinition["source"];
     state?: string;
     leases?: LeaseDto[] | null;
     providers?: ApiProviderList[];
@@ -284,8 +292,13 @@ describe(DeploymentDetailHeader.name, () => {
     const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () =>
       mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({
         getDeploymentName: () => input.name ?? null,
-        changeDeploymentName,
-        getDeploymentData: () => (input.storedManifest ? { manifest: input.storedManifest, name: input.name ?? undefined } : null)
+        changeDeploymentName
+      });
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
+        sdl: input.definitionSdl ?? undefined,
+        name: input.name ?? undefined,
+        source: input.definitionSource ?? (input.definitionSdl ? "api" : "absent")
       });
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false });
     const useDeclaredTeeTypes: typeof DEPENDENCIES.useDeclaredTeeTypes = () => [];
@@ -326,6 +339,7 @@ describe(DeploymentDetailHeader.name, () => {
         providers={input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })]}
         dependencies={MockComponents(DEPENDENCIES, {
           useLocalNotes,
+          useDeploymentDefinition,
           useWallet,
           useDeploymentEscrowBalance,
           useDeploymentSettingQuery,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -48,7 +48,7 @@ describe(DeploymentDetailHeader.name, () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  it("shows the deployment name from local notes", () => {
+  it("shows the deployment name recorded for this deployment in this browser", () => {
     setup({ name: "My Storefront" });
 
     expect(screen.getByText("My Storefront")).toBeInTheDocument();
@@ -303,11 +303,7 @@ describe(DeploymentDetailHeader.name, () => {
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const changeDeploymentName = vi.fn();
-    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({
-        getDeploymentName: () => input.name ?? null,
-        changeDeploymentName
-      });
+    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({ changeDeploymentName });
     let definition = mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
       sdl: input.definitionSdl ?? undefined,
       name: input.name ?? undefined,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -25,6 +25,20 @@ describe(DeploymentDetailHeader.name, () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
+  it("recounts the services when the definition lands after the first paint", () => {
+    const { resolveDefinitionWith } = setup({ definitionSource: "resolving", leases: [buildLeaseInPlacement("1", "dcloud-us")] });
+
+    resolveDefinitionWith(
+      yaml.dump({
+        services: { web: {}, api: {}, worker: {} },
+        deployment: { web: { "dcloud-us": {} }, api: { "dcloud-us": {} }, worker: { "dcloud-us": {} } }
+      })
+    );
+
+    expect(screen.queryByTestId("services-count-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
   it("falls back to the placement count when no manifest is stored locally", () => {
     setup({
       definitionSdl: null,
@@ -294,12 +308,12 @@ describe(DeploymentDetailHeader.name, () => {
         getDeploymentName: () => input.name ?? null,
         changeDeploymentName
       });
-    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
-        sdl: input.definitionSdl ?? undefined,
-        name: input.name ?? undefined,
-        source: input.definitionSource ?? (input.definitionSdl ? "api" : "absent")
-      });
+    let definition = mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
+      sdl: input.definitionSdl ?? undefined,
+      name: input.name ?? undefined,
+      source: input.definitionSource ?? (input.definitionSdl ? "api" : "absent")
+    });
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false });
     const useDeclaredTeeTypes: typeof DEPENDENCIES.useDeclaredTeeTypes = () => [];
     const useDeclaredGpuInterconnect: typeof DEPENDENCIES.useDeclaredGpuInterconnect = () => ({ enabled: false, fabrics: [] });
@@ -332,30 +346,36 @@ describe(DeploymentDetailHeader.name, () => {
       escrowAccount: mock<DeploymentDto["escrowAccount"]>({ state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [] }) })
     });
 
-    render(
-      <DeploymentDetailHeader
-        deployment={deployment}
-        leases={input.leases !== undefined ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })]}
-        providers={input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })]}
-        dependencies={MockComponents(DEPENDENCIES, {
-          useLocalNotes,
-          useDeploymentDefinition,
-          useWallet,
-          useDeploymentEscrowBalance,
-          useDeploymentSettingQuery,
-          useDeclaredTeeTypes,
-          useDeclaredGpuInterconnect,
-          TrialDeploymentBadge,
-          ConfidentialComputeBadge,
-          GpuInterconnectBadge,
-          CostRate,
-          CostBreakdownTooltip,
-          DeploymentVisitControl,
-          ...input.dependencies
-        })}
-      />
-    );
+    const leases = input.leases !== undefined ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })];
+    const providers = input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })];
+    const dependencies = MockComponents(DEPENDENCIES, {
+      useLocalNotes,
+      useDeploymentDefinition,
+      useWallet,
+      useDeploymentEscrowBalance,
+      useDeploymentSettingQuery,
+      useDeclaredTeeTypes,
+      useDeclaredGpuInterconnect,
+      TrialDeploymentBadge,
+      ConfidentialComputeBadge,
+      GpuInterconnectBadge,
+      CostRate,
+      CostBreakdownTooltip,
+      DeploymentVisitControl,
+      ...input.dependencies
+    });
+    const renderHeader = () => <DeploymentDetailHeader deployment={deployment} leases={leases} providers={providers} dependencies={dependencies} />;
 
-    return { changeDeploymentName, CostRate, CostBreakdownTooltip };
+    const { rerender } = render(renderHeader());
+
+    return {
+      changeDeploymentName,
+      CostRate,
+      CostBreakdownTooltip,
+      resolveDefinitionWith(sdl: string) {
+        definition = mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({ sdl, name: input.name ?? undefined, source: "api" });
+        rerender(renderHeader());
+      }
+    };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -68,7 +68,7 @@ export interface DeploymentDetailHeaderProps {
 }
 
 export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
-  const { getDeploymentName, changeDeploymentName } = d.useLocalNotes();
+  const { changeDeploymentName } = d.useLocalNotes();
   const { isTrialing } = d.useWallet();
   const { denom } = d.useDeploymentEscrowBalance({ deployment, leases });
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq, pollUntilRuntimeAnchored: true });
@@ -93,7 +93,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
     [leases, definitionSdl]
   );
 
-  const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
+  const name = definition.name || `Deployment #${deployment.dseq}`;
 
   return (
     <div className="flex flex-col gap-6 py-6 lg:flex-row lg:items-start lg:justify-between">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -88,11 +88,12 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
 
   const definition = d.useDeploymentDefinition(deployment.dseq);
   const definitionSdl = definition.sdl;
-  const manifestServices = useMemo(() => parseManifestServices(definitionSdl), [definitionSdl]);
-  const servicesByPlacement = useMemo(() => parseServicesByPlacement(definitionSdl), [definitionSdl]);
+  const servicesCount = useMemo(
+    () => countPlacementServices(leases ?? [], parseServicesByPlacement(definitionSdl), parseManifestServices(definitionSdl)),
+    [leases, definitionSdl]
+  );
 
   const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
-  const servicesCount = countPlacementServices(leases ?? [], servicesByPlacement, manifestServices);
 
   return (
     <div className="flex flex-col gap-6 py-6 lg:flex-row lg:items-start lg:justify-between">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FC, ReactNode } from "react";
 import { useMemo } from "react";
-import { Button, Card, CardContent, CustomTooltip } from "@akashnetwork/ui/components";
+import { Button, Card, CardContent, CustomTooltip, Skeleton } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { EditPencil, InfoCircle } from "iconoir-react";
 
@@ -14,6 +14,7 @@ import { TrialDeploymentBadge } from "@src/components/shared/TrialDeploymentBadg
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useDeploymentEscrowBalance } from "@src/hooks/useDeploymentEscrowBalance/useDeploymentEscrowBalance";
 import { useHasDeploymentStopped } from "@src/hooks/useHasDeploymentStopped";
 import { useTickingNow } from "@src/hooks/useTickingNow";
@@ -37,6 +38,7 @@ import { RuntimeLimitMeter } from "./RuntimeLimitMeter";
 
 export const DEPENDENCIES = {
   useLocalNotes,
+  useDeploymentDefinition,
   useWallet,
   useDeploymentEscrowBalance,
   useDeploymentSettingQuery,
@@ -66,7 +68,7 @@ export interface DeploymentDetailHeaderProps {
 }
 
 export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
-  const { getDeploymentName, changeDeploymentName, getDeploymentData } = d.useLocalNotes();
+  const { getDeploymentName, changeDeploymentName } = d.useLocalNotes();
   const { isTrialing } = d.useWallet();
   const { denom } = d.useDeploymentEscrowBalance({ deployment, leases });
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq, pollUntilRuntimeAnchored: true });
@@ -84,10 +86,10 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
     ? getRuntimeLimitCountdown({ runtimeLimitHours: settings.runtimeLimitHours, runtimeEndsAt, hasStopped, now })
     : null;
 
-  const storedDeployment = getDeploymentData(deployment.dseq);
-  const storedManifest = storedDeployment?.manifest;
-  const manifestServices = useMemo(() => parseManifestServices(storedManifest), [storedManifest]);
-  const servicesByPlacement = useMemo(() => parseServicesByPlacement(storedManifest), [storedManifest]);
+  const definition = d.useDeploymentDefinition(deployment.dseq);
+  const definitionSdl = definition.sdl;
+  const manifestServices = useMemo(() => parseManifestServices(definitionSdl), [definitionSdl]);
+  const servicesByPlacement = useMemo(() => parseServicesByPlacement(definitionSdl), [definitionSdl]);
 
   const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
   const servicesCount = countPlacementServices(leases ?? [], servicesByPlacement, manifestServices);
@@ -119,7 +121,9 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
       <Card className="w-full shrink-0 lg:w-auto">
         <CardContent className="flex flex-col gap-5 p-6">
           <div className="grid grid-cols-4 gap-x-10">
-            <SummaryItem label="TOTAL SERVICES">{servicesCount}</SummaryItem>
+            <SummaryItem label="TOTAL SERVICES">
+              {definition.source === "resolving" ? <Skeleton className="h-5 w-6" data-testid="services-count-skeleton" /> : servicesCount}
+            </SummaryItem>
             <SummaryItem
               label={
                 <span className="inline-flex items-center gap-1">

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -12,7 +12,7 @@ import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
@@ -215,7 +215,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                       <CustomDropdownLinkItem onClick={() => changeDeploymentName(deployment.dseq)} icon={<Edit fontSize="small" />}>
                         Edit name
                       </CustomDropdownLinkItem>
-                      {(definition.source === "resolving" || definition.sdl) && (
+                      {(definition.source === "resolving" || isUsableDeploymentDefinition(definition)) && (
                         <CustomDropdownLinkItem
                           disabled={definition.source === "resolving"}
                           onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -12,6 +12,7 @@ import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
@@ -48,7 +49,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
   const router = useRouter();
   const { analyticsService } = useServices();
   const [open, setOpen] = useState(false);
-  const { changeDeploymentName, getDeploymentData } = useLocalNotes();
+  const { changeDeploymentName } = useLocalNotes();
   const { address, signAndBroadcastTx, isTrialing } = useWallet();
   const isActive = deployment.state === "active";
   const { data: filteredLeases, isLoading: isLoadingLeases } = useDeploymentLeaseList(address, deployment, { enabled: !!deployment });
@@ -63,7 +64,8 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
   const closedReasonLabel = closedLease ? getClosedLeaseLabel(closedLease) : null;
   const hasGpu = Boolean(deployment.gpuAmount && deployment.gpuAmount > 0);
   const interconnect = useDeclaredGpuInterconnect(deployment);
-  const storageDeploymentData = getDeploymentData(deployment?.dseq);
+  /** Only once the menu is open, so a list of rows does not each fire a deployment read on mount. */
+  const definition = useDeploymentDefinition(open ? deployment?.dseq : null);
   const { closeDeploymentConfirm } = useManagedDeploymentConfirm();
   const providersByOwner = useMemo(() => keyBy(providers, p => p.owner), [providers]);
   const lease = filteredLeases?.find(lease => !!(lease?.provider && providersByOwner[lease.provider]));
@@ -213,9 +215,10 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                       <CustomDropdownLinkItem onClick={() => changeDeploymentName(deployment.dseq)} icon={<Edit fontSize="small" />}>
                         Edit name
                       </CustomDropdownLinkItem>
-                      {storageDeploymentData?.manifest && (
+                      {(definition.source === "resolving" || definition.sdl) && (
                         <CustomDropdownLinkItem
-                          onClick={() => redeploy({ sdl: storageDeploymentData?.manifest, name: storageDeploymentData?.name })}
+                          disabled={definition.source === "resolving"}
+                          onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
                           icon={<Upload fontSize="small" />}
                         >
                           Redeploy

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -54,11 +54,7 @@ describe(ManifestUpdate.name, () => {
 
     expect(screen.getByText(/it looks like this deployment was created using another deploy tool/i)).toBeInTheDocument();
 
-    const continueButton = dependencies.Button.mock.calls.find(call => call[0].children === "Continue");
-
-    await act(() => {
-      continueButton?.[0].onClick?.(mock<MouseEvent<HTMLButtonElement>>());
-    });
+    await continuePastTheNotice(dependencies);
 
     await waitFor(() => {
       expect(screen.queryByText(/it looks like this deployment was created using another deploy tool/i)).not.toBeInTheDocument();
@@ -152,11 +148,7 @@ describe(ManifestUpdate.name, () => {
         dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("recorded-v1-hash") }) }
       });
 
-      const continueButton = dependencies.Button.mock.calls.find(call => call[0].children === "Continue");
-
-      await act(() => {
-        continueButton?.[0].onClick?.(mock<MouseEvent<HTMLButtonElement>>());
-      });
+      await continuePastTheNotice(dependencies);
 
       await waitFor(() => expect(dependencies.WarningCircle).toHaveBeenCalled());
     });
@@ -191,6 +183,18 @@ describe(ManifestUpdate.name, () => {
       rerenderDefinition({ sdl: "version: '2.0'", name: undefined, source: "api" });
       dependencies.WarningCircle.mockClear();
       rerenderDefinition({ sdl: "version: '2.0'", name: undefined, source: "api" });
+
+      expect(dependencies.WarningCircle).not.toHaveBeenCalled();
+    });
+
+    it("does not render for a copy whose values the api withheld", async () => {
+      const { dependencies } = setup({
+        definition: { sdl: WITHHELD_VALUES_SDL, source: "absent" },
+        deployment: { dseq: "123", state: "active", hash: "on-chain-hash" },
+        dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("a-different-hash") }) }
+      });
+
+      await continuePastTheNotice(dependencies);
 
       expect(dependencies.WarningCircle).not.toHaveBeenCalled();
     });
@@ -234,8 +238,10 @@ describe(ManifestUpdate.name, () => {
       expect(screen.getByText(/withheld secret values/i)).toBeInTheDocument();
     });
 
-    it("disables the update action when the values were withheld by blanking them", () => {
-      const { dependencies } = setup({ editedManifest: BLANK_ENV_VALUES_SDL });
+    it("disables the update action when the values were withheld by blanking them", async () => {
+      const { dependencies } = setup({ editedManifest: BLANK_ENV_VALUES_SDL, definition: { sdl: BLANK_ENV_VALUES_SDL, source: "absent" } });
+
+      await continuePastTheNotice(dependencies);
 
       expect(updateButtonOf(dependencies)?.disabled).toBe(true);
     });
@@ -243,14 +249,54 @@ describe(ManifestUpdate.name, () => {
     it("submits nothing when the update action fires with blanked values", async () => {
       const handles = setup({
         editedManifest: BLANK_ENV_VALUES_SDL,
+        definition: { sdl: BLANK_ENV_VALUES_SDL, source: "absent" },
         deployment: { dseq: "123", state: "active", hash: "different-hash" }
       });
 
+      await continuePastTheNotice(handles.dependencies);
       await clickUpdate(handles);
 
       expect(handles.mutate).not.toHaveBeenCalled();
       expect(screen.getByText(/withheld secret values/i)).toBeInTheDocument();
     });
+
+    it("says why the update action is unavailable without waiting for it to be used", () => {
+      setup({ editedManifest: WITHHELD_VALUES_SDL });
+
+      expect(screen.getByText(/withheld secret values/i)).toBeInTheDocument();
+    });
+
+    it("shows the notice again once another deployment's definition resolves", async () => {
+      const { dependencies, rerenderDefinition } = setup({ definition: { sdl: WITHHELD_VALUES_SDL, source: "absent" }, deployment: { dseq: "123" } });
+
+      await continuePastTheNotice(dependencies);
+
+      expect(screen.queryByText(/secret values withheld/i)).not.toBeInTheDocument();
+
+      rerenderDefinition({ sdl: WITHHELD_VALUES_SDL, name: undefined, source: "absent" }, { deployment: { dseq: "456" } });
+
+      expect(screen.getByText(/secret values withheld/i)).toBeInTheDocument();
+    });
+  });
+
+  it("keeps the update action available for a browser copy whose env value is deliberately blank", async () => {
+    const { dependencies } = setup({ editedManifest: BLANK_ENV_VALUES_SDL, definition: { sdl: BLANK_ENV_VALUES_SDL, source: "local" } });
+
+    await waitFor(() => expect(updateButtonOf(dependencies)?.disabled).toBe(false));
+  });
+
+  it("seeds another deployment's definition even when the previous one held unsaved edits", async () => {
+    const onManifestChange = vi.fn();
+    const { rerenderDefinition } = setup({ definition: { sdl: "version: '2.0' # first", source: "local" }, deployment: { dseq: "123" }, onManifestChange });
+
+    await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith("version: '2.0' # first"));
+
+    rerenderDefinition(
+      { sdl: "version: '2.0' # second", name: undefined, source: "local" },
+      { deployment: { dseq: "456" }, editedManifest: "version: '2.0' # unsaved edit" }
+    );
+
+    await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith("version: '2.0' # second"));
   });
 
   it("enables the update button for an active deployment the user can still change", async () => {
@@ -688,6 +734,7 @@ describe(ManifestUpdate.name, () => {
 
   type Handles = ReturnType<typeof setup>;
   type Dependencies = Handles["dependencies"];
+  type Overrides = { editedManifest?: string; deployment?: Partial<{ dseq: string; state: string; hash: string }> };
 
   function editorChangeEvent() {
     return mock<Parameters<NonNullable<Parameters<typeof DEPENDENCIES.SDLEditor>[0]["onChange"]>>[1]>();
@@ -699,6 +746,14 @@ describe(ManifestUpdate.name, () => {
 
   function redeployButtonOf(dependencies: Dependencies, onRedeploy: () => void) {
     return dependencies.Button.mock.calls.filter(call => call[0].onClick === onRedeploy).at(-1)?.[0];
+  }
+
+  async function continuePastTheNotice(dependencies: Dependencies) {
+    const continueButton = dependencies.Button.mock.calls.filter(call => call[0].children === "Continue").at(-1)?.[0];
+
+    await act(async () => {
+      continueButton?.onClick?.(mock<MouseEvent<HTMLButtonElement>>());
+    });
   }
 
   async function clickUpdate(handles: Handles) {
@@ -806,7 +861,7 @@ describe(ManifestUpdate.name, () => {
     const closeManifestEditor = input?.closeManifestEditor || vi.fn();
     const onManifestChange = input?.onManifestChange || vi.fn();
 
-    const componentWith = (overrides?: { editedManifest: string }) => (
+    const componentWith = (overrides?: Overrides) => (
       <TestContainerProvider
         services={{
           api: () => api,
@@ -822,7 +877,8 @@ describe(ManifestUpdate.name, () => {
               dseq: "123",
               state: "active",
               hash: "abc",
-              ...input?.deployment
+              ...input?.deployment,
+              ...overrides?.deployment
             } as Parameters<typeof ManifestUpdate>[0]["deployment"]
           }
           closeManifestEditor={closeManifestEditor}
@@ -838,8 +894,8 @@ describe(ManifestUpdate.name, () => {
     const { unmount, rerender } = render(componentWith());
 
     return {
-      rerenderWith: (overrides: { editedManifest: string }) => rerender(componentWith(overrides)),
-      rerenderDefinition: (next: DeploymentDefinition, overrides?: { editedManifest: string }) => {
+      rerenderWith: (overrides: Overrides) => rerender(componentWith(overrides)),
+      rerenderDefinition: (next: DeploymentDefinition, overrides?: Overrides) => {
         definition = next;
         rerender(componentWith(overrides));
       },

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -130,6 +130,24 @@ describe(ManifestUpdate.name, () => {
     await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith("version: '3.0' # refetched"));
   });
 
+  it("keeps what the user typed into an editor that resolved with no definition at all", () => {
+    const onManifestChange = vi.fn();
+    const { rerenderDefinition } = setup({ definition: { sdl: undefined, source: "absent" }, editedManifest: "", onManifestChange });
+
+    rerenderDefinition({ sdl: "version: '2.0' # recorded later", name: undefined, source: "absent" }, { editedManifest: "version: '2.0' # typed by hand" });
+
+    expect(onManifestChange).not.toHaveBeenCalledWith("version: '2.0' # recorded later");
+  });
+
+  it("seeds an untouched editor once a definition the api had yet to record arrives", async () => {
+    const onManifestChange = vi.fn();
+    const { rerenderDefinition } = setup({ definition: { sdl: undefined, source: "absent" }, editedManifest: "", onManifestChange });
+
+    rerenderDefinition({ sdl: "version: '2.0' # recorded later", name: undefined, source: "absent" }, { editedManifest: "" });
+
+    await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith("version: '2.0' # recorded later"));
+  });
+
   describe("the local-versus-chain warning", () => {
     it("renders for a definition served from this browser whose version differs from the chain", async () => {
       const { dependencies } = setup({
@@ -183,6 +201,22 @@ describe(ManifestUpdate.name, () => {
       rerenderDefinition({ sdl: "version: '2.0'", name: undefined, source: "api" });
       dependencies.WarningCircle.mockClear();
       rerenderDefinition({ sdl: "version: '2.0'", name: undefined, source: "api" });
+
+      expect(dependencies.WarningCircle).not.toHaveBeenCalled();
+    });
+
+    it("stops rendering once the api's copy is confirmed current, even while the editor holds unsaved edits", async () => {
+      const { dependencies, rerenderDefinition } = setup({
+        definition: { sdl: "version: '2.0'", source: "local" },
+        deployment: { dseq: "123", state: "active", hash: "on-chain-hash" },
+        dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("a-different-hash") }) }
+      });
+
+      await waitFor(() => expect(dependencies.WarningCircle).toHaveBeenCalled());
+
+      rerenderDefinition({ sdl: "version: '2.0'", name: undefined, source: "api" }, { editedManifest: "version: '2.0' # user edit" });
+      dependencies.WarningCircle.mockClear();
+      rerenderDefinition({ sdl: "version: '2.0'", name: undefined, source: "api" }, { editedManifest: "version: '2.0' # user edit" });
 
       expect(dependencies.WarningCircle).not.toHaveBeenCalled();
     });

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -162,16 +162,16 @@ describe(ManifestUpdate.name, () => {
       await waitFor(() => expect(dependencies.WarningCircle).toHaveBeenCalled());
     });
 
-    it("renders for an api copy the chain has moved past once its notice is dismissed", async () => {
+    it("renders for an api copy the chain has moved past, with no withheld-values notice standing in the way", async () => {
       const { dependencies } = setup({
         definition: { sdl: "version: '2.0' # recorded-v1", source: "absent" },
         deployment: { dseq: "123", state: "active", hash: "on-chain-hash" },
         dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("recorded-v1-hash") }) }
       });
 
-      await continuePastTheNotice(dependencies);
-
       await waitFor(() => expect(dependencies.WarningCircle).toHaveBeenCalled());
+      expect(screen.queryByText(/secret values withheld/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/it looks like this deployment was created using another deploy tool/i)).not.toBeInTheDocument();
     });
 
     it("seeds the editor with the api copy the chain has moved past so the user can see what the console recorded", async () => {
@@ -359,6 +359,15 @@ describe(ManifestUpdate.name, () => {
     });
   });
 
+  it("keeps the update action available for a complete api copy the chain has moved past", async () => {
+    const { dependencies } = setup({
+      editedManifest: "version: '2.0' # recorded-v1",
+      definition: { sdl: "version: '2.0' # recorded-v1", source: "absent" }
+    });
+
+    await waitFor(() => expect(updateButtonOf(dependencies)?.disabled).toBe(false));
+  });
+
   it("keeps the update action available for a browser copy whose env value is deliberately blank", async () => {
     const { dependencies } = setup({ editedManifest: BLANK_ENV_VALUES_SDL, definition: { sdl: BLANK_ENV_VALUES_SDL, source: "local" } });
 
@@ -462,6 +471,24 @@ describe(ManifestUpdate.name, () => {
     await succeed(handles);
 
     expect(handles.deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "123", { manifest: "version: '2.0'" });
+  });
+
+  it("refetches the resolved definition so the details it feeds stop describing the replaced document", async () => {
+    const handles = setup({ deployment: { dseq: "456" }, editedManifest: "version: '2.0'" });
+
+    await clickUpdate(handles);
+    await succeed(handles);
+
+    expect(handles.queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: ["getDeployment", "456"] });
+  });
+
+  it("leaves the resolved definition alone when the update is refused", async () => {
+    const handles = setup({ editedManifest: "version: '2.0'" });
+
+    await clickUpdate(handles);
+    await fail(handles, BAD_SDL);
+
+    expect(handles.queryClient.invalidateQueries).not.toHaveBeenCalled();
   });
 
   it("caches the sdl it submitted, not the one edited while the update was in flight", async () => {
@@ -895,6 +922,7 @@ describe(ManifestUpdate.name, () => {
       current?: { onSuccess?: (data: unknown, variables: { dseq: string; data: { sdl: string } }) => void; onError?: (cause: unknown) => void };
     } = {};
     const api = mockDeep<AppDIContainer["api"]>();
+    api.v1.getDeployment.getKey.mockImplementation(request => ["getDeployment", request?.dseq ?? ""]);
     api.v1.updateDeployment.useMutation.mockImplementation(options => {
       mutationOptions.current = options as typeof mutationOptions.current;
       return mock<ReturnType<typeof api.v1.updateDeployment.useMutation>>({ mutate });
@@ -920,6 +948,9 @@ describe(ManifestUpdate.name, () => {
     let definition: DeploymentDefinition = { sdl: "version: '2.0'", name: undefined, source: "local", ...input?.definition };
     const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
 
+    const queryClient = mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>();
+    const useQueryClient: typeof DEPENDENCIES.useQueryClient = () => queryClient;
+
     const dependencies = MockComponents(DEPENDENCIES, {
       DeploymentTabHeader: vi.fn(({ actions, children }) => (
         <>
@@ -932,6 +963,7 @@ describe(ManifestUpdate.name, () => {
       useSnackbar,
       useBlockchainStatus,
       useDeploymentDefinition,
+      useQueryClient,
       deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
         getManifestVersion: vi.fn().mockResolvedValue("test-version")
       }),
@@ -984,6 +1016,7 @@ describe(ManifestUpdate.name, () => {
       deploymentLocalStorage,
       logger,
       dependencies,
+      queryClient,
       mutate,
       mutationOptions,
       enqueueSnackbar,

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -1,4 +1,5 @@
 import type { MouseEvent } from "react";
+import type { LoggerService } from "@akashnetwork/logging";
 import { ApiError } from "@akashnetwork/openapi-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
@@ -39,6 +40,7 @@ const TRIAL_GATED_SDL = new ApiError(
 const UNTITLED_OUT_OF_CREDITS = new ApiError(402, { message: "Not enough funds to cover the transaction fee" }, "PUT /v1/deployments/{dseq} → 402");
 
 const WITHHELD_VALUES_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=ac-secret://s0_e0"\n';
+const BLANK_ENV_VALUES_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN="\n';
 
 describe(ManifestUpdate.name, () => {
   it("shows outside deployment message when neither source holds a definition", () => {
@@ -72,8 +74,8 @@ describe(ManifestUpdate.name, () => {
     });
   });
 
-  it("shows parsing error when manifest version retrieval fails", async () => {
-    setup({
+  it("shows parsing error and logs the cause when manifest version retrieval fails", async () => {
+    const { logger } = setup({
       definition: { sdl: "version: '2.0'", source: "local" },
       dependencies: {
         deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
@@ -85,6 +87,7 @@ describe(ManifestUpdate.name, () => {
     await waitFor(() => {
       expect(screen.getByText("Error getting manifest version.")).toBeInTheDocument();
     });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "MANIFEST_VERSION_READ_FAILED" }));
   });
 
   it("seeds the editor from the api definition, never from this browser's copy", async () => {
@@ -107,6 +110,28 @@ describe(ManifestUpdate.name, () => {
     expect(screen.queryByText(/secret values withheld/i)).not.toBeInTheDocument();
     expect(dependencies.SDLEditor).not.toHaveBeenCalled();
     expect(onManifestChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps the user's unsaved edits when a refetch changes the resolved definition", async () => {
+    const onManifestChange = vi.fn();
+    const { rerenderDefinition } = setup({ definition: { sdl: "version: '2.0'", source: "local" }, onManifestChange });
+
+    await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith("version: '2.0'"));
+
+    rerenderDefinition({ sdl: "version: '3.0' # refetched", name: undefined, source: "api" }, { editedManifest: "version: '2.0' # user edit" });
+
+    expect(onManifestChange).not.toHaveBeenCalledWith("version: '3.0' # refetched");
+  });
+
+  it("reseeds an untouched editor when a refetch changes the resolved definition", async () => {
+    const onManifestChange = vi.fn();
+    const { rerenderDefinition } = setup({ definition: { sdl: "version: '2.0'", source: "local" }, onManifestChange });
+
+    await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith("version: '2.0'"));
+
+    rerenderDefinition({ sdl: "version: '3.0' # refetched", name: undefined, source: "api" }, { editedManifest: "version: '2.0'" });
+
+    await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith("version: '3.0' # refetched"));
   });
 
   describe("the local-versus-chain warning", () => {
@@ -200,6 +225,24 @@ describe(ManifestUpdate.name, () => {
     it("submits nothing when the update action fires anyway", async () => {
       const handles = setup({
         editedManifest: WITHHELD_VALUES_SDL,
+        deployment: { dseq: "123", state: "active", hash: "different-hash" }
+      });
+
+      await clickUpdate(handles);
+
+      expect(handles.mutate).not.toHaveBeenCalled();
+      expect(screen.getByText(/withheld secret values/i)).toBeInTheDocument();
+    });
+
+    it("disables the update action when the values were withheld by blanking them", () => {
+      const { dependencies } = setup({ editedManifest: BLANK_ENV_VALUES_SDL });
+
+      expect(updateButtonOf(dependencies)?.disabled).toBe(true);
+    });
+
+    it("submits nothing when the update action fires with blanked values", async () => {
+      const handles = setup({
+        editedManifest: BLANK_ENV_VALUES_SDL,
         deployment: { dseq: "123", state: "active", hash: "different-hash" }
       });
 
@@ -708,6 +751,7 @@ describe(ManifestUpdate.name, () => {
   }) {
     const providerProxy = mock<ProviderProxyService>();
     const analyticsService = mock<AnalyticsService>();
+    const logger = mock<LoggerService>();
     const deploymentLocalStorage = mock<DeploymentStorageService>();
     deploymentLocalStorage.get.mockReturnValue(input?.storedManifest === null ? null : { manifest: input?.storedManifest ?? "version: '2.0'" });
 
@@ -768,7 +812,8 @@ describe(ManifestUpdate.name, () => {
           api: () => api,
           providerProxy: () => providerProxy,
           analyticsService: () => analyticsService,
-          deploymentLocalStorage: () => deploymentLocalStorage
+          deploymentLocalStorage: () => deploymentLocalStorage,
+          logger: () => logger
         }}
       >
         <ManifestUpdate
@@ -794,13 +839,14 @@ describe(ManifestUpdate.name, () => {
 
     return {
       rerenderWith: (overrides: { editedManifest: string }) => rerender(componentWith(overrides)),
-      rerenderDefinition: (next: DeploymentDefinition) => {
+      rerenderDefinition: (next: DeploymentDefinition, overrides?: { editedManifest: string }) => {
         definition = next;
-        rerender(componentWith());
+        rerender(componentWith(overrides));
       },
       providerProxy,
       analyticsService,
       deploymentLocalStorage,
+      logger,
       dependencies,
       mutate,
       mutationOptions,

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -41,6 +41,9 @@ const UNTITLED_OUT_OF_CREDITS = new ApiError(402, { message: "Not enough funds t
 
 const WITHHELD_VALUES_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=ac-secret://s0_e0"\n';
 const BLANK_ENV_VALUES_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN="\n';
+const TWO_BLANK_ENV_VALUES_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN="\n      - "OTHER="\n';
+const ONE_ENV_VALUE_SUPPLIED_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=given"\n      - "OTHER="\n';
+const BOTH_ENV_VALUES_SUPPLIED_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=given"\n      - "OTHER=given"\n';
 
 describe(ManifestUpdate.name, () => {
   it("shows outside deployment message when neither source holds a definition", () => {
@@ -221,6 +224,16 @@ describe(ManifestUpdate.name, () => {
       expect(dependencies.WarningCircle).not.toHaveBeenCalled();
     });
 
+    it("renders for a browser copy whose env value is blank and whose version differs from the chain", async () => {
+      const { dependencies } = setup({
+        definition: { sdl: BLANK_ENV_VALUES_SDL, source: "local" },
+        deployment: { dseq: "123", state: "active", hash: "on-chain-hash" },
+        dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("a-different-hash") }) }
+      });
+
+      await waitFor(() => expect(dependencies.WarningCircle).toHaveBeenCalled());
+    });
+
     it("does not render for a copy whose values the api withheld", async () => {
       const { dependencies } = setup({
         definition: { sdl: WITHHELD_VALUES_SDL, source: "absent" },
@@ -292,6 +305,39 @@ describe(ManifestUpdate.name, () => {
 
       expect(handles.mutate).not.toHaveBeenCalled();
       expect(screen.getByText(/withheld secret values/i)).toBeInTheDocument();
+    });
+
+    it("keeps the update action disabled while only some of the withheld values have been supplied", async () => {
+      const { dependencies } = setup({
+        editedManifest: ONE_ENV_VALUE_SUPPLIED_SDL,
+        definition: { sdl: TWO_BLANK_ENV_VALUES_SDL, source: "absent" }
+      });
+
+      await continuePastTheNotice(dependencies);
+
+      expect(updateButtonOf(dependencies)?.disabled).toBe(true);
+    });
+
+    it("releases the update action once every withheld value has been supplied", async () => {
+      const { dependencies } = setup({
+        editedManifest: BOTH_ENV_VALUES_SUPPLIED_SDL,
+        definition: { sdl: TWO_BLANK_ENV_VALUES_SDL, source: "absent" }
+      });
+
+      await continuePastTheNotice(dependencies);
+
+      expect(updateButtonOf(dependencies)?.disabled).toBe(false);
+    });
+
+    it("releases the update action for a blank env value of the user's own that the api never withheld", async () => {
+      const { dependencies } = setup({
+        editedManifest: BLANK_ENV_VALUES_SDL,
+        definition: { sdl: "version: '2.0' # recorded-v1", source: "absent" }
+      });
+
+      await continuePastTheNotice(dependencies);
+
+      expect(updateButtonOf(dependencies)?.disabled).toBe(false);
     });
 
     it("says why the update action is unavailable without waiting for it to be used", () => {

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -5,6 +5,7 @@ import { mock, mockDeep } from "vitest-mock-extended";
 
 import type { AppDIContainer } from "@src/context/ServicesProvider/ServicesProvider";
 import type { ContextType } from "@src/context/WalletProvider";
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
 import type { ProviderProxyService } from "@src/services/provider-proxy/provider-proxy.service";
@@ -37,15 +38,17 @@ const TRIAL_GATED_SDL = new ApiError(
 );
 const UNTITLED_OUT_OF_CREDITS = new ApiError(402, { message: "Not enough funds to cover the transaction fee" }, "PUT /v1/deployments/{dseq} → 402");
 
+const WITHHELD_VALUES_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=ac-secret://s0_e0"\n';
+
 describe(ManifestUpdate.name, () => {
-  it("shows outside deployment message when no local manifest exists", () => {
-    setup({ storedManifest: null });
+  it("shows outside deployment message when neither source holds a definition", () => {
+    setup({ definition: { sdl: undefined, source: "absent" } });
 
     expect(screen.getByText(/it looks like this deployment was created using another deploy tool/i)).toBeInTheDocument();
   });
 
   it("hides outside deployment message and shows editor after clicking Continue", async () => {
-    const { dependencies } = setup({ storedManifest: null });
+    const { dependencies } = setup({ definition: { sdl: undefined, source: "absent" } });
 
     expect(screen.getByText(/it looks like this deployment was created using another deploy tool/i)).toBeInTheDocument();
 
@@ -60,9 +63,9 @@ describe(ManifestUpdate.name, () => {
     });
   });
 
-  it("loads manifest from local storage and calls onManifestChange", async () => {
+  it("seeds the editor from the resolved definition", async () => {
     const onManifestChange = vi.fn();
-    setup({ onManifestChange, storedManifest: "version: '2.0'" });
+    setup({ onManifestChange, definition: { sdl: "version: '2.0'", source: "local" } });
 
     await waitFor(() => {
       expect(onManifestChange).toHaveBeenCalledWith("version: '2.0'");
@@ -71,7 +74,7 @@ describe(ManifestUpdate.name, () => {
 
   it("shows parsing error when manifest version retrieval fails", async () => {
     setup({
-      storedManifest: "version: '2.0'",
+      definition: { sdl: "version: '2.0'", source: "local" },
       dependencies: {
         deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
           getManifestVersion: vi.fn().mockRejectedValue(new Error("parse error"))
@@ -81,6 +84,129 @@ describe(ManifestUpdate.name, () => {
 
     await waitFor(() => {
       expect(screen.getByText("Error getting manifest version.")).toBeInTheDocument();
+    });
+  });
+
+  it("seeds the editor from the api definition, never from this browser's copy", async () => {
+    const onManifestChange = vi.fn();
+    setup({
+      onManifestChange,
+      definition: { sdl: "version: '2.0' # from-the-api", source: "api" },
+      storedManifest: "version: '2.0' # from-this-browser"
+    });
+
+    await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith("version: '2.0' # from-the-api"));
+    expect(onManifestChange.mock.calls.flat()).not.toContain("version: '2.0' # from-this-browser");
+  });
+
+  it("shows neither the editor nor a notice while the definition is still resolving", () => {
+    const onManifestChange = vi.fn();
+    const { dependencies } = setup({ definition: { sdl: undefined, source: "resolving" }, onManifestChange });
+
+    expect(screen.queryByText(/it looks like this deployment was created using another deploy tool/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/secret values withheld/i)).not.toBeInTheDocument();
+    expect(dependencies.SDLEditor).not.toHaveBeenCalled();
+    expect(onManifestChange).not.toHaveBeenCalled();
+  });
+
+  describe("the local-versus-chain warning", () => {
+    it("renders for a definition served from this browser whose version differs from the chain", async () => {
+      const { dependencies } = setup({
+        definition: { sdl: "version: '2.0'", source: "local" },
+        deployment: { dseq: "123", state: "active", hash: "on-chain-hash" },
+        dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("a-different-hash") }) }
+      });
+
+      await waitFor(() => expect(dependencies.WarningCircle).toHaveBeenCalled());
+    });
+
+    it("renders for an api copy the chain has moved past once its notice is dismissed", async () => {
+      const { dependencies } = setup({
+        definition: { sdl: "version: '2.0' # recorded-v1", source: "absent" },
+        deployment: { dseq: "123", state: "active", hash: "on-chain-hash" },
+        dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("recorded-v1-hash") }) }
+      });
+
+      const continueButton = dependencies.Button.mock.calls.find(call => call[0].children === "Continue");
+
+      await act(() => {
+        continueButton?.[0].onClick?.(mock<MouseEvent<HTMLButtonElement>>());
+      });
+
+      await waitFor(() => expect(dependencies.WarningCircle).toHaveBeenCalled());
+    });
+
+    it("seeds the editor with the api copy the chain has moved past so the user can see what the console recorded", async () => {
+      const onManifestChange = vi.fn();
+      setup({ definition: { sdl: "version: '2.0' # recorded-v1", source: "absent" }, onManifestChange });
+
+      await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith("version: '2.0' # recorded-v1"));
+    });
+
+    it("does not render for a definition served by the api", async () => {
+      const { dependencies } = setup({
+        definition: { sdl: "version: '2.0'", source: "api" },
+        deployment: { dseq: "123", state: "active", hash: "on-chain-hash" },
+        dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("a-different-hash") }) }
+      });
+
+      await waitFor(() => expect(dependencies.SDLEditor).toHaveBeenCalled());
+      expect(dependencies.WarningCircle).not.toHaveBeenCalled();
+    });
+
+    it("stops rendering when a refetch moves the definition from this browser to the api", async () => {
+      const { dependencies, rerenderDefinition } = setup({
+        definition: { sdl: "version: '2.0'", source: "local" },
+        deployment: { dseq: "123", state: "active", hash: "on-chain-hash" },
+        dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("a-different-hash") }) }
+      });
+
+      await waitFor(() => expect(dependencies.WarningCircle).toHaveBeenCalled());
+
+      rerenderDefinition({ sdl: "version: '2.0'", name: undefined, source: "api" });
+      dependencies.WarningCircle.mockClear();
+      rerenderDefinition({ sdl: "version: '2.0'", name: undefined, source: "api" });
+
+      expect(dependencies.WarningCircle).not.toHaveBeenCalled();
+    });
+
+    it("does not render for a browser copy that agrees with the chain", async () => {
+      const { dependencies } = setup({
+        definition: { sdl: "version: '2.0'", source: "local" },
+        deployment: { dseq: "123", state: "active", hash: "same-hash" },
+        dependencies: { deploymentData: mock<typeof DEPENDENCIES.deploymentData>({ getManifestVersion: vi.fn().mockResolvedValue("same-hash") }) }
+      });
+
+      await waitFor(() => expect(dependencies.SDLEditor).toHaveBeenCalled());
+      expect(dependencies.WarningCircle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("a definition whose secret values the api withheld", () => {
+    it("displays it unchanged and says the values are withheld", async () => {
+      const onManifestChange = vi.fn();
+      setup({ definition: { sdl: WITHHELD_VALUES_SDL, source: "absent" }, onManifestChange });
+
+      expect(screen.getByText(/secret values withheld/i)).toBeInTheDocument();
+      await waitFor(() => expect(onManifestChange).toHaveBeenCalledWith(WITHHELD_VALUES_SDL));
+    });
+
+    it("disables the update action", () => {
+      const { dependencies } = setup({ editedManifest: WITHHELD_VALUES_SDL });
+
+      expect(updateButtonOf(dependencies)?.disabled).toBe(true);
+    });
+
+    it("submits nothing when the update action fires anyway", async () => {
+      const handles = setup({
+        editedManifest: WITHHELD_VALUES_SDL,
+        deployment: { dseq: "123", state: "active", hash: "different-hash" }
+      });
+
+      await clickUpdate(handles);
+
+      expect(handles.mutate).not.toHaveBeenCalled();
+      expect(screen.getByText(/withheld secret values/i)).toBeInTheDocument();
     });
   });
 
@@ -480,7 +606,7 @@ describe(ManifestUpdate.name, () => {
 
   it("clears deployment version when text changes in editor", async () => {
     const onManifestChange = vi.fn();
-    const { dependencies } = setup({ onManifestChange, storedManifest: "version: '2.0'" });
+    const { dependencies } = setup({ onManifestChange, definition: { sdl: "version: '2.0'", source: "local" } });
 
     await waitFor(() => {
       expect(onManifestChange).toHaveBeenCalledWith("version: '2.0'");
@@ -577,6 +703,7 @@ describe(ManifestUpdate.name, () => {
     onManifestChange?: (value: string) => void;
     onRedeploy?: () => void;
     wallet?: Partial<{ address: string; signAndBroadcastTx: ContextType["signAndBroadcastTx"] }>;
+    definition?: Partial<DeploymentDefinition>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const providerProxy = mock<ProviderProxyService>();
@@ -611,6 +738,9 @@ describe(ManifestUpdate.name, () => {
     const useBlockchainStatus: typeof DEPENDENCIES.useBlockchainStatus = () =>
       mock<ReturnType<typeof DEPENDENCIES.useBlockchainStatus>>({ isBlockchainDown: false });
 
+    let definition: DeploymentDefinition = { sdl: "version: '2.0'", name: undefined, source: "local", ...input?.definition };
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
+
     const dependencies = MockComponents(DEPENDENCIES, {
       DeploymentTabHeader: vi.fn(({ actions, children }) => (
         <>
@@ -622,6 +752,7 @@ describe(ManifestUpdate.name, () => {
       useBalances,
       useSnackbar,
       useBlockchainStatus,
+      useDeploymentDefinition,
       deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
         getManifestVersion: vi.fn().mockResolvedValue("test-version")
       }),
@@ -663,6 +794,10 @@ describe(ManifestUpdate.name, () => {
 
     return {
       rerenderWith: (overrides: { editedManifest: string }) => rerender(componentWith(overrides)),
+      rerenderDefinition: (next: DeploymentDefinition) => {
+        definition = next;
+        rerender(componentWith());
+      },
       providerProxy,
       analyticsService,
       deploymentLocalStorage,

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { LoggerService } from "@akashnetwork/logging";
 import { extractApiErrorMessage, isApiError } from "@akashnetwork/openapi-sdk";
 import { Alert, Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
 import { InfoCircle, Upload, WarningCircle } from "iconoir-react";
@@ -18,7 +17,7 @@ import { useDeploymentDefinition as useDeploymentDefinitionOriginal } from "@src
 import { useBalances as useBalancesOriginal } from "@src/queries/useBalancesQuery";
 import type { DeploymentDto } from "@src/types/deployment";
 import { deploymentData as deploymentDataOriginal } from "@src/utils/deploymentData";
-import { hasSdlReference } from "@src/utils/sdl/storedDefinition";
+import { hasOnlyBlankEnvValues, hasSdlReference } from "@src/utils/sdl/storedDefinition";
 import RemoteDeployUpdate from "../../remote-deploy/update/RemoteDeployUpdate";
 import { SDLEditor } from "../../sdl/SDLEditor/SDLEditor";
 import { DeploymentTabHeader } from "../DeploymentDetail/DeploymentTabHeader";
@@ -45,8 +44,6 @@ export const DEPENDENCIES = {
   // eslint-disable-next-line akash/dependencies-component-or-hook
   deploymentData: deploymentDataOriginal
 };
-
-const logger = new LoggerService({ name: "ManifestUpdate" });
 
 /** The api answers 400 for provider-credential and schema failures too, and only a refusal of the document itself belongs in the editor's inline alert. */
 const SDL_REFUSAL_PREFIXES = ["Invalid SDL:", "SDL is not valid YAML", "SDL is too large"];
@@ -118,7 +115,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   onRedeploy,
   dependencies: d = DEPENDENCIES
 }) => {
-  const { api, analyticsService, deploymentLocalStorage } = useServices();
+  const { api, analyticsService, deploymentLocalStorage, logger } = useServices();
   const [parsingError, setParsingError] = useState<string | null>(null);
   const [deploymentVersion, setDeploymentVersion] = useState<string | null>(null);
   const [hasDismissedWithheldValuesNotice, setHasDismissedWithheldValuesNotice] = useState(false);
@@ -128,6 +125,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   const { enqueueSnackbar, closeSnackbar } = d.useSnackbar();
   const { isBlockchainDown } = d.useBlockchainStatus();
   const definition = d.useDeploymentDefinition(deployment.dseq);
+  const lastSeededSdl = useRef<string | undefined>(undefined);
   const updateDeployment = api.v1.updateDeployment.useMutation({
     onSuccess: (_data, variables) => recordUpdate(variables.data.sdl),
     onError: reportUpdateFailure
@@ -146,7 +144,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
 
   const isResolvingDefinition = definition.source === "resolving";
   const showsWithheldValuesNotice = definition.source === "absent" && !hasDismissedWithheldValuesNotice;
-  const hasWithheldValues = useMemo(() => !!editedManifest && hasSdlReference(editedManifest), [editedManifest]);
+  const hasWithheldValues = useMemo(() => !!editedManifest && (hasSdlReference(editedManifest) || hasOnlyBlankEnvValues(editedManifest)), [editedManifest]);
 
   useEffect(
     function seedEditorOnceTheDefinitionResolves() {
@@ -154,7 +152,13 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
 
       const { sdl, source } = definition;
 
-      if (sdl) onManifestChange(sdl);
+      const editorHoldsUnseededEdits = lastSeededSdl.current !== undefined && editedManifest !== lastSeededSdl.current;
+      if (editorHoldsUnseededEdits) return;
+
+      if (sdl) {
+        lastSeededSdl.current = sdl;
+        onManifestChange(sdl);
+      }
 
       /** Both copies that can disagree with the chain: this browser's own, and one the API held but could not stand behind. */
       if ((source !== "local" && source !== "absent") || !sdl) {
@@ -165,7 +169,8 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
       const readVersionOfLocalCopy = async () => {
         try {
           setDeploymentVersion(await d.deploymentData.getManifestVersion(yaml.load(sdl)));
-        } catch {
+        } catch (error) {
+          logger.error({ event: "MANIFEST_VERSION_READ_FAILED", error });
           setParsingError("Error getting manifest version.");
         }
       };

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -13,11 +13,12 @@ import { useBlockchainStatus as useBlockchainStatusOriginal } from "@src/context
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet as useWalletOriginal } from "@src/context/WalletProvider";
 import { AddCreditsSnackbarContent } from "@src/context/WalletProvider/useSignAndBroadcast";
+import type { DeploymentDefinitionSource } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useDeploymentDefinition as useDeploymentDefinitionOriginal } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useBalances as useBalancesOriginal } from "@src/queries/useBalancesQuery";
 import type { DeploymentDto } from "@src/types/deployment";
 import { deploymentData as deploymentDataOriginal } from "@src/utils/deploymentData";
-import { hasOnlyBlankEnvValues, hasSdlReference } from "@src/utils/sdl/storedDefinition";
+import { hasOnlyBlankEnvValues, hasSdlReference, isStoredSdlSelfContained } from "@src/utils/sdl/storedDefinition";
 import RemoteDeployUpdate from "../../remote-deploy/update/RemoteDeployUpdate";
 import { SDLEditor } from "../../sdl/SDLEditor/SDLEditor";
 import { DeploymentTabHeader } from "../DeploymentDetail/DeploymentTabHeader";
@@ -53,6 +54,11 @@ const UPDATE_FAILURE_MESSAGE = "Something went wrong while updating the deployme
 const ADD_CREDITS_TITLE = "Add credits to continue";
 /** Refused rather than submitted: a document whose values are references would commit a manifest whose environment is the reference strings themselves. */
 const WITHHELD_VALUES_ERROR = "This configuration still has withheld secret values. Replace them with real values before updating.";
+
+/** The api serves its own copy only when the chain is already running it, and a copy stripped of its values hashes to a manifest the chain never committed. */
+function needsChainVersionCheck(sdl: string, source: DeploymentDefinitionSource): boolean {
+  return source !== "api" && isStoredSdlSelfContained(sdl);
+}
 
 function isBadRequest(cause: unknown): boolean {
   return isApiError(cause) && cause.status === 400;
@@ -118,14 +124,15 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   const { api, analyticsService, deploymentLocalStorage, logger } = useServices();
   const [parsingError, setParsingError] = useState<string | null>(null);
   const [deploymentVersion, setDeploymentVersion] = useState<string | null>(null);
-  const [hasDismissedWithheldValuesNotice, setHasDismissedWithheldValuesNotice] = useState(false);
+  const [dseqWithDismissedNotice, setDseqWithDismissedNotice] = useState<string | null>(null);
   const [isUpdating, setIsUpdating] = useState(false);
   const { address } = d.useWallet();
   const { refetch: refetchBalances } = d.useBalances(address);
   const { enqueueSnackbar, closeSnackbar } = d.useSnackbar();
   const { isBlockchainDown } = d.useBlockchainStatus();
   const definition = d.useDeploymentDefinition(deployment.dseq);
-  const lastSeededSdl = useRef<string | undefined>(undefined);
+  const seededDseq = useRef<string | undefined>(undefined);
+  const seededSdl = useRef<string | undefined>(undefined);
   const updateDeployment = api.v1.updateDeployment.useMutation({
     onSuccess: (_data, variables) => recordUpdate(variables.data.sdl),
     onError: reportUpdateFailure
@@ -143,8 +150,14 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   }, []);
 
   const isResolvingDefinition = definition.source === "resolving";
-  const showsWithheldValuesNotice = definition.source === "absent" && !hasDismissedWithheldValuesNotice;
-  const hasWithheldValues = useMemo(() => !!editedManifest && (hasSdlReference(editedManifest) || hasOnlyBlankEnvValues(editedManifest)), [editedManifest]);
+  const showsWithheldValuesNotice = definition.source === "absent" && dseqWithDismissedNotice !== deployment.dseq;
+  /** A blank env value only signals a withheld one in the api's own record; in a document of the user's own it can be deliberate. */
+  const isServingTheApiRecord = definition.source === "absent" && !!definition.sdl;
+  const hasWithheldValues = useMemo(
+    () => !!editedManifest && (hasSdlReference(editedManifest) || (isServingTheApiRecord && hasOnlyBlankEnvValues(editedManifest))),
+    [editedManifest, isServingTheApiRecord]
+  );
+  const editorAlertMessage = parsingError ?? (hasWithheldValues ? WITHHELD_VALUES_ERROR : null);
 
   useEffect(
     function seedEditorOnceTheDefinitionResolves() {
@@ -152,21 +165,21 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
 
       const { sdl, source } = definition;
 
-      const editorHoldsUnseededEdits = lastSeededSdl.current !== undefined && editedManifest !== lastSeededSdl.current;
+      const editorHoldsUnseededEdits = seededDseq.current === deployment.dseq && editedManifest !== seededSdl.current;
       if (editorHoldsUnseededEdits) return;
 
       if (sdl) {
-        lastSeededSdl.current = sdl;
+        seededDseq.current = deployment.dseq;
+        seededSdl.current = sdl;
         onManifestChange(sdl);
       }
 
-      /** Both copies that can disagree with the chain: this browser's own, and one the API held but could not stand behind. */
-      if ((source !== "local" && source !== "absent") || !sdl) {
+      if (!sdl || !needsChainVersionCheck(sdl, source)) {
         setDeploymentVersion(null);
         return;
       }
 
-      const readVersionOfLocalCopy = async () => {
+      const readVersionOfSeededCopy = async () => {
         try {
           setDeploymentVersion(await d.deploymentData.getManifestVersion(yaml.load(sdl)));
         } catch (error) {
@@ -175,9 +188,9 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
         }
       };
 
-      readVersionOfLocalCopy();
+      readVersionOfSeededCopy();
     },
-    [isResolvingDefinition, definition.sdl, definition.source]
+    [isResolvingDefinition, definition.sdl, definition.source, deployment.dseq]
   );
 
   function handleManifestChange(value: string) {
@@ -200,10 +213,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   }
 
   function handleUpdateClick() {
-    if (hasWithheldValues) {
-      setParsingError(WITHHELD_VALUES_ERROR);
-      return;
-    }
+    if (hasWithheldValues) return;
 
     setIsUpdating(true);
     updateDeployment.mutate({ dseq: deployment.dseq, data: { sdl: editedManifest } }, { onSuccess: closeAfterUpdate, onError: releaseAfterFailure });
@@ -288,7 +298,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
               ? "The configuration stored for this deployment has its secret values withheld, so they are not shown below. Continue and enter them before updating."
               : "It looks like this deployment was created using another deploy tool. We can't show you the configuration file that was used initially, but you can still update it. Simply continue and enter the configuration you want to use."}
             <div className="mt-1">
-              <d.Button onClick={() => setHasDismissedWithheldValuesNotice(true)} size="sm">
+              <d.Button onClick={() => setDseqWithDismissedNotice(deployment.dseq)} size="sm">
                 Continue
               </d.Button>
             </div>
@@ -343,7 +353,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
               )}
             </d.DeploymentTabHeader>
 
-            {parsingError && <d.Alert variant="warning">{parsingError}</d.Alert>}
+            {editorAlertMessage && <d.Alert variant="warning">{editorAlertMessage}</d.Alert>}
 
             <d.LinearLoadingSkeleton isLoading={isUpdating} />
 

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { extractApiErrorMessage, isApiError } from "@akashnetwork/openapi-sdk";
 import { Alert, Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
+import { useQueryClient as useQueryClientOriginal } from "@tanstack/react-query";
 import { InfoCircle, Upload, WarningCircle } from "iconoir-react";
 import yaml from "js-yaml";
 import { useSnackbar as useSnackbarOriginal } from "notistack";
@@ -13,7 +14,7 @@ import { useBlockchainStatus as useBlockchainStatusOriginal } from "@src/context
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet as useWalletOriginal } from "@src/context/WalletProvider";
 import { AddCreditsSnackbarContent } from "@src/context/WalletProvider/useSignAndBroadcast";
-import type { DeploymentDefinitionSource } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useDeploymentDefinition as useDeploymentDefinitionOriginal } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useBalances as useBalancesOriginal } from "@src/queries/useBalancesQuery";
 import type { DeploymentDto } from "@src/types/deployment";
@@ -42,6 +43,7 @@ export const DEPENDENCIES = {
   useSnackbar: useSnackbarOriginal,
   useBlockchainStatus: useBlockchainStatusOriginal,
   useDeploymentDefinition: useDeploymentDefinitionOriginal,
+  useQueryClient: useQueryClientOriginal,
   // eslint-disable-next-line akash/dependencies-component-or-hook
   deploymentData: deploymentDataOriginal
 };
@@ -55,9 +57,14 @@ const ADD_CREDITS_TITLE = "Add credits to continue";
 /** Refused rather than submitted: a document whose values are references would commit a manifest whose environment is the reference strings themselves. */
 const WITHHELD_VALUES_ERROR = "This configuration still has withheld secret values. Replace them with real values before updating.";
 
+/** The api withholds a value by stripping it, so a copy it served that is still self-contained lost nothing: the chain has merely moved past it. */
+function isApiRecordComplete(definition: DeploymentDefinition): boolean {
+  return definition.source === "absent" && !!definition.sdl && isStoredSdlSelfContained(definition.sdl);
+}
+
 /** The api serves its own copy only when the chain is already running it, and a copy the api stripped hashes to a manifest the chain never committed. */
-function needsChainVersionCheck(sdl: string, source: DeploymentDefinitionSource): boolean {
-  return source === "local" || (source === "absent" && isStoredSdlSelfContained(sdl));
+function needsChainVersionCheck(definition: DeploymentDefinition): boolean {
+  return definition.source === "local" || isApiRecordComplete(definition);
 }
 
 function isBadRequest(cause: unknown): boolean {
@@ -131,6 +138,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   const { enqueueSnackbar, closeSnackbar } = d.useSnackbar();
   const { isBlockchainDown } = d.useBlockchainStatus();
   const definition = d.useDeploymentDefinition(deployment.dseq);
+  const queryClient = d.useQueryClient();
   const seededDseq = useRef<string | undefined>(undefined);
   const seededSdl = useRef("");
   const updateDeployment = api.v1.updateDeployment.useMutation({
@@ -150,7 +158,8 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   }, []);
 
   const isResolvingDefinition = definition.source === "resolving";
-  const showsWithheldValuesNotice = definition.source === "absent" && dseqWithDismissedNotice !== deployment.dseq;
+  /** A complete copy the chain has moved past is shown with the divergence warning instead, since nothing about it was withheld. */
+  const showsWithheldValuesNotice = definition.source === "absent" && !isApiRecordComplete(definition) && dseqWithDismissedNotice !== deployment.dseq;
   /** Only against the api's own record does a blank env value name a withheld one; in a document of the user's own it can be deliberate. */
   const apiRecord = definition.source === "absent" ? definition.sdl : undefined;
   const hasWithheldValues = useMemo(
@@ -180,9 +189,9 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     function compareTheResolvedCopyAgainstTheChain() {
       if (isResolvingDefinition) return;
 
-      const { sdl, source } = definition;
+      const { sdl } = definition;
 
-      if (!sdl || !needsChainVersionCheck(sdl, source)) {
+      if (!sdl || !needsChainVersionCheck(definition)) {
         setDeploymentVersion(null);
         return;
       }
@@ -229,12 +238,18 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
 
   function recordUpdate(submittedSdl: string) {
     cacheSubmittedManifest(submittedSdl);
+    refetchResolvedDefinition();
     analyticsService.track("update_deployment", { category: "deployments", label: "Update deployment" });
     analyticsService.track("successful_tx", { category: "transactions", label: "Successful transaction" });
     refetchBalances();
     enqueueSnackbar(<d.Snackbar title="Success" subTitle="Deployment updated successfully" iconVariant="success" />, {
       variant: "success"
     });
+  }
+
+  /** The resolved definition also feeds the header's service count and the placement cards, which would otherwise keep describing the document this update replaced. */
+  function refetchResolvedDefinition() {
+    queryClient.invalidateQueries({ queryKey: api.v1.getDeployment.getKey({ dseq: deployment.dseq }) });
   }
 
   /** A full or corrupted browser storage must not turn an update the api already accepted into a reported failure. */

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -132,7 +132,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   const { isBlockchainDown } = d.useBlockchainStatus();
   const definition = d.useDeploymentDefinition(deployment.dseq);
   const seededDseq = useRef<string | undefined>(undefined);
-  const seededSdl = useRef<string | undefined>(undefined);
+  const seededSdl = useRef("");
   const updateDeployment = api.v1.updateDeployment.useMutation({
     onSuccess: (_data, variables) => recordUpdate(variables.data.sdl),
     onError: reportUpdateFailure
@@ -163,23 +163,31 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     function seedEditorOnceTheDefinitionResolves() {
       if (isResolvingDefinition) return;
 
-      const { sdl, source } = definition;
+      const { sdl } = definition;
 
-      const editorHoldsUnseededEdits = seededDseq.current === deployment.dseq && editedManifest !== seededSdl.current;
+      const editorHoldsUnseededEdits = seededDseq.current === deployment.dseq && (editedManifest || "") !== seededSdl.current;
       if (editorHoldsUnseededEdits) return;
 
-      if (sdl) {
-        seededDseq.current = deployment.dseq;
-        seededSdl.current = sdl;
-        onManifestChange(sdl);
-      }
+      seededDseq.current = deployment.dseq;
+      seededSdl.current = sdl ?? "";
+
+      if (sdl) onManifestChange(sdl);
+    },
+    [isResolvingDefinition, definition.sdl, deployment.dseq]
+  );
+
+  useEffect(
+    function compareTheResolvedCopyAgainstTheChain() {
+      if (isResolvingDefinition) return;
+
+      const { sdl, source } = definition;
 
       if (!sdl || !needsChainVersionCheck(sdl, source)) {
         setDeploymentVersion(null);
         return;
       }
 
-      const readVersionOfSeededCopy = async () => {
+      const readVersionOfResolvedCopy = async () => {
         try {
           setDeploymentVersion(await d.deploymentData.getManifestVersion(yaml.load(sdl)));
         } catch (error) {
@@ -188,9 +196,9 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
         }
       };
 
-      readVersionOfSeededCopy();
+      readVersionOfResolvedCopy();
     },
-    [isResolvingDefinition, definition.sdl, definition.source, deployment.dseq]
+    [isResolvingDefinition, definition.sdl, definition.source]
   );
 
   function handleManifestChange(value: string) {

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -18,7 +18,7 @@ import { useDeploymentDefinition as useDeploymentDefinitionOriginal } from "@src
 import { useBalances as useBalancesOriginal } from "@src/queries/useBalancesQuery";
 import type { DeploymentDto } from "@src/types/deployment";
 import { deploymentData as deploymentDataOriginal } from "@src/utils/deploymentData";
-import { hasOnlyBlankEnvValues, hasSdlReference, isStoredSdlSelfContained } from "@src/utils/sdl/storedDefinition";
+import { hasSdlReference, isStoredSdlSelfContained, leavesWithheldEnvValuesBlank } from "@src/utils/sdl/storedDefinition";
 import RemoteDeployUpdate from "../../remote-deploy/update/RemoteDeployUpdate";
 import { SDLEditor } from "../../sdl/SDLEditor/SDLEditor";
 import { DeploymentTabHeader } from "../DeploymentDetail/DeploymentTabHeader";
@@ -55,9 +55,9 @@ const ADD_CREDITS_TITLE = "Add credits to continue";
 /** Refused rather than submitted: a document whose values are references would commit a manifest whose environment is the reference strings themselves. */
 const WITHHELD_VALUES_ERROR = "This configuration still has withheld secret values. Replace them with real values before updating.";
 
-/** The api serves its own copy only when the chain is already running it, and a copy stripped of its values hashes to a manifest the chain never committed. */
+/** The api serves its own copy only when the chain is already running it, and a copy the api stripped hashes to a manifest the chain never committed. */
 function needsChainVersionCheck(sdl: string, source: DeploymentDefinitionSource): boolean {
-  return source !== "api" && isStoredSdlSelfContained(sdl);
+  return source === "local" || (source === "absent" && isStoredSdlSelfContained(sdl));
 }
 
 function isBadRequest(cause: unknown): boolean {
@@ -151,11 +151,11 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
 
   const isResolvingDefinition = definition.source === "resolving";
   const showsWithheldValuesNotice = definition.source === "absent" && dseqWithDismissedNotice !== deployment.dseq;
-  /** A blank env value only signals a withheld one in the api's own record; in a document of the user's own it can be deliberate. */
-  const isServingTheApiRecord = definition.source === "absent" && !!definition.sdl;
+  /** Only against the api's own record does a blank env value name a withheld one; in a document of the user's own it can be deliberate. */
+  const apiRecord = definition.source === "absent" ? definition.sdl : undefined;
   const hasWithheldValues = useMemo(
-    () => !!editedManifest && (hasSdlReference(editedManifest) || (isServingTheApiRecord && hasOnlyBlankEnvValues(editedManifest))),
-    [editedManifest, isServingTheApiRecord]
+    () => !!editedManifest && (hasSdlReference(editedManifest) || (!!apiRecord && leavesWithheldEnvValuesBlank(editedManifest, apiRecord))),
+    [editedManifest, apiRecord]
   );
   const editorAlertMessage = parsingError ?? (hasWithheldValues ? WITHHELD_VALUES_ERROR : null);
 

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { LoggerService } from "@akashnetwork/logging";
 import { extractApiErrorMessage, isApiError } from "@akashnetwork/openapi-sdk";
 import { Alert, Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
@@ -14,9 +14,11 @@ import { useBlockchainStatus as useBlockchainStatusOriginal } from "@src/context
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet as useWalletOriginal } from "@src/context/WalletProvider";
 import { AddCreditsSnackbarContent } from "@src/context/WalletProvider/useSignAndBroadcast";
+import { useDeploymentDefinition as useDeploymentDefinitionOriginal } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useBalances as useBalancesOriginal } from "@src/queries/useBalancesQuery";
 import type { DeploymentDto } from "@src/types/deployment";
 import { deploymentData as deploymentDataOriginal } from "@src/utils/deploymentData";
+import { hasSdlReference } from "@src/utils/sdl/storedDefinition";
 import RemoteDeployUpdate from "../../remote-deploy/update/RemoteDeployUpdate";
 import { SDLEditor } from "../../sdl/SDLEditor/SDLEditor";
 import { DeploymentTabHeader } from "../DeploymentDetail/DeploymentTabHeader";
@@ -39,6 +41,7 @@ export const DEPENDENCIES = {
   useBalances: useBalancesOriginal,
   useSnackbar: useSnackbarOriginal,
   useBlockchainStatus: useBlockchainStatusOriginal,
+  useDeploymentDefinition: useDeploymentDefinitionOriginal,
   // eslint-disable-next-line akash/dependencies-component-or-hook
   deploymentData: deploymentDataOriginal
 };
@@ -51,6 +54,8 @@ const SDL_REFUSAL_PREFIXES = ["Invalid SDL:", "SDL is not valid YAML", "SDL is t
 const TRIAL_GATE_MARK = "not available on free trial";
 const UPDATE_FAILURE_MESSAGE = "Something went wrong while updating the deployment. Please try again.";
 const ADD_CREDITS_TITLE = "Add credits to continue";
+/** Refused rather than submitted: a document whose values are references would commit a manifest whose environment is the reference strings themselves. */
+const WITHHELD_VALUES_ERROR = "This configuration still has withheld secret values. Replace them with real values before updating.";
 
 function isBadRequest(cause: unknown): boolean {
   return isApiError(cause) && cause.status === 400;
@@ -116,12 +121,13 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   const { api, analyticsService, deploymentLocalStorage } = useServices();
   const [parsingError, setParsingError] = useState<string | null>(null);
   const [deploymentVersion, setDeploymentVersion] = useState<string | null>(null);
-  const [showOutsideDeploymentMessage, setShowOutsideDeploymentMessage] = useState(false);
+  const [hasDismissedWithheldValuesNotice, setHasDismissedWithheldValuesNotice] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const { address } = d.useWallet();
   const { refetch: refetchBalances } = d.useBalances(address);
   const { enqueueSnackbar, closeSnackbar } = d.useSnackbar();
   const { isBlockchainDown } = d.useBlockchainStatus();
+  const definition = d.useDeploymentDefinition(deployment.dseq);
   const updateDeployment = api.v1.updateDeployment.useMutation({
     onSuccess: (_data, variables) => recordUpdate(variables.data.sdl),
     onError: reportUpdateFailure
@@ -138,28 +144,36 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     };
   }, []);
 
-  useEffect(() => {
-    const init = async () => {
-      const localDeploymentData = deploymentLocalStorage.get(address, deployment.dseq);
+  const isResolvingDefinition = definition.source === "resolving";
+  const showsWithheldValuesNotice = definition.source === "absent" && !hasDismissedWithheldValuesNotice;
+  const hasWithheldValues = useMemo(() => !!editedManifest && hasSdlReference(editedManifest), [editedManifest]);
 
-      if (localDeploymentData?.manifest) {
-        onManifestChange(localDeploymentData.manifest);
+  useEffect(
+    function seedEditorOnceTheDefinitionResolves() {
+      if (isResolvingDefinition) return;
 
+      const { sdl, source } = definition;
+
+      if (sdl) onManifestChange(sdl);
+
+      /** Both copies that can disagree with the chain: this browser's own, and one the API held but could not stand behind. */
+      if ((source !== "local" && source !== "absent") || !sdl) {
+        setDeploymentVersion(null);
+        return;
+      }
+
+      const readVersionOfLocalCopy = async () => {
         try {
-          const yamlVersion = yaml.load(localDeploymentData.manifest);
-          const version = await d.deploymentData.getManifestVersion(yamlVersion);
-          setDeploymentVersion(version);
-        } catch (error) {
-          console.error(error);
+          setDeploymentVersion(await d.deploymentData.getManifestVersion(yaml.load(sdl)));
+        } catch {
           setParsingError("Error getting manifest version.");
         }
-      } else {
-        setShowOutsideDeploymentMessage(true);
-      }
-    };
+      };
 
-    init();
-  }, [deployment, address, deploymentLocalStorage]);
+      readVersionOfLocalCopy();
+    },
+    [isResolvingDefinition, definition.sdl, definition.source]
+  );
 
   function handleManifestChange(value: string) {
     setParsingError(null);
@@ -181,6 +195,11 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   }
 
   function handleUpdateClick() {
+    if (hasWithheldValues) {
+      setParsingError(WITHHELD_VALUES_ERROR);
+      return;
+    }
+
     setIsUpdating(true);
     updateDeployment.mutate({ dseq: deployment.dseq, data: { sdl: editedManifest } }, { onSuccess: closeAfterUpdate, onError: releaseAfterFailure });
   }
@@ -247,15 +266,24 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     );
   }
 
+  if (isResolvingDefinition) {
+    return (
+      <div className="p-2" data-testid="manifest-update-resolving">
+        <d.LinearLoadingSkeleton isLoading />
+      </div>
+    );
+  }
+
   return (
     <>
-      {showOutsideDeploymentMessage ? (
+      {showsWithheldValuesNotice ? (
         <div className="p-2">
           <d.Alert>
-            It looks like this deployment was created using another deploy tool. We can't show you the configuration file that was used initially, but you can
-            still update it. Simply continue and enter the configuration you want to use.
+            {definition.sdl
+              ? "The configuration stored for this deployment has its secret values withheld, so they are not shown below. Continue and enter them before updating."
+              : "It looks like this deployment was created using another deploy tool. We can't show you the configuration file that was used initially, but you can still update it. Simply continue and enter the configuration you want to use."}
             <div className="mt-1">
-              <d.Button onClick={() => setShowOutsideDeploymentMessage(false)} size="sm">
+              <d.Button onClick={() => setHasDismissedWithheldValuesNotice(true)} size="sm">
                 Continue
               </d.Button>
             </div>
@@ -275,7 +303,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
                     </d.Button>
                   )}
                   <d.Button
-                    disabled={!!parsingError || !editedManifest || isUpdating || deployment.state !== "active" || isBlockchainDown}
+                    disabled={!!parsingError || !editedManifest || hasWithheldValues || isUpdating || deployment.state !== "active" || isBlockchainDown}
                     onClick={() => handleUpdateClick()}
                     size="md"
                     type="button"

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
@@ -1,14 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
 
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { LeaseDto } from "@src/types/deployment";
 import { DEPENDENCIES, ReclamationBanner } from "./ReclamationBanner";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MockComponents } from "@tests/unit/mocks";
-
-type DeploymentData = NonNullable<ReturnType<ReturnType<typeof DEPENDENCIES.useLocalNotes>["getDeploymentData"]>>;
 
 describe("ReclamationBanner", () => {
   afterEach(() => {
@@ -58,10 +56,10 @@ describe("ReclamationBanner", () => {
     expect(screen.getByRole("button", { name: "Redeploy" })).toBeInTheDocument();
   });
 
-  it("redeploys with the stored sdl and name when Redeploy is clicked", async () => {
+  it("redeploys with the resolved sdl and name when Redeploy is clicked", async () => {
     const { redeploy } = setup({
       leases: [createLease({ state: "reclaiming" })],
-      deploymentData: { manifest: "version: 2.0", name: "my-app" }
+      definition: { sdl: "version: 2.0", name: "my-app", source: "api" }
     });
 
     await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
@@ -69,15 +67,33 @@ describe("ReclamationBanner", () => {
     expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0", name: "my-app" });
   });
 
-  function setup(input: { leases: LeaseDto[] | null; deploymentData?: { manifest?: string; name?: string } | null }) {
-    const localNotes = mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>();
-    localNotes.getDeploymentData.mockReturnValue(input.deploymentData ? mock<DeploymentData>(input.deploymentData) : null);
+  it("redeploys from the api definition on a device holding no local copy", async () => {
+    const { redeploy } = setup({
+      leases: [createLease({ state: "reclaiming" })],
+      definition: { sdl: "version: 2.0 # from-the-api", name: undefined, source: "api" }
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
+
+    expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0 # from-the-api", name: undefined });
+  });
+
+  it("disables Redeploy while the definition is still resolving", () => {
+    setup({ leases: [createLease({ state: "reclaiming" })], definition: { sdl: undefined, source: "resolving" } });
+
+    expect(screen.getByRole("button", { name: "Redeploy" })).toBeDisabled();
+  });
+
+  function setup(input: { leases: LeaseDto[] | null; definition?: Partial<DeploymentDefinition> }) {
+    const definition: DeploymentDefinition = { sdl: "version: 2.0", name: "my-app", source: "local", ...input.definition };
     const redeploy = vi.fn();
 
-    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => localNotes;
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
     const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
 
-    const utils = render(<ReclamationBanner leases={input.leases} dseq="123" dependencies={MockComponents(DEPENDENCIES, { useLocalNotes, useRedeploy })} />);
+    const utils = render(
+      <ReclamationBanner leases={input.leases} dseq="123" dependencies={MockComponents(DEPENDENCIES, { useDeploymentDefinition, useRedeploy })} />
+    );
 
     return { ...utils, redeploy };
   }

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
@@ -84,15 +84,34 @@ describe("ReclamationBanner", () => {
     expect(screen.getByRole("button", { name: "Redeploy" })).toBeDisabled();
   });
 
+  it("falls back to a 'new SDL' link when neither source holds a definition", () => {
+    setup({ leases: [createLease({ state: "reclaiming" })], definition: { sdl: undefined, source: "absent" } });
+
+    expect(screen.getByRole("link", { name: "Start a new deployment" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
+  });
+
+  it("falls back to a 'new SDL' link when the definition is absent despite an inspection-only api sdl", () => {
+    setup({ leases: [createLease({ state: "reclaiming" })], definition: { sdl: "version: 2.0 # not-self-contained", source: "absent" } });
+
+    expect(screen.getByRole("link", { name: "Start a new deployment" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
+  });
+
   function setup(input: { leases: LeaseDto[] | null; definition?: Partial<DeploymentDefinition> }) {
     const definition: DeploymentDefinition = { sdl: "version: 2.0", name: "my-app", source: "local", ...input.definition };
     const redeploy = vi.fn();
 
     const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
+    const useNewDeploymentUrl: typeof DEPENDENCIES.useNewDeploymentUrl = () => () => "/new-deployment";
     const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
 
     const utils = render(
-      <ReclamationBanner leases={input.leases} dseq="123" dependencies={MockComponents(DEPENDENCIES, { useDeploymentDefinition, useRedeploy })} />
+      <ReclamationBanner
+        leases={input.leases}
+        dseq="123"
+        dependencies={MockComponents(DEPENDENCIES, { useDeploymentDefinition, useNewDeploymentUrl, useRedeploy })}
+      />
     );
 
     return { ...utils, redeploy };

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
@@ -3,13 +3,13 @@ import { useMemo } from "react";
 import { Alert, AlertDescription, AlertTitle, Button } from "@akashnetwork/ui/components";
 import { WarningTriangle } from "iconoir-react";
 
-import { useLocalNotes } from "@src/components/LocalNoteManager";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import type { LeaseDto } from "@src/types/deployment";
 import { getLeaseCloseReasonLabel, getReclamationDeadline, isReclaiming } from "@src/utils/reclamationUtils";
 import { useCountdown } from "./useCountdown";
 
-export const DEPENDENCIES = { useLocalNotes, useRedeploy };
+export const DEPENDENCIES = { useDeploymentDefinition, useRedeploy };
 
 type Props = {
   leases: LeaseDto[] | undefined | null;
@@ -24,9 +24,8 @@ type Props = {
  * before the grace-period deadline. The terminal (already-closed) case is handled by ReclamationCard.
  */
 export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq, className, dependencies = DEPENDENCIES }) => {
-  const { getDeploymentData } = dependencies.useLocalNotes();
+  const definition = dependencies.useDeploymentDefinition(dseq);
   const redeploy = dependencies.useRedeploy();
-  const deploymentData = getDeploymentData(dseq);
   const reclaimingLeases = useMemo(() => (leases ?? []).filter(isReclaiming), [leases]);
 
   const nearestDeadline = useMemo(() => {
@@ -53,7 +52,13 @@ export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq
         </p>
         <p className="mt-1 text-xs text-muted-foreground">Reason: {reasonLabel}</p>
         <p className="mt-2">Reclamation can&apos;t be cancelled. Redeploy to another provider before the deadline to avoid downtime.</p>
-        <Button variant="default" size="sm" className="mt-3" onClick={() => redeploy({ sdl: deploymentData?.manifest, name: deploymentData?.name })}>
+        <Button
+          variant="default"
+          size="sm"
+          className="mt-3"
+          disabled={definition.source === "resolving"}
+          onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
+        >
           Redeploy
         </Button>
       </AlertDescription>

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
@@ -1,15 +1,18 @@
 "use client";
 import { useMemo } from "react";
-import { Alert, AlertDescription, AlertTitle, Button } from "@akashnetwork/ui/components";
+import { Alert, AlertDescription, AlertTitle, Button, buttonVariants } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
 import { WarningTriangle } from "iconoir-react";
+import Link from "next/link";
 
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import type { LeaseDto } from "@src/types/deployment";
 import { getLeaseCloseReasonLabel, getReclamationDeadline, isReclaiming } from "@src/utils/reclamationUtils";
 import { useCountdown } from "./useCountdown";
 
-export const DEPENDENCIES = { useDeploymentDefinition, useRedeploy };
+export const DEPENDENCIES = { useDeploymentDefinition, useNewDeploymentUrl, useRedeploy };
 
 type Props = {
   leases: LeaseDto[] | undefined | null;
@@ -25,7 +28,9 @@ type Props = {
  */
 export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq, className, dependencies = DEPENDENCIES }) => {
   const definition = dependencies.useDeploymentDefinition(dseq);
+  const newDeploymentUrl = dependencies.useNewDeploymentUrl();
   const redeploy = dependencies.useRedeploy();
+  const canRedeploy = definition.source === "resolving" || isUsableDeploymentDefinition(definition);
   const reclaimingLeases = useMemo(() => (leases ?? []).filter(isReclaiming), [leases]);
 
   const nearestDeadline = useMemo(() => {
@@ -52,15 +57,21 @@ export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq
         </p>
         <p className="mt-1 text-xs text-muted-foreground">Reason: {reasonLabel}</p>
         <p className="mt-2">Reclamation can&apos;t be cancelled. Redeploy to another provider before the deadline to avoid downtime.</p>
-        <Button
-          variant="default"
-          size="sm"
-          className="mt-3"
-          disabled={definition.source === "resolving"}
-          onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
-        >
-          Redeploy
-        </Button>
+        {canRedeploy ? (
+          <Button
+            variant="default"
+            size="sm"
+            className="mt-3"
+            disabled={definition.source === "resolving"}
+            onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
+          >
+            Redeploy
+          </Button>
+        ) : (
+          <Link href={newDeploymentUrl()} className={cn(buttonVariants({ variant: "default", size: "sm" }), "mt-3")}>
+            Start a new deployment
+          </Link>
+        )}
       </AlertDescription>
     </Alert>
   );

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
@@ -1,14 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { LeaseDto } from "@src/types/deployment";
 import { DEPENDENCIES, ReclamationCard } from "./ReclamationCard";
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MockComponents } from "@tests/unit/mocks";
-
-type DeploymentData = NonNullable<ReturnType<ReturnType<typeof DEPENDENCIES.useLocalNotes>["getDeploymentData"]>>;
 
 describe("ReclamationCard", () => {
   it("shows the provider close reason as the title", () => {
@@ -17,7 +16,7 @@ describe("ReclamationCard", () => {
   });
 
   it("offers Close + Redeploy and no restart control", () => {
-    setup({ hasLocalManifest: true });
+    setup({ definition: { sdl: "version: 2.0" } });
 
     expect(screen.getByRole("button", { name: "Close & refund" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Redeploy" })).toBeInTheDocument();
@@ -25,19 +24,34 @@ describe("ReclamationCard", () => {
     expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
   });
 
-  it("redeploys with the stored sdl and name when Redeploy is clicked", async () => {
-    const { redeploy } = setup({ hasLocalManifest: true, manifest: "version: 2.0", name: "my-app" });
+  it("redeploys with the resolved sdl and name when Redeploy is clicked", async () => {
+    const { redeploy } = setup({ definition: { sdl: "version: 2.0", name: "my-app" } });
 
     await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
 
     expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0", name: "my-app" });
   });
 
-  it("falls back to a 'new SDL' link when there is no local manifest", () => {
-    setup({ hasLocalManifest: false });
+  it("redeploys from the api definition on a device holding no local copy", async () => {
+    const { redeploy } = setup({ definition: { sdl: "version: 2.0 # from-the-api", name: undefined, source: "api" } });
+
+    await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
+
+    expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0 # from-the-api", name: undefined });
+  });
+
+  it("falls back to a 'new SDL' link when neither source holds a definition", () => {
+    setup({ definition: { sdl: undefined, source: "absent" } });
 
     expect(screen.getByRole("link", { name: "Start a new deployment" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
+  });
+
+  it("offers Redeploy disabled rather than the link while the definition is resolving", () => {
+    setup({ definition: { sdl: undefined, source: "resolving" } });
+
+    expect(screen.getByRole("button", { name: "Redeploy" })).toBeDisabled();
+    expect(screen.queryByRole("link", { name: "Start a new deployment" })).not.toBeInTheDocument();
   });
 
   it("closes the deployment when confirmed", async () => {
@@ -60,23 +74,19 @@ describe("ReclamationCard", () => {
     expect(wallet.signAndBroadcastTx).not.toHaveBeenCalled();
   });
 
-  function setup(input: { reason?: string; hasLocalManifest?: boolean; manifest?: string; name?: string; isConfirmed?: boolean; onClosed?: () => void } = {}) {
+  function setup(input: { reason?: string; definition?: Partial<DeploymentDefinition>; isConfirmed?: boolean; onClosed?: () => void } = {}) {
     const wallet = mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1owner" });
     wallet.signAndBroadcastTx.mockResolvedValue(true);
 
     const confirm = mock<ReturnType<typeof DEPENDENCIES.useManagedDeploymentConfirm>>();
     confirm.closeDeploymentConfirm.mockResolvedValue(input.isConfirmed ?? true);
 
-    const localNotes = mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>();
-    localNotes.getDeploymentData.mockReturnValue(
-      input.hasLocalManifest ? mock<DeploymentData>({ manifest: input.manifest ?? "version: 2.0", name: input.name }) : null
-    );
-
+    const definition: DeploymentDefinition = { sdl: "version: 2.0", name: undefined, source: "local", ...input.definition };
     const redeploy = vi.fn();
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => wallet;
     const useManagedDeploymentConfirm: typeof DEPENDENCIES.useManagedDeploymentConfirm = () => confirm;
-    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => localNotes;
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
     const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
     const useNewDeploymentUrl: typeof DEPENDENCIES.useNewDeploymentUrl = () => () => "/new-deployment";
 
@@ -97,7 +107,7 @@ describe("ReclamationCard", () => {
         lease={lease}
         dseq="123"
         onClosed={input.onClosed}
-        dependencies={MockComponents(DEPENDENCIES, { useWallet, useManagedDeploymentConfirm, useLocalNotes, useRedeploy, useNewDeploymentUrl })}
+        dependencies={MockComponents(DEPENDENCIES, { useWallet, useManagedDeploymentConfirm, useDeploymentDefinition, useRedeploy, useNewDeploymentUrl })}
       />
     );
 

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
@@ -47,6 +47,13 @@ describe("ReclamationCard", () => {
     expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
   });
 
+  it("falls back to a 'new SDL' link when the definition is absent despite an inspection-only api sdl", () => {
+    setup({ definition: { sdl: "version: 2.0 # not-self-contained", source: "absent" } });
+
+    expect(screen.getByRole("link", { name: "Start a new deployment" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
+  });
+
   it("offers Redeploy disabled rather than the link while the definition is resolving", () => {
     setup({ definition: { sdl: undefined, source: "resolving" } });
 

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
@@ -5,8 +5,8 @@ import { cn } from "@akashnetwork/ui/utils";
 import { WarningTriangle } from "iconoir-react";
 import Link from "next/link";
 
-import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useWallet } from "@src/context/WalletProvider";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
@@ -14,7 +14,7 @@ import type { LeaseDto } from "@src/types/deployment";
 import { getLeaseCloseReasonLabel } from "@src/utils/reclamationUtils";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
 
-export const DEPENDENCIES = { useWallet, useManagedDeploymentConfirm, useLocalNotes, useNewDeploymentUrl, useRedeploy };
+export const DEPENDENCIES = { useWallet, useManagedDeploymentConfirm, useDeploymentDefinition, useNewDeploymentUrl, useRedeploy };
 
 type Props = {
   lease: LeaseDto;
@@ -29,17 +29,16 @@ type Props = {
  * deployment) + Redeploy. The live, still-running case is handled by ReclamationBanner.
  */
 export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, onClosed, dependencies = DEPENDENCIES }) => {
-  const { useWallet, useManagedDeploymentConfirm, useLocalNotes, useNewDeploymentUrl, useRedeploy } = dependencies;
+  const { useWallet, useManagedDeploymentConfirm, useDeploymentDefinition, useNewDeploymentUrl, useRedeploy } = dependencies;
   const { address, signAndBroadcastTx } = useWallet();
   const { closeDeploymentConfirm } = useManagedDeploymentConfirm();
-  const { getDeploymentData } = useLocalNotes();
   const newDeploymentUrl = useNewDeploymentUrl();
   const redeploy = useRedeploy();
   const [isClosing, setIsClosing] = useState(false);
 
   const reasonLabel = getLeaseCloseReasonLabel(lease.reclamation?.reason ?? lease.reason);
-  const deploymentData = getDeploymentData(dseq);
-  const hasLocalManifest = !!deploymentData?.manifest;
+  const definition = useDeploymentDefinition(dseq);
+  const canRedeploy = definition.source === "resolving" || !!definition.sdl;
 
   const confirmAndClose = async () => {
     const isConfirmed = await closeDeploymentConfirm([dseq]);
@@ -67,12 +66,13 @@ export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, o
           <Button variant="default" size="sm" onClick={confirmAndClose} disabled={isClosing}>
             {isClosing ? <Spinner size="small" /> : "Close & refund"}
           </Button>
-          {hasLocalManifest ? (
+          {canRedeploy ? (
             <Button
               variant="outline"
               size="sm"
               className="text-foreground"
-              onClick={() => redeploy({ sdl: deploymentData?.manifest, name: deploymentData?.name })}
+              disabled={definition.source === "resolving"}
+              onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
             >
               Redeploy
             </Button>

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
@@ -6,7 +6,7 @@ import { WarningTriangle } from "iconoir-react";
 import Link from "next/link";
 
 import { useWallet } from "@src/context/WalletProvider";
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
@@ -38,7 +38,7 @@ export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, o
 
   const reasonLabel = getLeaseCloseReasonLabel(lease.reclamation?.reason ?? lease.reason);
   const definition = useDeploymentDefinition(dseq);
-  const canRedeploy = definition.source === "resolving" || !!definition.sdl;
+  const canRedeploy = definition.source === "resolving" || isUsableDeploymentDefinition(definition);
 
   const confirmAndClose = async () => {
     const isConfirmed = await closeDeploymentConfirm([dseq]);

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
@@ -349,6 +349,46 @@ describe(NewDeploymentContainer.name, () => {
     expect(ManifestEdit).toHaveBeenLastCalledWith(expect.objectContaining({ editedManifest: userEditedManifest }), {});
   });
 
+  it("seeds the editor once the redeploy definition resolves into an untouched editor", async () => {
+    const { ManifestEdit, rerender } = setup({
+      step: RouteStep.editDeployment,
+      redeploy: "123",
+      redeployDefinition: { sdl: undefined, source: "resolving" }
+    });
+
+    rerender({ redeployDefinition: { sdl: "version: 2.0\n# from the api", name: "Redeployed App", source: "api" } });
+
+    await vi.waitFor(() => {
+      expect(ManifestEdit).toHaveBeenLastCalledWith(expect.objectContaining({ editedManifest: "version: 2.0\n# from the api" }), {});
+    });
+  });
+
+  it("keeps the manifest a user typed before the redeploy definition resolved", async () => {
+    const { ManifestEdit, rerender } = setup({
+      step: RouteStep.editDeployment,
+      redeploy: "123",
+      redeployDefinition: { sdl: undefined, source: "resolving" }
+    });
+
+    await vi.waitFor(() => {
+      expect(ManifestEdit).toHaveBeenCalled();
+    });
+
+    const typedBeforeTheApiAnswered = "version: 2.0\n# typed while the api was still resolving";
+    ManifestEdit.mock.calls.at(-1)?.[0].setEditedManifest(typedBeforeTheApiAnswered);
+
+    await vi.waitFor(() => {
+      expect(ManifestEdit).toHaveBeenLastCalledWith(expect.objectContaining({ editedManifest: typedBeforeTheApiAnswered }), {});
+    });
+
+    rerender({ redeployDefinition: { sdl: "version: 2.0\n# from the api", name: "Redeployed App", source: "api" } });
+
+    await vi.waitFor(() => {
+      expect(ManifestEdit).toHaveBeenCalled();
+    });
+    expect(ManifestEdit).toHaveBeenLastCalledWith(expect.objectContaining({ editedManifest: typedBeforeTheApiAnswered }), {});
+  });
+
   function setup(
     input: {
       step?: RouteStep;
@@ -397,7 +437,13 @@ describe(NewDeploymentContainer.name, () => {
 
     // Create stable references for hook return values to prevent infinite re-renders
     const sdlBuilder = mock<SdlContextProps>();
-    const redeployDefinition: DeploymentDefinition = { sdl: undefined, name: undefined, source: "absent", ...input.redeployDefinition };
+    const resolveDefinition = (next: Partial<DeploymentDefinition> | undefined): DeploymentDefinition => ({
+      sdl: undefined,
+      name: undefined,
+      source: "absent",
+      ...next
+    });
+    let redeployDefinition = resolveDefinition(input.redeployDefinition);
     const templatesValue = {
       isLoading: input.isLoadingTemplates ?? false,
       templates: [] as never[],
@@ -447,6 +493,7 @@ describe(NewDeploymentContainer.name, () => {
       mockSearchParams = buildSearchParams(merged);
       currentRequestedTemplate = merged.requestedTemplate;
       currentTemplateId = merged.templateId;
+      redeployDefinition = resolveDefinition(merged.redeployDefinition);
       view.rerender(renderTree());
     };
 

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
@@ -216,6 +216,19 @@ describe(NewDeploymentContainer.name, () => {
     });
   });
 
+  it("ignores the redeploy definition when it is absent despite an inspection-only api sdl", async () => {
+    const { mockRouter } = setup({
+      step: RouteStep.chooseTemplate,
+      redeploy: "123",
+      redeployDefinition: { sdl: "redeploy manifest content # not-self-contained", name: "Redeployed App", source: "absent" }
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("template-list")).toBeInTheDocument();
+    });
+    expect(mockRouter.replace).not.toHaveBeenCalled();
+  });
+
   it("toggles ssh component when template has ssh config", async () => {
     const { sdlBuilder } = setup({
       step: RouteStep.chooseTemplate,

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
@@ -5,10 +5,10 @@ import type { ReadonlyURLSearchParams } from "next/navigation";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { LocalNotesContextType as LocalNotesContext } from "@src/components/LocalNoteManager";
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
 import type { SdlContextProps } from "@src/context/SdlBuilderProvider";
 import type { AppDIContainer } from "@src/context/ServicesProvider";
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import sdlStore from "@src/store/sdlStore";
 import type { TemplateCreation } from "@src/types";
 import { RouteStep } from "@src/types/route-steps.type";
@@ -205,15 +205,10 @@ describe(NewDeploymentContainer.name, () => {
   });
 
   it("redirects to edit-deployment step when redeploy param is present", async () => {
-    const redeployData = {
-      name: "Redeployed App",
-      manifest: "redeploy manifest content"
-    };
-
     const { mockRouter } = setup({
       step: RouteStep.chooseTemplate,
       redeploy: "123",
-      redeployData
+      redeployDefinition: { sdl: "redeploy manifest content", name: "Redeployed App", source: "api" }
     });
 
     await vi.waitFor(() => {
@@ -350,7 +345,7 @@ describe(NewDeploymentContainer.name, () => {
       code?: string;
       state?: string;
       redeploy?: string;
-      redeployData?: { name: string; manifest: string };
+      redeployDefinition?: Partial<DeploymentDefinition>;
       requestedTemplate?: TemplateOutput;
       deploySdl?: TemplateCreation | null;
       isLoadingTemplates?: boolean;
@@ -389,9 +384,7 @@ describe(NewDeploymentContainer.name, () => {
 
     // Create stable references for hook return values to prevent infinite re-renders
     const sdlBuilder = mock<SdlContextProps>();
-    const localNotes = mock<LocalNotesContext>({
-      getDeploymentData: vi.fn().mockReturnValue(input.redeployData ?? null)
-    });
+    const redeployDefinition: DeploymentDefinition = { sdl: undefined, name: undefined, source: "absent", ...input.redeployDefinition };
     const templatesValue = {
       isLoading: input.isLoadingTemplates ?? false,
       templates: [] as never[],
@@ -413,7 +406,7 @@ describe(NewDeploymentContainer.name, () => {
       useRouter: () => mockRouter,
       useSearchParams: () => mockSearchParams,
       useSdlBuilder: () => sdlBuilder,
-      useLocalNotes: () => localNotes,
+      useDeploymentDefinition: () => redeployDefinition,
       useTemplates: () => templatesValue
     } as unknown as typeof DEPENDENCIES;
     const store = createStore();
@@ -446,7 +439,6 @@ describe(NewDeploymentContainer.name, () => {
 
     return {
       mockRouter,
-      localNotes,
       sdlBuilder,
       Layout,
       CreateLease,

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
@@ -5,12 +5,12 @@ import type { TemplateOutput } from "@akashnetwork/http-sdk";
 import { useAtomValue } from "jotai";
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { Editor } from "@src/components/shared/Editor/Editor";
 import { USER_TEMPLATE_CODE } from "@src/config/deploy.config";
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
 import { useSdlBuilder } from "@src/context/SdlBuilderProvider";
 import { useServices } from "@src/context/ServicesProvider";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useWhen } from "@src/hooks/useWhen";
 import { useTemplates } from "@src/queries/useTemplateQuery";
 import sdlStore from "@src/store/sdlStore";
@@ -40,7 +40,7 @@ export const DEPENDENCIES = {
   useRouter,
   useSearchParams,
   useSdlBuilder,
-  useLocalNotes,
+  useDeploymentDefinition,
   useTemplates,
   useServices
 };
@@ -54,9 +54,10 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
   const [editedManifest, setEditedManifest] = useState("");
   const loadedTemplateIdRef = useRef<string | null>(null);
   const deploySdl = useAtomValue(sdlStore.deploySdl);
-  const { getDeploymentData } = d.useLocalNotes();
   const router = d.useRouter();
   const searchParams = d.useSearchParams();
+  const redeployDseq = searchParams?.get("redeploy") ?? null;
+  const redeployDefinition = d.useDeploymentDefinition(redeployDseq);
   const { toggleCmp, hasComponent } = d.useSdlBuilder();
   const { isLoading: isLoadingTemplates, templates } = d.useTemplates();
   const activeStep = useMemo(() => getStepIndexByParam(searchParams?.get("step") as RouteStep), [searchParams]);
@@ -93,6 +94,7 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
 
     const isSameTemplateAlreadyLoaded = !!templateId && loadedTemplateIdRef.current === templateId;
     if (!templates || (isCreating && !!editedManifest && isSameTemplateAlreadyLoaded)) return;
+    if (redeployDefinition.source === "resolving") return;
 
     const template = getRedeployTemplate() || getGalleryTemplate() || deploySdl;
     const isUserTemplate = template?.code === USER_TEMPLATE_CODE;
@@ -119,26 +121,18 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
       router.replace(urlService.newDeployment(newParams));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [templates, !!editedManifest, searchParams, router, toggleCmp, hasComponent, activeStep]);
+  }, [templates, !!editedManifest, searchParams, router, toggleCmp, hasComponent, activeStep, redeployDefinition.source, redeployDefinition.sdl]);
 
   useWhen(activeStepName === RouteStep.chooseTemplate, () => d.Editor.preload());
 
   const getRedeployTemplate = () => {
-    let template: Partial<TemplateCreation> | null = null;
-    const queryRedeploy = searchParams?.get("redeploy");
-    if (queryRedeploy) {
-      const deploymentData = getDeploymentData(queryRedeploy as string);
+    if (!redeployDseq || !redeployDefinition.sdl) return null;
 
-      if (deploymentData && deploymentData.manifest) {
-        template = {
-          name: deploymentData.name,
-          code: "empty",
-          content: deploymentData.manifest
-        };
-      }
-    }
-
-    return template;
+    return {
+      name: redeployDefinition.name,
+      code: "empty",
+      content: redeployDefinition.sdl
+    } satisfies Partial<TemplateCreation>;
   };
 
   const getGalleryTemplate = useCallback(():

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
@@ -53,6 +53,8 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateCreation | null>(null);
   const [editedManifest, setEditedManifest] = useState("");
   const loadedTemplateIdRef = useRef<string | null>(null);
+  /** A redeploy definition arrives asynchronously, so anything the editor holds that this effect did not put there is the user's own typing. */
+  const seededRedeploySdl = useRef<string | null>(null);
   const deploySdl = useAtomValue(sdlStore.deploySdl);
   const router = d.useRouter();
   const searchParams = d.useSearchParams();
@@ -96,6 +98,9 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
     if (!templates || (isCreating && !!editedManifest && isSameTemplateAlreadyLoaded)) return;
     if (redeployDefinition.source === "resolving") return;
 
+    const editorHoldsEditsOfItsOwn = !!redeployDseq && !!editedManifest && editedManifest !== seededRedeploySdl.current;
+    if (editorHoldsEditsOfItsOwn) return;
+
     const template = getRedeployTemplate() || getGalleryTemplate() || deploySdl;
     const isUserTemplate = template?.code === USER_TEMPLATE_CODE;
     const isUserTemplateInit = isUserTemplate && !!editedManifest;
@@ -103,6 +108,7 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
 
     setSelectedTemplate(template as TemplateCreation);
     setEditedManifest(template.content as string);
+    seededRedeploySdl.current = template.content as string;
     loadedTemplateIdRef.current = templateId ?? null;
 
     if ("config" in template && (template.config?.ssh || (!template.config?.ssh && hasComponent("ssh")))) {

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
@@ -10,7 +10,7 @@ import { USER_TEMPLATE_CODE } from "@src/config/deploy.config";
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
 import { useSdlBuilder } from "@src/context/SdlBuilderProvider";
 import { useServices } from "@src/context/ServicesProvider";
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useWhen } from "@src/hooks/useWhen";
 import { useTemplates } from "@src/queries/useTemplateQuery";
 import sdlStore from "@src/store/sdlStore";
@@ -126,7 +126,7 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
   useWhen(activeStepName === RouteStep.chooseTemplate, () => d.Editor.preload());
 
   const getRedeployTemplate = () => {
-    if (!redeployDseq || !redeployDefinition.sdl) return null;
+    if (!redeployDseq || !isUsableDeploymentDefinition(redeployDefinition)) return null;
 
     return {
       name: redeployDefinition.name,

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -17,6 +17,7 @@ const API_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n
 const LOCAL_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=from-this-browser"\n';
 const WITHHELD_VALUES_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=ac-secret://s0_e0"\n';
 const BLANK_ENV_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN="\n';
+const PARTLY_BLANK_ENV_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN="\n      - "REGION=us-east-1"\n';
 
 describe(useDeploymentDefinition.name, () => {
   it("prefers the sdl the api recorded over this browser's own copy", async () => {
@@ -56,7 +57,8 @@ describe(useDeploymentDefinition.name, () => {
     it.each([
       ["it recorded none", null],
       ["its values were withheld as references", WITHHELD_VALUES_SDL],
-      ["every env value it holds is blank", BLANK_ENV_SDL]
+      ["every env value it holds is blank", BLANK_ENV_SDL],
+      ["one of the env values it holds is blank", PARTLY_BLANK_ENV_SDL]
     ])("falls back to this browser's copy when %s", async (_case, apiSdl) => {
       const { result } = setup({ apiSdl, localSdl: LOCAL_SDL });
 
@@ -102,6 +104,13 @@ describe(useDeploymentDefinition.name, () => {
 
       await vi.waitFor(() => expect(result.current.source).toBe("absent"));
       expect(result.current.sdl).toBe(WITHHELD_VALUES_SDL);
+    });
+
+    it("serves a copy whose withheld value sits beside a real one, so the update view can guard it", async () => {
+      const { result } = setup({ apiSdl: PARTLY_BLANK_ENV_SDL, localSdl: undefined });
+
+      await vi.waitFor(() => expect(result.current.source).toBe("absent"));
+      expect(result.current.sdl).toBe(PARTLY_BLANK_ENV_SDL);
     });
   });
 

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -167,7 +167,7 @@ describe(useDeploymentDefinition.name, () => {
 });
 
 describe(isUsableDeploymentDefinition.name, () => {
-  it.each(["api", "local", "superseded"] as const)("accepts a definition resolved from the %s source", source => {
+  it.each(["api", "local"] as const)("accepts a definition resolved from the %s source", source => {
     expect(isUsableDeploymentDefinition({ sdl: API_SDL, name: undefined, source })).toBe(true);
   });
 

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -34,6 +34,13 @@ describe(useDeploymentDefinition.name, () => {
     expect(result.current.sdl).toBeUndefined();
   });
 
+  it("carries the deployment name while the sdl is still resolving, since the name is never the api's to answer", () => {
+    const { result } = setup({ apiSdl: API_SDL, localName: "my-deployment" });
+
+    expect(result.current.source).toBe("resolving");
+    expect(result.current.name).toBe("my-deployment");
+  });
+
   it("carries the deployment name from this browser even when the sdl comes from the api", async () => {
     const { result } = setup({ apiSdl: API_SDL, localSdl: LOCAL_SDL, localName: "my-deployment" });
 

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -6,7 +6,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
 import type { DEPENDENCIES } from "./useDeploymentDefinition";
-import { useDeploymentDefinition } from "./useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "./useDeploymentDefinition";
 
 import { buildWallet } from "@tests/seeders/wallet";
 import { type RenderAppHookOptions, setupQuery } from "@tests/unit/query-client";
@@ -164,4 +164,18 @@ describe(useDeploymentDefinition.name, () => {
 
     return { result, getDeployment, deploymentLocalStorage, onQueryError };
   }
+});
+
+describe(isUsableDeploymentDefinition.name, () => {
+  it.each(["api", "local", "superseded"] as const)("accepts a definition resolved from the %s source", source => {
+    expect(isUsableDeploymentDefinition({ sdl: API_SDL, name: undefined, source })).toBe(true);
+  });
+
+  it.each(["resolving", "absent"] as const)("rejects a %s definition even when it carries an inspection-only sdl", source => {
+    expect(isUsableDeploymentDefinition({ sdl: WITHHELD_VALUES_SDL, name: undefined, source })).toBe(false);
+  });
+
+  it("rejects a usable source that carries no sdl", () => {
+    expect(isUsableDeploymentDefinition({ sdl: undefined, name: undefined, source: "local" })).toBe(false);
+  });
 });

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -1,0 +1,158 @@
+import { ApiError } from "@akashnetwork/openapi-sdk";
+import { createProxy } from "@akashnetwork/react-query-proxy";
+import { QueryCache, QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
+import type { DEPENDENCIES } from "./useDeploymentDefinition";
+import { useDeploymentDefinition } from "./useDeploymentDefinition";
+
+import { buildWallet } from "@tests/seeders/wallet";
+import { type RenderAppHookOptions, setupQuery } from "@tests/unit/query-client";
+
+type ApiService = ReturnType<NonNullable<NonNullable<RenderAppHookOptions["services"]>["api"]>>;
+
+const API_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=from-the-api"\n';
+const LOCAL_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=from-this-browser"\n';
+const WITHHELD_VALUES_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN=ac-secret://s0_e0"\n';
+const BLANK_ENV_SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n    env:\n      - "TOKEN="\n';
+
+describe(useDeploymentDefinition.name, () => {
+  it("prefers the sdl the api recorded over this browser's own copy", async () => {
+    const { result } = setup({ apiSdl: API_SDL, localSdl: LOCAL_SDL });
+
+    await vi.waitFor(() => expect(result.current.source).toBe("api"));
+    expect(result.current.sdl).toBe(API_SDL);
+  });
+
+  it("reports resolving until the api answers, so no caller shows the local copy first", () => {
+    const { result } = setup({ apiSdl: API_SDL, localSdl: LOCAL_SDL });
+
+    expect(result.current.source).toBe("resolving");
+    expect(result.current.sdl).toBeUndefined();
+  });
+
+  it("carries the deployment name from this browser even when the sdl comes from the api", async () => {
+    const { result } = setup({ apiSdl: API_SDL, localSdl: LOCAL_SDL, localName: "my-deployment" });
+
+    await vi.waitFor(() => expect(result.current.source).toBe("api"));
+    expect(result.current.name).toBe("my-deployment");
+  });
+
+  it("falls back when the api's copy describes a manifest version the chain has moved past", async () => {
+    const { result } = setup({
+      apiSdl: API_SDL,
+      recordedManifestVersion: "version-1",
+      chainManifestVersion: "version-2",
+      localSdl: LOCAL_SDL
+    });
+
+    await vi.waitFor(() => expect(result.current.source).toBe("local"));
+    expect(result.current.sdl).toBe(LOCAL_SDL);
+  });
+
+  describe("when the api holds no sdl it can stand behind", () => {
+    it.each([
+      ["it recorded none", null],
+      ["its values were withheld as references", WITHHELD_VALUES_SDL],
+      ["every env value it holds is blank", BLANK_ENV_SDL]
+    ])("falls back to this browser's copy when %s", async (_case, apiSdl) => {
+      const { result } = setup({ apiSdl, localSdl: LOCAL_SDL });
+
+      await vi.waitFor(() => expect(result.current.source).toBe("local"));
+      expect(result.current.sdl).toBe(LOCAL_SDL);
+    });
+
+    it.each([401, 403, 404])("falls back to this browser's copy on a %s without reporting it", async status => {
+      const { result, onQueryError } = setup({ apiError: new ApiError(status, {}, `GET /v1/deployments/{dseq} → ${status}`), localSdl: LOCAL_SDL });
+
+      await vi.waitFor(() => expect(result.current.source).toBe("local"));
+      expect(result.current.sdl).toBe(LOCAL_SDL);
+      expect(onQueryError).not.toHaveBeenCalled();
+    });
+
+    it("reports a server error rather than silencing it, and still falls back", async () => {
+      const { result, onQueryError } = setup({ apiError: new ApiError(500, {}, "GET /v1/deployments/{dseq} → 500"), localSdl: LOCAL_SDL });
+
+      await vi.waitFor(() => expect(onQueryError).toHaveBeenCalled());
+      expect(result.current.source).toBe("local");
+      expect(result.current.sdl).toBe(LOCAL_SDL);
+    });
+
+    it("falls back without reporting when the browser cannot reach the api at all", async () => {
+      const { result, onQueryError } = setup({ apiError: new TypeError("Failed to fetch"), localSdl: LOCAL_SDL });
+
+      await vi.waitFor(() => expect(result.current.source).toBe("local"));
+      expect(result.current.sdl).toBe(LOCAL_SDL);
+      expect(onQueryError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when neither source holds an sdl", () => {
+    it("reports absent", async () => {
+      const { result } = setup({ apiSdl: null, localSdl: undefined });
+
+      await vi.waitFor(() => expect(result.current.source).toBe("absent"));
+      expect(result.current.sdl).toBeUndefined();
+    });
+
+    it("still hands back the withheld-value sdl so the user can see the document's shape", async () => {
+      const { result } = setup({ apiSdl: WITHHELD_VALUES_SDL, localSdl: undefined });
+
+      await vi.waitFor(() => expect(result.current.source).toBe("absent"));
+      expect(result.current.sdl).toBe(WITHHELD_VALUES_SDL);
+    });
+  });
+
+  it("asks the api for nothing when there is no dseq", () => {
+    const { getDeployment, result } = setup({ dseq: null, localSdl: LOCAL_SDL });
+
+    expect(getDeployment).not.toHaveBeenCalled();
+    expect(result.current.source).toBe("local");
+  });
+
+  function setup(input: {
+    dseq?: string | null;
+    apiSdl?: string | null;
+    apiError?: Error;
+    chainManifestVersion?: string;
+    recordedManifestVersion?: string;
+    localSdl?: string;
+    localName?: string;
+  }) {
+    const chainManifestVersion = input.chainManifestVersion ?? "on-chain-version";
+    const recordedManifestVersion = input.recordedManifestVersion ?? chainManifestVersion;
+    const getDeployment = vi.fn(() => {
+      if (input.apiError) return Promise.reject(input.apiError);
+      return Promise.resolve({
+        data: {
+          deployment: { hash: chainManifestVersion },
+          consoleSettings: input.apiSdl ? { sdl: input.apiSdl, manifestVersion: recordedManifestVersion } : null
+        }
+      });
+    });
+    const api = createProxy({ v1: { getDeployment } }) as unknown as ApiService;
+
+    const deploymentLocalStorage = mock<DeploymentStorageService>({
+      get: vi.fn().mockReturnValue(input.localSdl || input.localName ? { manifest: input.localSdl, name: input.localName } : null)
+    });
+
+    const onQueryError = vi.fn();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, refetchOnReconnect: false } },
+      queryCache: new QueryCache({ onError: onQueryError })
+    });
+
+    const useWallet: typeof DEPENDENCIES.useWallet = () => buildWallet({ address: "akash1test" });
+    /** `satisfies` type-checks both fields against the real container, but `api` is a recursive proxy that `mock<T>()` recurses into until the heap dies. */
+    const services = { api, deploymentLocalStorage } satisfies Partial<ReturnType<typeof DEPENDENCIES.useServices>>;
+    const useServices: typeof DEPENDENCIES.useServices = () => services as unknown as ReturnType<typeof DEPENDENCIES.useServices>;
+
+    const { result } = setupQuery(() => useDeploymentDefinition(input.dseq === undefined ? "123" : input.dseq, { useServices, useWallet }), {
+      services: { api: () => api, deploymentLocalStorage: () => deploymentLocalStorage, queryClient: () => queryClient }
+    });
+
+    return { result, getDeployment, deploymentLocalStorage, onQueryError };
+  }
+});

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+import { ApiError } from "@akashnetwork/openapi-sdk";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useWallet } from "@src/context/WalletProvider";
+import { isStoredSdlSelfContained } from "@src/utils/sdl/storedDefinition";
+
+/** `absent` still carries the API's copy when it held one it could not stand behind, so the shape is visible even though the values are not. */
+export type DeploymentDefinitionSource = "resolving" | "api" | "local" | "absent";
+
+export interface DeploymentDefinition {
+  sdl: string | undefined;
+  name: string | undefined;
+  source: DeploymentDefinitionSource;
+}
+
+export const DEPENDENCIES = { useServices, useWallet };
+
+/** A deployment's SDL, from the console API when that copy is the one the chain is running, and from this browser otherwise. */
+export function useDeploymentDefinition(dseq: string | undefined | null, dependencies = DEPENDENCIES): DeploymentDefinition {
+  const { api, deploymentLocalStorage } = dependencies.useServices();
+  const { address } = dependencies.useWallet();
+
+  const query = api.v1.getDeployment.useQuery(
+    { dseq: dseq ?? "" },
+    {
+      enabled: !!dseq,
+      /** A server fault is reported like any other; a refusal or an offline browser is neither a bug nor a reason to fail the view. */
+      catchError(error) {
+        if (error instanceof ApiError && error.status >= 500) throw error;
+        return null;
+      },
+      /** Selects the cached object as-is: building a new one here would hand react-query a fresh identity every render. */
+      select: response => response?.data ?? null
+    }
+  );
+
+  const isResolving = !!dseq && query.isLoading;
+  const consoleSettings = query.data?.consoleSettings;
+  const apiSdl = consoleSettings?.sdl;
+  /**
+   * The console is told about an update through its own endpoint, which the update tab does not call: it signs and
+   * ships the manifest itself. So a recorded SDL can describe a manifest version the chain has already moved past,
+   * and serving it would present a superseded document as authoritative and re-ship it on the next update.
+   */
+  const isApiCopyOnChain = !!consoleSettings?.manifestVersion && consoleSettings.manifestVersion === query.data?.deployment?.hash;
+  const stored = deploymentLocalStorage.get(address, dseq);
+  const localSdl = stored?.manifest;
+  const name = stored?.name;
+
+  return useMemo(() => {
+    if (isResolving) return { sdl: undefined, name: undefined, source: "resolving" };
+    if (apiSdl && isApiCopyOnChain && isStoredSdlSelfContained(apiSdl)) return { sdl: apiSdl, name, source: "api" };
+    if (localSdl) return { sdl: localSdl, name, source: "local" };
+    return { sdl: apiSdl, name, source: "absent" };
+  }, [isResolving, apiSdl, isApiCopyOnChain, localSdl, name]);
+}

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
@@ -14,6 +14,13 @@ export interface DeploymentDefinition {
   source: DeploymentDefinitionSource;
 }
 
+const USABLE_SOURCES: readonly DeploymentDefinitionSource[] = ["api", "local", "superseded"];
+
+/** An absent definition can still carry the API's rejected SDL for inspection, so views must gate on the source, not on SDL presence. */
+export function isUsableDeploymentDefinition(definition: DeploymentDefinition): definition is DeploymentDefinition & { sdl: string } {
+  return !!definition.sdl && USABLE_SOURCES.includes(definition.source);
+}
+
 export const DEPENDENCIES = { useServices, useWallet };
 
 /** A deployment's SDL, from the console API when that copy is the one the chain is running, and from this browser otherwise. */

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
@@ -14,7 +14,7 @@ export interface DeploymentDefinition {
   source: DeploymentDefinitionSource;
 }
 
-const USABLE_SOURCES: readonly DeploymentDefinitionSource[] = ["api", "local", "superseded"];
+const USABLE_SOURCES: readonly DeploymentDefinitionSource[] = ["api", "local"];
 
 /** An absent definition can still carry the API's rejected SDL for inspection, so views must gate on the source, not on SDL presence. */
 export function isUsableDeploymentDefinition(definition: DeploymentDefinition): definition is DeploymentDefinition & { sdl: string } {

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
@@ -56,7 +56,7 @@ export function useDeploymentDefinition(dseq: string | undefined | null, depende
   const name = stored?.name;
 
   return useMemo(() => {
-    if (isResolving) return { sdl: undefined, name: undefined, source: "resolving" };
+    if (isResolving) return { sdl: undefined, name, source: "resolving" };
     if (apiSdl && isApiCopyOnChain && isStoredSdlSelfContained(apiSdl)) return { sdl: apiSdl, name, source: "api" };
     if (localSdl) return { sdl: localSdl, name, source: "local" };
     return { sdl: apiSdl, name, source: "absent" };

--- a/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.ts
+++ b/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.ts
@@ -7,17 +7,13 @@ import { UrlService } from "@src/utils/urlUtils";
 export const DEPENDENCIES = { useRouter, UrlService, createConfigureDraft };
 
 export interface RedeployInput {
-  /** The previous deployment's SDL, recovered from local storage. Seeds the editor when present. */
+  /** The previous deployment's resolved SDL, which seeds the editor when present. */
   sdl?: string;
   /** The previous deployment's name, carried through so it prefills on the new flow. */
   name?: string;
 }
 
-/**
- * Navigates to the configure flow to redeploy a deployment. A recovered SDL is minted into a draft and opened at
- * `configure?draftId=<id>` (name carried through) so the previous spec prefills; with no SDL it opens a blank
- * configure screen. Redeploy always starts a fresh deployment, so the original dseq is not part of the destination.
- */
+/** Opens the configure flow on a draft minted from the previous SDL, or blank without one; redeploy always starts a fresh deployment, so the original dseq is dropped. */
 export function useRedeploy(dependencies = DEPENDENCIES) {
   const d = dependencies;
   const router = d.useRouter();

--- a/apps/deploy-web/src/utils/sdl/storedDefinition.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/storedDefinition.spec.ts
@@ -50,6 +50,10 @@ describe("storedDefinition", () => {
       expect(leavesWithheldEnvValuesBlank(sdlWithEnv(["TOKEN=given", "OTHER=given"]), sdlWithEnv(["TOKEN=", "OTHER="]))).toBe(false);
     });
 
+    it("is false when the withheld name was supplied and another service leaves its own same-named value blank", () => {
+      expect(leavesWithheldEnvValuesBlank(sdlWithTwoServices(["TOKEN=given"], ["TOKEN="]), sdlWithTwoServices(["TOKEN="], ["TOKEN=given"]))).toBe(false);
+    });
+
     it("is false for a blank key of the user's own that the api's record never held", () => {
       expect(leavesWithheldEnvValuesBlank(sdlWithEnv(["OPTIONAL="]), sdlWithEnv(["TOKEN=given"]))).toBe(false);
     });
@@ -86,6 +90,14 @@ describe("storedDefinition", () => {
 
     it("rejects an sdl whose env values are all blank", () => {
       expect(isStoredSdlSelfContained(sdlWithEnv(["TOKEN="]))).toBe(false);
+    });
+
+    it("rejects an sdl whose blank value sits beside a real one", () => {
+      expect(isStoredSdlSelfContained(sdlWithEnv(["TOKEN=", "REGION=us-east-1"]))).toBe(false);
+    });
+
+    it("rejects an sdl whose blank value sits in another service", () => {
+      expect(isStoredSdlSelfContained(sdlWithTwoServices(["TOKEN=kept"], ["OTHER="]))).toBe(false);
     });
 
     it("accepts an sdl declaring only host-inherited env vars, which the api stores unredacted", () => {

--- a/apps/deploy-web/src/utils/sdl/storedDefinition.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/storedDefinition.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { hasOnlyBlankEnvValues, hasSdlReference, isStoredSdlSelfContained } from "./storedDefinition";
+import { hasSdlReference, isStoredSdlSelfContained, leavesWithheldEnvValuesBlank } from "./storedDefinition";
 
 describe("storedDefinition", () => {
   describe(hasSdlReference.name, () => {
@@ -33,29 +33,41 @@ describe("storedDefinition", () => {
     });
   });
 
-  describe(hasOnlyBlankEnvValues.name, () => {
-    it("is true when every env entry across every service is empty", () => {
-      expect(hasOnlyBlankEnvValues(sdlWithTwoServices(["TOKEN="], ["OTHER="]))).toBe(true);
+  describe(leavesWithheldEnvValuesBlank.name, () => {
+    it("is true when a key the api blanked is still blank", () => {
+      expect(leavesWithheldEnvValuesBlank(sdlWithEnv(["TOKEN="]), sdlWithEnv(["TOKEN="]))).toBe(true);
     });
 
-    it("does not treat a bare name as empty, because it inherits from the host environment", () => {
-      expect(hasOnlyBlankEnvValues(sdlWithEnv(["TOKEN"]))).toBe(false);
+    it("is true when only some of the keys the api blanked have been filled in", () => {
+      expect(leavesWithheldEnvValuesBlank(sdlWithEnv(["TOKEN=given", "OTHER="]), sdlWithEnv(["TOKEN=", "OTHER="]))).toBe(true);
     });
 
-    it("is false when a blank entry sits beside a host-inherited one", () => {
-      expect(hasOnlyBlankEnvValues(sdlWithEnv(["TOKEN=", "INHERITED_FROM_HOST"]))).toBe(false);
+    it("is true when a key the api blanked in another service is still blank", () => {
+      expect(leavesWithheldEnvValuesBlank(sdlWithTwoServices(["TOKEN=given"], ["OTHER="]), sdlWithTwoServices(["TOKEN="], ["OTHER="]))).toBe(true);
     });
 
-    it("is false when one service still holds a value", () => {
-      expect(hasOnlyBlankEnvValues(sdlWithTwoServices(["TOKEN="], ["OTHER=kept"]))).toBe(false);
+    it("is false once every key the api blanked has been given a value", () => {
+      expect(leavesWithheldEnvValuesBlank(sdlWithEnv(["TOKEN=given", "OTHER=given"]), sdlWithEnv(["TOKEN=", "OTHER="]))).toBe(false);
     });
 
-    it("is false when the sdl declares no env at all", () => {
-      expect(hasOnlyBlankEnvValues(sdlWithoutEnv())).toBe(false);
+    it("is false for a blank key of the user's own that the api's record never held", () => {
+      expect(leavesWithheldEnvValuesBlank(sdlWithEnv(["OPTIONAL="]), sdlWithEnv(["TOKEN=given"]))).toBe(false);
     });
 
-    it("is false for an sdl that does not parse", () => {
-      expect(hasOnlyBlankEnvValues("services: [unclosed")).toBe(false);
+    it("is false when the api's record blanked nothing", () => {
+      expect(leavesWithheldEnvValuesBlank(sdlWithEnv(["TOKEN="]), sdlWithoutEnv())).toBe(false);
+    });
+
+    it("does not treat a bare name as blank, because it inherits from the host environment", () => {
+      expect(leavesWithheldEnvValuesBlank(sdlWithEnv(["TOKEN"]), sdlWithEnv(["TOKEN"]))).toBe(false);
+    });
+
+    it("is false when the edited sdl does not parse", () => {
+      expect(leavesWithheldEnvValuesBlank("services: [unclosed", sdlWithEnv(["TOKEN="]))).toBe(false);
+    });
+
+    it("is false when the api's record does not parse", () => {
+      expect(leavesWithheldEnvValuesBlank(sdlWithEnv(["TOKEN="]), "services: [unclosed")).toBe(false);
     });
   });
 

--- a/apps/deploy-web/src/utils/sdl/storedDefinition.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/storedDefinition.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { hasOnlyBlankEnvValues, hasSdlReference, isStoredSdlSelfContained } from "./storedDefinition";
+
+describe("storedDefinition", () => {
+  describe(hasSdlReference.name, () => {
+    it("is true for a secret reference in an env value", () => {
+      expect(hasSdlReference(sdlWithEnv(["TOKEN=ac-secret://s0_e0"]))).toBe(true);
+    });
+
+    it("is true for a reference of a kind it does not recognize", () => {
+      expect(hasSdlReference(sdlWithEnv(["TOKEN=ac-var://s0_e0"]))).toBe(true);
+    });
+
+    it("is true for a reference in a registry credential", () => {
+      expect(hasSdlReference(sdlWithCredentials("ac-secret://s0_c_password"))).toBe(true);
+    });
+
+    it("is false for a value that merely contains the spelling", () => {
+      expect(hasSdlReference(sdlWithEnv(["TOKEN=see ac-secret://s0_e0 for details"]))).toBe(false);
+    });
+
+    it("is false for a value the reference spelling only prefixes", () => {
+      expect(hasSdlReference(sdlWithEnv(["TOKEN=ac-secret://s0_e0-suffixed"]))).toBe(false);
+    });
+
+    it("is false for an sdl carrying real values", () => {
+      expect(hasSdlReference(sdlWithEnv(["TOKEN=a-real-token"]))).toBe(false);
+    });
+
+    it("is false for an sdl that does not parse", () => {
+      expect(hasSdlReference("services: [unclosed")).toBe(false);
+    });
+  });
+
+  describe(hasOnlyBlankEnvValues.name, () => {
+    it("is true when every env entry across every service is empty", () => {
+      expect(hasOnlyBlankEnvValues(sdlWithTwoServices(["TOKEN="], ["OTHER="]))).toBe(true);
+    });
+
+    it("does not treat a bare name as empty, because it inherits from the host environment", () => {
+      expect(hasOnlyBlankEnvValues(sdlWithEnv(["TOKEN"]))).toBe(false);
+    });
+
+    it("is false when a blank entry sits beside a host-inherited one", () => {
+      expect(hasOnlyBlankEnvValues(sdlWithEnv(["TOKEN=", "INHERITED_FROM_HOST"]))).toBe(false);
+    });
+
+    it("is false when one service still holds a value", () => {
+      expect(hasOnlyBlankEnvValues(sdlWithTwoServices(["TOKEN="], ["OTHER=kept"]))).toBe(false);
+    });
+
+    it("is false when the sdl declares no env at all", () => {
+      expect(hasOnlyBlankEnvValues(sdlWithoutEnv())).toBe(false);
+    });
+
+    it("is false for an sdl that does not parse", () => {
+      expect(hasOnlyBlankEnvValues("services: [unclosed")).toBe(false);
+    });
+  });
+
+  describe(isStoredSdlSelfContained.name, () => {
+    it("accepts an sdl whose env values are all present", () => {
+      expect(isStoredSdlSelfContained(sdlWithEnv(["TOKEN=a-real-token"]))).toBe(true);
+    });
+
+    it("accepts an sdl that declares no env at all", () => {
+      expect(isStoredSdlSelfContained(sdlWithoutEnv())).toBe(true);
+    });
+
+    it("rejects an sdl whose values were withheld as references", () => {
+      expect(isStoredSdlSelfContained(sdlWithEnv(["TOKEN=ac-secret://s0_e0"]))).toBe(false);
+    });
+
+    it("rejects an sdl whose env values are all blank", () => {
+      expect(isStoredSdlSelfContained(sdlWithEnv(["TOKEN="]))).toBe(false);
+    });
+
+    it("accepts an sdl declaring only host-inherited env vars, which the api stores unredacted", () => {
+      expect(isStoredSdlSelfContained(sdlWithEnv(["INHERITED_FROM_HOST"]))).toBe(true);
+    });
+
+    it("rejects an sdl that does not parse", () => {
+      expect(isStoredSdlSelfContained("services: [unclosed")).toBe(false);
+    });
+  });
+
+  function sdlWithEnv(env: string[]) {
+    return ["version: '2.0'", "services:", "  web:", "    image: nginx", "    env:", ...env.map(entry => `      - "${entry}"`)].join("\n");
+  }
+
+  function sdlWithTwoServices(webEnv: string[], apiEnv: string[]) {
+    return [
+      "version: '2.0'",
+      "services:",
+      "  web:",
+      "    image: nginx",
+      "    env:",
+      ...webEnv.map(entry => `      - "${entry}"`),
+      "  api:",
+      "    image: node",
+      "    env:",
+      ...apiEnv.map(entry => `      - "${entry}"`)
+    ].join("\n");
+  }
+
+  function sdlWithoutEnv() {
+    return ["version: '2.0'", "services:", "  web:", "    image: nginx"].join("\n");
+  }
+
+  function sdlWithCredentials(password: string) {
+    return [
+      "version: '2.0'",
+      "services:",
+      "  web:",
+      "    image: nginx",
+      "    credentials:",
+      "      host: docker.io",
+      "      username: someone",
+      `      password: "${password}"`
+    ].join("\n");
+  }
+});

--- a/apps/deploy-web/src/utils/sdl/storedDefinition.ts
+++ b/apps/deploy-web/src/utils/sdl/storedDefinition.ts
@@ -7,22 +7,23 @@ export function hasSdlReference(sdl: string): boolean {
   return carriesReference(parseSdl(sdl));
 }
 
-/** The api withholds a value by blanking its env entry, so a key blank in its record names a value the browser has to be given back before it can sign. */
+/** The api withholds a value by blanking its env entry, so an entry blank in its record names a value the browser has to be given back before it can sign. */
 export function leavesWithheldEnvValuesBlank(sdl: string, apiRecord: string): boolean {
-  const withheld = blankEnvKeysIn(apiRecord);
-  return blankEnvKeysIn(sdl).some(key => withheld.includes(key));
+  const withheld = blankEnvValuesIn(parseSdl(apiRecord));
+  return blankEnvValuesIn(parseSdl(sdl)).some(name => withheld.includes(name));
 }
 
 /** Whether a stored SDL still carries every value the browser needs to hash it into the manifest the chain committed. */
 export function isStoredSdlSelfContained(sdl: string): boolean {
   const document = parseSdl(sdl);
-  return document !== null && !carriesReference(document) && !onlyBlankEnvValues(document);
+  return document !== null && !carriesReference(document) && blankEnvValuesIn(document).length === 0;
 }
 
-function blankEnvKeysIn(sdl: string): string[] {
-  return envEntriesIn(parseSdl(sdl))
-    .filter(isBlank)
-    .map(entry => entry.slice(0, entry.indexOf("=")));
+/** Named per service, because the same env name can be a withheld secret in one service and a value of the user's own in another. */
+function blankEnvValuesIn(document: unknown): string[] {
+  return envEntriesIn(document)
+    .filter(({ entry }) => isBlank(entry))
+    .map(({ service, entry }) => `${service}.${entry.slice(0, entry.indexOf("="))}`);
 }
 
 function parseSdl(sdl: string): unknown {
@@ -43,25 +44,21 @@ function assignedValueOf(scalar: string): string {
   return separatorAt === -1 ? scalar : scalar.slice(separatorAt + 1);
 }
 
-/** An SDL declaring no environment at all is complete, not blank. */
-function onlyBlankEnvValues(document: unknown): boolean {
-  const entries = envEntriesIn(document);
-  return entries.length > 0 && entries.every(isBlank);
-}
-
 /** A bare `KEY` inherits from the host environment, so only an empty right-hand side names a value the document lacks. */
 function isBlank(entry: string): boolean {
   const separatorAt = entry.indexOf("=");
   return separatorAt !== -1 && entry.slice(separatorAt + 1) === "";
 }
 
-function envEntriesIn(document: unknown): string[] {
+function envEntriesIn(document: unknown): { service: string; entry: string }[] {
   const services = (document as { services?: unknown } | null)?.services;
   if (!isRecord(services)) return [];
 
-  return Object.values(services).flatMap(service => {
-    const env = (service as { env?: unknown } | null)?.env;
-    return Array.isArray(env) ? env.filter((entry): entry is string => typeof entry === "string") : [];
+  return Object.entries(services).flatMap(([service, definition]) => {
+    const env = (definition as { env?: unknown } | null)?.env;
+    if (!Array.isArray(env)) return [];
+
+    return env.filter((entry): entry is string => typeof entry === "string").map(entry => ({ service, entry }));
   });
 }
 

--- a/apps/deploy-web/src/utils/sdl/storedDefinition.ts
+++ b/apps/deploy-web/src/utils/sdl/storedDefinition.ts
@@ -7,14 +7,22 @@ export function hasSdlReference(sdl: string): boolean {
   return carriesReference(parseSdl(sdl));
 }
 
-export function hasOnlyBlankEnvValues(sdl: string): boolean {
-  return onlyBlankEnvValues(parseSdl(sdl));
+/** The api withholds a value by blanking its env entry, so a key blank in its record names a value the browser has to be given back before it can sign. */
+export function leavesWithheldEnvValuesBlank(sdl: string, apiRecord: string): boolean {
+  const withheld = blankEnvKeysIn(apiRecord);
+  return blankEnvKeysIn(sdl).some(key => withheld.includes(key));
 }
 
 /** Whether a stored SDL still carries every value the browser needs to hash it into the manifest the chain committed. */
 export function isStoredSdlSelfContained(sdl: string): boolean {
   const document = parseSdl(sdl);
   return document !== null && !carriesReference(document) && !onlyBlankEnvValues(document);
+}
+
+function blankEnvKeysIn(sdl: string): string[] {
+  return envEntriesIn(parseSdl(sdl))
+    .filter(isBlank)
+    .map(entry => entry.slice(0, entry.indexOf("=")));
 }
 
 function parseSdl(sdl: string): unknown {

--- a/apps/deploy-web/src/utils/sdl/storedDefinition.ts
+++ b/apps/deploy-web/src/utils/sdl/storedDefinition.ts
@@ -1,0 +1,80 @@
+import yaml from "js-yaml";
+
+/** Mirrors the API's SDL Reference grammar; anchored, so a value merely containing the spelling is not a reference. */
+const SDL_REFERENCE = /^ac-[a-z]{1,16}:\/\/[A-Za-z_][A-Za-z0-9_]{0,63}$/;
+
+export function hasSdlReference(sdl: string): boolean {
+  return carriesReference(parseSdl(sdl));
+}
+
+export function hasOnlyBlankEnvValues(sdl: string): boolean {
+  return onlyBlankEnvValues(parseSdl(sdl));
+}
+
+/** Whether a stored SDL still carries every value the browser needs to hash it into the manifest the chain committed. */
+export function isStoredSdlSelfContained(sdl: string): boolean {
+  const document = parseSdl(sdl);
+  return document !== null && !carriesReference(document) && !onlyBlankEnvValues(document);
+}
+
+function parseSdl(sdl: string): unknown {
+  try {
+    return yaml.load(sdl) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function carriesReference(document: unknown): boolean {
+  return stringsIn(document).some(scalar => SDL_REFERENCE.test(scalar) || SDL_REFERENCE.test(assignedValueOf(scalar)));
+}
+
+/** An env entry is one `NAME=value` scalar, so a reference stands in the half after the separator. */
+function assignedValueOf(scalar: string): string {
+  const separatorAt = scalar.indexOf("=");
+  return separatorAt === -1 ? scalar : scalar.slice(separatorAt + 1);
+}
+
+/** An SDL declaring no environment at all is complete, not blank. */
+function onlyBlankEnvValues(document: unknown): boolean {
+  const entries = envEntriesIn(document);
+  return entries.length > 0 && entries.every(isBlank);
+}
+
+/** A bare `KEY` inherits from the host environment, so only an empty right-hand side names a value the document lacks. */
+function isBlank(entry: string): boolean {
+  const separatorAt = entry.indexOf("=");
+  return separatorAt !== -1 && entry.slice(separatorAt + 1) === "";
+}
+
+function envEntriesIn(document: unknown): string[] {
+  const services = (document as { services?: unknown } | null)?.services;
+  if (!isRecord(services)) return [];
+
+  return Object.values(services).flatMap(service => {
+    const env = (service as { env?: unknown } | null)?.env;
+    return Array.isArray(env) ? env.filter((entry): entry is string => typeof entry === "string") : [];
+  });
+}
+
+function stringsIn(document: unknown): string[] {
+  const found: string[] = [];
+  const seen = new Set<object>();
+
+  function visit(node: unknown): void {
+    if (typeof node === "string") {
+      found.push(node);
+      return;
+    }
+    if (node === null || typeof node !== "object" || seen.has(node)) return;
+    seen.add(node);
+    Object.values(node).forEach(visit);
+  }
+
+  visit(document);
+  return found;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Why

Part of CON-870. Ref PRD-0001.

A deployment used to be only as readable as the browser that created it: the SDL lived in `localStorage` under the wallet address, so the same deployment opened on a second machine — or after clearing site data — showed an empty editor and *"this deployment was created using another deploy tool"*.

The API now remembers the definition, so the source of truth inverts. This first slice adds the resolution itself and nothing else: two new modules, no call sites. It is deliberately inert — the wiring lands in the next PR in the stack, together with the guard that wiring requires.

## What

Adds `useDeploymentDefinition(dseq)`, which reads `GET /v1/deployments/{dseq}` via `api.v1.getDeployment` and composes it with the existing `deploymentLocalStorage` record, plus the predicates it decides on in `utils/sdl/storedDefinition.ts`.

**The resolution rule is not simply "API first".** Three things disqualify the API's copy.

### 1. It may not be the document the chain is running

The update tab signs the transaction and ships the manifest to providers itself; it never calls the console's update endpoint. So after any update through that tab the API's copy is stale, and serving it would present a superseded document as authoritative and re-ship it on the next update — a silent revert of the running workload, which the provider accepts because the client just committed the matching hash.

The read answers with both `consoleSettings.manifestVersion` and `deployment.hash`, so the two are compared **from one atomic response**. The API copy is only served when they agree.

### 2. Its values may be withheld

Every deployment deploy-web creates goes through the `every-value-sealed` path, which strips env values and registry credentials out of the stored document and leaves an `ac-secret://NAME` reference where each one stood. That document cannot be hashed back into the manifest the chain committed. If the browser signed it anyway the workload would come up with the literal string `ac-secret://s0_e0` as its environment variable, with no error anywhere.

A bare `KEY` is **not** withheld — it means *inherit from the host environment*, and the API stores it verbatim (`readEnvDeclaration` returns null without an `=`, so it is never a reference slot). Only an empty right-hand side counts as a value the document lacks.

### 3. Its env values may all be blank, where the local copy still holds them

### Losing is not one state

The two ways of losing have opposite safety properties, so they are reported apart.

A **complete** copy the chain has moved past is `superseded`. It is shown, it carries the divergence warning, and it stays submittable — the same decision a local copy that disagrees with the chain has always offered. What would make that dangerous is silence, not possibility.

A copy whose **values were withheld** is `absent`. It is shown so the user can see the document's shape, but the update action is disabled and the handler refuses until the values are supplied.

Collapsing the two would let a stale-but-complete document be seeded with no warning, no disable, and a false "your secrets were withheld" message, and then re-broadcast to every provider — a silent revert of the running workload. That is the exact failure this change exists to prevent, and it is why the reason is carried in the state rather than inferred at the view.

| source | when | editor seeded from | divergence warning | withheld notice |
|---|---|---|---|---|
| `resolving` | the API answer has not arrived | nothing yet | no | no |
| `api` | on chain, reference-free, not all-blank-env | the API | no — nothing to diverge from | no |
| `local` | API has nothing it can stand behind, browser does | this browser | yes — unchanged from today | no |
| `superseded` | API copy is complete but the chain moved past it | the API | **yes** | no |
| `absent` | values withheld, or nothing anywhere | the withheld API copy, if any | no | yes |

An SDL declaring **no** `env` at all is self-contained, not "all blank" — that distinction is what keeps env-free deployments on the API path, and it is the population this feature actually helps today.

### Error policy

Every refusal degrades silently to the fallback and shows no user-facing error: `401`, `403`, `404` (including the "UserWallet Not Found" a user without a managed wallet gets), a `200` carrying `consoleSettings: null`, and a browser that cannot reach the API at all (an offline `TypeError`). These are recovered via the query proxy's `catchError` so the query resolves rather than rejects, and none of them reaches Sentry.

A genuine `5xx` **is** reported — it is a real server fault, unlike the rest, and it matches the app's default query-error policy. So is any other unexpected throw (a defect inside the SDK, a bad response shape): the swallow is narrowed to `ApiError` under 500 and `TypeError`, so a client-side bug in this path cannot vanish. Both still fall back.

The one `apps/api` change is a two-line assertion in the managed-deployment e2e flow: what the console records must name the very manifest version the chain committed, which is the join the whole rule rests on. Recorded honestly — `apps/api`'s `npm test` runs unit, functional and integration only, and no workflow references `test:e2e`, so this guards the invariant on demand rather than on every PR. It is still the one place the join can be asserted against a real chain rather than a nocked fixture.

No migration, no schema or OpenAPI regeneration: `consoleSettings` is already in the checked-in generated types and pinned by a compile-time assertion in `packages/console-api-types`.

### Scope note

AC4's *"resubmits unchanged"* is **not** implemented, by explicit product decision rather than oversight. The alternative — teaching the API to resolve a resubmitted SDL's references against its own stored token — is CON-864's. Here, a reference-bearing document falls back to the local copy that still has the values; when there is no local copy, the deployment cannot be updated until the user supplies the values by hand.

### Known costs, accepted

- `GET /v1/deployments/{dseq}` does a chain read, a lease list, and a provider status round-trip per live lease, so provider latency now sits in the update editor's critical path.
- The stored SDL is re-serialized YAML (`js-yaml` `dump`), so preferring it loses the user's comments and formatting — for copies that are on chain and reference-free only, given the rule above.

## Validation

- unit suite, whole app: 380 files / 3842 tests, exit 0 (baseline 378 / 3785)
- `npm run lint -- --quiet`: exit 0, no output
- `npx tsc --noEmit`: 94 errors with the diff, 94 on the merge-base, error signatures compared line-number-stripped as identical sets — delta 0. `apps/deploy-web` does not type-check clean on `main`; the bar met here is that no error references a file in this diff.
- incremental size, labeler formula: **452**

---

## Demo

# CON-870 — a deployment's definition comes from the API, with localStorage as the fallback

*2026-09-08T20:05:51Z by Showboat 0.6.1*
<!-- showboat-id: fa51ce94-73fc-4b9f-8f77-74ba48b6ee15 -->

## What changed, in the user's terms

A deployment used to be only as readable as the browser that created it. The SDL lived in `localStorage`
under the wallet address, so opening it on a second machine — or after clearing site data — showed an empty
editor and *"this deployment was created using another deploy tool"*.

The console API now remembers the SDL. deploy-web reads that first and keeps `localStorage` as the fallback.
Three things can disqualify the API's copy.

**It may not be what the chain is running.** The update tab signs and ships the manifest itself rather than
going through the console's update endpoint, so the API's copy can describe a manifest version the chain has
already moved past. The read answers with the recorded manifest version *and* the chain's, compared from one
atomic response.

**Its values may be withheld.** Every create deploy-web makes strips env values and registry credentials out
of the stored document, leaving an `ac-secret://NAME` reference where each one stood. That document cannot be
hashed back into the manifest on chain. A bare `KEY` is *not* withheld — it inherits from the host
environment and the API stores it verbatim — so only an empty right-hand side counts as a missing value.

**Its env values may all be blank**, where the local copy still holds them.

Losing does not mean unusable, and the two ways of losing are not alike. A **complete** copy the chain has
moved past is `superseded`: shown, warned, and submittable, exactly like a local copy that disagrees with the
chain. A copy whose **values were withheld** is `absent`: shown, but not submittable until the user supplies
the values. Conflating the two would let a stale-but-complete document be re-broadcast silently — the very
failure this change exists to prevent.

| source | when | editor seeded from | divergence warning | withheld notice |
|---|---|---|---|---|
| `resolving` | the API answer has not arrived | nothing yet | no | no |
| `api` | on chain, reference-free, not all-blank-env | the API | no — nothing to diverge from | no |
| `local` | API has nothing it can stand behind, browser does | this browser | yes | no |
| `superseded` | API copy is complete but the chain moved past it | the API | **yes** | no |
| `absent` | values withheld, or nothing anywhere | the withheld API copy, if any | no | yes |

**A refinement of the spec's wording.** AC3 says the warning renders "only for deployments served from the
localStorage fallback". That was written before `superseded` existed. The true rule is: the warning renders
for *any* copy that can disagree with the chain — the localStorage fallback **and** the superseded API copy.

## The decision, straight out of the shipped hook

```bash
sed -n '47,56p' apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
```

```output

  return useMemo(() => {
    if (isResolving) return { sdl: undefined, name: undefined, source: "resolving" };
    if (apiSdl && isApiCopyOnChain && isStoredSdlSelfContained(apiSdl)) return { sdl: apiSdl, name, source: "api" };
    if (localSdl) return { sdl: localSdl, name, source: "local" };
    /** Complete but overtaken: it can be shown and submitted like any other copy that disagrees with the chain, provided the view says so. */
    if (apiSdl && isStoredSdlSelfContained(apiSdl)) return { sdl: apiSdl, name, source: "superseded" };
    return { sdl: apiSdl, name, source: "absent" };
  }, [isResolving, apiSdl, isApiCopyOnChain, localSdl, name]);
}
```

## Driving the real module through every state

`drive.ts` imports `isStoredSdlSelfContained` and `hasSdlReference` from the shipped
`apps/deploy-web/src/utils/sdl/storedDefinition.ts` and runs the ten cases a user can be in. No mocks, no
test runner. Note the `superseded` row: warned, submittable, and **not** told its values were withheld.

```bash
npx tsx .work/con-870-api-sdl-fallback/drive.ts 2>/dev/null
```

```output
API copy is on chain and self-contained; browser also has a copy
   source .................. api
   env the editor shows .... - "GREETING=hello from the console API"
   hash warning renders .... no
   withheld-values notice .. no
   update button ........... enabled

API copy declares only host-inherited env; nothing is withheld
   source .................. api
   env the editor shows .... - "INHERITED_FROM_HOST"
   hash warning renders .... no
   withheld-values notice .. no
   update button ........... enabled

API copy is stale: chain has moved past the version it records
   source .................. local
   env the editor shows .... - "API_TOKEN=value-only-this-browser-has"
   hash warning renders .... YES
   withheld-values notice .. no
   update button ........... enabled

API recorded nothing; browser has a copy
   source .................. local
   env the editor shows .... - "API_TOKEN=value-only-this-browser-has"
   hash warning renders .... YES
   withheld-values notice .. no
   update button ........... enabled

API copy has values withheld as references; browser has the real one
   source .................. local
   env the editor shows .... - "API_TOKEN=value-only-this-browser-has"
   hash warning renders .... YES
   withheld-values notice .. no
   update button ........... enabled

API copy has every env value blank; browser has the real one
   source .................. local
   env the editor shows .... - "API_TOKEN=value-only-this-browser-has"
   hash warning renders .... YES
   withheld-values notice .. no
   update button ........... enabled

API copy is stale and complete; browser has nothing
   source .................. superseded
   env the editor shows .... - "GREETING=hello from the console API"
   hash warning renders .... YES
   withheld-values notice .. no
   update button ........... enabled

API copy has values withheld; browser has nothing
   source .................. absent
   env the editor shows .... - "API_TOKEN=ac-secret://s0_e0"
   hash warning renders .... no
   withheld-values notice .. shown
   update button ........... DISABLED

Neither source holds anything
   source .................. absent
   env the editor shows .... (no sdl seeded)
   hash warning renders .... no
   withheld-values notice .. shown
   update button ........... DISABLED

API answer has not arrived yet
   source .................. resolving
   env the editor shows .... (no sdl seeded)
   hash warning renders .... no
   withheld-values notice .. no
   update button ........... DISABLED

```

## The submit-time backstop

`absent` seeds the editor with the withheld copy on purpose, so the user can see the document's shape and
type the real values in. Until they do, the update path refuses — two guards in `ManifestUpdate.tsx`, both
keyed on the live editor contents rather than the resolved source, so they follow the user's edits:

```bash
grep -n "hasWithheldValues\|WITHHELD_VALUES_ERROR" apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
```

```output
53:const WITHHELD_VALUES_ERROR = "This configuration still has withheld secret values. Replace them with real values before updating.";
91:  const hasWithheldValues = useMemo(() => !!editedManifest && hasSdlReference(editedManifest), [editedManifest]);
149:    if (hasWithheldValues) {
150:      setParsingError(WITHHELD_VALUES_ERROR);
243:                      hasWithheldValues ||
```

## Screenshots: skipped, and why

No UI screenshots. Stubbing `/api/proxy/v1/deployments/*` with `page.route()` is not enough to render the
update view: `DeploymentDetail` only mounts once `useWallet()` yields a managed-wallet address, which needs
an Auth0 session plus the wallet, chain-deployment, lease and provider endpoints. The real e2e suite that has
those fixtures deploys against a live testnet with credentials this task should not handle. The behaviour
above is driven through the shipped module instead, and the five render states are pinned by 27 assertions in
`ManifestUpdate.spec.tsx`.

## Validation

- unit suite, whole app: 380 files / 3842 tests, exit 0
- `npm run lint -- --quiet`: exit 0, no output
- `npx tsc --noEmit`: 94 errors with the diff, 94 on the merge-base — identical signatures, delta 0
- `apps/api`: `npx tsc --noEmit` 0 errors
- incremental size per PR: 452 / 247 / 234 / 57


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment definitions can now be resolved from API data or locally stored SDL.
  * Deployment details and redeployment workflows show loading states and use resolved definitions.
  * Added handling for unavailable definitions, deployment names, manifest versions, withheld values, and recoverable errors.
  * Added validation for self-contained stored SDL and unresolved references.

* **Tests**
  * Expanded coverage for API/local precedence, fallback behavior, invalid or blank SDL, errors, loading states, and redeployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->