### PR TITLE
feat(deployment): redeploy from an api-served definition

### DIFF
--- a/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.spec.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.spec.tsx
@@ -101,7 +101,6 @@ describe(LocalNoteManager.name, () => {
     const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => ({
       getDeploymentName,
       changeDeploymentName: vi.fn(),
-      getDeploymentData: vi.fn().mockReturnValue(null),
       favoriteProviders: [],
       updateFavoriteProviders: vi.fn(),
       selectedDeploymentDseq: dseq,

--- a/apps/deploy-web/src/components/LocalNoteManager/useLocalNotes.ts
+++ b/apps/deploy-web/src/components/LocalNoteManager/useLocalNotes.ts
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import { useAtom } from "jotai";
 
 import { useServices } from "@src/context/ServicesProvider";
-import type { LocalDeploymentData } from "@src/services/deployment-storage/deployment-storage.service";
 import { settingsIdAtom } from "@src/store/settingsStore";
 import { getProviderLocalData, updateProviderLocalData } from "@src/utils/providerUtils";
 import { localNoteStore } from "./localNoteStore";
@@ -11,7 +10,6 @@ import { localNoteStore } from "./localNoteStore";
 export type LocalNotesContextType = {
   getDeploymentName: (dseq: string | number | null) => string | null;
   changeDeploymentName: (dseq: string | number) => void;
-  getDeploymentData: (dseq: string | number) => Partial<LocalDeploymentData> | null;
   favoriteProviders: string[];
   updateFavoriteProviders: (newFavorites: string[]) => void;
   selectedDeploymentDseq: string | number | null;
@@ -32,14 +30,6 @@ export function useLocalNotes(): LocalNotesContextType {
     [deploymentLocalStorage, settingsId]
   );
 
-  const getDeploymentData = useCallback(
-    (dseq: string | number) => {
-      const localData = deploymentLocalStorage.get(settingsId, dseq);
-      return localData ?? null;
-    },
-    [deploymentLocalStorage, settingsId]
-  );
-
   const changeDeploymentName = useCallback(
     (dseq: string | number) => {
       selectDeployment(dseq);
@@ -55,7 +45,7 @@ export function useLocalNotes(): LocalNotesContextType {
     [setFavoriteProviders]
   );
 
-  return { getDeploymentName, changeDeploymentName, getDeploymentData, favoriteProviders, updateFavoriteProviders, selectedDeploymentDseq, selectDeployment };
+  return { getDeploymentName, changeDeploymentName, favoriteProviders, updateFavoriteProviders, selectedDeploymentDseq, selectDeployment };
 }
 
 export function useInitFavoriteProviders() {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { DEPENDENCIES, DeploymentDetail } from "./DeploymentDetail";
@@ -102,16 +103,22 @@ describe("DeploymentDetail", () => {
     expect(screen.queryByTestId("deployment-detail-skeleton")).not.toBeInTheDocument();
   });
 
+  it("holds the page skeleton until the definition resolves, so placements never render with no services", () => {
+    setup({ definition: { sdl: undefined, source: "resolving" } });
+
+    expect(screen.getByTestId("deployment-detail-skeleton")).toBeInTheDocument();
+  });
+
   it("redirects an in-progress deployment with no lease to the configure flow", () => {
     const { router } = setup({ leases: [] });
 
     expect(router.replace).toHaveBeenCalledWith(expect.stringContaining("configure"));
   });
 
-  it("offers redeploy on the Update tab when a manifest is stored locally", () => {
+  it("offers redeploy on the Update tab when a definition resolves", () => {
     const { redeploy, analyticsService, ManifestUpdate } = setup({
       tab: "UPDATE",
-      storedDeployment: { manifest: "version: '2.0'", name: "My Storefront" }
+      definition: { sdl: "version: '2.0'", name: "My Storefront", source: "api" }
     });
 
     ManifestUpdate.mock.calls[0][0].onRedeploy?.();
@@ -120,10 +127,22 @@ describe("DeploymentDetail", () => {
     expect(analyticsService.track).toHaveBeenCalledWith("redeploy_btn_clk", "Amplitude");
   });
 
-  it("withholds redeploy from the Update tab when no manifest is stored locally", () => {
-    const { ManifestUpdate } = setup({ tab: "UPDATE", storedDeployment: null });
+  it("withholds redeploy from the Update tab when neither source holds a definition", () => {
+    const { ManifestUpdate } = setup({ tab: "UPDATE", definition: { sdl: undefined, source: "absent" } });
 
     expect(ManifestUpdate.mock.calls[0][0].onRedeploy).toBeUndefined();
+  });
+
+  it("seeds the configure draft from the api definition when redirecting a lease-less deployment", () => {
+    const { router } = setup({ leases: [], definition: { sdl: "version: '2.0' # from-the-api", source: "api" } });
+
+    expect(router.replace).toHaveBeenCalledWith(expect.stringContaining("draftId"));
+  });
+
+  it("does not redirect a lease-less deployment until the definition resolves", () => {
+    const { router } = setup({ leases: [], definition: { sdl: undefined, source: "resolving" } });
+
+    expect(router.replace).not.toHaveBeenCalled();
   });
 
   function isRenderedBefore(earlier: Element, later: Element) {
@@ -138,7 +157,7 @@ describe("DeploymentDetail", () => {
     error?: Error | null;
     tab?: string;
     leaseState?: string;
-    storedDeployment?: { manifest?: string; name?: string } | null;
+    definition?: Partial<DeploymentDefinition>;
   }) {
     const deployment = input && "deployment" in input ? input.deployment : mock<DeploymentDto>({ dseq: "1786440078202", state: "active", groups: [] });
     const leases = input && "leases" in input ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: input?.leaseState ?? "active" })];
@@ -149,9 +168,6 @@ describe("DeploymentDetail", () => {
 
     const useServices: typeof DEPENDENCIES.useServices = () =>
       mock<ReturnType<typeof DEPENDENCIES.useServices>>({
-        deploymentLocalStorage: mock<ReturnType<typeof DEPENDENCIES.useServices>["deploymentLocalStorage"]>({
-          get: () => input?.storedDeployment ?? null
-        }),
         sdlAnalyzer: mock<ReturnType<typeof DEPENDENCIES.useServices>["sdlAnalyzer"]>({ hasCiCdImage: () => false }),
         analyticsService
       });
@@ -172,6 +188,8 @@ describe("DeploymentDetail", () => {
       mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: providers, isFetching: false });
     const redeploy = vi.fn();
     const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
+    const definition: DeploymentDefinition = { sdl: "version: '2.0'", name: undefined, source: "local", ...input?.definition };
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
 
     const DeploymentDetailHeader = vi.fn(() => <div>detail-header</div>);
     const ReclamationBanner = vi.fn(() => <div>reclamation-banner</div>);
@@ -195,6 +213,7 @@ describe("DeploymentDetail", () => {
           useRouter,
           useSearchParams,
           useRedeploy,
+          useDeploymentDefinition,
           useDeploymentDetail,
           useDeploymentLeaseList,
           useProviderList,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -107,6 +107,8 @@ describe("DeploymentDetail", () => {
     setup({ definition: { sdl: undefined, source: "resolving" } });
 
     expect(screen.getByTestId("deployment-detail-skeleton")).toBeInTheDocument();
+    expect(screen.queryByText("detail-header")).not.toBeInTheDocument();
+    expect(screen.queryByText("placements")).not.toBeInTheDocument();
   });
 
   it("redirects an in-progress deployment with no lease to the configure flow", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.spec.tsx
@@ -135,10 +135,22 @@ describe("DeploymentDetail", () => {
     expect(ManifestUpdate.mock.calls[0][0].onRedeploy).toBeUndefined();
   });
 
+  it("withholds redeploy from the Update tab when the definition is absent despite an inspection-only api sdl", () => {
+    const { ManifestUpdate } = setup({ tab: "UPDATE", definition: { sdl: "version: '2.0' # not-self-contained", source: "absent" } });
+
+    expect(ManifestUpdate.mock.calls[0][0].onRedeploy).toBeUndefined();
+  });
+
   it("seeds the configure draft from the api definition when redirecting a lease-less deployment", () => {
     const { router } = setup({ leases: [], definition: { sdl: "version: '2.0' # from-the-api", source: "api" } });
 
     expect(router.replace).toHaveBeenCalledWith(expect.stringContaining("draftId"));
+  });
+
+  it("redirects a lease-less deployment without a draft when the definition is absent despite an inspection-only api sdl", () => {
+    const { router } = setup({ leases: [], definition: { sdl: "version: '2.0' # not-self-contained", source: "absent" } });
+
+    expect(router.replace).toHaveBeenCalledWith(expect.not.stringContaining("draftId"));
   });
 
   it("does not redirect a lease-less deployment until the definition resolves", () => {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -11,6 +11,7 @@ import { NextSeo } from "next-seo";
 import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
@@ -33,6 +34,7 @@ export const DEPENDENCIES = {
   useRouter,
   useSearchParams,
   useRedeploy,
+  useDeploymentDefinition,
   useDeploymentDetail,
   useDeploymentLeaseList,
   useProviderList,
@@ -69,7 +71,7 @@ export interface DeploymentDetailProps {
 }
 
 export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies: d = DEPENDENCIES }) => {
-  const { deploymentLocalStorage, sdlAnalyzer, analyticsService } = d.useServices();
+  const { sdlAnalyzer, analyticsService } = d.useServices();
   const router = d.useRouter();
   const searchParams = d.useSearchParams();
   const { address } = d.useWallet();
@@ -92,11 +94,13 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
   });
   const { data: providers, isFetching: isLoadingProviders, refetch: getProviders } = d.useProviderList();
 
-  const storedDeployment = deployment ? deploymentLocalStorage.get(address, dseq) : null;
-  const deploymentManifest = storedDeployment?.manifest || "";
+  const definition = d.useDeploymentDefinition(dseq);
+  const deploymentManifest = definition.sdl || "";
   const isActive = deployment?.state === "active" && !!leases?.some(isLeaseLive);
   const isDeploymentNotFound = !!deploymentError && (deploymentError as any).response?.data?.message?.includes("Deployment not found") && !isLoadingDeployment;
-  const showsPageSkeleton = !isDeploymentNotFound && !deploymentError && !isLeasesError && (!deployment || !isLeasesLoaded);
+  /** The definition feeds the service counts and the placement cards, so showing the page before it lands renders "0 services" and then corrects itself. */
+  const showsPageSkeleton =
+    !isDeploymentNotFound && !deploymentError && !isLeasesError && (!deployment || !isLeasesLoaded || definition.source === "resolving");
 
   useEffect(() => {
     if (deployment) {
@@ -107,13 +111,14 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
 
   useEffect(
     function redirectWhenInProgressWithoutLease() {
+      if (definition.source === "resolving") return;
+
       if (leases && deployment?.state === "active" && leases.length === 0 && !deployment.groups?.some(g => g.state === "paused")) {
-        const localData = deploymentLocalStorage.get(address, dseq);
-        const draftId = localData?.manifest ? createConfigureDraft(localData.manifest, localData.name) : undefined;
+        const draftId = definition.sdl ? createConfigureDraft(definition.sdl, definition.name) : undefined;
         router.replace(UrlService.configureDeployment({ dseq, draftId }));
       }
     },
-    [address, deployment?.state, deployment?.groups, deploymentLocalStorage, dseq, leases, router]
+    [deployment?.state, deployment?.groups, definition.source, definition.sdl, definition.name, dseq, leases, router]
   );
 
   const tabQuery = searchParams?.get("tab");
@@ -130,8 +135,8 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
     }
   }
 
-  function redeployFromStoredManifest() {
-    redeploy({ sdl: storedDeployment?.manifest, name: storedDeployment?.name });
+  function redeployFromResolvedDefinition() {
+    redeploy({ sdl: definition.sdl, name: definition.name });
     analyticsService.track("redeploy_btn_clk", "Amplitude");
   }
 
@@ -211,7 +216,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
                     onManifestChange={setEditedManifest}
                     isRemoteDeploy={isRemoteDeploy}
                     deployment={deployment}
-                    onRedeploy={storedDeployment?.manifest ? redeployFromStoredManifest : undefined}
+                    onRedeploy={definition.sdl ? redeployFromResolvedDefinition : undefined}
                     closeManifestEditor={() => {
                       changeTab("DETAILS");
                       loadDeploymentDetail();

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -11,7 +11,7 @@ import { NextSeo } from "next-seo";
 import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
@@ -114,7 +114,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
       if (definition.source === "resolving") return;
 
       if (leases && deployment?.state === "active" && leases.length === 0 && !deployment.groups?.some(g => g.state === "paused")) {
-        const draftId = definition.sdl ? createConfigureDraft(definition.sdl, definition.name) : undefined;
+        const draftId = isUsableDeploymentDefinition(definition) ? createConfigureDraft(definition.sdl, definition.name) : undefined;
         router.replace(UrlService.configureDeployment({ dseq, draftId }));
       }
     },
@@ -216,7 +216,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
                     onManifestChange={setEditedManifest}
                     isRemoteDeploy={isRemoteDeploy}
                     deployment={deployment}
-                    onRedeploy={definition.sdl ? redeployFromResolvedDefinition : undefined}
+                    onRedeploy={isUsableDeploymentDefinition(definition) ? redeployFromResolvedDefinition : undefined}
                     closeManifestEditor={() => {
                       changeTab("DETAILS");
                       loadDeploymentDetail();

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -171,7 +171,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
 
       {showsPageSkeleton && <DeploymentDetailSkeleton />}
 
-      {deployment && isLeasesLoaded && (
+      {!showsPageSkeleton && deployment && isLeasesLoaded && (
         <>
           <div className={PAGE_BAND}>
             <d.DeploymentDetailHeader deployment={deployment} leases={leases} providers={providers || []} />

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -3,6 +3,7 @@ import yaml from "js-yaml";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { DeploymentDto, DeploymentGroup, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { DEPENDENCIES, DeploymentDetailHeader } from "./DeploymentDetailHeader";
@@ -14,7 +15,7 @@ import { MockComponents } from "@tests/unit/mocks";
 describe(DeploymentDetailHeader.name, () => {
   it("counts the services of every placement, not just the one whose status is loaded", () => {
     setup({
-      storedManifest: yaml.dump({
+      definitionSdl: yaml.dump({
         services: { web: {}, api: {}, worker: {} },
         deployment: { web: { "dcloud-us": {} }, api: { "dcloud-us": {} }, worker: { "dcloud-eu": {} } }
       }),
@@ -26,7 +27,7 @@ describe(DeploymentDetailHeader.name, () => {
 
   it("falls back to the placement count when no manifest is stored locally", () => {
     setup({
-      storedManifest: null,
+      definitionSdl: null,
       leases: [buildLeaseInPlacement("1", "dcloud-us"), buildLeaseInPlacement("2", "dcloud-eu"), buildLeaseInPlacement("3", "dcloud-ap")]
     });
 
@@ -223,7 +224,7 @@ describe(DeploymentDetailHeader.name, () => {
   });
 
   it("keeps redeploy off the header now that it lives on the update tab", () => {
-    setup({ storedManifest: "version: '2.0'" });
+    setup({ definitionSdl: "version: '2.0'" });
 
     expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
   });
@@ -267,12 +268,19 @@ describe(DeploymentDetailHeader.name, () => {
     });
   }
 
+  it("holds a skeleton for the service count until the definition resolves", () => {
+    setup({ definitionSource: "resolving" });
+
+    expect(screen.getByTestId("services-count-skeleton")).toBeInTheDocument();
+  });
+
   function setup(input: {
     runtimeLimitHours?: number | null;
     runtimeEndsAt?: string | null;
     name?: string | null;
     isTrialing?: boolean;
-    storedManifest?: string | null;
+    definitionSdl?: string | null;
+    definitionSource?: DeploymentDefinition["source"];
     state?: string;
     leases?: LeaseDto[] | null;
     providers?: ApiProviderList[];
@@ -284,8 +292,13 @@ describe(DeploymentDetailHeader.name, () => {
     const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () =>
       mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({
         getDeploymentName: () => input.name ?? null,
-        changeDeploymentName,
-        getDeploymentData: () => (input.storedManifest ? { manifest: input.storedManifest, name: input.name ?? undefined } : null)
+        changeDeploymentName
+      });
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
+        sdl: input.definitionSdl ?? undefined,
+        name: input.name ?? undefined,
+        source: input.definitionSource ?? (input.definitionSdl ? "api" : "absent")
       });
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false });
     const useDeclaredTeeTypes: typeof DEPENDENCIES.useDeclaredTeeTypes = () => [];
@@ -326,6 +339,7 @@ describe(DeploymentDetailHeader.name, () => {
         providers={input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })]}
         dependencies={MockComponents(DEPENDENCIES, {
           useLocalNotes,
+          useDeploymentDefinition,
           useWallet,
           useDeploymentEscrowBalance,
           useDeploymentSettingQuery,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -48,7 +48,7 @@ describe(DeploymentDetailHeader.name, () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  it("shows the deployment name from local notes", () => {
+  it("shows the deployment name recorded for this deployment in this browser", () => {
     setup({ name: "My Storefront" });
 
     expect(screen.getByText("My Storefront")).toBeInTheDocument();
@@ -303,11 +303,7 @@ describe(DeploymentDetailHeader.name, () => {
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const changeDeploymentName = vi.fn();
-    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({
-        getDeploymentName: () => input.name ?? null,
-        changeDeploymentName
-      });
+    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({ changeDeploymentName });
     let definition = mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
       sdl: input.definitionSdl ?? undefined,
       name: input.name ?? undefined,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -25,6 +25,20 @@ describe(DeploymentDetailHeader.name, () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
+  it("recounts the services when the definition lands after the first paint", () => {
+    const { resolveDefinitionWith } = setup({ definitionSource: "resolving", leases: [buildLeaseInPlacement("1", "dcloud-us")] });
+
+    resolveDefinitionWith(
+      yaml.dump({
+        services: { web: {}, api: {}, worker: {} },
+        deployment: { web: { "dcloud-us": {} }, api: { "dcloud-us": {} }, worker: { "dcloud-us": {} } }
+      })
+    );
+
+    expect(screen.queryByTestId("services-count-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
   it("falls back to the placement count when no manifest is stored locally", () => {
     setup({
       definitionSdl: null,
@@ -294,12 +308,12 @@ describe(DeploymentDetailHeader.name, () => {
         getDeploymentName: () => input.name ?? null,
         changeDeploymentName
       });
-    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
-        sdl: input.definitionSdl ?? undefined,
-        name: input.name ?? undefined,
-        source: input.definitionSource ?? (input.definitionSdl ? "api" : "absent")
-      });
+    let definition = mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
+      sdl: input.definitionSdl ?? undefined,
+      name: input.name ?? undefined,
+      source: input.definitionSource ?? (input.definitionSdl ? "api" : "absent")
+    });
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false });
     const useDeclaredTeeTypes: typeof DEPENDENCIES.useDeclaredTeeTypes = () => [];
     const useDeclaredGpuInterconnect: typeof DEPENDENCIES.useDeclaredGpuInterconnect = () => ({ enabled: false, fabrics: [] });
@@ -332,30 +346,36 @@ describe(DeploymentDetailHeader.name, () => {
       escrowAccount: mock<DeploymentDto["escrowAccount"]>({ state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [] }) })
     });
 
-    render(
-      <DeploymentDetailHeader
-        deployment={deployment}
-        leases={input.leases !== undefined ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })]}
-        providers={input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })]}
-        dependencies={MockComponents(DEPENDENCIES, {
-          useLocalNotes,
-          useDeploymentDefinition,
-          useWallet,
-          useDeploymentEscrowBalance,
-          useDeploymentSettingQuery,
-          useDeclaredTeeTypes,
-          useDeclaredGpuInterconnect,
-          TrialDeploymentBadge,
-          ConfidentialComputeBadge,
-          GpuInterconnectBadge,
-          CostRate,
-          CostBreakdownTooltip,
-          DeploymentVisitControl,
-          ...input.dependencies
-        })}
-      />
-    );
+    const leases = input.leases !== undefined ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })];
+    const providers = input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })];
+    const dependencies = MockComponents(DEPENDENCIES, {
+      useLocalNotes,
+      useDeploymentDefinition,
+      useWallet,
+      useDeploymentEscrowBalance,
+      useDeploymentSettingQuery,
+      useDeclaredTeeTypes,
+      useDeclaredGpuInterconnect,
+      TrialDeploymentBadge,
+      ConfidentialComputeBadge,
+      GpuInterconnectBadge,
+      CostRate,
+      CostBreakdownTooltip,
+      DeploymentVisitControl,
+      ...input.dependencies
+    });
+    const renderHeader = () => <DeploymentDetailHeader deployment={deployment} leases={leases} providers={providers} dependencies={dependencies} />;
 
-    return { changeDeploymentName, CostRate, CostBreakdownTooltip };
+    const { rerender } = render(renderHeader());
+
+    return {
+      changeDeploymentName,
+      CostRate,
+      CostBreakdownTooltip,
+      resolveDefinitionWith(sdl: string) {
+        definition = mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({ sdl, name: input.name ?? undefined, source: "api" });
+        rerender(renderHeader());
+      }
+    };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -68,7 +68,7 @@ export interface DeploymentDetailHeaderProps {
 }
 
 export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
-  const { getDeploymentName, changeDeploymentName } = d.useLocalNotes();
+  const { changeDeploymentName } = d.useLocalNotes();
   const { isTrialing } = d.useWallet();
   const { denom } = d.useDeploymentEscrowBalance({ deployment, leases });
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq, pollUntilRuntimeAnchored: true });
@@ -93,7 +93,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
     [leases, definitionSdl]
   );
 
-  const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
+  const name = definition.name || `Deployment #${deployment.dseq}`;
 
   return (
     <div className="flex flex-col gap-6 py-6 lg:flex-row lg:items-start lg:justify-between">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -88,11 +88,12 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
 
   const definition = d.useDeploymentDefinition(deployment.dseq);
   const definitionSdl = definition.sdl;
-  const manifestServices = useMemo(() => parseManifestServices(definitionSdl), [definitionSdl]);
-  const servicesByPlacement = useMemo(() => parseServicesByPlacement(definitionSdl), [definitionSdl]);
+  const servicesCount = useMemo(
+    () => countPlacementServices(leases ?? [], parseServicesByPlacement(definitionSdl), parseManifestServices(definitionSdl)),
+    [leases, definitionSdl]
+  );
 
   const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
-  const servicesCount = countPlacementServices(leases ?? [], servicesByPlacement, manifestServices);
 
   return (
     <div className="flex flex-col gap-6 py-6 lg:flex-row lg:items-start lg:justify-between">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FC, ReactNode } from "react";
 import { useMemo } from "react";
-import { Button, Card, CardContent, CustomTooltip } from "@akashnetwork/ui/components";
+import { Button, Card, CardContent, CustomTooltip, Skeleton } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { EditPencil, InfoCircle } from "iconoir-react";
 
@@ -14,6 +14,7 @@ import { TrialDeploymentBadge } from "@src/components/shared/TrialDeploymentBadg
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useDeploymentEscrowBalance } from "@src/hooks/useDeploymentEscrowBalance/useDeploymentEscrowBalance";
 import { useHasDeploymentStopped } from "@src/hooks/useHasDeploymentStopped";
 import { useTickingNow } from "@src/hooks/useTickingNow";
@@ -37,6 +38,7 @@ import { RuntimeLimitMeter } from "./RuntimeLimitMeter";
 
 export const DEPENDENCIES = {
   useLocalNotes,
+  useDeploymentDefinition,
   useWallet,
   useDeploymentEscrowBalance,
   useDeploymentSettingQuery,
@@ -66,7 +68,7 @@ export interface DeploymentDetailHeaderProps {
 }
 
 export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
-  const { getDeploymentName, changeDeploymentName, getDeploymentData } = d.useLocalNotes();
+  const { getDeploymentName, changeDeploymentName } = d.useLocalNotes();
   const { isTrialing } = d.useWallet();
   const { denom } = d.useDeploymentEscrowBalance({ deployment, leases });
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq, pollUntilRuntimeAnchored: true });
@@ -84,10 +86,10 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
     ? getRuntimeLimitCountdown({ runtimeLimitHours: settings.runtimeLimitHours, runtimeEndsAt, hasStopped, now })
     : null;
 
-  const storedDeployment = getDeploymentData(deployment.dseq);
-  const storedManifest = storedDeployment?.manifest;
-  const manifestServices = useMemo(() => parseManifestServices(storedManifest), [storedManifest]);
-  const servicesByPlacement = useMemo(() => parseServicesByPlacement(storedManifest), [storedManifest]);
+  const definition = d.useDeploymentDefinition(deployment.dseq);
+  const definitionSdl = definition.sdl;
+  const manifestServices = useMemo(() => parseManifestServices(definitionSdl), [definitionSdl]);
+  const servicesByPlacement = useMemo(() => parseServicesByPlacement(definitionSdl), [definitionSdl]);
 
   const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
   const servicesCount = countPlacementServices(leases ?? [], servicesByPlacement, manifestServices);
@@ -119,7 +121,9 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
       <Card className="w-full shrink-0 lg:w-auto">
         <CardContent className="flex flex-col gap-5 p-6">
           <div className="grid grid-cols-4 gap-x-10">
-            <SummaryItem label="TOTAL SERVICES">{servicesCount}</SummaryItem>
+            <SummaryItem label="TOTAL SERVICES">
+              {definition.source === "resolving" ? <Skeleton className="h-5 w-6" data-testid="services-count-skeleton" /> : servicesCount}
+            </SummaryItem>
             <SummaryItem
               label={
                 <span className="inline-flex items-center gap-1">

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -12,7 +12,7 @@ import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
@@ -215,7 +215,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                       <CustomDropdownLinkItem onClick={() => changeDeploymentName(deployment.dseq)} icon={<Edit fontSize="small" />}>
                         Edit name
                       </CustomDropdownLinkItem>
-                      {(definition.source === "resolving" || definition.sdl) && (
+                      {(definition.source === "resolving" || isUsableDeploymentDefinition(definition)) && (
                         <CustomDropdownLinkItem
                           disabled={definition.source === "resolving"}
                           onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -12,6 +12,7 @@ import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
@@ -48,7 +49,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
   const router = useRouter();
   const { analyticsService } = useServices();
   const [open, setOpen] = useState(false);
-  const { changeDeploymentName, getDeploymentData } = useLocalNotes();
+  const { changeDeploymentName } = useLocalNotes();
   const { address, signAndBroadcastTx, isTrialing } = useWallet();
   const isActive = deployment.state === "active";
   const { data: filteredLeases, isLoading: isLoadingLeases } = useDeploymentLeaseList(address, deployment, { enabled: !!deployment });
@@ -63,7 +64,8 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
   const closedReasonLabel = closedLease ? getClosedLeaseLabel(closedLease) : null;
   const hasGpu = Boolean(deployment.gpuAmount && deployment.gpuAmount > 0);
   const interconnect = useDeclaredGpuInterconnect(deployment);
-  const storageDeploymentData = getDeploymentData(deployment?.dseq);
+  /** Only once the menu is open, so a list of rows does not each fire a deployment read on mount. */
+  const definition = useDeploymentDefinition(open ? deployment?.dseq : null);
   const { closeDeploymentConfirm } = useManagedDeploymentConfirm();
   const providersByOwner = useMemo(() => keyBy(providers, p => p.owner), [providers]);
   const lease = filteredLeases?.find(lease => !!(lease?.provider && providersByOwner[lease.provider]));
@@ -213,9 +215,10 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                       <CustomDropdownLinkItem onClick={() => changeDeploymentName(deployment.dseq)} icon={<Edit fontSize="small" />}>
                         Edit name
                       </CustomDropdownLinkItem>
-                      {storageDeploymentData?.manifest && (
+                      {(definition.source === "resolving" || definition.sdl) && (
                         <CustomDropdownLinkItem
-                          onClick={() => redeploy({ sdl: storageDeploymentData?.manifest, name: storageDeploymentData?.name })}
+                          disabled={definition.source === "resolving"}
+                          onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
                           icon={<Upload fontSize="small" />}
                         >
                           Redeploy

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
@@ -1,14 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
 
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { LeaseDto } from "@src/types/deployment";
 import { DEPENDENCIES, ReclamationBanner } from "./ReclamationBanner";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MockComponents } from "@tests/unit/mocks";
-
-type DeploymentData = NonNullable<ReturnType<ReturnType<typeof DEPENDENCIES.useLocalNotes>["getDeploymentData"]>>;
 
 describe("ReclamationBanner", () => {
   afterEach(() => {
@@ -58,10 +56,10 @@ describe("ReclamationBanner", () => {
     expect(screen.getByRole("button", { name: "Redeploy" })).toBeInTheDocument();
   });
 
-  it("redeploys with the stored sdl and name when Redeploy is clicked", async () => {
+  it("redeploys with the resolved sdl and name when Redeploy is clicked", async () => {
     const { redeploy } = setup({
       leases: [createLease({ state: "reclaiming" })],
-      deploymentData: { manifest: "version: 2.0", name: "my-app" }
+      definition: { sdl: "version: 2.0", name: "my-app", source: "api" }
     });
 
     await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
@@ -69,15 +67,33 @@ describe("ReclamationBanner", () => {
     expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0", name: "my-app" });
   });
 
-  function setup(input: { leases: LeaseDto[] | null; deploymentData?: { manifest?: string; name?: string } | null }) {
-    const localNotes = mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>();
-    localNotes.getDeploymentData.mockReturnValue(input.deploymentData ? mock<DeploymentData>(input.deploymentData) : null);
+  it("redeploys from the api definition on a device holding no local copy", async () => {
+    const { redeploy } = setup({
+      leases: [createLease({ state: "reclaiming" })],
+      definition: { sdl: "version: 2.0 # from-the-api", name: undefined, source: "api" }
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
+
+    expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0 # from-the-api", name: undefined });
+  });
+
+  it("disables Redeploy while the definition is still resolving", () => {
+    setup({ leases: [createLease({ state: "reclaiming" })], definition: { sdl: undefined, source: "resolving" } });
+
+    expect(screen.getByRole("button", { name: "Redeploy" })).toBeDisabled();
+  });
+
+  function setup(input: { leases: LeaseDto[] | null; definition?: Partial<DeploymentDefinition> }) {
+    const definition: DeploymentDefinition = { sdl: "version: 2.0", name: "my-app", source: "local", ...input.definition };
     const redeploy = vi.fn();
 
-    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => localNotes;
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
     const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
 
-    const utils = render(<ReclamationBanner leases={input.leases} dseq="123" dependencies={MockComponents(DEPENDENCIES, { useLocalNotes, useRedeploy })} />);
+    const utils = render(
+      <ReclamationBanner leases={input.leases} dseq="123" dependencies={MockComponents(DEPENDENCIES, { useDeploymentDefinition, useRedeploy })} />
+    );
 
     return { ...utils, redeploy };
   }

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.spec.tsx
@@ -84,15 +84,34 @@ describe("ReclamationBanner", () => {
     expect(screen.getByRole("button", { name: "Redeploy" })).toBeDisabled();
   });
 
+  it("falls back to a 'new SDL' link when neither source holds a definition", () => {
+    setup({ leases: [createLease({ state: "reclaiming" })], definition: { sdl: undefined, source: "absent" } });
+
+    expect(screen.getByRole("link", { name: "Start a new deployment" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
+  });
+
+  it("falls back to a 'new SDL' link when the definition is absent despite an inspection-only api sdl", () => {
+    setup({ leases: [createLease({ state: "reclaiming" })], definition: { sdl: "version: 2.0 # not-self-contained", source: "absent" } });
+
+    expect(screen.getByRole("link", { name: "Start a new deployment" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
+  });
+
   function setup(input: { leases: LeaseDto[] | null; definition?: Partial<DeploymentDefinition> }) {
     const definition: DeploymentDefinition = { sdl: "version: 2.0", name: "my-app", source: "local", ...input.definition };
     const redeploy = vi.fn();
 
     const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
+    const useNewDeploymentUrl: typeof DEPENDENCIES.useNewDeploymentUrl = () => () => "/new-deployment";
     const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
 
     const utils = render(
-      <ReclamationBanner leases={input.leases} dseq="123" dependencies={MockComponents(DEPENDENCIES, { useDeploymentDefinition, useRedeploy })} />
+      <ReclamationBanner
+        leases={input.leases}
+        dseq="123"
+        dependencies={MockComponents(DEPENDENCIES, { useDeploymentDefinition, useNewDeploymentUrl, useRedeploy })}
+      />
     );
 
     return { ...utils, redeploy };

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
@@ -3,13 +3,13 @@ import { useMemo } from "react";
 import { Alert, AlertDescription, AlertTitle, Button } from "@akashnetwork/ui/components";
 import { WarningTriangle } from "iconoir-react";
 
-import { useLocalNotes } from "@src/components/LocalNoteManager";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import type { LeaseDto } from "@src/types/deployment";
 import { getLeaseCloseReasonLabel, getReclamationDeadline, isReclaiming } from "@src/utils/reclamationUtils";
 import { useCountdown } from "./useCountdown";
 
-export const DEPENDENCIES = { useLocalNotes, useRedeploy };
+export const DEPENDENCIES = { useDeploymentDefinition, useRedeploy };
 
 type Props = {
   leases: LeaseDto[] | undefined | null;
@@ -24,9 +24,8 @@ type Props = {
  * before the grace-period deadline. The terminal (already-closed) case is handled by ReclamationCard.
  */
 export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq, className, dependencies = DEPENDENCIES }) => {
-  const { getDeploymentData } = dependencies.useLocalNotes();
+  const definition = dependencies.useDeploymentDefinition(dseq);
   const redeploy = dependencies.useRedeploy();
-  const deploymentData = getDeploymentData(dseq);
   const reclaimingLeases = useMemo(() => (leases ?? []).filter(isReclaiming), [leases]);
 
   const nearestDeadline = useMemo(() => {
@@ -53,7 +52,13 @@ export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq
         </p>
         <p className="mt-1 text-xs text-muted-foreground">Reason: {reasonLabel}</p>
         <p className="mt-2">Reclamation can&apos;t be cancelled. Redeploy to another provider before the deadline to avoid downtime.</p>
-        <Button variant="default" size="sm" className="mt-3" onClick={() => redeploy({ sdl: deploymentData?.manifest, name: deploymentData?.name })}>
+        <Button
+          variant="default"
+          size="sm"
+          className="mt-3"
+          disabled={definition.source === "resolving"}
+          onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
+        >
           Redeploy
         </Button>
       </AlertDescription>

--- a/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationBanner/ReclamationBanner.tsx
@@ -1,15 +1,18 @@
 "use client";
 import { useMemo } from "react";
-import { Alert, AlertDescription, AlertTitle, Button } from "@akashnetwork/ui/components";
+import { Alert, AlertDescription, AlertTitle, Button, buttonVariants } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
 import { WarningTriangle } from "iconoir-react";
+import Link from "next/link";
 
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
 import type { LeaseDto } from "@src/types/deployment";
 import { getLeaseCloseReasonLabel, getReclamationDeadline, isReclaiming } from "@src/utils/reclamationUtils";
 import { useCountdown } from "./useCountdown";
 
-export const DEPENDENCIES = { useDeploymentDefinition, useRedeploy };
+export const DEPENDENCIES = { useDeploymentDefinition, useNewDeploymentUrl, useRedeploy };
 
 type Props = {
   leases: LeaseDto[] | undefined | null;
@@ -25,7 +28,9 @@ type Props = {
  */
 export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq, className, dependencies = DEPENDENCIES }) => {
   const definition = dependencies.useDeploymentDefinition(dseq);
+  const newDeploymentUrl = dependencies.useNewDeploymentUrl();
   const redeploy = dependencies.useRedeploy();
+  const canRedeploy = definition.source === "resolving" || isUsableDeploymentDefinition(definition);
   const reclaimingLeases = useMemo(() => (leases ?? []).filter(isReclaiming), [leases]);
 
   const nearestDeadline = useMemo(() => {
@@ -52,15 +57,21 @@ export const ReclamationBanner: React.FunctionComponent<Props> = ({ leases, dseq
         </p>
         <p className="mt-1 text-xs text-muted-foreground">Reason: {reasonLabel}</p>
         <p className="mt-2">Reclamation can&apos;t be cancelled. Redeploy to another provider before the deadline to avoid downtime.</p>
-        <Button
-          variant="default"
-          size="sm"
-          className="mt-3"
-          disabled={definition.source === "resolving"}
-          onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
-        >
-          Redeploy
-        </Button>
+        {canRedeploy ? (
+          <Button
+            variant="default"
+            size="sm"
+            className="mt-3"
+            disabled={definition.source === "resolving"}
+            onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
+          >
+            Redeploy
+          </Button>
+        ) : (
+          <Link href={newDeploymentUrl()} className={cn(buttonVariants({ variant: "default", size: "sm" }), "mt-3")}>
+            Start a new deployment
+          </Link>
+        )}
       </AlertDescription>
     </Alert>
   );

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
@@ -1,14 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { LeaseDto } from "@src/types/deployment";
 import { DEPENDENCIES, ReclamationCard } from "./ReclamationCard";
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MockComponents } from "@tests/unit/mocks";
-
-type DeploymentData = NonNullable<ReturnType<ReturnType<typeof DEPENDENCIES.useLocalNotes>["getDeploymentData"]>>;
 
 describe("ReclamationCard", () => {
   it("shows the provider close reason as the title", () => {
@@ -17,7 +16,7 @@ describe("ReclamationCard", () => {
   });
 
   it("offers Close + Redeploy and no restart control", () => {
-    setup({ hasLocalManifest: true });
+    setup({ definition: { sdl: "version: 2.0" } });
 
     expect(screen.getByRole("button", { name: "Close & refund" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Redeploy" })).toBeInTheDocument();
@@ -25,19 +24,34 @@ describe("ReclamationCard", () => {
     expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
   });
 
-  it("redeploys with the stored sdl and name when Redeploy is clicked", async () => {
-    const { redeploy } = setup({ hasLocalManifest: true, manifest: "version: 2.0", name: "my-app" });
+  it("redeploys with the resolved sdl and name when Redeploy is clicked", async () => {
+    const { redeploy } = setup({ definition: { sdl: "version: 2.0", name: "my-app" } });
 
     await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
 
     expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0", name: "my-app" });
   });
 
-  it("falls back to a 'new SDL' link when there is no local manifest", () => {
-    setup({ hasLocalManifest: false });
+  it("redeploys from the api definition on a device holding no local copy", async () => {
+    const { redeploy } = setup({ definition: { sdl: "version: 2.0 # from-the-api", name: undefined, source: "api" } });
+
+    await userEvent.click(screen.getByRole("button", { name: "Redeploy" }));
+
+    expect(redeploy).toHaveBeenCalledWith({ sdl: "version: 2.0 # from-the-api", name: undefined });
+  });
+
+  it("falls back to a 'new SDL' link when neither source holds a definition", () => {
+    setup({ definition: { sdl: undefined, source: "absent" } });
 
     expect(screen.getByRole("link", { name: "Start a new deployment" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
+  });
+
+  it("offers Redeploy disabled rather than the link while the definition is resolving", () => {
+    setup({ definition: { sdl: undefined, source: "resolving" } });
+
+    expect(screen.getByRole("button", { name: "Redeploy" })).toBeDisabled();
+    expect(screen.queryByRole("link", { name: "Start a new deployment" })).not.toBeInTheDocument();
   });
 
   it("closes the deployment when confirmed", async () => {
@@ -60,23 +74,19 @@ describe("ReclamationCard", () => {
     expect(wallet.signAndBroadcastTx).not.toHaveBeenCalled();
   });
 
-  function setup(input: { reason?: string; hasLocalManifest?: boolean; manifest?: string; name?: string; isConfirmed?: boolean; onClosed?: () => void } = {}) {
+  function setup(input: { reason?: string; definition?: Partial<DeploymentDefinition>; isConfirmed?: boolean; onClosed?: () => void } = {}) {
     const wallet = mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ address: "akash1owner" });
     wallet.signAndBroadcastTx.mockResolvedValue(true);
 
     const confirm = mock<ReturnType<typeof DEPENDENCIES.useManagedDeploymentConfirm>>();
     confirm.closeDeploymentConfirm.mockResolvedValue(input.isConfirmed ?? true);
 
-    const localNotes = mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>();
-    localNotes.getDeploymentData.mockReturnValue(
-      input.hasLocalManifest ? mock<DeploymentData>({ manifest: input.manifest ?? "version: 2.0", name: input.name }) : null
-    );
-
+    const definition: DeploymentDefinition = { sdl: "version: 2.0", name: undefined, source: "local", ...input.definition };
     const redeploy = vi.fn();
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => wallet;
     const useManagedDeploymentConfirm: typeof DEPENDENCIES.useManagedDeploymentConfirm = () => confirm;
-    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => localNotes;
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
     const useRedeploy: typeof DEPENDENCIES.useRedeploy = () => redeploy;
     const useNewDeploymentUrl: typeof DEPENDENCIES.useNewDeploymentUrl = () => () => "/new-deployment";
 
@@ -97,7 +107,7 @@ describe("ReclamationCard", () => {
         lease={lease}
         dseq="123"
         onClosed={input.onClosed}
-        dependencies={MockComponents(DEPENDENCIES, { useWallet, useManagedDeploymentConfirm, useLocalNotes, useRedeploy, useNewDeploymentUrl })}
+        dependencies={MockComponents(DEPENDENCIES, { useWallet, useManagedDeploymentConfirm, useDeploymentDefinition, useRedeploy, useNewDeploymentUrl })}
       />
     );
 

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
@@ -47,6 +47,13 @@ describe("ReclamationCard", () => {
     expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
   });
 
+  it("falls back to a 'new SDL' link when the definition is absent despite an inspection-only api sdl", () => {
+    setup({ definition: { sdl: "version: 2.0 # not-self-contained", source: "absent" } });
+
+    expect(screen.getByRole("link", { name: "Start a new deployment" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
+  });
+
   it("offers Redeploy disabled rather than the link while the definition is resolving", () => {
     setup({ definition: { sdl: undefined, source: "resolving" } });
 

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
@@ -5,8 +5,8 @@ import { cn } from "@akashnetwork/ui/utils";
 import { WarningTriangle } from "iconoir-react";
 import Link from "next/link";
 
-import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useWallet } from "@src/context/WalletProvider";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
@@ -14,7 +14,7 @@ import type { LeaseDto } from "@src/types/deployment";
 import { getLeaseCloseReasonLabel } from "@src/utils/reclamationUtils";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
 
-export const DEPENDENCIES = { useWallet, useManagedDeploymentConfirm, useLocalNotes, useNewDeploymentUrl, useRedeploy };
+export const DEPENDENCIES = { useWallet, useManagedDeploymentConfirm, useDeploymentDefinition, useNewDeploymentUrl, useRedeploy };
 
 type Props = {
   lease: LeaseDto;
@@ -29,17 +29,16 @@ type Props = {
  * deployment) + Redeploy. The live, still-running case is handled by ReclamationBanner.
  */
 export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, onClosed, dependencies = DEPENDENCIES }) => {
-  const { useWallet, useManagedDeploymentConfirm, useLocalNotes, useNewDeploymentUrl, useRedeploy } = dependencies;
+  const { useWallet, useManagedDeploymentConfirm, useDeploymentDefinition, useNewDeploymentUrl, useRedeploy } = dependencies;
   const { address, signAndBroadcastTx } = useWallet();
   const { closeDeploymentConfirm } = useManagedDeploymentConfirm();
-  const { getDeploymentData } = useLocalNotes();
   const newDeploymentUrl = useNewDeploymentUrl();
   const redeploy = useRedeploy();
   const [isClosing, setIsClosing] = useState(false);
 
   const reasonLabel = getLeaseCloseReasonLabel(lease.reclamation?.reason ?? lease.reason);
-  const deploymentData = getDeploymentData(dseq);
-  const hasLocalManifest = !!deploymentData?.manifest;
+  const definition = useDeploymentDefinition(dseq);
+  const canRedeploy = definition.source === "resolving" || !!definition.sdl;
 
   const confirmAndClose = async () => {
     const isConfirmed = await closeDeploymentConfirm([dseq]);
@@ -67,12 +66,13 @@ export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, o
           <Button variant="default" size="sm" onClick={confirmAndClose} disabled={isClosing}>
             {isClosing ? <Spinner size="small" /> : "Close & refund"}
           </Button>
-          {hasLocalManifest ? (
+          {canRedeploy ? (
             <Button
               variant="outline"
               size="sm"
               className="text-foreground"
-              onClick={() => redeploy({ sdl: deploymentData?.manifest, name: deploymentData?.name })}
+              disabled={definition.source === "resolving"}
+              onClick={() => redeploy({ sdl: definition.sdl, name: definition.name })}
             >
               Redeploy
             </Button>

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
@@ -6,7 +6,7 @@ import { WarningTriangle } from "iconoir-react";
 import Link from "next/link";
 
 import { useWallet } from "@src/context/WalletProvider";
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useNewDeploymentUrl } from "@src/hooks/useNewDeploymentUrl/useNewDeploymentUrl";
 import { useRedeploy } from "@src/hooks/useRedeploy/useRedeploy";
@@ -38,7 +38,7 @@ export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, o
 
   const reasonLabel = getLeaseCloseReasonLabel(lease.reclamation?.reason ?? lease.reason);
   const definition = useDeploymentDefinition(dseq);
-  const canRedeploy = definition.source === "resolving" || !!definition.sdl;
+  const canRedeploy = definition.source === "resolving" || isUsableDeploymentDefinition(definition);
 
   const confirmAndClose = async () => {
     const isConfirmed = await closeDeploymentConfirm([dseq]);

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
@@ -216,6 +216,19 @@ describe(NewDeploymentContainer.name, () => {
     });
   });
 
+  it("ignores the redeploy definition when it is absent despite an inspection-only api sdl", async () => {
+    const { mockRouter } = setup({
+      step: RouteStep.chooseTemplate,
+      redeploy: "123",
+      redeployDefinition: { sdl: "redeploy manifest content # not-self-contained", name: "Redeployed App", source: "absent" }
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("template-list")).toBeInTheDocument();
+    });
+    expect(mockRouter.replace).not.toHaveBeenCalled();
+  });
+
   it("toggles ssh component when template has ssh config", async () => {
     const { sdlBuilder } = setup({
       step: RouteStep.chooseTemplate,

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
@@ -5,10 +5,10 @@ import type { ReadonlyURLSearchParams } from "next/navigation";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { LocalNotesContextType as LocalNotesContext } from "@src/components/LocalNoteManager";
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
 import type { SdlContextProps } from "@src/context/SdlBuilderProvider";
 import type { AppDIContainer } from "@src/context/ServicesProvider";
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import sdlStore from "@src/store/sdlStore";
 import type { TemplateCreation } from "@src/types";
 import { RouteStep } from "@src/types/route-steps.type";
@@ -205,15 +205,10 @@ describe(NewDeploymentContainer.name, () => {
   });
 
   it("redirects to edit-deployment step when redeploy param is present", async () => {
-    const redeployData = {
-      name: "Redeployed App",
-      manifest: "redeploy manifest content"
-    };
-
     const { mockRouter } = setup({
       step: RouteStep.chooseTemplate,
       redeploy: "123",
-      redeployData
+      redeployDefinition: { sdl: "redeploy manifest content", name: "Redeployed App", source: "api" }
     });
 
     await vi.waitFor(() => {
@@ -350,7 +345,7 @@ describe(NewDeploymentContainer.name, () => {
       code?: string;
       state?: string;
       redeploy?: string;
-      redeployData?: { name: string; manifest: string };
+      redeployDefinition?: Partial<DeploymentDefinition>;
       requestedTemplate?: TemplateOutput;
       deploySdl?: TemplateCreation | null;
       isLoadingTemplates?: boolean;
@@ -389,9 +384,7 @@ describe(NewDeploymentContainer.name, () => {
 
     // Create stable references for hook return values to prevent infinite re-renders
     const sdlBuilder = mock<SdlContextProps>();
-    const localNotes = mock<LocalNotesContext>({
-      getDeploymentData: vi.fn().mockReturnValue(input.redeployData ?? null)
-    });
+    const redeployDefinition: DeploymentDefinition = { sdl: undefined, name: undefined, source: "absent", ...input.redeployDefinition };
     const templatesValue = {
       isLoading: input.isLoadingTemplates ?? false,
       templates: [] as never[],
@@ -413,7 +406,7 @@ describe(NewDeploymentContainer.name, () => {
       useRouter: () => mockRouter,
       useSearchParams: () => mockSearchParams,
       useSdlBuilder: () => sdlBuilder,
-      useLocalNotes: () => localNotes,
+      useDeploymentDefinition: () => redeployDefinition,
       useTemplates: () => templatesValue
     } as unknown as typeof DEPENDENCIES;
     const store = createStore();
@@ -446,7 +439,6 @@ describe(NewDeploymentContainer.name, () => {
 
     return {
       mockRouter,
-      localNotes,
       sdlBuilder,
       Layout,
       CreateLease,

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
@@ -5,12 +5,12 @@ import type { TemplateOutput } from "@akashnetwork/http-sdk";
 import { useAtomValue } from "jotai";
 import { useRouter, useSearchParams } from "next/navigation";
 
-import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { Editor } from "@src/components/shared/Editor/Editor";
 import { USER_TEMPLATE_CODE } from "@src/config/deploy.config";
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
 import { useSdlBuilder } from "@src/context/SdlBuilderProvider";
 import { useServices } from "@src/context/ServicesProvider";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useWhen } from "@src/hooks/useWhen";
 import { useTemplates } from "@src/queries/useTemplateQuery";
 import sdlStore from "@src/store/sdlStore";
@@ -40,7 +40,7 @@ export const DEPENDENCIES = {
   useRouter,
   useSearchParams,
   useSdlBuilder,
-  useLocalNotes,
+  useDeploymentDefinition,
   useTemplates,
   useServices
 };
@@ -54,9 +54,10 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
   const [editedManifest, setEditedManifest] = useState("");
   const loadedTemplateIdRef = useRef<string | null>(null);
   const deploySdl = useAtomValue(sdlStore.deploySdl);
-  const { getDeploymentData } = d.useLocalNotes();
   const router = d.useRouter();
   const searchParams = d.useSearchParams();
+  const redeployDseq = searchParams?.get("redeploy") ?? null;
+  const redeployDefinition = d.useDeploymentDefinition(redeployDseq);
   const { toggleCmp, hasComponent } = d.useSdlBuilder();
   const { isLoading: isLoadingTemplates, templates } = d.useTemplates();
   const activeStep = useMemo(() => getStepIndexByParam(searchParams?.get("step") as RouteStep), [searchParams]);
@@ -93,6 +94,7 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
 
     const isSameTemplateAlreadyLoaded = !!templateId && loadedTemplateIdRef.current === templateId;
     if (!templates || (isCreating && !!editedManifest && isSameTemplateAlreadyLoaded)) return;
+    if (redeployDefinition.source === "resolving") return;
 
     const template = getRedeployTemplate() || getGalleryTemplate() || deploySdl;
     const isUserTemplate = template?.code === USER_TEMPLATE_CODE;
@@ -119,26 +121,18 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
       router.replace(urlService.newDeployment(newParams));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [templates, !!editedManifest, searchParams, router, toggleCmp, hasComponent, activeStep]);
+  }, [templates, !!editedManifest, searchParams, router, toggleCmp, hasComponent, activeStep, redeployDefinition.source, redeployDefinition.sdl]);
 
   useWhen(activeStepName === RouteStep.chooseTemplate, () => d.Editor.preload());
 
   const getRedeployTemplate = () => {
-    let template: Partial<TemplateCreation> | null = null;
-    const queryRedeploy = searchParams?.get("redeploy");
-    if (queryRedeploy) {
-      const deploymentData = getDeploymentData(queryRedeploy as string);
+    if (!redeployDseq || !redeployDefinition.sdl) return null;
 
-      if (deploymentData && deploymentData.manifest) {
-        template = {
-          name: deploymentData.name,
-          code: "empty",
-          content: deploymentData.manifest
-        };
-      }
-    }
-
-    return template;
+    return {
+      name: redeployDefinition.name,
+      code: "empty",
+      content: redeployDefinition.sdl
+    } satisfies Partial<TemplateCreation>;
   };
 
   const getGalleryTemplate = useCallback(():

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
@@ -10,7 +10,7 @@ import { USER_TEMPLATE_CODE } from "@src/config/deploy.config";
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
 import { useSdlBuilder } from "@src/context/SdlBuilderProvider";
 import { useServices } from "@src/context/ServicesProvider";
-import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useWhen } from "@src/hooks/useWhen";
 import { useTemplates } from "@src/queries/useTemplateQuery";
 import sdlStore from "@src/store/sdlStore";
@@ -126,7 +126,7 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
   useWhen(activeStepName === RouteStep.chooseTemplate, () => d.Editor.preload());
 
   const getRedeployTemplate = () => {
-    if (!redeployDseq || !redeployDefinition.sdl) return null;
+    if (!redeployDseq || !isUsableDeploymentDefinition(redeployDefinition)) return null;
 
     return {
       name: redeployDefinition.name,

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -167,7 +167,7 @@ describe(useDeploymentDefinition.name, () => {
 });
 
 describe(isUsableDeploymentDefinition.name, () => {
-  it.each(["api", "local", "superseded"] as const)("accepts a definition resolved from the %s source", source => {
+  it.each(["api", "local"] as const)("accepts a definition resolved from the %s source", source => {
     expect(isUsableDeploymentDefinition({ sdl: API_SDL, name: undefined, source })).toBe(true);
   });
 

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -34,6 +34,13 @@ describe(useDeploymentDefinition.name, () => {
     expect(result.current.sdl).toBeUndefined();
   });
 
+  it("carries the deployment name while the sdl is still resolving, since the name is never the api's to answer", () => {
+    const { result } = setup({ apiSdl: API_SDL, localName: "my-deployment" });
+
+    expect(result.current.source).toBe("resolving");
+    expect(result.current.name).toBe("my-deployment");
+  });
+
   it("carries the deployment name from this browser even when the sdl comes from the api", async () => {
     const { result } = setup({ apiSdl: API_SDL, localSdl: LOCAL_SDL, localName: "my-deployment" });
 

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -6,7 +6,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
 import type { DEPENDENCIES } from "./useDeploymentDefinition";
-import { useDeploymentDefinition } from "./useDeploymentDefinition";
+import { isUsableDeploymentDefinition, useDeploymentDefinition } from "./useDeploymentDefinition";
 
 import { buildWallet } from "@tests/seeders/wallet";
 import { type RenderAppHookOptions, setupQuery } from "@tests/unit/query-client";
@@ -164,4 +164,18 @@ describe(useDeploymentDefinition.name, () => {
 
     return { result, getDeployment, deploymentLocalStorage, onQueryError };
   }
+});
+
+describe(isUsableDeploymentDefinition.name, () => {
+  it.each(["api", "local", "superseded"] as const)("accepts a definition resolved from the %s source", source => {
+    expect(isUsableDeploymentDefinition({ sdl: API_SDL, name: undefined, source })).toBe(true);
+  });
+
+  it.each(["resolving", "absent"] as const)("rejects a %s definition even when it carries an inspection-only sdl", source => {
+    expect(isUsableDeploymentDefinition({ sdl: WITHHELD_VALUES_SDL, name: undefined, source })).toBe(false);
+  });
+
+  it("rejects a usable source that carries no sdl", () => {
+    expect(isUsableDeploymentDefinition({ sdl: undefined, name: undefined, source: "local" })).toBe(false);
+  });
 });

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
@@ -14,6 +14,13 @@ export interface DeploymentDefinition {
   source: DeploymentDefinitionSource;
 }
 
+const USABLE_SOURCES: readonly DeploymentDefinitionSource[] = ["api", "local", "superseded"];
+
+/** An absent definition can still carry the API's rejected SDL for inspection, so views must gate on the source, not on SDL presence. */
+export function isUsableDeploymentDefinition(definition: DeploymentDefinition): definition is DeploymentDefinition & { sdl: string } {
+  return !!definition.sdl && USABLE_SOURCES.includes(definition.source);
+}
+
 export const DEPENDENCIES = { useServices, useWallet };
 
 /** A deployment's SDL, from the console API when that copy is the one the chain is running, and from this browser otherwise. */

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
@@ -14,7 +14,7 @@ export interface DeploymentDefinition {
   source: DeploymentDefinitionSource;
 }
 
-const USABLE_SOURCES: readonly DeploymentDefinitionSource[] = ["api", "local", "superseded"];
+const USABLE_SOURCES: readonly DeploymentDefinitionSource[] = ["api", "local"];
 
 /** An absent definition can still carry the API's rejected SDL for inspection, so views must gate on the source, not on SDL presence. */
 export function isUsableDeploymentDefinition(definition: DeploymentDefinition): definition is DeploymentDefinition & { sdl: string } {

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
@@ -56,7 +56,7 @@ export function useDeploymentDefinition(dseq: string | undefined | null, depende
   const name = stored?.name;
 
   return useMemo(() => {
-    if (isResolving) return { sdl: undefined, name: undefined, source: "resolving" };
+    if (isResolving) return { sdl: undefined, name, source: "resolving" };
     if (apiSdl && isApiCopyOnChain && isStoredSdlSelfContained(apiSdl)) return { sdl: apiSdl, name, source: "api" };
     if (localSdl) return { sdl: localSdl, name, source: "local" };
     return { sdl: apiSdl, name, source: "absent" };

--- a/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.ts
+++ b/apps/deploy-web/src/hooks/useRedeploy/useRedeploy.ts
@@ -7,17 +7,13 @@ import { UrlService } from "@src/utils/urlUtils";
 export const DEPENDENCIES = { useRouter, UrlService, createConfigureDraft };
 
 export interface RedeployInput {
-  /** The previous deployment's SDL, recovered from local storage. Seeds the editor when present. */
+  /** The previous deployment's resolved SDL, which seeds the editor when present. */
   sdl?: string;
   /** The previous deployment's name, carried through so it prefills on the new flow. */
   name?: string;
 }
 
-/**
- * Navigates to the configure flow to redeploy a deployment. A recovered SDL is minted into a draft and opened at
- * `configure?draftId=<id>` (name carried through) so the previous spec prefills; with no SDL it opens a blank
- * configure screen. Redeploy always starts a fresh deployment, so the original dseq is not part of the destination.
- */
+/** Opens the configure flow on a draft minted from the previous SDL, or blank without one; redeploy always starts a fresh deployment, so the original dseq is dropped. */
 export function useRedeploy(dependencies = DEPENDENCIES) {
   const d = dependencies;
   const router = d.useRouter();


### PR DESCRIPTION
## Why

Part of CON-870. Stacked on #3867.

Redeploy had the same problem the update view had: every affordance keyed on the synchronous presence of a `localStorage` record, so a deployment created on another machine offered no Redeploy button at all. With the definition now resolved API-first, those deployments can be redeployed from the API's copy.

## What

Points every redeploy affordance at `useDeploymentDefinition` instead of reading `deploymentLocalStorage` directly:

- `DeploymentDetail` — the redeploy handler, the button's visibility, and `redirectWhenInProgressWithoutLease`, which mints the configure draft that is the only bridge supplying an existing dseq's SDL to the configure screen
- `DeploymentListRow`
- `ReclamationBanner` and `ReclamationCard`
- `NewDeploymentContainer` — the legacy `?redeploy=<dseq>` entry point, still reachable because the builder redirect explicitly excludes `redeploy`

**Two user-visible consequences worth calling out.** Redeploy now appears for deployments where it is hidden today — those the API has an SDL for and this browser does not. That is the point of the change, but it is a change in what users see on the deployments list. And while the definition is resolving the affordance is **disabled rather than hidden**, so a deployment that does have a definition never flickers out of existence and back.

`CreateLease` is deliberately untouched: it reads the local manifest to push to the provider, a write path PRD-0001 already moved server-side.

The detail page now holds its existing skeleton until the definition resolves. The service count and the placement cards both read from it, so showing the page earlier rendered "N placements · 0 services" and then corrected itself. The cost is that the header and tabs appear once the definition lands rather than once the chain data does; the two queries start together, so in practice they arrive together.

## Validation

- unit suite, whole app: 380 files / 3842 tests, exit 0
- `npm run lint -- --quiet`: exit 0, no output
- `npx tsc --noEmit`: delta 0 against the merge-base, identical error signatures
- incremental size, labeler formula: **234**

Full behavioural demo: #3866.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redeployment workflows now use the latest resolved deployment definition.
  * Redeploy actions remain disabled while deployment details are loading.
  * Added fallback behavior to start a new deployment when definitions or names are unavailable.
  * Deferred redirects and deployment initialization until required definition data is ready.
  * Prevented inspection-only SDL from triggering an unintended redirect or redeployment draft.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

