### PR TITLE
refactor(deployment): count services from the resolved definition

### DIFF
--- a/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.spec.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.spec.tsx
@@ -101,7 +101,6 @@ describe(LocalNoteManager.name, () => {
     const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => ({
       getDeploymentName,
       changeDeploymentName: vi.fn(),
-      getDeploymentData: vi.fn().mockReturnValue(null),
       favoriteProviders: [],
       updateFavoriteProviders: vi.fn(),
       selectedDeploymentDseq: dseq,

--- a/apps/deploy-web/src/components/LocalNoteManager/useLocalNotes.ts
+++ b/apps/deploy-web/src/components/LocalNoteManager/useLocalNotes.ts
@@ -3,7 +3,6 @@ import { useCallback } from "react";
 import { useAtom } from "jotai";
 
 import { useServices } from "@src/context/ServicesProvider";
-import type { LocalDeploymentData } from "@src/services/deployment-storage/deployment-storage.service";
 import { settingsIdAtom } from "@src/store/settingsStore";
 import { getProviderLocalData, updateProviderLocalData } from "@src/utils/providerUtils";
 import { localNoteStore } from "./localNoteStore";
@@ -11,7 +10,6 @@ import { localNoteStore } from "./localNoteStore";
 export type LocalNotesContextType = {
   getDeploymentName: (dseq: string | number | null) => string | null;
   changeDeploymentName: (dseq: string | number) => void;
-  getDeploymentData: (dseq: string | number) => Partial<LocalDeploymentData> | null;
   favoriteProviders: string[];
   updateFavoriteProviders: (newFavorites: string[]) => void;
   selectedDeploymentDseq: string | number | null;
@@ -32,14 +30,6 @@ export function useLocalNotes(): LocalNotesContextType {
     [deploymentLocalStorage, settingsId]
   );
 
-  const getDeploymentData = useCallback(
-    (dseq: string | number) => {
-      const localData = deploymentLocalStorage.get(settingsId, dseq);
-      return localData ?? null;
-    },
-    [deploymentLocalStorage, settingsId]
-  );
-
   const changeDeploymentName = useCallback(
     (dseq: string | number) => {
       selectDeployment(dseq);
@@ -55,7 +45,7 @@ export function useLocalNotes(): LocalNotesContextType {
     [setFavoriteProviders]
   );
 
-  return { getDeploymentName, changeDeploymentName, getDeploymentData, favoriteProviders, updateFavoriteProviders, selectedDeploymentDseq, selectDeployment };
+  return { getDeploymentName, changeDeploymentName, favoriteProviders, updateFavoriteProviders, selectedDeploymentDseq, selectDeployment };
 }
 
 export function useInitFavoriteProviders() {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -3,6 +3,7 @@ import yaml from "js-yaml";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import type { DeploymentDto, DeploymentGroup, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { DEPENDENCIES, DeploymentDetailHeader } from "./DeploymentDetailHeader";
@@ -14,7 +15,7 @@ import { MockComponents } from "@tests/unit/mocks";
 describe(DeploymentDetailHeader.name, () => {
   it("counts the services of every placement, not just the one whose status is loaded", () => {
     setup({
-      storedManifest: yaml.dump({
+      definitionSdl: yaml.dump({
         services: { web: {}, api: {}, worker: {} },
         deployment: { web: { "dcloud-us": {} }, api: { "dcloud-us": {} }, worker: { "dcloud-eu": {} } }
       }),
@@ -26,7 +27,7 @@ describe(DeploymentDetailHeader.name, () => {
 
   it("falls back to the placement count when no manifest is stored locally", () => {
     setup({
-      storedManifest: null,
+      definitionSdl: null,
       leases: [buildLeaseInPlacement("1", "dcloud-us"), buildLeaseInPlacement("2", "dcloud-eu"), buildLeaseInPlacement("3", "dcloud-ap")]
     });
 
@@ -223,7 +224,7 @@ describe(DeploymentDetailHeader.name, () => {
   });
 
   it("keeps redeploy off the header now that it lives on the update tab", () => {
-    setup({ storedManifest: "version: '2.0'" });
+    setup({ definitionSdl: "version: '2.0'" });
 
     expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
   });
@@ -267,12 +268,19 @@ describe(DeploymentDetailHeader.name, () => {
     });
   }
 
+  it("holds a skeleton for the service count until the definition resolves", () => {
+    setup({ definitionSource: "resolving" });
+
+    expect(screen.getByTestId("services-count-skeleton")).toBeInTheDocument();
+  });
+
   function setup(input: {
     runtimeLimitHours?: number | null;
     runtimeEndsAt?: string | null;
     name?: string | null;
     isTrialing?: boolean;
-    storedManifest?: string | null;
+    definitionSdl?: string | null;
+    definitionSource?: DeploymentDefinition["source"];
     state?: string;
     leases?: LeaseDto[] | null;
     providers?: ApiProviderList[];
@@ -284,8 +292,13 @@ describe(DeploymentDetailHeader.name, () => {
     const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () =>
       mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({
         getDeploymentName: () => input.name ?? null,
-        changeDeploymentName,
-        getDeploymentData: () => (input.storedManifest ? { manifest: input.storedManifest, name: input.name ?? undefined } : null)
+        changeDeploymentName
+      });
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
+        sdl: input.definitionSdl ?? undefined,
+        name: input.name ?? undefined,
+        source: input.definitionSource ?? (input.definitionSdl ? "api" : "absent")
       });
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false });
     const useDeclaredTeeTypes: typeof DEPENDENCIES.useDeclaredTeeTypes = () => [];
@@ -326,6 +339,7 @@ describe(DeploymentDetailHeader.name, () => {
         providers={input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })]}
         dependencies={MockComponents(DEPENDENCIES, {
           useLocalNotes,
+          useDeploymentDefinition,
           useWallet,
           useDeploymentEscrowBalance,
           useDeploymentSettingQuery,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -48,7 +48,7 @@ describe(DeploymentDetailHeader.name, () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  it("shows the deployment name from local notes", () => {
+  it("shows the deployment name recorded for this deployment in this browser", () => {
     setup({ name: "My Storefront" });
 
     expect(screen.getByText("My Storefront")).toBeInTheDocument();
@@ -303,11 +303,7 @@ describe(DeploymentDetailHeader.name, () => {
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const changeDeploymentName = vi.fn();
-    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({
-        getDeploymentName: () => input.name ?? null,
-        changeDeploymentName
-      });
+    const useLocalNotes: typeof DEPENDENCIES.useLocalNotes = () => mock<ReturnType<typeof DEPENDENCIES.useLocalNotes>>({ changeDeploymentName });
     let definition = mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
       sdl: input.definitionSdl ?? undefined,
       name: input.name ?? undefined,

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -25,6 +25,20 @@ describe(DeploymentDetailHeader.name, () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
+  it("recounts the services when the definition lands after the first paint", () => {
+    const { resolveDefinitionWith } = setup({ definitionSource: "resolving", leases: [buildLeaseInPlacement("1", "dcloud-us")] });
+
+    resolveDefinitionWith(
+      yaml.dump({
+        services: { web: {}, api: {}, worker: {} },
+        deployment: { web: { "dcloud-us": {} }, api: { "dcloud-us": {} }, worker: { "dcloud-us": {} } }
+      })
+    );
+
+    expect(screen.queryByTestId("services-count-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
   it("falls back to the placement count when no manifest is stored locally", () => {
     setup({
       definitionSdl: null,
@@ -294,12 +308,12 @@ describe(DeploymentDetailHeader.name, () => {
         getDeploymentName: () => input.name ?? null,
         changeDeploymentName
       });
-    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
-        sdl: input.definitionSdl ?? undefined,
-        name: input.name ?? undefined,
-        source: input.definitionSource ?? (input.definitionSdl ? "api" : "absent")
-      });
+    let definition = mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({
+      sdl: input.definitionSdl ?? undefined,
+      name: input.name ?? undefined,
+      source: input.definitionSource ?? (input.definitionSdl ? "api" : "absent")
+    });
+    const useDeploymentDefinition: typeof DEPENDENCIES.useDeploymentDefinition = () => definition;
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false });
     const useDeclaredTeeTypes: typeof DEPENDENCIES.useDeclaredTeeTypes = () => [];
     const useDeclaredGpuInterconnect: typeof DEPENDENCIES.useDeclaredGpuInterconnect = () => ({ enabled: false, fabrics: [] });
@@ -332,30 +346,36 @@ describe(DeploymentDetailHeader.name, () => {
       escrowAccount: mock<DeploymentDto["escrowAccount"]>({ state: mock<DeploymentDto["escrowAccount"]["state"]>({ funds: [] }) })
     });
 
-    render(
-      <DeploymentDetailHeader
-        deployment={deployment}
-        leases={input.leases !== undefined ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })]}
-        providers={input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })]}
-        dependencies={MockComponents(DEPENDENCIES, {
-          useLocalNotes,
-          useDeploymentDefinition,
-          useWallet,
-          useDeploymentEscrowBalance,
-          useDeploymentSettingQuery,
-          useDeclaredTeeTypes,
-          useDeclaredGpuInterconnect,
-          TrialDeploymentBadge,
-          ConfidentialComputeBadge,
-          GpuInterconnectBadge,
-          CostRate,
-          CostBreakdownTooltip,
-          DeploymentVisitControl,
-          ...input.dependencies
-        })}
-      />
-    );
+    const leases = input.leases !== undefined ? input.leases : [mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })];
+    const providers = input.providers ?? [mock<ApiProviderList>({ owner: "akash1provider" })];
+    const dependencies = MockComponents(DEPENDENCIES, {
+      useLocalNotes,
+      useDeploymentDefinition,
+      useWallet,
+      useDeploymentEscrowBalance,
+      useDeploymentSettingQuery,
+      useDeclaredTeeTypes,
+      useDeclaredGpuInterconnect,
+      TrialDeploymentBadge,
+      ConfidentialComputeBadge,
+      GpuInterconnectBadge,
+      CostRate,
+      CostBreakdownTooltip,
+      DeploymentVisitControl,
+      ...input.dependencies
+    });
+    const renderHeader = () => <DeploymentDetailHeader deployment={deployment} leases={leases} providers={providers} dependencies={dependencies} />;
 
-    return { changeDeploymentName, CostRate, CostBreakdownTooltip };
+    const { rerender } = render(renderHeader());
+
+    return {
+      changeDeploymentName,
+      CostRate,
+      CostBreakdownTooltip,
+      resolveDefinitionWith(sdl: string) {
+        definition = mock<ReturnType<typeof DEPENDENCIES.useDeploymentDefinition>>({ sdl, name: input.name ?? undefined, source: "api" });
+        rerender(renderHeader());
+      }
+    };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -68,7 +68,7 @@ export interface DeploymentDetailHeaderProps {
 }
 
 export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
-  const { getDeploymentName, changeDeploymentName } = d.useLocalNotes();
+  const { changeDeploymentName } = d.useLocalNotes();
   const { isTrialing } = d.useWallet();
   const { denom } = d.useDeploymentEscrowBalance({ deployment, leases });
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq, pollUntilRuntimeAnchored: true });
@@ -93,7 +93,7 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
     [leases, definitionSdl]
   );
 
-  const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
+  const name = definition.name || `Deployment #${deployment.dseq}`;
 
   return (
     <div className="flex flex-col gap-6 py-6 lg:flex-row lg:items-start lg:justify-between">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -88,11 +88,12 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
 
   const definition = d.useDeploymentDefinition(deployment.dseq);
   const definitionSdl = definition.sdl;
-  const manifestServices = useMemo(() => parseManifestServices(definitionSdl), [definitionSdl]);
-  const servicesByPlacement = useMemo(() => parseServicesByPlacement(definitionSdl), [definitionSdl]);
+  const servicesCount = useMemo(
+    () => countPlacementServices(leases ?? [], parseServicesByPlacement(definitionSdl), parseManifestServices(definitionSdl)),
+    [leases, definitionSdl]
+  );
 
   const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
-  const servicesCount = countPlacementServices(leases ?? [], servicesByPlacement, manifestServices);
 
   return (
     <div className="flex flex-col gap-6 py-6 lg:flex-row lg:items-start lg:justify-between">

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FC, ReactNode } from "react";
 import { useMemo } from "react";
-import { Button, Card, CardContent, CustomTooltip } from "@akashnetwork/ui/components";
+import { Button, Card, CardContent, CustomTooltip, Skeleton } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { EditPencil, InfoCircle } from "iconoir-react";
 
@@ -14,6 +14,7 @@ import { TrialDeploymentBadge } from "@src/components/shared/TrialDeploymentBadg
 import { useWallet } from "@src/context/WalletProvider";
 import { useDeclaredGpuInterconnect } from "@src/hooks/useDeclaredGpuInterconnect";
 import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
+import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
 import { useDeploymentEscrowBalance } from "@src/hooks/useDeploymentEscrowBalance/useDeploymentEscrowBalance";
 import { useHasDeploymentStopped } from "@src/hooks/useHasDeploymentStopped";
 import { useTickingNow } from "@src/hooks/useTickingNow";
@@ -37,6 +38,7 @@ import { RuntimeLimitMeter } from "./RuntimeLimitMeter";
 
 export const DEPENDENCIES = {
   useLocalNotes,
+  useDeploymentDefinition,
   useWallet,
   useDeploymentEscrowBalance,
   useDeploymentSettingQuery,
@@ -66,7 +68,7 @@ export interface DeploymentDetailHeaderProps {
 }
 
 export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deployment, leases, providers, dependencies: d = DEPENDENCIES }) => {
-  const { getDeploymentName, changeDeploymentName, getDeploymentData } = d.useLocalNotes();
+  const { getDeploymentName, changeDeploymentName } = d.useLocalNotes();
   const { isTrialing } = d.useWallet();
   const { denom } = d.useDeploymentEscrowBalance({ deployment, leases });
   const { data: settings } = d.useDeploymentSettingQuery({ dseq: deployment.dseq, pollUntilRuntimeAnchored: true });
@@ -84,10 +86,10 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
     ? getRuntimeLimitCountdown({ runtimeLimitHours: settings.runtimeLimitHours, runtimeEndsAt, hasStopped, now })
     : null;
 
-  const storedDeployment = getDeploymentData(deployment.dseq);
-  const storedManifest = storedDeployment?.manifest;
-  const manifestServices = useMemo(() => parseManifestServices(storedManifest), [storedManifest]);
-  const servicesByPlacement = useMemo(() => parseServicesByPlacement(storedManifest), [storedManifest]);
+  const definition = d.useDeploymentDefinition(deployment.dseq);
+  const definitionSdl = definition.sdl;
+  const manifestServices = useMemo(() => parseManifestServices(definitionSdl), [definitionSdl]);
+  const servicesByPlacement = useMemo(() => parseServicesByPlacement(definitionSdl), [definitionSdl]);
 
   const name = getDeploymentName(deployment.dseq) || `Deployment #${deployment.dseq}`;
   const servicesCount = countPlacementServices(leases ?? [], servicesByPlacement, manifestServices);
@@ -119,7 +121,9 @@ export const DeploymentDetailHeader: FC<DeploymentDetailHeaderProps> = ({ deploy
       <Card className="w-full shrink-0 lg:w-auto">
         <CardContent className="flex flex-col gap-5 p-6">
           <div className="grid grid-cols-4 gap-x-10">
-            <SummaryItem label="TOTAL SERVICES">{servicesCount}</SummaryItem>
+            <SummaryItem label="TOTAL SERVICES">
+              {definition.source === "resolving" ? <Skeleton className="h-5 w-6" data-testid="services-count-skeleton" /> : servicesCount}
+            </SummaryItem>
             <SummaryItem
               label={
                 <span className="inline-flex items-center gap-1">

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -34,6 +34,13 @@ describe(useDeploymentDefinition.name, () => {
     expect(result.current.sdl).toBeUndefined();
   });
 
+  it("carries the deployment name while the sdl is still resolving, since the name is never the api's to answer", () => {
+    const { result } = setup({ apiSdl: API_SDL, localName: "my-deployment" });
+
+    expect(result.current.source).toBe("resolving");
+    expect(result.current.name).toBe("my-deployment");
+  });
+
   it("carries the deployment name from this browser even when the sdl comes from the api", async () => {
     const { result } = setup({ apiSdl: API_SDL, localSdl: LOCAL_SDL, localName: "my-deployment" });
 

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
@@ -56,7 +56,7 @@ export function useDeploymentDefinition(dseq: string | undefined | null, depende
   const name = stored?.name;
 
   return useMemo(() => {
-    if (isResolving) return { sdl: undefined, name: undefined, source: "resolving" };
+    if (isResolving) return { sdl: undefined, name, source: "resolving" };
     if (apiSdl && isApiCopyOnChain && isStoredSdlSelfContained(apiSdl)) return { sdl: apiSdl, name, source: "api" };
     if (localSdl) return { sdl: localSdl, name, source: "local" };
     return { sdl: apiSdl, name, source: "absent" };


### PR DESCRIPTION
## Why

Closes CON-870. Stacked on #3868.

The last two read-for-display surfaces still counted services out of the `localStorage` record, so a deployment opened on another machine showed a service count and placement list of zero even though the API knew exactly what it was running.

## What

Points the deployment detail header's service count and the placement service rows at the same resolved definition the rest of the stack uses. Also resolves a pre-existing inconsistency in `DeploymentDetail`, where the header read through `useLocalNotes`' `settingsId` while the body read through `useWallet().address` — the same value with different hydration timing, and a plausible first-paint mismatch.

A reference-bearing SDL feeds these surfaces perfectly well: they read resources and service names, not env values.

The count used to be synchronous and correct on first paint. It is now resolved, so it holds a skeleton rather than rendering a wrong number and correcting itself. With this the last caller of `useLocalNotes().getDeploymentData` is gone, so it goes too.

## Validation

- unit suite, whole app: 380 files / 3842 tests, exit 0
- `npm run lint -- --quiet`: exit 0, no output
- `npx tsc --noEmit`: delta 0 against the merge-base, identical error signatures
- incremental size, labeler formula: **57**

Full behavioural demo: #3866.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Deployment detail headers now calculate service totals from the current deployment definition.
  - Service totals display a loading indicator while definition data is being resolved and update automatically when available.
  - Deployment names remain visible while definition data loads.

- **Bug Fixes**
  - Improved deployment detail handling during asynchronous definition loading.
  - Deployment information now remains consistent while updated definition data is retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->