### PR TITLE
fix(auth): redirect to login on callback state mismatch instead of returning a 500

### DIFF
--- a/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.spec.ts
+++ b/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.spec.ts
@@ -5,37 +5,29 @@ import { CallbackHandlerError, MissingStateCookieError } from "@src/lib/auth0";
 import { getStateMismatchReturnTo } from "./getStateMismatchReturnTo";
 
 describe(getStateMismatchReturnTo.name, () => {
-  it("returns the relative return path encoded in the callback state when the transaction cookie holds another state", () => {
+  it("returns the return path encoded in the callback state when the transaction cookie holds another state", () => {
     const error = setup({
-      cookieReturnTo: "https://console.akash.network/terms-of-service",
-      callbackReturnTo: "https://console.akash.network/?_gl=1*abc"
+      cookieState: encodeState("https://console.akash.network/terms-of-service"),
+      callbackState: encodeState("https://console.akash.network/?_gl=1*18a3tmt")
     });
 
-    expect(getStateMismatchReturnTo(error)).toBe("/?_gl=1*abc");
+    expect(getStateMismatchReturnTo(error)).toBe("/?_gl=1*18a3tmt");
   });
 
   it("drops a foreign origin from the callback return path", () => {
-    const error = setup({
-      cookieReturnTo: "https://console.akash.network/",
-      callbackReturnTo: "https://evil.example/steal?x=1"
-    });
+    const error = setup({ cookieState: encodeState("https://console.akash.network/"), callbackState: encodeState("https://evil.example/steal?x=1") });
 
     expect(getStateMismatchReturnTo(error)).toBe("/steal?x=1");
   });
 
-  it("returns the root path when the callback state cannot be decoded", () => {
-    const error = new CallbackHandlerError(
-      stateMismatchCause({ checks: { state: encodeState({ returnTo: "https://console.akash.network/" }) }, params: { state: "not-base64-json" } })
-    );
+  it("keeps a callback return path that is already relative", () => {
+    const error = setup({ cookieState: encodeState("/terms-of-service"), callbackState: encodeState("/deployments?tab=EVENTS") });
 
-    expect(getStateMismatchReturnTo(error)).toBe("/");
+    expect(getStateMismatchReturnTo(error)).toBe("/deployments?tab=EVENTS");
   });
 
   it("keeps a nested return stack recoverable once pushed onto the login url", () => {
-    const error = setup({
-      cookieReturnTo: "https://console.akash.network/terms-of-service",
-      callbackReturnTo: "https://console.akash.network/deployments?returnTo=%2Fonboarding"
-    });
+    const error = setup({ cookieState: encodeState("/terms-of-service"), callbackState: encodeState("/deployments?returnTo=%2Fonboarding") });
     const recovered = getStateMismatchReturnTo(error) as string;
 
     const loginUrl = UrlReturnToStack.createReturnable(recovered, "/login?error=provider_login_failed");
@@ -43,10 +35,30 @@ describe(getStateMismatchReturnTo.name, () => {
     expect(UrlReturnToStack.getReturnTo(loginUrl)).toBe(recovered);
   });
 
-  it("returns undefined when both states match", () => {
-    const state = encodeState({ returnTo: "https://console.akash.network/" });
+  it("returns the root path when the callback state cannot be decoded", () => {
+    const error = setup({ cookieState: encodeState("/terms-of-service"), callbackState: "not-base64-json" });
 
-    expect(getStateMismatchReturnTo(new CallbackHandlerError(stateMismatchCause({ checks: { state }, params: { state } })))).toBeUndefined();
+    expect(getStateMismatchReturnTo(error)).toBe("/");
+  });
+
+  it("returns the root path when the callback state carries no return url", () => {
+    const error = setup({ cookieState: encodeState("/terms-of-service"), callbackState: Buffer.from("{}").toString("base64url") });
+
+    expect(getStateMismatchReturnTo(error)).toBe("/");
+  });
+
+  it("returns undefined when both states match", () => {
+    const state = encodeState("https://console.akash.network/");
+
+    expect(getStateMismatchReturnTo(setup({ cookieState: state, callbackState: state }))).toBeUndefined();
+  });
+
+  it("returns undefined when only the transaction cookie carries a state", () => {
+    expect(getStateMismatchReturnTo(setup({ cookieState: encodeState("/terms-of-service") }))).toBeUndefined();
+  });
+
+  it("returns undefined when only the callback carries a state", () => {
+    expect(getStateMismatchReturnTo(setup({ callbackState: encodeState("/terms-of-service") }))).toBeUndefined();
   });
 
   it("returns undefined for a callback handler error with another cause", () => {
@@ -58,20 +70,16 @@ describe(getStateMismatchReturnTo.name, () => {
     expect(getStateMismatchReturnTo(undefined)).toBeUndefined();
   });
 
-  function setup(input: { cookieReturnTo: string; callbackReturnTo: string }) {
+  function setup(input: { cookieState?: string; callbackState?: string }) {
     return new CallbackHandlerError(
-      stateMismatchCause({
-        checks: { state: encodeState({ returnTo: input.cookieReturnTo }) },
-        params: { state: encodeState({ returnTo: input.callbackReturnTo }) }
+      Object.assign(new Error("state mismatch"), {
+        ...(input.cookieState ? { checks: { state: input.cookieState } } : {}),
+        ...(input.callbackState ? { params: { state: input.callbackState } } : {})
       })
     );
   }
 
-  function stateMismatchCause(input: { checks: { state: string }; params: { state: string } }) {
-    return Object.assign(new Error(`state mismatch, expected ${input.checks.state}, got: ${input.params.state}`), input);
-  }
-
-  function encodeState(state: { returnTo: string }) {
-    return Buffer.from(JSON.stringify(state)).toString("base64url");
+  function encodeState(returnTo: string) {
+    return Buffer.from(JSON.stringify({ returnTo })).toString("base64url");
   }
 });

--- a/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.spec.ts
+++ b/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { UrlReturnToStack } from "@src/hooks/useReturnTo/UrlReturnToStack";
 import { CallbackHandlerError, MissingStateCookieError } from "@src/lib/auth0";
 import { getStateMismatchReturnTo } from "./getStateMismatchReturnTo";
 
@@ -23,9 +24,23 @@ describe(getStateMismatchReturnTo.name, () => {
   });
 
   it("returns the root path when the callback state cannot be decoded", () => {
-    const error = new CallbackHandlerError(stateMismatchCause({ checks: { state: encodeState({ returnTo: "https://console.akash.network/" }) }, params: { state: "not-base64-json" } }));
+    const error = new CallbackHandlerError(
+      stateMismatchCause({ checks: { state: encodeState({ returnTo: "https://console.akash.network/" }) }, params: { state: "not-base64-json" } })
+    );
 
     expect(getStateMismatchReturnTo(error)).toBe("/");
+  });
+
+  it("keeps a nested return stack recoverable once pushed onto the login url", () => {
+    const error = setup({
+      cookieReturnTo: "https://console.akash.network/terms-of-service",
+      callbackReturnTo: "https://console.akash.network/deployments?returnTo=%2Fonboarding"
+    });
+    const recovered = getStateMismatchReturnTo(error) as string;
+
+    const loginUrl = UrlReturnToStack.createReturnable(recovered, "/login?error=provider_login_failed");
+
+    expect(UrlReturnToStack.getReturnTo(loginUrl)).toBe(recovered);
   });
 
   it("returns undefined when both states match", () => {

--- a/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.spec.ts
+++ b/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { CallbackHandlerError, MissingStateCookieError } from "@src/lib/auth0";
+import { getStateMismatchReturnTo } from "./getStateMismatchReturnTo";
+
+describe(getStateMismatchReturnTo.name, () => {
+  it("returns the relative return path encoded in the callback state when the transaction cookie holds another state", () => {
+    const error = setup({
+      cookieReturnTo: "https://console.akash.network/terms-of-service",
+      callbackReturnTo: "https://console.akash.network/?_gl=1*abc"
+    });
+
+    expect(getStateMismatchReturnTo(error)).toBe("/?_gl=1*abc");
+  });
+
+  it("drops a foreign origin from the callback return path", () => {
+    const error = setup({
+      cookieReturnTo: "https://console.akash.network/",
+      callbackReturnTo: "https://evil.example/steal?x=1"
+    });
+
+    expect(getStateMismatchReturnTo(error)).toBe("/steal?x=1");
+  });
+
+  it("returns the root path when the callback state cannot be decoded", () => {
+    const error = new CallbackHandlerError(stateMismatchCause({ checks: { state: encodeState({ returnTo: "https://console.akash.network/" }) }, params: { state: "not-base64-json" } }));
+
+    expect(getStateMismatchReturnTo(error)).toBe("/");
+  });
+
+  it("returns undefined when both states match", () => {
+    const state = encodeState({ returnTo: "https://console.akash.network/" });
+
+    expect(getStateMismatchReturnTo(new CallbackHandlerError(stateMismatchCause({ checks: { state }, params: { state } })))).toBeUndefined();
+  });
+
+  it("returns undefined for a callback handler error with another cause", () => {
+    expect(getStateMismatchReturnTo(new CallbackHandlerError(new MissingStateCookieError()))).toBeUndefined();
+  });
+
+  it("returns undefined for non-auth errors", () => {
+    expect(getStateMismatchReturnTo(new Error("state mismatch, expected a, got: b"))).toBeUndefined();
+    expect(getStateMismatchReturnTo(undefined)).toBeUndefined();
+  });
+
+  function setup(input: { cookieReturnTo: string; callbackReturnTo: string }) {
+    return new CallbackHandlerError(
+      stateMismatchCause({
+        checks: { state: encodeState({ returnTo: input.cookieReturnTo }) },
+        params: { state: encodeState({ returnTo: input.callbackReturnTo }) }
+      })
+    );
+  }
+
+  function stateMismatchCause(input: { checks: { state: string }; params: { state: string } }) {
+    return Object.assign(new Error(`state mismatch, expected ${input.checks.state}, got: ${input.params.state}`), input);
+  }
+
+  function encodeState(state: { returnTo: string }) {
+    return Buffer.from(JSON.stringify(state)).toString("base64url");
+  }
+});

--- a/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.ts
+++ b/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.ts
@@ -1,0 +1,44 @@
+import { CallbackHandlerError } from "@src/lib/auth0";
+
+interface StateMismatchCause {
+  checks: { state?: string };
+  params: { state?: string };
+}
+
+/** Resolves the relative path a login should return to when the callback state was overwritten by a newer login start, or undefined for any other error. */
+export function getStateMismatchReturnTo(error: unknown): string | undefined {
+  if (!(error instanceof CallbackHandlerError) || !isStateMismatchCause(error.cause)) {
+    return undefined;
+  }
+
+  return toRelativePath(decodeReturnTo(error.cause.params.state));
+}
+
+function isStateMismatchCause(cause: unknown): cause is StateMismatchCause & { params: { state: string } } {
+  if (typeof cause !== "object" || cause === null) return false;
+
+  const { checks, params } = cause as Partial<StateMismatchCause>;
+  return typeof checks?.state === "string" && typeof params?.state === "string" && checks.state !== params.state;
+}
+
+function decodeReturnTo(state: string): string | undefined {
+  try {
+    const decoded: unknown = JSON.parse(Buffer.from(state, "base64url").toString());
+    return typeof decoded === "object" && decoded !== null && typeof (decoded as { returnTo?: unknown }).returnTo === "string"
+      ? (decoded as { returnTo: string }).returnTo
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function toRelativePath(returnTo: string | undefined): string {
+  if (!returnTo) return "/";
+
+  try {
+    const url = new URL(returnTo, "http://localhost");
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return "/";
+  }
+}

--- a/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.ts
+++ b/apps/deploy-web/src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo.ts
@@ -1,43 +1,33 @@
 import { CallbackHandlerError } from "@src/lib/auth0";
 
-interface StateMismatchCause {
-  checks: { state?: string };
-  params: { state?: string };
+/** Only the path of a return url survives, so this base exists to make a relative one parseable and never validates the origin. */
+const URL_PARSE_BASE = "https://console.akash.network";
+
+interface StateMismatchCause extends Error {
+  checks?: { state?: string };
+  params?: { state?: string };
 }
 
-/** Resolves the relative path a login should return to when the callback state was overwritten by a newer login start, or undefined for any other error. */
+/** Resolves the path the returning login was headed for once a newer login start has replaced the transaction cookie, or undefined for any other error. */
 export function getStateMismatchReturnTo(error: unknown): string | undefined {
-  if (!(error instanceof CallbackHandlerError) || !isStateMismatchCause(error.cause)) {
-    return undefined;
-  }
+  if (!(error instanceof CallbackHandlerError)) return undefined;
 
-  return toRelativePath(decodeReturnTo(error.cause.params.state));
+  const { checks, params } = error.cause as StateMismatchCause;
+
+  if (!checks?.state || !params?.state || checks.state === params.state) return undefined;
+
+  return toReturnToPath(params.state);
 }
 
-function isStateMismatchCause(cause: unknown): cause is StateMismatchCause & { params: { state: string } } {
-  if (typeof cause !== "object" || cause === null) return false;
-
-  const { checks, params } = cause as Partial<StateMismatchCause>;
-  return typeof checks?.state === "string" && typeof params?.state === "string" && checks.state !== params.state;
-}
-
-function decodeReturnTo(state: string): string | undefined {
+function toReturnToPath(state: string): string {
   try {
-    const decoded: unknown = JSON.parse(Buffer.from(state, "base64url").toString());
-    return typeof decoded === "object" && decoded !== null && typeof (decoded as { returnTo?: unknown }).returnTo === "string"
-      ? (decoded as { returnTo: string }).returnTo
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
+    const decoded = JSON.parse(Buffer.from(state, "base64url").toString()) as { returnTo?: unknown };
 
-function toRelativePath(returnTo: string | undefined): string {
-  if (!returnTo) return "/";
+    if (typeof decoded.returnTo !== "string") return "/";
 
-  try {
-    const url = new URL(returnTo, "http://localhost");
-    return `${url.pathname}${url.search}`;
+    const { pathname, search } = new URL(decoded.returnTo, URL_PARSE_BASE);
+
+    return `${pathname}${search}`;
   } catch {
     return "/";
   }

--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -10,6 +10,7 @@ import { CallbackHandlerError, MissingStateCookieError } from "@src/lib/auth0";
 import { handleAuth, handleCallback, handleLogin, handleLogout } from "@src/lib/auth0";
 import { clearSessionCookies } from "@src/lib/auth0/clearSessionCookies/clearSessionCookies";
 import { getIdentityProviderError } from "@src/lib/auth0/getIdentityProviderError/getIdentityProviderError";
+import { getStateMismatchReturnTo } from "@src/lib/auth0/getStateMismatchReturnTo/getStateMismatchReturnTo";
 import { isAccessTokenExpired } from "@src/lib/auth0/isAccessTokenExpired/isAccessTokenExpired";
 import { isInvalidSessionError } from "@src/lib/auth0/isInvalidSessionError/isInvalidSessionError";
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
@@ -59,6 +60,14 @@ const authHandler = once((services: AppServices) =>
         if (isMissingStateCookieError(error)) {
           services.logger.warn({ event: "AUTH_CALLBACK_MISSING_STATE_COOKIE", error });
           res.writeHead(302, { Location: "/login" });
+          res.end();
+          return;
+        }
+
+        const stateMismatchReturnTo = getStateMismatchReturnTo(error);
+        if (stateMismatchReturnTo) {
+          services.logger.warn({ event: "AUTH_CALLBACK_STATE_MISMATCH", returnTo: stateMismatchReturnTo });
+          res.writeHead(302, { Location: `/login?error=provider_login_failed&returnTo=${encodeURIComponent(stateMismatchReturnTo)}` });
           res.end();
           return;
         }

--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -66,8 +66,8 @@ const authHandler = once((services: AppServices) =>
 
         const stateMismatchReturnTo = getStateMismatchReturnTo(error);
         if (stateMismatchReturnTo) {
-          services.logger.warn({ event: "AUTH_CALLBACK_STATE_MISMATCH", returnTo: stateMismatchReturnTo });
-          res.writeHead(302, { Location: `/login?error=provider_login_failed&returnTo=${encodeURIComponent(stateMismatchReturnTo)}` });
+          services.logger.warn({ event: "AUTH_CALLBACK_STATE_MISMATCH", returnToPath: getPathWithoutQuery(stateMismatchReturnTo) });
+          res.writeHead(302, { Location: services.urlReturnToStack.createReturnable(stateMismatchReturnTo, "/login?error=provider_login_failed") });
           res.end();
           return;
         }
@@ -145,6 +145,10 @@ const authHandler = once((services: AppServices) =>
 
 function isGeneralAxiosError(error: unknown): error is AxiosError {
   return isAxiosError(error) && !!error?.status && error.status >= 400 && error.status < 500;
+}
+
+function getPathWithoutQuery(url: string): string {
+  return url.split("?")[0];
 }
 
 function isMissingStateCookieError(error: unknown): boolean {


### PR DESCRIPTION
## Why

Sentry occasionally reports `CallbackHandlerError: state mismatch, expected X, got: Y` from `/api/auth/callback`. nextjs-auth0 v3 keeps one pending login in the `auth_verification` cookie. If a user starts a second login before the first one comes back (the usual path: the Terms link on the login form opens a new tab, and that tab has its own Sign in button), the cookie now holds the second state and the first flow fails on return.

Today that fails as a bare 500 with a JSON body. The user has nowhere to go, and we get an error-level Sentry event for behaviour that is not a bug on our side. It happened 3 times in the last 30 days in prod.

## What

- Added `getStateMismatchReturnTo`, which recognises the openid-client state mismatch under `CallbackHandlerError` and decodes the callback's own `state` to recover the path that tab was trying to reach. The origin is dropped and unreadable states fall back to `/`.
- The callback handler now logs `AUTH_CALLBACK_STATE_MISMATCH` at warn level and redirects to `/login?error=provider_login_failed&returnTo=<path>`, same shape as the existing missing-cookie branch. The login page already shows the "did not complete" notice for that error param.

No change to how logins start. The proper fix is per-login transaction cookies, which is a nextjs-auth0 v4 upgrade.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling when a callback state mismatch occurs.
  * Users are redirected through login and returned to the intended page, including supported nested return destinations.
  * Return paths are handled safely without exposing query parameters during recovery.
  * Invalid, malformed, or unavailable destinations continue to use safe fallback behavior.
  * Authentication recovery now more reliably handles incomplete or unrelated callback errors without disrupting existing error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->