### PR TITLE
refactor(deployment): share one secret merge precedence between writers

### DIFF
--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -144,28 +144,6 @@ export const CreateDeploymentResponseSchema = z.object({
   })
 });
 
-/** Both fields are overrides, so a body of `{}` redeploys the source exactly as the console stored it. */
-export const RedeployDeploymentRequestSchema = z.object({
-  data: z
-    .object({
-      sealedSecrets: SealedSecretsSchema.optional().openapi({
-        description:
-          "Compact JWE sealing a flat name-to-value map, as on create. A name present here replaces the value the source deployment holds for it; every other name is carried forward untouched."
-      }),
-      runtimeLimitHours: z
-        .number()
-        .int()
-        .min(1)
-        .max(MAX_RUNTIME_LIMIT_INCREMENT_HOURS)
-        .optional()
-        .openapi({
-          description: `Optional runtime limit in hours (1 to ${MAX_RUNTIME_LIMIT_INCREMENT_HOURS}) for the new deployment. Omit to carry the source deployment's own limit forward.`
-        })
-    })
-    .optional()
-    .default({})
-});
-
 export const CloseDeploymentParamsSchema = z.object({
   dseq: DseqSchema.describe("Deployment sequence number")
 });
@@ -470,7 +448,6 @@ export type DepositDeploymentResponse = z.infer<typeof DepositDeploymentResponse
 export type UpdateDeploymentRequest = z.infer<typeof UpdateDeploymentRequestSchema>;
 export type PatchService = z.infer<typeof PatchServiceSchema>;
 export type PatchDeploymentRequest = z.infer<typeof PatchDeploymentRequestSchema>;
-export type RedeployDeploymentRequest = z.infer<typeof RedeployDeploymentRequestSchema>;
 export type PatchDeploymentResponse = z.infer<typeof PatchDeploymentResponseSchema>;
 export type UpdateDeploymentResponse = z.infer<typeof UpdateDeploymentResponseSchema>;
 export type ListWithResourcesParams = z.infer<typeof ListWithResourcesParamsSchema>;

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -144,6 +144,28 @@ export const CreateDeploymentResponseSchema = z.object({
   })
 });
 
+/** Both fields are overrides, so a body of `{}` redeploys the source exactly as the console stored it. */
+export const RedeployDeploymentRequestSchema = z.object({
+  data: z
+    .object({
+      sealedSecrets: SealedSecretsSchema.optional().openapi({
+        description:
+          "Compact JWE sealing a flat name-to-value map, as on create. A name present here replaces the value the source deployment holds for it; every other name is carried forward untouched."
+      }),
+      runtimeLimitHours: z
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_RUNTIME_LIMIT_INCREMENT_HOURS)
+        .optional()
+        .openapi({
+          description: `Optional runtime limit in hours (1 to ${MAX_RUNTIME_LIMIT_INCREMENT_HOURS}) for the new deployment. Omit to carry the source deployment's own limit forward.`
+        })
+    })
+    .optional()
+    .default({})
+});
+
 export const CloseDeploymentParamsSchema = z.object({
   dseq: DseqSchema.describe("Deployment sequence number")
 });
@@ -448,6 +470,7 @@ export type DepositDeploymentResponse = z.infer<typeof DepositDeploymentResponse
 export type UpdateDeploymentRequest = z.infer<typeof UpdateDeploymentRequestSchema>;
 export type PatchService = z.infer<typeof PatchServiceSchema>;
 export type PatchDeploymentRequest = z.infer<typeof PatchDeploymentRequestSchema>;
+export type RedeployDeploymentRequest = z.infer<typeof RedeployDeploymentRequestSchema>;
 export type PatchDeploymentResponse = z.infer<typeof PatchDeploymentResponseSchema>;
 export type UpdateDeploymentResponse = z.infer<typeof UpdateDeploymentResponseSchema>;
 export type ListWithResourcesParams = z.infer<typeof ListWithResourcesParamsSchema>;

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -112,10 +112,14 @@ const SealedSecretsSchema = z.string().min(1);
 export const CreateDeploymentRequestSchema = z.object({
   data: z.object({
     sdl: z.string().max(MAX_SUBMITTED_SDL_LENGTH),
-    /** Accepted and validated but withheld from every generated document by the route's `undocumentedRequestFields`, so the capability works before it is announced. */
-    sealedSecrets: SealedSecretsSchema.optional(),
-    /** Withheld alongside `sealedSecrets`, whose values it carries forward, so both halves of the capability are announced together. */
-    inheritSecretsFrom: DseqSchema.optional(),
+    sealedSecrets: SealedSecretsSchema.optional().openapi({
+      description:
+        "Compact JWE sealing a flat name-to-value map of the secrets this SDL references, encrypted to the console's public sealing key. Fetch that key and the claims to sign from GET /v1/sdl-secrets-context. Values are never returned by any endpoint once sealed."
+    }),
+    inheritSecretsFrom: DseqSchema.optional().openapi({
+      description:
+        "Dseq of one of your own deployments whose stored secrets this deployment starts from, for redeploying an SDL without re-entering its values. The source may be closed. A name also present in `sealedSecrets` takes precedence over the inherited one."
+    }),
     deposit: z.number().optional().openapi({
       deprecated: true,
       description: "Deprecated and ignored. The platform funds every deployment automatically from your account credits."
@@ -274,7 +278,10 @@ export const PatchDeploymentRequestSchema = z.object({
         .openapi({
           description: "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
         }),
-      sealedSecrets: SealedSecretsSchema.optional(),
+      sealedSecrets: SealedSecretsSchema.optional().openapi({
+        description:
+          "Compact JWE sealing a flat name-to-value map, as on create, but holding only the names this patch replaces. Omitted names keep the values the deployment already stores."
+      }),
       ifManifestVersion: z.string().min(1).max(MAX_MANIFEST_VERSION_LENGTH).optional().openapi({
         description:
           "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -114,6 +114,8 @@ export const CreateDeploymentRequestSchema = z.object({
     sdl: z.string().max(MAX_SUBMITTED_SDL_LENGTH),
     /** Accepted and validated but withheld from every generated document by the route's `undocumentedRequestFields`, so the capability works before it is announced. */
     sealedSecrets: SealedSecretsSchema.optional(),
+    /** Withheld alongside `sealedSecrets`, whose values it carries forward, so both halves of the capability are announced together. */
+    inheritSecretsFrom: DseqSchema.optional(),
     deposit: z.number().optional().openapi({
       deprecated: true,
       description: "Deprecated and ignored. The platform funds every deployment automatically from your account credits."

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -76,7 +76,7 @@ const postRoute = createRoute({
   /** The only route that can carry a seal, sized so the stated secret limits are reachable rather than shadowed by the default allowance. */
   bodyLimit: { maxSize: CREATE_DEPLOYMENT_BODY_LIMIT_BYTES },
   /** Accepted and validated in full; unpublished because sealed secrets are not announced yet, and reverting this line is what announces them. */
-  undocumentedRequestFields: ["sealedSecrets"],
+  undocumentedRequestFields: ["sealedSecrets", "inheritSecretsFrom"],
   request: {
     body: {
       content: {

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -39,6 +39,14 @@ import { FallbackDeploymentReaderService } from "@src/deployment/services/fallba
 
 export const deploymentsRouter = new OpenApiHonoHandler();
 
+/** What `HonoErrorHandlerService` actually returns for a refused request, rather than the `message` alone the first draft of this route declared. */
+const ErrorResponseSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+  code: z.string(),
+  type: z.string()
+});
+
 const getRoute = createRoute({
   method: "get",
   path: "/v1/deployments/{dseq}",
@@ -75,8 +83,6 @@ const postRoute = createRoute({
   security: SECURITY_BEARER_OR_API_KEY,
   /** The only route that can carry a seal, sized so the stated secret limits are reachable rather than shadowed by the default allowance. */
   bodyLimit: { maxSize: CREATE_DEPLOYMENT_BODY_LIMIT_BYTES },
-  /** Accepted and validated in full; unpublished because sealed secrets are not announced yet, and reverting this line is what announces them. */
-  undocumentedRequestFields: ["sealedSecrets", "inheritSecretsFrom"],
   request: {
     body: {
       content: {
@@ -92,6 +98,40 @@ const postRoute = createRoute({
       content: {
         "application/json": {
           schema: CreateDeploymentResponseSchema
+        }
+      }
+    },
+    400: {
+      description:
+        "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, or would carry more secrets than one deployment may hold",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    404: {
+      description: "No deployment of yours matches `inheritSecretsFrom`. Deliberately says nothing about whether that deployment exists",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    409: {
+      description:
+        "The secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    503: {
+      description: "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 409 above",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
         }
       }
     }
@@ -203,14 +243,6 @@ deploymentsRouter.openapi(updateRoute, async function routeUpdateDeployment(c) {
   return c.json(result, 200);
 });
 
-/** What `HonoErrorHandlerService` actually returns for a refused request, rather than the `message` alone the first draft of this route declared. */
-const ErrorResponseSchema = z.object({
-  error: z.string(),
-  message: z.string(),
-  code: z.string(),
-  type: z.string()
-});
-
 const patchRoute = createRoute({
   method: "patch",
   path: "/v1/deployments/{dseq}",
@@ -222,8 +254,6 @@ const patchRoute = createRoute({
   security: SECURITY_BEARER_OR_API_KEY,
   /** Sized like the create route, because a patch may carry a seal and the default allowance would shadow the stated secret limits. */
   bodyLimit: { maxSize: CREATE_DEPLOYMENT_BODY_LIMIT_BYTES },
-  /** Accepted and validated in full; unpublished because sealed secrets are not announced yet, matching the create route. */
-  undocumentedRequestFields: ["sealedSecrets"],
   request: {
     params: PatchDeploymentParamsSchema,
     body: {

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -103,7 +103,15 @@ const postRoute = createRoute({
     },
     400: {
       description:
-        "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, or would carry more secrets than one deployment may hold",
+        "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, would carry more secrets than one deployment may hold, or carries a `sealedSecrets` value that is malformed, tampered with, expired or not a flat object of string values",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    403: {
+      description: "The `sealedSecrets` value was sealed for a different user, or bound to a different SDL than the one submitted",
       content: {
         "application/json": {
           schema: ErrorResponseSchema
@@ -120,7 +128,7 @@ const postRoute = createRoute({
     },
     409: {
       description:
-        "The secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
+        "Either the `sealedSecrets` value was sealed to a key the console no longer holds — refetch `GET /v1/sdl-secrets-context` and seal again — or, with `code` `inherited_secrets_unreadable`, the secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted. The second is permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
       content: {
         "application/json": {
           schema: ErrorResponseSchema

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -137,6 +137,15 @@ ${Array.from({ length: 24 }, (_, level) => `        a${level + 1}: &a${level + 1
 
 const CLIENT_SEAL = "client.seal.aaa.bbb.ccc";
 
+/** Answers one reference from the request while leaving credentials in the clear, so a create stores both what was supplied and what the console took out. */
+const SDL_REFERENCING_A_SUPPLIED_VALUE = sdlAround(`    credentials:
+      host: registry.example.test
+      username: ${REGISTRY_USERNAME}
+      password: ${REGISTRY_PASSWORD}
+    env:
+      - TOKEN=ac-secret://TOKEN
+`);
+
 describe(DeploymentWriterService.name, () => {
   const wallet: WalletInitialized = {
     id: 1,
@@ -342,7 +351,7 @@ describe(DeploymentWriterService.name, () => {
       const { service, sdlSecretsService } = setup({ received: { TOKEN: "resolved" } });
       vi.spyOn(Date, "now").mockReturnValue(1748400000000);
 
-      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
+      await service.create({ userId: "user-1", sdl: SDL_REFERENCING_A_SUPPLIED_VALUE, sealedSecrets: SEAL, deposit: 5 });
 
       expect(sdlSecretsService.sealForStorage).toHaveBeenCalledWith({
         userId: wallet.userId,

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -18,6 +18,7 @@ import type { CreateLogger, JobQueueService, TxService } from "@src/core";
 import { JOB_NAME } from "@src/core";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
+import { MAX_RUNTIME_LIMIT_HOURS, MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { GenerateResolvedManifestResult, SdlManifest, SdlService } from "@src/deployment/services/sdl/sdl.service";
@@ -160,6 +161,9 @@ const SDL_OF_A_REDEPLOY_WITH_PLAINTEXT = sdlAround(`    env:
       - API_TOKEN=ac-secret://API_TOKEN
       - LOG_LEVEL=${ENV_VALUE}
 `);
+
+/** Short cleartext values lengthen when re-derived into references, so enough of them fit in storage yet cannot be redeployed. */
+const SDL_TOO_LARGE_ONCE_REDERIVED = sdlAround(`    env:\n${Array.from({ length: 6000 }, (_, index) => `      - E${index}=x\n`).join("")}`);
 
 describe(DeploymentWriterService.name, () => {
   const wallet: WalletInitialized = {
@@ -1067,6 +1071,166 @@ describe(DeploymentWriterService.name, () => {
           expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
           expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
         });
+      });
+    });
+  });
+
+  describe("redeployByUserIdAndDseq", () => {
+    it("deploys the sdl the console stored for the source, never one from the request", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedSdl: SDL_OF_A_REDEPLOY, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
+      expect(recorded.sdl).toContain("API_TOKEN=ac-secret://API_TOKEN");
+    });
+
+    it("mints a dseq of its own rather than writing over the source", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
+      expect(recorded.dseq).toBe("1748400000000");
+      expect(recorded.dseq).not.toBe(SOURCE_DSEQ);
+    });
+
+    it("inherits the source's secrets by naming it, so no value passes through the request", async () => {
+      const { service, sdlSecretsInheritanceService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(sdlSecretsInheritanceService.open).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
+    });
+
+    it("carries the source's runtime limit forward", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(5);
+    });
+
+    it("prefers an explicitly supplied runtime limit to the carried one", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { runtimeLimitHours: 9 }, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(9);
+    });
+
+    it("carries no runtime limit when the source has none", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: null, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBeUndefined();
+    });
+
+    it("hands a supplied seal to the intake, so its names replace what the source holds", async () => {
+      const { service, sdlSecretsService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { sealedSecrets: CLIENT_SEAL }, ability);
+
+      expect(sdlSecretsService.receive).toHaveBeenCalledWith(expect.objectContaining({ sealedSecrets: CLIENT_SEAL }));
+    });
+
+    it("reads the source through the caller's own ability", async () => {
+      const { service, deploymentSettingRepository, scopedSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(ability, "read");
+      expect(scopedSettingRepository.findOneBy).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
+    });
+
+    it("reduces a carried runtime limit longer than one request may grant to that increment", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({
+        storedRuntimeLimitHours: MAX_RUNTIME_LIMIT_HOURS,
+        inherited: { API_TOKEN: "a", DATABASE_URL: "b" }
+      });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
+    });
+
+    describe("a stored sdl the console cannot redeploy", () => {
+      it("blames itself rather than the caller for one that will not parse", async () => {
+        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
+          status: 500,
+          errorCode: "stored_sdl_unreadable"
+        });
+      });
+
+      it("tells the caller nothing about a document they could not have written", async () => {
+        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
+
+        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
+
+        expect(thrown.message).toBe("The SDL recorded for this deployment cannot be read");
+        expect(thrown.data).toBeUndefined();
+        expect(thrownTextOf(thrown)).not.toContain("LEAKED");
+        expect(thrownTextOf(thrown)).not.toContain(MALFORMED_SDL_VALUE);
+        expect(thrownTextOf(thrown)).not.toMatch(/line \d+, column \d+/);
+      });
+
+      it("blames itself rather than the caller for one too large once its values are re-derived", async () => {
+        const { service, ability } = setup({ storedSdl: SDL_TOO_LARGE_ONCE_REDERIVED, inherited: { API_TOKEN: "a" } });
+
+        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
+
+        expect(thrown).toMatchObject({ status: 500, errorCode: "redeployed_sdl_too_large" });
+        expect(thrown.data).toBeUndefined();
+        expect(thrownTextOf(thrown)).not.toContain("ac-secret://");
+      });
+
+      it("records nothing and broadcasts nothing for either", async () => {
+        const { service, deploymentSettingRepository, signerService, ability } = setup({
+          storedSdl: "this: is: not: yaml:",
+          inherited: { API_TOKEN: "a" }
+        });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
+
+        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("a source the console recorded no sdl for", () => {
+      it("answers not found", async () => {
+        const { service, ability } = setup({ sourceSetting: undefined });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
+      });
+
+      it("says there is nothing to redeploy rather than nothing to patch", async () => {
+        const { service, ability } = setup({ sourceSetting: undefined });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
+          message: "This deployment has no SDL recorded by the console, so there is nothing to redeploy"
+        });
+      });
+
+      it("mints no dseq, records nothing and broadcasts nothing", async () => {
+        const { service, deploymentSettingRepository, signerService, ability } = setup({ sourceSetting: undefined });
+        const now = vi.spyOn(Date, "now");
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
+
+        expect(now).not.toHaveBeenCalled();
+        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      });
+
+      it("answers not found for a row that exists but holds no sdl", async () => {
+        const { service, ability } = setup({ sourceSetting: mock<DeploymentSettingsOutput>({ sdl: null }) });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
       });
     });
   });
@@ -2057,6 +2221,9 @@ describe(DeploymentWriterService.name, () => {
     inheritanceError?: Error;
     maxCount?: number;
     sealedSecrets?: string | null;
+    storedSdl?: string;
+    storedRuntimeLimitHours?: number | null;
+    sourceSetting?: DeploymentSettingsOutput;
   }) {
     const signerService = mock<ManagedSignerService>();
     const rpcMessageService = mock<RpcMessageService>();
@@ -2080,6 +2247,17 @@ describe(DeploymentWriterService.name, () => {
     });
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.upsertDefinition.mockResolvedValue(DEPLOYMENT_SETTING_ID);
+    const scopedSettingRepository = mock<DeploymentSettingRepository>();
+    scopedSettingRepository.findOneBy.mockResolvedValue(
+      "sourceSetting" in (input ?? {})
+        ? input!.sourceSetting
+        : mock<DeploymentSettingsOutput>({
+            sdl: input?.storedSdl ?? SDL_OF_A_REDEPLOY,
+            runtimeLimitHours: input?.storedRuntimeLimitHours ?? null,
+            sealedSecrets: "stored.token.aaa.bbb.ccc"
+          })
+    );
+    deploymentSettingRepository.accessibleBy.mockReturnValue(scopedSettingRepository);
     const txService = mock<TxService>();
     txService.transaction.mockImplementation(async cb => (input?.transactionRuns === false ? (undefined as never) : await cb()));
     const jobQueueService = mock<JobQueueService>();
@@ -2156,6 +2334,8 @@ describe(DeploymentWriterService.name, () => {
       jobQueueService,
       sdlSecretsService,
       sdlSecretsInheritanceService,
+      scopedSettingRepository,
+      ability: mock<AnyAbility>(),
       storedSecrets
     };
   }

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -25,6 +25,7 @@ import { SdlPatchService } from "@src/deployment/services/sdl-patch/sdl-patch.se
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import type { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
+import type { SdlSecretsInheritanceService } from "@src/deployment/services/sdl-secrets-inheritance/sdl-secrets-inheritance.service";
 import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
 import { SECRET_UNREADABLE_ERROR_MESSAGE } from "@src/secret/config/secret-at-rest.config";
@@ -137,6 +138,8 @@ ${Array.from({ length: 24 }, (_, level) => `        a${level + 1}: &a${level + 1
 
 const CLIENT_SEAL = "client.seal.aaa.bbb.ccc";
 
+const SOURCE_DSEQ = "1420000000001";
+
 /** Answers one reference from the request while leaving credentials in the clear, so a create stores both what was supplied and what the console took out. */
 const SDL_REFERENCING_A_SUPPLIED_VALUE = sdlAround(`    credentials:
       host: registry.example.test
@@ -144,6 +147,18 @@ const SDL_REFERENCING_A_SUPPLIED_VALUE = sdlAround(`    credentials:
       password: ${REGISTRY_PASSWORD}
     env:
       - TOKEN=ac-secret://TOKEN
+`);
+
+/** A redeploy submits the sdl a previous deployment stored, so every value it needs already stands as a reference. */
+const SDL_OF_A_REDEPLOY = sdlAround(`    env:
+      - API_TOKEN=ac-secret://API_TOKEN
+      - DATABASE_URL=ac-secret://DATABASE_URL
+`);
+
+/** The same document with one value still in the clear, so the console derives a name of its own beside the inherited ones. */
+const SDL_OF_A_REDEPLOY_WITH_PLAINTEXT = sdlAround(`    env:
+      - API_TOKEN=ac-secret://API_TOKEN
+      - LOG_LEVEL=${ENV_VALUE}
 `);
 
 describe(DeploymentWriterService.name, () => {
@@ -335,7 +350,7 @@ describe(DeploymentWriterService.name, () => {
 
       await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, deposit: 5 });
 
-      expect(sdlSecretsService.receive).toHaveBeenCalledWith({ sdl: parsedSdlValue, rawSdl: SDL_WITH_SECRETS, sealedSecrets: SEAL });
+      expect(sdlSecretsService.receive).toHaveBeenCalledWith({ sdl: parsedSdlValue, rawSdl: SDL_WITH_SECRETS, sealedSecrets: SEAL, inherited: {} });
     });
 
     it("resolves the manifest from the values the intake handed back", async () => {
@@ -908,6 +923,143 @@ describe(DeploymentWriterService.name, () => {
 
       await expect(service.create({ userId: "user-1", sdl: SDL_ALIASING_ONE_SCALAR, deposit: 5 })).rejects.toMatchObject({ status: 400 });
       expect(staleDeploymentsCleaner.cleanUpForWallet).not.toHaveBeenCalled();
+    });
+
+    describe("values inherited from another deployment", () => {
+      it("seals what the source deployment held, against the dseq it just minted", async () => {
+        const carried = { API_TOKEN: faker.string.alphanumeric(24), DATABASE_URL: faker.internet.url() };
+        const { service, sdlSecretsService } = setup({ inherited: carried });
+        vi.spyOn(Date, "now").mockReturnValue(1748400000000);
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(sdlSecretsService.sealForStorage).toHaveBeenCalledWith({ userId: wallet.userId, dseq: "1748400000000", secrets: carried });
+      });
+
+      it("looks the source up as the caller's own deployment", async () => {
+        const { service, sdlSecretsInheritanceService } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(sdlSecretsInheritanceService.open).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
+      });
+
+      it("consults no source when the request names none", async () => {
+        const { service, sdlSecretsInheritanceService } = setup();
+
+        await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+        expect(sdlSecretsInheritanceService.open).not.toHaveBeenCalled();
+      });
+
+      it("stores none of the source's values the new sdl does not reference", async () => {
+        const spare = faker.string.alphanumeric(24);
+        const { service, storedSecrets } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b", SPARE: spare } });
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(storedSecrets()).toEqual({ API_TOKEN: "a", DATABASE_URL: "b" });
+      });
+
+      it("prefers an explicitly supplied value to the inherited one of the same name", async () => {
+        const replaced = faker.internet.url();
+        const { service, storedSecrets } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "stale" }, received: { DATABASE_URL: replaced } });
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, sealedSecrets: CLIENT_SEAL, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(storedSecrets()).toEqual({ API_TOKEN: "a", DATABASE_URL: replaced });
+      });
+
+      it("prefers a value the document itself gave up to an inherited name that collides with it", async () => {
+        const { service, storedSecrets } = setup({ inherited: { API_TOKEN: "a", s0_e1: "stale" } });
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY_WITH_PLAINTEXT, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(storedSecrets()).toEqual({ API_TOKEN: "a", s0_e1: ENV_VALUE });
+      });
+
+      it("resolves the submitted document against what it inherited as well as what was supplied", async () => {
+        const replaced = faker.internet.url();
+        const { service, sdlService } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "stale" }, received: { DATABASE_URL: replaced } });
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, sealedSecrets: CLIENT_SEAL, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(sdlService.generateResolvedManifest).toHaveBeenCalledWith(expect.objectContaining({ secrets: { API_TOKEN: "a", DATABASE_URL: replaced } }));
+      });
+
+      it("hands the inherited set to the intake, so a reference it answers needs no supplied value", async () => {
+        const carried = { API_TOKEN: "a", DATABASE_URL: "b" };
+        const { service, sdlSecretsService } = setup({ inherited: carried });
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(sdlSecretsService.receive).toHaveBeenCalledWith(expect.objectContaining({ inherited: carried }));
+      });
+
+      it("holds everything it did not derive from this request's own document to the seal limits", async () => {
+        const replaced = faker.internet.url();
+        const { service, sdlSecretsService } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "stale" }, received: { DATABASE_URL: replaced } });
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, sealedSecrets: CLIENT_SEAL, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(sdlSecretsService.assertStorable).toHaveBeenCalledWith({ API_TOKEN: "a", DATABASE_URL: replaced });
+      });
+
+      it("leaves what it derived out of that bound, the sdl's own size ceiling already holding it", async () => {
+        const { service, sdlSecretsService } = setup({ inherited: { API_TOKEN: "a" } });
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY_WITH_PLAINTEXT, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(sdlSecretsService.assertStorable).toHaveBeenCalledWith({ API_TOKEN: "a" });
+      });
+
+      it("refuses a chain that would carry more than a deployment may hold, before minting a dseq", async () => {
+        const { service, deploymentSettingRepository, signerService } = setup({
+          inherited: { API_TOKEN: "a", DATABASE_URL: "b" },
+          maxCount: 1
+        });
+        const now = vi.spyOn(Date, "now");
+
+        await expect(service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, inheritSecretsFrom: SOURCE_DSEQ })).rejects.toMatchObject({
+          status: 400,
+          message: "At most 1 secrets may be carried by one deployment, counting those inherited from another"
+        });
+
+        expect(now).not.toHaveBeenCalled();
+        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      });
+
+      describe("a source it cannot read", () => {
+        it("answers the not found the lookup raised", async () => {
+          const { service } = setup({ inheritanceError: createError(404, "No deployment was found to inherit secrets from") });
+
+          await expect(service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, inheritSecretsFrom: SOURCE_DSEQ })).rejects.toMatchObject({ status: 404 });
+        });
+
+        it("answers the conflict the lookup raised for a token beyond this data key", async () => {
+          const { service } = setup({
+            inheritanceError: createError(409, "The secrets recorded for the deployment being inherited from can no longer be decrypted")
+          });
+
+          await expect(service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, inheritSecretsFrom: SOURCE_DSEQ })).rejects.toMatchObject({ status: 409 });
+        });
+
+        it("mints no dseq, seals nothing, records nothing and broadcasts nothing", async () => {
+          const { service, sdlSecretsService, deploymentSettingRepository, signerService, txService } = setup({
+            inheritanceError: createError(409, "unreadable")
+          });
+          const now = vi.spyOn(Date, "now");
+
+          await expect(service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, inheritSecretsFrom: SOURCE_DSEQ })).rejects.toThrow();
+
+          expect(now).not.toHaveBeenCalled();
+          expect(sdlSecretsService.sealForStorage).not.toHaveBeenCalled();
+          expect(txService.transaction).not.toHaveBeenCalled();
+          expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+          expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+        });
+      });
     });
   });
 
@@ -1834,7 +1986,7 @@ describe(DeploymentWriterService.name, () => {
       const maxCount = input?.maxCount;
       sdlSecretsService.assertStorable.mockImplementation(secrets => {
         if (maxCount !== undefined && Object.keys(secrets).length > maxCount) {
-          throw createError(400, `At most ${maxCount} secrets may be supplied for one deployment`);
+          throw createError(400, `At most ${maxCount} secrets may be carried by one deployment, counting those inherited from another`);
         }
       });
 
@@ -1862,7 +2014,8 @@ describe(DeploymentWriterService.name, () => {
         sdlSecretsService,
         new SdlSecretsDerivationService(new SdlReferenceService()),
         new SdlPatchService(),
-        sdlReferenceService
+        sdlReferenceService,
+        mock<SdlSecretsInheritanceService>()
       );
 
       function sealedFor() {
@@ -1892,6 +2045,9 @@ describe(DeploymentWriterService.name, () => {
     compensationAlreadyWaiting?: boolean;
     manifestVersion?: Uint8Array;
     received?: SdlSecrets;
+    inherited?: SdlSecrets;
+    inheritanceError?: Error;
+    maxCount?: number;
     sealedSecrets?: string | null;
   }) {
     const signerService = mock<ManagedSignerService>();
@@ -1928,6 +2084,17 @@ describe(DeploymentWriterService.name, () => {
     sdlSecretsService.receive.mockResolvedValue({ ok: true, value: input?.received ?? {} });
     sdlSecretsService.sealForStorage.mockResolvedValue(input?.sealedSecrets ?? null);
 
+    const maxCount = input?.maxCount;
+    sdlSecretsService.assertStorable.mockImplementation(secrets => {
+      if (maxCount !== undefined && Object.keys(secrets).length > maxCount) {
+        throw createError(400, `At most ${maxCount} secrets may be carried by one deployment, counting those inherited from another`);
+      }
+    });
+
+    const sdlSecretsInheritanceService = mock<SdlSecretsInheritanceService>();
+    if (input?.inheritanceError) sdlSecretsInheritanceService.open.mockRejectedValue(input.inheritanceError);
+    else sdlSecretsInheritanceService.open.mockResolvedValue(input?.inherited ?? {});
+
     walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
     sdlService.parse.mockReturnValue({ ok: true, value: parsedSdlValue } as any);
     sdlService.generateManifest.mockResolvedValue({ ok: true, value: manifestValue } as any);
@@ -1955,8 +2122,13 @@ describe(DeploymentWriterService.name, () => {
       sdlSecretsService,
       sdlSecretsDerivationService,
       new SdlPatchService(),
-      new SdlReferenceService()
+      new SdlReferenceService(),
+      sdlSecretsInheritanceService
     );
+
+    function storedSecrets() {
+      return vi.mocked(sdlSecretsService.sealForStorage).mock.calls[0][0].secrets;
+    }
 
     return {
       service,
@@ -1974,7 +2146,9 @@ describe(DeploymentWriterService.name, () => {
       deploymentSettingRepository,
       txService,
       jobQueueService,
-      sdlSecretsService
+      sdlSecretsService,
+      sdlSecretsInheritanceService,
+      storedSecrets
     };
   }
 });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -18,7 +18,6 @@ import type { CreateLogger, JobQueueService, TxService } from "@src/core";
 import { JOB_NAME } from "@src/core";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
-import { MAX_RUNTIME_LIMIT_HOURS, MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { GenerateResolvedManifestResult, SdlManifest, SdlService } from "@src/deployment/services/sdl/sdl.service";
@@ -161,9 +160,6 @@ const SDL_OF_A_REDEPLOY_WITH_PLAINTEXT = sdlAround(`    env:
       - API_TOKEN=ac-secret://API_TOKEN
       - LOG_LEVEL=${ENV_VALUE}
 `);
-
-/** Short cleartext values lengthen when re-derived into references, so enough of them fit in storage yet cannot be redeployed. */
-const SDL_TOO_LARGE_ONCE_REDERIVED = sdlAround(`    env:\n${Array.from({ length: 6000 }, (_, index) => `      - E${index}=x\n`).join("")}`);
 
 describe(DeploymentWriterService.name, () => {
   const wallet: WalletInitialized = {
@@ -1071,166 +1067,6 @@ describe(DeploymentWriterService.name, () => {
           expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
           expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
         });
-      });
-    });
-  });
-
-  describe("redeployByUserIdAndDseq", () => {
-    it("deploys the sdl the console stored for the source, never one from the request", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedSdl: SDL_OF_A_REDEPLOY, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
-      expect(recorded.sdl).toContain("API_TOKEN=ac-secret://API_TOKEN");
-    });
-
-    it("mints a dseq of its own rather than writing over the source", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
-      expect(recorded.dseq).toBe("1748400000000");
-      expect(recorded.dseq).not.toBe(SOURCE_DSEQ);
-    });
-
-    it("inherits the source's secrets by naming it, so no value passes through the request", async () => {
-      const { service, sdlSecretsInheritanceService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(sdlSecretsInheritanceService.open).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
-    });
-
-    it("carries the source's runtime limit forward", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(5);
-    });
-
-    it("prefers an explicitly supplied runtime limit to the carried one", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { runtimeLimitHours: 9 }, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(9);
-    });
-
-    it("carries no runtime limit when the source has none", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: null, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBeUndefined();
-    });
-
-    it("hands a supplied seal to the intake, so its names replace what the source holds", async () => {
-      const { service, sdlSecretsService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { sealedSecrets: CLIENT_SEAL }, ability);
-
-      expect(sdlSecretsService.receive).toHaveBeenCalledWith(expect.objectContaining({ sealedSecrets: CLIENT_SEAL }));
-    });
-
-    it("reads the source through the caller's own ability", async () => {
-      const { service, deploymentSettingRepository, scopedSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(ability, "read");
-      expect(scopedSettingRepository.findOneBy).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
-    });
-
-    it("reduces a carried runtime limit longer than one request may grant to that increment", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({
-        storedRuntimeLimitHours: MAX_RUNTIME_LIMIT_HOURS,
-        inherited: { API_TOKEN: "a", DATABASE_URL: "b" }
-      });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
-    });
-
-    describe("a stored sdl the console cannot redeploy", () => {
-      it("blames itself rather than the caller for one that will not parse", async () => {
-        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
-          status: 500,
-          errorCode: "stored_sdl_unreadable"
-        });
-      });
-
-      it("tells the caller nothing about a document they could not have written", async () => {
-        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
-
-        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
-
-        expect(thrown.message).toBe("The SDL recorded for this deployment cannot be read");
-        expect(thrown.data).toBeUndefined();
-        expect(thrownTextOf(thrown)).not.toContain("LEAKED");
-        expect(thrownTextOf(thrown)).not.toContain(MALFORMED_SDL_VALUE);
-        expect(thrownTextOf(thrown)).not.toMatch(/line \d+, column \d+/);
-      });
-
-      it("blames itself rather than the caller for one too large once its values are re-derived", async () => {
-        const { service, ability } = setup({ storedSdl: SDL_TOO_LARGE_ONCE_REDERIVED, inherited: { API_TOKEN: "a" } });
-
-        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
-
-        expect(thrown).toMatchObject({ status: 500, errorCode: "redeployed_sdl_too_large" });
-        expect(thrown.data).toBeUndefined();
-        expect(thrownTextOf(thrown)).not.toContain("ac-secret://");
-      });
-
-      it("records nothing and broadcasts nothing for either", async () => {
-        const { service, deploymentSettingRepository, signerService, ability } = setup({
-          storedSdl: "this: is: not: yaml:",
-          inherited: { API_TOKEN: "a" }
-        });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
-
-        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
-        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("a source the console recorded no sdl for", () => {
-      it("answers not found", async () => {
-        const { service, ability } = setup({ sourceSetting: undefined });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
-      });
-
-      it("says there is nothing to redeploy rather than nothing to patch", async () => {
-        const { service, ability } = setup({ sourceSetting: undefined });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
-          message: "This deployment has no SDL recorded by the console, so there is nothing to redeploy"
-        });
-      });
-
-      it("mints no dseq, records nothing and broadcasts nothing", async () => {
-        const { service, deploymentSettingRepository, signerService, ability } = setup({ sourceSetting: undefined });
-        const now = vi.spyOn(Date, "now");
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
-
-        expect(now).not.toHaveBeenCalled();
-        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
-        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
-      });
-
-      it("answers not found for a row that exists but holds no sdl", async () => {
-        const { service, ability } = setup({ sourceSetting: mock<DeploymentSettingsOutput>({ sdl: null }) });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
       });
     });
   });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1002,7 +1002,7 @@ describe(DeploymentWriterService.name, () => {
 
         await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY, sealedSecrets: CLIENT_SEAL, inheritSecretsFrom: SOURCE_DSEQ });
 
-        expect(sdlSecretsService.assertStorable).toHaveBeenCalledWith({ API_TOKEN: "a", DATABASE_URL: replaced });
+        expect(sdlSecretsService.assertStorable).toHaveBeenCalledWith({ API_TOKEN: "a", DATABASE_URL: replaced }, "carried");
       });
 
       it("leaves what it derived out of that bound, the sdl's own size ceiling already holding it", async () => {
@@ -1010,7 +1010,15 @@ describe(DeploymentWriterService.name, () => {
 
         await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY_WITH_PLAINTEXT, inheritSecretsFrom: SOURCE_DSEQ });
 
-        expect(sdlSecretsService.assertStorable).toHaveBeenCalledWith({ API_TOKEN: "a" });
+        expect(sdlSecretsService.assertStorable).toHaveBeenCalledWith({ API_TOKEN: "a" }, "carried");
+      });
+
+      it("leaves an inherited value a derived name displaces out of that bound, it never being stored", async () => {
+        const { service, sdlSecretsService } = setup({ inherited: { API_TOKEN: "a", s0_e1: "stale" } });
+
+        await service.create({ userId: "user-1", sdl: SDL_OF_A_REDEPLOY_WITH_PLAINTEXT, inheritSecretsFrom: SOURCE_DSEQ });
+
+        expect(sdlSecretsService.assertStorable).toHaveBeenCalledWith({ API_TOKEN: "a" }, "carried");
       });
 
       it("refuses a chain that would carry more than a deployment may hold, before minting a dseq", async () => {
@@ -1568,7 +1576,7 @@ describe(DeploymentWriterService.name, () => {
 
         await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { image: "x" } } }, ability);
 
-        expect(sdlSecretsService.assertStorable).toHaveBeenCalledWith({ s0_e0: "a", s0_e1: "b" });
+        expect(sdlSecretsService.assertStorable).toHaveBeenCalledWith({ s0_e0: "a", s0_e1: "b" }, "stored");
       });
 
       it("writes nothing when the merged set is refused", async () => {
@@ -1986,7 +1994,7 @@ describe(DeploymentWriterService.name, () => {
       const maxCount = input?.maxCount;
       sdlSecretsService.assertStorable.mockImplementation(secrets => {
         if (maxCount !== undefined && Object.keys(secrets).length > maxCount) {
-          throw createError(400, `At most ${maxCount} secrets may be carried by one deployment, counting those inherited from another`);
+          throw createError(400, `At most ${maxCount} secrets may be stored for one deployment`);
         }
       });
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -19,8 +19,10 @@ import {
   DeploymentResponse,
   PatchDeploymentRequest,
   PatchDeploymentResponse,
+  RedeployDeploymentRequest,
   UpdateDeploymentRequest
 } from "@src/deployment/http-schemas/deployment.schema";
+import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import {
   DeleteUnbackedDeploymentSetting,
@@ -47,8 +49,14 @@ const SECRET_REFERENCE_KIND = "secret";
 /** Distinct from the sealed-secret failure so a client can tell which half of the stored state it cannot read, both being permanent. */
 const STORED_SDL_UNREADABLE_ERROR_CODE = "stored_sdl_unreadable";
 
+/** Redeploying re-derives cleartext values into references, which lengthens the document, so a source can be stored yet be too large to redeploy. */
+const REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE = "redeployed_sdl_too_large";
+
 /** A deployment the console never recorded an SDL for has nothing to patch, and the SDL is deliberately not accepted from the request. */
 const NOT_PATCHABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to patch";
+
+/** Its own wording rather than the one above, because the patch endpoint's 404 message is a shipped behaviour its callers already read. */
+const NOT_REDEPLOYABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to redeploy";
 
 /** What becomes of the values a submitted document carries in the clear. There is no longer a way to say "dropped": every writer can seal, so a value is never lost to be safe. */
 type StoredSdlValues =
@@ -56,6 +64,30 @@ type StoredSdlValues =
   | "every-value-sealed"
   /** Only a registry credential is, a seal having already said which of the rest are secret. */
   | "only-credentials-sealed";
+
+/**
+ * A 400 by default, so every caller that submitted the document keeps answering exactly as it did, while a
+ * caller that submitted none can catch this and answer for the console instead. `name` must stay unset:
+ * the error handler echoes it into the response body, so assigning it would change a shipped 400.
+ */
+class UnstorableSdlError extends HTTPException {
+  readonly refusal: StoredSdlRefusal;
+
+  constructor(refusal: StoredSdlRefusal, message: string) {
+    super(400, { message });
+    this.refusal = refusal;
+  }
+}
+
+/**
+ * A redeploy creates a deployment that has none, so the most one request may grant it is the same first
+ * increment every other entry point allows; a longer limit stays reachable by extending after the redeploy.
+ */
+function carriedRuntimeLimitOf(storedRuntimeLimitHours: number | null | undefined) {
+  if (typeof storedRuntimeLimitHours !== "number") return undefined;
+
+  return Math.min(storedRuntimeLimitHours, MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
+}
 
 /** Lowest precedence first: what the deployment carried in, then what the request supplied, then what the document gave up. */
 function prunedOverlayOf(sets: { carried: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, referenced: ReadonlySet<string>): SdlSecrets {
@@ -281,12 +313,32 @@ export class DeploymentWriterService {
     if (refusal === "unparseable") {
       this.logger.warn({ event: "DEPLOYMENT_SDL_UNPARSEABLE", ...loggable, line: at?.line, column: at?.column });
 
-      return new HTTPException(400, { message: at ? `SDL is not valid YAML: line ${at.line}, column ${at.column}` : "SDL is not valid YAML" });
+      return new UnstorableSdlError(refusal, at ? `SDL is not valid YAML: line ${at.line}, column ${at.column}` : "SDL is not valid YAML");
     }
 
     this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE", ...loggable, maxLength: SDL_MAX_LENGTH });
 
-    return new HTTPException(400, { message: `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored` });
+    return new UnstorableSdlError(refusal, `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored`);
+  }
+
+  /**
+   * Built from the refusal kind alone and never from the error carrying it, so no line, column or fragment of
+   * the console's own document reaches a caller who could not have written it.
+   */
+  #rejectUnredeployableStoredSdl(refusal: StoredSdlRefusal, key: { userId: string; dseq: string }) {
+    if (refusal === "unparseable") {
+      this.logger.error({ event: "DEPLOYMENT_STORED_SDL_UNPARSEABLE", ...key });
+
+      return createError(500, "The SDL recorded for this deployment cannot be read", { errorCode: STORED_SDL_UNREADABLE_ERROR_CODE });
+    }
+
+    this.logger.error({ event: "DEPLOYMENT_REDEPLOYED_SDL_TOO_LARGE", ...key, maxLength: SDL_MAX_LENGTH });
+
+    return createError(
+      500,
+      `The SDL recorded for this deployment cannot be redeployed: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once its values are re-derived`,
+      { errorCode: REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE }
+    );
   }
 
   /**
@@ -392,7 +444,10 @@ export class DeploymentWriterService {
     input: PatchDeploymentRequest["data"],
     ability: AnyAbility
   ): Promise<PatchDeploymentResponse["data"]> {
-    const [wallet, stored] = await Promise.all([this.walletReaderService.getWalletByUserId(userId), this.#findStoredDefinition({ userId, dseq }, ability)]);
+    const [wallet, stored] = await Promise.all([
+      this.walletReaderService.getWalletByUserId(userId),
+      this.#findStoredDefinition({ userId, dseq }, ability, NOT_PATCHABLE_MESSAGE)
+    ]);
     const parsed = this.#parseStored(stored.sdl, { userId, dseq });
     const document = parsed.document;
 
@@ -445,18 +500,61 @@ export class DeploymentWriterService {
     return { ...(await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq)), manifestVersion: recordedVersion };
   }
 
+  /**
+   * Deploys again what the console stored for a deployment — its SDL, its secrets and its runtime limit —
+   * as a new deployment of its own. The SDL is never accepted from the request, and the secrets are carried
+   * by the same inheritance a create performs, so nothing about them passes through the client.
+   *
+   * The definition is read here and its token read again inside `create`. A patch landing between the two
+   * can only pair the older SDL with a newer token, which either resolves — a value the patch changed being
+   * what a caller would want anyway — or is refused when the token no longer covers what the SDL references.
+   * The worst a race produces is a spurious refusal, never a deployment of something other than the source.
+   */
+  public async redeployByUserIdAndDseq(
+    userId: string,
+    dseq: string,
+    input: RedeployDeploymentRequest["data"],
+    ability: AnyAbility
+  ): Promise<CreateDeploymentResponse["data"]> {
+    const stored = await this.#findStoredDefinition({ userId, dseq }, ability, NOT_REDEPLOYABLE_MESSAGE);
+
+    this.logger.info({ event: "DEPLOYMENT_REDEPLOY_STARTED", userId, dseq, overridesRuntimeLimit: input.runtimeLimitHours !== undefined });
+
+    try {
+      return await this.create({
+        userId,
+        sdl: stored.sdl,
+        inheritSecretsFrom: dseq,
+        sealedSecrets: input.sealedSecrets,
+        runtimeLimitHours: input.runtimeLimitHours ?? carriedRuntimeLimitOf(stored.runtimeLimitHours)
+      });
+    } catch (error) {
+      if (error instanceof UnstorableSdlError) {
+        throw this.#rejectUnredeployableStoredSdl(error.refusal, { userId, dseq });
+      }
+
+      throw error;
+    }
+  }
+
   /** Read through the caller's own ability as well as their id, so a definition is unreachable by anyone the ability excludes even before the write re-checks it. */
   async #findStoredDefinition(
     key: { userId: string; dseq: string },
-    ability: AnyAbility
-  ): Promise<{ sdl: string; sealedSecrets: string | null; manifestVersion?: string }> {
+    ability: AnyAbility,
+    notFoundMessage: string
+  ): Promise<{ sdl: string; sealedSecrets: string | null; manifestVersion?: string; runtimeLimitHours?: number }> {
     const setting = await this.deploymentSettingRepository.accessibleBy(ability, "read").findOneBy(key);
 
     if (!setting?.sdl) {
-      throw createError(404, NOT_PATCHABLE_MESSAGE);
+      throw createError(404, notFoundMessage);
     }
 
-    return { sdl: setting.sdl, sealedSecrets: setting.sealedSecrets, manifestVersion: setting.manifestVersion ?? undefined };
+    return {
+      sdl: setting.sdl,
+      sealedSecrets: setting.sealedSecrets,
+      manifestVersion: setting.manifestVersion ?? undefined,
+      runtimeLimitHours: setting.runtimeLimitHours ?? undefined
+    };
   }
 
   /** The caller did not supply this document, so an unparseable one is the console's fault and never a 400. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -56,6 +56,13 @@ type StoredSdlValues =
   /** Only a registry credential is, a seal having already said which of the rest are secret. */
   | "only-credentials-sealed";
 
+/** Lowest precedence first: what the deployment carried in, then what the request supplied, then what the document gave up. */
+function prunedOverlayOf(sets: { carried?: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, referenced: ReadonlySet<string>): SdlSecrets {
+  const overlaid: SdlSecrets = { ...sets.carried, ...sets.supplied, ...sets.derived };
+
+  return Object.fromEntries(Object.entries(overlaid).filter(([name]) => referenced.has(name)));
+}
+
 @singleton()
 export class DeploymentWriterService {
   private readonly logger: ReturnType<CreateLogger>;
@@ -85,12 +92,12 @@ export class DeploymentWriterService {
   /** The dseq is minted once everything that can refuse the submitted document has run, because the token written below names it and a client sealing beforehand cannot; a refusal that needs the resolved document — a sealed registry password below the schema's minimum, say — can only come after it, and spends a dseq nothing is written under. */
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
     /** SDL for storage ONLY, and the values taken out of it. Never stands in for the submitted document anywhere a hash is taken. */
-    const { sdl, derived } = this.#storedSdlOf(input.sdl, input.sealedSecrets ? "only-credentials-sealed" : "every-value-sealed");
+    const { sdl, storedDocument, derived } = this.#storedSdlOf(input.sdl, input.sealedSecrets ? "only-credentials-sealed" : "every-value-sealed");
 
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const depositInDollars = this.deploymentConfig.get("DEPLOYMENT_DEFAULT_DEPOSIT");
     const supplied = await this.#receiveSecrets(input);
-    const stored = this.#storedSecretsOf(supplied, derived);
+    const stored = this.#storedSecretsOf({ supplied, derived }, storedDocument);
 
     const dseq = Date.now().toString();
     const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: supplied, isTrialing: !!wallet.isTrialing });
@@ -210,7 +217,7 @@ export class DeploymentWriterService {
   }
 
   /** `dseq` is a log field only, so a create can run this before minting one and still say which request it refused. */
-  #storedSdlOf(submittedSdl: string, values: StoredSdlValues, dseq?: string): { sdl: string; derived: SdlSecrets } {
+  #storedSdlOf(submittedSdl: string, values: StoredSdlValues, dseq?: string): { sdl: string; storedDocument: SDLInput; derived: SdlSecrets } {
     const parsed = parseSdlForStorage(submittedSdl);
 
     if (parsed.document === null) {
@@ -224,7 +231,7 @@ export class DeploymentWriterService {
       throw this.#rejectUnstorableSdl("too-large", { dseq, length });
     }
 
-    return { sdl, derived };
+    return { sdl, storedDocument: parsed.document, derived };
   }
 
   /** Runs before the document is measured, so that what the size guard bounds is exactly what gets stored. */
@@ -237,8 +244,8 @@ export class DeploymentWriterService {
    * took out of the document itself. A name in both is refused rather than merged, because the two would
    * be different values under one name and the stored SDL would then reference whichever won.
    */
-  #storedSecretsOf(supplied: SdlSecrets, derived: SdlSecrets): SdlSecrets {
-    const collisions = Object.keys(derived).filter(name => Object.hasOwn(supplied, name));
+  #storedSecretsOf(sets: { supplied: SdlSecrets; derived: SdlSecrets }, document: SDLInput): SdlSecrets {
+    const collisions = Object.keys(sets.derived).filter(name => Object.hasOwn(sets.supplied, name));
 
     if (collisions.length > 0) {
       const echoed = collisions[0].slice(0, MAX_ECHOED_REFERENCE_LENGTH);
@@ -247,7 +254,7 @@ export class DeploymentWriterService {
       throw createError(400, `"${echoed}" is a name the console derives for this deployment and cannot also be supplied for it`);
     }
 
-    return { ...supplied, ...derived };
+    return prunedOverlayOf(sets, this.#referencedNamesOf(document));
   }
 
   /** Carries none of the document and attaches no parse error as a cause, because a `js-yaml` message quotes the line it failed on and the error handler logs the whole chain. */
@@ -463,16 +470,19 @@ export class DeploymentWriterService {
 
   /** What the deployment held, overlaid by what the request supplied and then by what the patched document gave up, pruned to the names the document still references. */
   #mergeAndPrune(sets: { held: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, document: SDLInput): SdlSecrets {
-    const overlaid: SdlSecrets = { ...sets.held, ...sets.supplied, ...sets.derived };
-    const referenced = new Set(this.sdlReferenceService.declarationsOf(document, SECRET_REFERENCE_KIND).map(declaration => declaration.name));
+    const referenced = this.#referencedNamesOf(document);
 
     this.#assertEverySuppliedNameIsReferenced(sets.supplied, referenced);
 
-    const merged = Object.fromEntries(Object.entries(overlaid).filter(([name]) => referenced.has(name)));
+    const merged = prunedOverlayOf({ carried: sets.held, supplied: sets.supplied, derived: sets.derived }, referenced);
 
     this.sdlSecretsService.assertStorable(merged);
 
     return merged;
+  }
+
+  #referencedNamesOf(document: SDLInput): ReadonlySet<string> {
+    return new Set(this.sdlReferenceService.declarationsOf(document, SECRET_REFERENCE_KIND).map(declaration => declaration.name));
   }
 
   /** A misspelt name is refused rather than dropped, so a caller cannot receive a 200 believing a credential rotated when nothing changed. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -19,10 +19,8 @@ import {
   DeploymentResponse,
   PatchDeploymentRequest,
   PatchDeploymentResponse,
-  RedeployDeploymentRequest,
   UpdateDeploymentRequest
 } from "@src/deployment/http-schemas/deployment.schema";
-import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import {
   DeleteUnbackedDeploymentSetting,
@@ -49,14 +47,8 @@ const SECRET_REFERENCE_KIND = "secret";
 /** Distinct from the sealed-secret failure so a client can tell which half of the stored state it cannot read, both being permanent. */
 const STORED_SDL_UNREADABLE_ERROR_CODE = "stored_sdl_unreadable";
 
-/** Redeploying re-derives cleartext values into references, which lengthens the document, so a source can be stored yet be too large to redeploy. */
-const REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE = "redeployed_sdl_too_large";
-
 /** A deployment the console never recorded an SDL for has nothing to patch, and the SDL is deliberately not accepted from the request. */
 const NOT_PATCHABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to patch";
-
-/** Its own wording rather than the one above, because the patch endpoint's 404 message is a shipped behaviour its callers already read. */
-const NOT_REDEPLOYABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to redeploy";
 
 /** What becomes of the values a submitted document carries in the clear. There is no longer a way to say "dropped": every writer can seal, so a value is never lost to be safe. */
 type StoredSdlValues =
@@ -77,16 +69,6 @@ class UnstorableSdlError extends HTTPException {
     super(400, { message });
     this.refusal = refusal;
   }
-}
-
-/**
- * A redeploy creates a deployment that has none, so the most one request may grant it is the same first
- * increment every other entry point allows; a longer limit stays reachable by extending after the redeploy.
- */
-function carriedRuntimeLimitOf(storedRuntimeLimitHours: number | null | undefined) {
-  if (typeof storedRuntimeLimitHours !== "number") return undefined;
-
-  return Math.min(storedRuntimeLimitHours, MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
 }
 
 /** Lowest precedence first: what the deployment carried in, then what the request supplied, then what the document gave up. */
@@ -322,26 +304,6 @@ export class DeploymentWriterService {
   }
 
   /**
-   * Built from the refusal kind alone and never from the error carrying it, so no line, column or fragment of
-   * the console's own document reaches a caller who could not have written it.
-   */
-  #rejectUnredeployableStoredSdl(refusal: StoredSdlRefusal, key: { userId: string; dseq: string }) {
-    if (refusal === "unparseable") {
-      this.logger.error({ event: "DEPLOYMENT_STORED_SDL_UNPARSEABLE", ...key });
-
-      return createError(500, "The SDL recorded for this deployment cannot be read", { errorCode: STORED_SDL_UNREADABLE_ERROR_CODE });
-    }
-
-    this.logger.error({ event: "DEPLOYMENT_REDEPLOYED_SDL_TOO_LARGE", ...key, maxLength: SDL_MAX_LENGTH });
-
-    return createError(
-      500,
-      `The SDL recorded for this deployment cannot be redeployed: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once its values are re-derived`,
-      { errorCode: REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE }
-    );
-  }
-
-  /**
    * Reclaims escrow from a trial wallet's orphaned (open, lease-less) deployments before a new create, so a stranded
    * trial user whose earlier close failed can deploy again without waiting for the periodic cleanup job. It runs
    * before the create tx so the freed deployment allowance is available when the create's balance check runs.
@@ -498,43 +460,6 @@ export class DeploymentWriterService {
     });
 
     return { ...(await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq)), manifestVersion: recordedVersion };
-  }
-
-  /**
-   * Deploys again what the console stored for a deployment — its SDL, its secrets and its runtime limit —
-   * as a new deployment of its own. The SDL is never accepted from the request, and the secrets are carried
-   * by the same inheritance a create performs, so nothing about them passes through the client.
-   *
-   * The definition is read here and its token read again inside `create`. A patch landing between the two
-   * can only pair the older SDL with a newer token, which either resolves — a value the patch changed being
-   * what a caller would want anyway — or is refused when the token no longer covers what the SDL references.
-   * The worst a race produces is a spurious refusal, never a deployment of something other than the source.
-   */
-  public async redeployByUserIdAndDseq(
-    userId: string,
-    dseq: string,
-    input: RedeployDeploymentRequest["data"],
-    ability: AnyAbility
-  ): Promise<CreateDeploymentResponse["data"]> {
-    const stored = await this.#findStoredDefinition({ userId, dseq }, ability, NOT_REDEPLOYABLE_MESSAGE);
-
-    this.logger.info({ event: "DEPLOYMENT_REDEPLOY_STARTED", userId, dseq, overridesRuntimeLimit: input.runtimeLimitHours !== undefined });
-
-    try {
-      return await this.create({
-        userId,
-        sdl: stored.sdl,
-        inheritSecretsFrom: dseq,
-        sealedSecrets: input.sealedSecrets,
-        runtimeLimitHours: input.runtimeLimitHours ?? carriedRuntimeLimitOf(stored.runtimeLimitHours)
-      });
-    } catch (error) {
-      if (error instanceof UnstorableSdlError) {
-        throw this.#rejectUnredeployableStoredSdl(error.refusal, { userId, dseq });
-      }
-
-      throw error;
-    }
   }
 
   /** Read through the caller's own ability as well as their id, so a definition is unreachable by anyone the ability excludes even before the write re-checks it. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -242,13 +242,7 @@ export class DeploymentWriterService {
     return this.sdlSecretsDerivationService.derive(document, { includeEnvValues: values === "every-value-sealed" });
   }
 
-  /**
-   * The one set of values the deployment's token carries: what the client sealed, what the deployment it
-   * inherits from held, and what the console took out of the document itself. A supplied name the console
-   * also derived is refused rather than merged, because the two would be different values under one name
-   * and the stored SDL would then reference whichever won. An inherited name loses to either silently: the
-   * client did not choose it for this request, and a derived name owns the slot the derivation just wrote.
-   */
+  /** The one set of values the deployment's token carries, overlaid as inherited, then supplied, then derived, refusing only a supplied name the console also derived because both were chosen for this request. */
   #storedSecretsOf(sets: { inherited: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, storedDocument: SDLInput): SdlSecrets {
     const collisions = Object.keys(sets.derived).filter(name => Object.hasOwn(sets.supplied, name));
 
@@ -265,9 +259,12 @@ export class DeploymentWriterService {
     return prunedOverlayOf({ carried: sets.inherited, supplied: sets.supplied, derived: sets.derived }, referenced);
   }
 
-  /** Bounds what this deployment will actually keep from elsewhere rather than everything the source held, so a large source cannot refuse a redeploy that references one of its names. */
-  #assertCarriedSetIsStorable(sets: { inherited: SdlSecrets; supplied: SdlSecrets }, referenced: ReadonlySet<string>): void {
-    this.sdlSecretsService.assertStorable(prunedOverlayOf({ carried: sets.inherited, supplied: sets.supplied, derived: {} }, referenced));
+  /** Bounds only what this deployment will actually keep from elsewhere, so neither a large source nor a stale inherited value a derived name displaces can refuse the redeploy. */
+  #assertCarriedSetIsStorable(sets: { inherited: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, referenced: ReadonlySet<string>): void {
+    const carried = prunedOverlayOf({ carried: sets.inherited, supplied: sets.supplied, derived: {} }, referenced);
+    const kept = Object.fromEntries(Object.entries(carried).filter(([name]) => !Object.hasOwn(sets.derived, name)));
+
+    this.sdlSecretsService.assertStorable(kept, "carried");
   }
 
   /** Refused before the dseq is minted, so a source that cannot be found or whose token will not open spends no dseq and leaves nothing recorded. */
@@ -496,7 +493,7 @@ export class DeploymentWriterService {
 
     const merged = prunedOverlayOf({ carried: sets.held, supplied: sets.supplied, derived: sets.derived }, referenced);
 
-    this.sdlSecretsService.assertStorable(merged);
+    this.sdlSecretsService.assertStorable(merged, "stored");
 
     return merged;
   }

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -32,6 +32,7 @@ import { SdlPatchService } from "@src/deployment/services/sdl-patch/sdl-patch.se
 import { MAX_ECHOED_REFERENCE_LENGTH, SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlSecretsService, unreferencedNameError } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
+import { SdlSecretsInheritanceService } from "@src/deployment/services/sdl-secrets-inheritance/sdl-secrets-inheritance.service";
 import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import type { StorableSdl, StoredSdlPosition, StoredSdlRefusal } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
 import { parseSdlForStorage, sdlForStorage } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
@@ -57,7 +58,7 @@ type StoredSdlValues =
   | "only-credentials-sealed";
 
 /** Lowest precedence first: what the deployment carried in, then what the request supplied, then what the document gave up. */
-function prunedOverlayOf(sets: { carried?: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, referenced: ReadonlySet<string>): SdlSecrets {
+function prunedOverlayOf(sets: { carried: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, referenced: ReadonlySet<string>): SdlSecrets {
   const overlaid: SdlSecrets = { ...sets.carried, ...sets.supplied, ...sets.derived };
 
   return Object.fromEntries(Object.entries(overlaid).filter(([name]) => referenced.has(name)));
@@ -84,7 +85,8 @@ export class DeploymentWriterService {
     private readonly sdlSecretsService: SdlSecretsService,
     private readonly sdlSecretsDerivationService: SdlSecretsDerivationService,
     private readonly sdlPatchService: SdlPatchService,
-    private readonly sdlReferenceService: SdlReferenceService
+    private readonly sdlReferenceService: SdlReferenceService,
+    private readonly sdlSecretsInheritanceService: SdlSecretsInheritanceService
   ) {
     this.logger = createLogger({ context: DeploymentWriterService.name });
   }
@@ -96,11 +98,12 @@ export class DeploymentWriterService {
 
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const depositInDollars = this.deploymentConfig.get("DEPLOYMENT_DEFAULT_DEPOSIT");
-    const supplied = await this.#receiveSecrets(input);
-    const stored = this.#storedSecretsOf({ supplied, derived }, storedDocument);
+    const inherited = await this.#inheritedSecretsOf(input);
+    const supplied = await this.#receiveSecrets(input, inherited);
+    const stored = this.#storedSecretsOf({ inherited, supplied, derived }, storedDocument);
 
     const dseq = Date.now().toString();
-    const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: supplied, isTrialing: !!wallet.isTrialing });
+    const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: { ...inherited, ...supplied }, isTrialing: !!wallet.isTrialing });
     const unresolvedManifest = await this.#unresolvedManifestOf(input.sdl);
     const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: stored });
 
@@ -240,11 +243,13 @@ export class DeploymentWriterService {
   }
 
   /**
-   * The one set of values the deployment's token carries: what the client sealed, plus what the console
-   * took out of the document itself. A name in both is refused rather than merged, because the two would
-   * be different values under one name and the stored SDL would then reference whichever won.
+   * The one set of values the deployment's token carries: what the client sealed, what the deployment it
+   * inherits from held, and what the console took out of the document itself. A supplied name the console
+   * also derived is refused rather than merged, because the two would be different values under one name
+   * and the stored SDL would then reference whichever won. An inherited name loses to either silently: the
+   * client did not choose it for this request, and a derived name owns the slot the derivation just wrote.
    */
-  #storedSecretsOf(sets: { supplied: SdlSecrets; derived: SdlSecrets }, document: SDLInput): SdlSecrets {
+  #storedSecretsOf(sets: { inherited: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, storedDocument: SDLInput): SdlSecrets {
     const collisions = Object.keys(sets.derived).filter(name => Object.hasOwn(sets.supplied, name));
 
     if (collisions.length > 0) {
@@ -254,7 +259,22 @@ export class DeploymentWriterService {
       throw createError(400, `"${echoed}" is a name the console derives for this deployment and cannot also be supplied for it`);
     }
 
-    return prunedOverlayOf(sets, this.#referencedNamesOf(document));
+    const referenced = this.#referencedNamesOf(storedDocument);
+    this.#assertCarriedSetIsStorable(sets, referenced);
+
+    return prunedOverlayOf({ carried: sets.inherited, supplied: sets.supplied, derived: sets.derived }, referenced);
+  }
+
+  /** Bounds what this deployment will actually keep from elsewhere rather than everything the source held, so a large source cannot refuse a redeploy that references one of its names. */
+  #assertCarriedSetIsStorable(sets: { inherited: SdlSecrets; supplied: SdlSecrets }, referenced: ReadonlySet<string>): void {
+    this.sdlSecretsService.assertStorable(prunedOverlayOf({ carried: sets.inherited, supplied: sets.supplied, derived: {} }, referenced));
+  }
+
+  /** Refused before the dseq is minted, so a source that cannot be found or whose token will not open spends no dseq and leaves nothing recorded. */
+  async #inheritedSecretsOf(input: { userId: string; inheritSecretsFrom?: string }): Promise<SdlSecrets> {
+    if (!input.inheritSecretsFrom) return {};
+
+    return await this.sdlSecretsInheritanceService.open({ userId: input.userId, dseq: input.inheritSecretsFrom });
   }
 
   /** Carries none of the document and attaches no parse error as a cause, because a `js-yaml` message quotes the line it failed on and the error handler logs the whole chain. */
@@ -505,7 +525,7 @@ export class DeploymentWriterService {
     return manifestToSortedJSON(result.value.groups);
   }
 
-  /** Only the manifest version is taken from the resolved SDL: the resolved manifest itself must not leave this call. Runs before any lookup so a bad reference always answers 400 rather than racing a 404. */
+  /** Only the manifest version is taken from the resolved SDL: the resolved manifest itself must not leave this call, and a bad reference answers 400 before any deployment is looked up. */
   async #resolveSdl(sdl: string, options: { secrets?: SdlSecrets; isTrialing?: boolean }) {
     const result = await this.sdlService.generateResolvedManifest({ sdl, ...options, secrets: options.secrets ?? {} });
 
@@ -517,14 +537,14 @@ export class DeploymentWriterService {
   }
 
   /** Reports through the same channel every other reference mistake uses, so a missing value reads identically whether the intake or substitution found it. */
-  async #receiveSecrets(input: CreateDeploymentRequest["data"]): Promise<SdlSecrets> {
+  async #receiveSecrets(input: CreateDeploymentRequest["data"], inherited: SdlSecrets): Promise<SdlSecrets> {
     const parsed = this.sdlService.parse(input.sdl);
 
     if (!parsed.ok) {
       throw this.#rejectInvalidSdl(parsed.value);
     }
 
-    const received = await this.sdlSecretsService.receive({ sdl: parsed.value, rawSdl: input.sdl, sealedSecrets: input.sealedSecrets });
+    const received = await this.sdlSecretsService.receive({ sdl: parsed.value, rawSdl: input.sdl, sealedSecrets: input.sealedSecrets, inherited });
 
     if (!received.ok) {
       throw this.#rejectInvalidSdl(received.value);

--- a/apps/api/src/deployment/services/sdl-secrets-inheritance/sdl-secrets-inheritance.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-inheritance/sdl-secrets-inheritance.service.spec.ts
@@ -1,0 +1,227 @@
+import type { Ability } from "@casl/ability";
+import { faker } from "@faker-js/faker";
+import createError from "http-errors";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthService } from "@src/auth/services/auth.service";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import { SECRET_UNREADABLE_ERROR_CODE, SECRET_UNREADABLE_ERROR_MESSAGE } from "@src/secret/config/secret-at-rest.config";
+import { SdlSecretsInheritanceService } from "./sdl-secrets-inheritance.service";
+
+const SOURCE = { userId: "user-1", dseq: "1420000000001" };
+const TOKEN = "stored.token.aaa.bbb.ccc";
+
+describe(SdlSecretsInheritanceService.name, () => {
+  it("returns the values the source deployment's token opens to", async () => {
+    const carried = { TOKEN: faker.string.alphanumeric(32) };
+    const { service } = setup({ opened: carried });
+
+    await expect(service.open(SOURCE)).resolves.toEqual(carried);
+  });
+
+  it("opens the token the source row holds, under the source's own key", async () => {
+    const { service, sdlSecretsService } = setup();
+
+    await service.open(SOURCE);
+
+    expect(sdlSecretsService.openStored).toHaveBeenCalledWith({ ...SOURCE, sealedSecrets: TOKEN });
+  });
+
+  it("reads the source through the caller's own ability as well as their id", async () => {
+    const { service, deploymentSettingRepository, scoped, ability } = setup();
+
+    await service.open(SOURCE);
+
+    expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(ability, "read");
+    expect(scoped.findOneBy).toHaveBeenCalledWith(SOURCE);
+  });
+
+  it("inherits from a closed deployment, because closing a deployment keeps its secrets", async () => {
+    const carried = { TOKEN: faker.string.alphanumeric(32) };
+    const { service } = setup({ setting: mock<DeploymentSettingsOutput>({ sealedSecrets: TOKEN, closed: true }), opened: carried });
+
+    await expect(service.open(SOURCE)).resolves.toEqual(carried);
+  });
+
+  it("inherits from a deployment the console recorded no sdl for, needing only its token", async () => {
+    const carried = { TOKEN: faker.string.alphanumeric(32) };
+    const { service } = setup({ setting: mock<DeploymentSettingsOutput>({ sealedSecrets: TOKEN, sdl: null }), opened: carried });
+
+    await expect(service.open(SOURCE)).resolves.toEqual(carried);
+  });
+
+  describe("a source the caller cannot reach", () => {
+    it("answers not found", async () => {
+      const { service } = setup({ setting: undefined });
+
+      await expect(service.open(SOURCE)).rejects.toMatchObject({ status: 404 });
+    });
+
+    it("says nothing about whether the deployment exists", async () => {
+      const { service } = setup({ setting: undefined });
+
+      await expect(service.open(SOURCE)).rejects.toMatchObject({ message: "No deployment was found to inherit secrets from" });
+    });
+
+    it("spends no key-service call on it", async () => {
+      const { service, sdlSecretsService } = setup({ setting: undefined });
+
+      await expect(service.open(SOURCE)).rejects.toThrow();
+      expect(sdlSecretsService.openStored).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("a source holding no token", () => {
+    it("inherits nothing rather than refusing, so an unanswered reference is reported by name instead", async () => {
+      const { service } = setup({ setting: mock<DeploymentSettingsOutput>({ sealedSecrets: null }) });
+
+      await expect(service.open(SOURCE)).resolves.toEqual({});
+    });
+
+    it("does not reach the key service", async () => {
+      const { service, sdlSecretsService } = setup({ setting: mock<DeploymentSettingsOutput>({ sealedSecrets: null }) });
+
+      await service.open(SOURCE);
+
+      expect(sdlSecretsService.openStored).not.toHaveBeenCalled();
+    });
+
+    it("records that it found nothing, so a silent no-op is distinguishable from a working inherit", async () => {
+      const { service, logger } = setup({ setting: mock<DeploymentSettingsOutput>({ sealedSecrets: null }) });
+
+      await service.open(SOURCE);
+
+      expect(logger.info).toHaveBeenCalledWith({ event: "SDL_SECRETS_INHERIT_SOURCE_HAS_NO_SECRETS", ...SOURCE });
+    });
+  });
+
+  describe("a token this data key can no longer open", () => {
+    it("answers conflict rather than the server error the cipher raised", async () => {
+      const { service } = setup({ openStoredError: unreadableTokenError() });
+
+      await expect(service.open(SOURCE)).rejects.toMatchObject({ status: 409 });
+    });
+
+    it("carries a code that tells the failure apart from stored state of the deployment being created", async () => {
+      const { service } = setup({ openStoredError: unreadableTokenError() });
+
+      await expect(service.open(SOURCE)).rejects.toMatchObject({ errorCode: "inherited_secrets_unreadable" });
+    });
+
+    it("explains that the secrets can no longer be decrypted", async () => {
+      const { service } = setup({ openStoredError: unreadableTokenError() });
+
+      await expect(service.open(SOURCE)).rejects.toMatchObject({
+        message: "The secrets recorded for the deployment being inherited from can no longer be decrypted"
+      });
+    });
+
+    it("records it as a token beyond this data key, with the cause it was given", async () => {
+      const cause = unreadableTokenError();
+      const { service, logger } = setup({ openStoredError: cause });
+
+      await expect(service.open(SOURCE)).rejects.toThrow();
+      expect(logger.error).toHaveBeenCalledWith({ event: "SDL_SECRETS_INHERIT_TOKEN_UNREADABLE", ...SOURCE, error: cause });
+    });
+
+    it("carries the cause on the error it raises, so a refusal can be diagnosed after the fact", async () => {
+      const cause = unreadableTokenError();
+      const { service } = setup({ openStoredError: cause });
+
+      await expect(service.open(SOURCE)).rejects.toMatchObject({ cause });
+    });
+  });
+
+  describe("stored state the console itself cannot read", () => {
+    it("answers the same conflict, the caller's remedy being the same", async () => {
+      const { service } = setup({ openStoredError: createError(500, SECRET_UNREADABLE_ERROR_MESSAGE) });
+
+      await expect(service.open(SOURCE)).rejects.toMatchObject({ status: 409, errorCode: "inherited_secrets_unreadable" });
+    });
+
+    it("records it under its own event, so it can be told apart from a token beyond the data key", async () => {
+      const cause = createError(500, SECRET_UNREADABLE_ERROR_MESSAGE);
+      const { service, logger } = setup({ openStoredError: cause });
+
+      await expect(service.open(SOURCE)).rejects.toThrow();
+      expect(logger.error).toHaveBeenCalledWith({ event: "SDL_SECRETS_INHERIT_STATE_UNREADABLE", ...SOURCE, error: cause });
+    });
+  });
+
+  describe("a key service that is merely unreachable", () => {
+    it("keeps the transient failure rather than reporting secrets that are gone", async () => {
+      const { service } = setup({ openStoredError: createError(503, "Service temporarily unavailable") });
+
+      await expect(service.open(SOURCE)).rejects.toMatchObject({ status: 503 });
+    });
+
+    it("attaches no permanent code to it", async () => {
+      const { service } = setup({ openStoredError: createError(503, "Service temporarily unavailable") });
+
+      await expect(service.open(SOURCE)).rejects.toSatisfy((error: { errorCode?: string }) => error.errorCode === undefined);
+    });
+  });
+
+  describe("a failure that never came from the cipher", () => {
+    it("raises it unchanged rather than reporting secrets that are gone", async () => {
+      const cause = new Error("connection terminated unexpectedly");
+      const { service } = setup({ openStoredError: cause });
+
+      await expect(service.open(SOURCE)).rejects.toBe(cause);
+    });
+
+    it("attaches no permanent code to it, so a pool blip is not read as undecryptable secrets", async () => {
+      const { service } = setup({ openStoredError: new Error("connection terminated unexpectedly") });
+
+      await expect(service.open(SOURCE)).rejects.toSatisfy((error: { errorCode?: string; status?: number }) => !error.errorCode && !error.status);
+    });
+  });
+
+  it("logs how many values it inherited and none of them", async () => {
+    const value = faker.string.alphanumeric(32);
+    const { service, logger } = setup({ opened: { TOKEN: value } });
+
+    await service.open(SOURCE);
+
+    expect(logger.info).toHaveBeenCalledWith({ event: "SDL_SECRETS_INHERITED", ...SOURCE, inheritedCount: 1 });
+  });
+
+  it("never logs an inherited value", async () => {
+    const value = faker.string.alphanumeric(32);
+    const { service, logger } = setup({ opened: { TOKEN: value } });
+
+    await service.open(SOURCE);
+
+    expect(JSON.stringify(vi.mocked(logger.info).mock.calls)).not.toContain(value);
+  });
+
+  function unreadableTokenError() {
+    return createError(500, SECRET_UNREADABLE_ERROR_MESSAGE, { errorCode: SECRET_UNREADABLE_ERROR_CODE });
+  }
+
+  function setup(input?: { setting?: DeploymentSettingsOutput; opened?: SdlSecrets; openStoredError?: Error }) {
+    const setting = "setting" in (input ?? {}) ? input!.setting : mock<DeploymentSettingsOutput>({ sealedSecrets: TOKEN });
+
+    const scoped = mock<DeploymentSettingRepository>();
+    scoped.findOneBy.mockResolvedValue(setting);
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.accessibleBy.mockReturnValue(scoped);
+
+    const ability = mock<Ability>();
+    const authService = mock<AuthService>({ ability });
+
+    const sdlSecretsService = mock<SdlSecretsService>();
+    if (input?.openStoredError) sdlSecretsService.openStored.mockRejectedValue(input.openStoredError);
+    else sdlSecretsService.openStored.mockResolvedValue(input?.opened ?? {});
+
+    const logger = mock<ReturnType<CreateLogger>>();
+    const service = new SdlSecretsInheritanceService(deploymentSettingRepository, authService, sdlSecretsService, () => logger);
+
+    return { service, deploymentSettingRepository, scoped, ability, sdlSecretsService, logger };
+  }
+});

--- a/apps/api/src/deployment/services/sdl-secrets-inheritance/sdl-secrets-inheritance.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-inheritance/sdl-secrets-inheritance.service.ts
@@ -1,0 +1,90 @@
+import createError, { isHttpError } from "http-errors";
+import { inject, singleton } from "tsyringe";
+
+import { AuthService } from "@src/auth/services/auth.service";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import { SECRET_UNREADABLE_ERROR_CODE } from "@src/secret/config/secret-at-rest.config";
+
+/** Says nothing about whether the deployment exists, so a caller cannot learn another user's dseqs by asking to inherit from them. */
+const SOURCE_NOT_FOUND_MESSAGE = "No deployment was found to inherit secrets from";
+
+/** The remedy is to supply the values instead, which is the same whichever of the permanent causes it was, so they share one message. */
+const SOURCE_UNREADABLE_MESSAGE = "The secrets recorded for the deployment being inherited from can no longer be decrypted";
+
+/** Distinct from the stored-state codes a patch answers with, because this one names the deployment the request pointed at rather than the one it addresses. */
+const SOURCE_UNREADABLE_ERROR_CODE = "inherited_secrets_unreadable";
+
+/** The only answer that means the source's secrets are gone for good: a 503 says the key service is merely unreachable, and anything else never came from the cipher at all. */
+function isPermanentlyUnreadable(error: unknown): boolean {
+  return isHttpError(error) && error.status === 500;
+}
+
+/** A permanent failure to decrypt is distinguished from one to read our own stored state, because only the first says the token itself is beyond this data key. */
+function isTokenUnreadable(error: unknown): boolean {
+  return isHttpError(error) && error.errorCode === SECRET_UNREADABLE_ERROR_CODE;
+}
+
+/**
+ * Opens the token another deployment of the same user holds, so a redeploy can carry its values forward.
+ * Reads nothing but the token: the source's SDL is never consulted, and its `closed` state is deliberately
+ * ignored, because secrets are kept when a deployment is closed and redeploying a reclaimed one is the case
+ * this serves.
+ */
+@singleton()
+export class SdlSecretsInheritanceService {
+  readonly #loggerService: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly authService: AuthService,
+    private readonly sdlSecretsService: SdlSecretsService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.#loggerService = createLogger({ context: SdlSecretsInheritanceService.name });
+  }
+
+  /** Read through the caller's own ability as well as their id, so another user's deployment is unreachable rather than merely refused. */
+  async open(key: { userId: string; dseq: string }): Promise<SdlSecrets> {
+    const setting = await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "read").findOneBy(key);
+
+    if (!setting) {
+      this.#loggerService.warn({ event: "SDL_SECRETS_INHERIT_SOURCE_NOT_FOUND", ...key });
+
+      throw createError(404, SOURCE_NOT_FOUND_MESSAGE);
+    }
+
+    if (!setting.sealedSecrets) {
+      this.#loggerService.info({ event: "SDL_SECRETS_INHERIT_SOURCE_HAS_NO_SECRETS", ...key });
+
+      return {};
+    }
+
+    const inherited = await this.#openStored(setting.sealedSecrets, key);
+
+    this.#loggerService.info({ event: "SDL_SECRETS_INHERITED", ...key, inheritedCount: Object.keys(inherited).length });
+
+    return inherited;
+  }
+
+  /** Only the cipher's own permanent answer is rewritten: a 503 stays retryable, and a failure from anywhere else must not masquerade as secrets that are gone. */
+  async #openStored(sealedSecrets: string, key: { userId: string; dseq: string }): Promise<SdlSecrets> {
+    try {
+      return await this.sdlSecretsService.openStored({ ...key, sealedSecrets });
+    } catch (error) {
+      if (!isPermanentlyUnreadable(error)) throw error;
+
+      throw this.#rejectUnreadable(error, key);
+    }
+  }
+
+  /** Carries the cause into both the log and the error, because the message a caller receives says only that the secrets will not open and never why. */
+  #rejectUnreadable(error: unknown, key: { userId: string; dseq: string }) {
+    const event = isTokenUnreadable(error) ? "SDL_SECRETS_INHERIT_TOKEN_UNREADABLE" : "SDL_SECRETS_INHERIT_STATE_UNREADABLE";
+    this.#loggerService.error({ event, ...key, error });
+
+    return createError(409, SOURCE_UNREADABLE_MESSAGE, { errorCode: SOURCE_UNREADABLE_ERROR_CODE, cause: error });
+  }
+}

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
@@ -646,26 +646,40 @@ describe(SdlSecretsService.name, () => {
       const { service } = setup({ maxCount: 2 });
       const merged = Object.fromEntries(Array.from({ length: 3 }, (_, index) => [`s0_e${index}`, "value"]));
 
-      expect(() => service.assertStorable(merged)).toThrow(expect.objectContaining({ status: 400 }));
+      expect(() => service.assertStorable(merged, "carried")).toThrow(expect.objectContaining({ status: 400 }));
     });
 
     it("refuses a value larger than a secret may be", () => {
       const { service } = setup({ maxValueBytes: 10 });
 
-      expect(() => service.assertStorable({ s0_e0: "x".repeat(50) })).toThrow(expect.objectContaining({ status: 400 }));
+      expect(() => service.assertStorable({ s0_e0: "x".repeat(50) }, "carried")).toThrow(expect.objectContaining({ status: 400 }));
     });
 
     it("accepts a set exactly at the count a deployment may carry", () => {
       const { service } = setup({ maxCount: 2 });
 
-      expect(() => service.assertStorable({ s0_e0: "a", s0_e1: "b" })).not.toThrow();
+      expect(() => service.assertStorable({ s0_e0: "a", s0_e1: "b" }, "carried")).not.toThrow();
     });
 
     it("names the count it enforces rather than the request that reached it", () => {
       const { service } = setup({ maxCount: 2 });
       const merged = Object.fromEntries(Array.from({ length: 3 }, (_, index) => [`s0_e${index}`, "value"]));
 
-      expect(() => service.assertStorable(merged)).toThrow(/At most 2 secrets/);
+      expect(() => service.assertStorable(merged, "carried")).toThrow(/At most 2 secrets/);
+    });
+
+    it("blames inheritance only for a carried set", () => {
+      const { service } = setup({ maxCount: 2 });
+      const merged = Object.fromEntries(Array.from({ length: 3 }, (_, index) => [`s0_e${index}`, "value"]));
+
+      expect(() => service.assertStorable(merged, "carried")).toThrow(/carried by one deployment, counting those inherited from another/);
+    });
+
+    it("says nothing of inheritance for a merged stored set", () => {
+      const { service } = setup({ maxCount: 2 });
+      const merged = Object.fromEntries(Array.from({ length: 3 }, (_, index) => [`s0_e${index}`, "value"]));
+
+      expect(() => service.assertStorable(merged, "stored")).toThrow(/stored for one deployment/);
     });
   });
 

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.spec.ts
@@ -333,7 +333,115 @@ describe(SdlSecretsService.name, () => {
 
       await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, sealedSecrets: SEAL });
 
-      expect(logger.info).toHaveBeenCalledWith({ event: "SDL_SECRETS_RECEIVED", suppliedCount: 1, referencedNames: ["TOKEN"], serviceCount: 1 });
+      expect(logger.info).toHaveBeenCalledWith({
+        event: "SDL_SECRETS_RECEIVED",
+        suppliedCount: 1,
+        inheritedCount: 0,
+        referencedNames: ["TOKEN"],
+        serviceCount: 1
+      });
+    });
+
+    describe("values inherited from another deployment", () => {
+      it("accepts a reference answered by the inherited set alone, without opening a seal", async () => {
+        const { service, unsealerService } = setup();
+
+        const result = await service.receive({
+          sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN", "DATABASE_URL=ac-secret://DATABASE_URL"] }),
+          rawSdl: RAW_SDL,
+          inherited: { TOKEN: "carried", DATABASE_URL: "carried-too" }
+        });
+
+        expect(result.ok).toBe(true);
+        expect(receivedOf(result)).toEqual({});
+        expect(unsealerService.open).not.toHaveBeenCalled();
+      });
+
+      it("names only the references neither set answers", async () => {
+        const { service } = setup({ supplied: { TOKEN: "supplied" } });
+
+        const result = await service.receive({
+          sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN", "DATABASE_URL=ac-secret://DATABASE_URL", "API_KEY=ac-secret://API_KEY"] }),
+          rawSdl: RAW_SDL,
+          sealedSecrets: SEAL,
+          inherited: { DATABASE_URL: "carried" }
+        });
+
+        expect(errorsOf(result)).toEqual([expect.objectContaining({ params: expect.objectContaining({ name: "API_KEY" }) })]);
+      });
+
+      it("keeps naming an unanswered reference when nothing was supplied and nothing inherited covers it", async () => {
+        const { service } = setup();
+
+        const result = await service.receive({
+          sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }),
+          rawSdl: RAW_SDL,
+          inherited: { UNRELATED: "carried" }
+        });
+
+        expect(errorsOf(result)).toEqual([expect.objectContaining({ params: expect.objectContaining({ name: "TOKEN" }) })]);
+      });
+
+      it("says nothing about an inherited name no service references, because a source carries more than one deployment needs", async () => {
+        const { service } = setup();
+
+        const result = await service.receive({
+          sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }),
+          rawSdl: RAW_SDL,
+          inherited: { TOKEN: "carried", SPARE: "carried-too" }
+        });
+
+        expect(result.ok).toBe(true);
+      });
+
+      it("still refuses a supplied name no service references, which the caller did choose for this request", async () => {
+        const { service } = setup({ supplied: { SPARE: "supplied" } });
+
+        const result = await service.receive({
+          sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }),
+          rawSdl: RAW_SDL,
+          sealedSecrets: SEAL,
+          inherited: { TOKEN: "carried" }
+        });
+
+        expect(errorsOf(result)).toEqual([expect.objectContaining({ params: { name: "SPARE" } })]);
+      });
+
+      it("says nothing at all for a create that references no secret and supplies none, the hottest write path", async () => {
+        const { service, logger } = setup();
+
+        await service.receive({ sdl: sdlWith({ web: ["LOG_LEVEL=debug"] }), rawSdl: RAW_SDL });
+
+        expect(logger.info).not.toHaveBeenCalled();
+      });
+
+      it("prefers a usable inherited value to a supplied name holding no string", async () => {
+        const { service } = setup({ supplied: { TOKEN: 0 as unknown as string } });
+
+        const result = await service.receive({
+          sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }),
+          rawSdl: RAW_SDL,
+          sealedSecrets: SEAL,
+          inherited: { TOKEN: "carried" }
+        });
+
+        expect(result.ok).toBe(true);
+      });
+
+      it("logs how many values it inherited and none of them", async () => {
+        const value = faker.string.alphanumeric(32);
+        const { service, logger } = setup();
+
+        await service.receive({ sdl: sdlWith({ web: ["TOKEN=ac-secret://TOKEN"] }), rawSdl: RAW_SDL, inherited: { TOKEN: value } });
+
+        expect(logger.info).toHaveBeenCalledWith({
+          event: "SDL_SECRETS_RECEIVED",
+          suppliedCount: 0,
+          inheritedCount: 1,
+          referencedNames: ["TOKEN"],
+          serviceCount: 1
+        });
+      });
     });
   });
 

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
@@ -28,12 +28,16 @@ export type ReceiveSdlSecretsResult = { ok: true; value: SdlSecrets } | { ok: fa
 const NOTHING_SUPPLIED: SdlSecrets = {};
 
 /** Which set broke a limit, because a redeploy that inherits its values supplied none of them and must not be told to supply fewer. */
-type SdlSecretsOrigin = "supplied" | "carried";
+type SdlSecretsOrigin = "supplied" | "carried" | "stored";
 
 function countExceededMessage(origin: SdlSecretsOrigin, maxCount: number): string {
-  return origin === "supplied"
-    ? `At most ${maxCount} secrets may be supplied for one deployment`
-    : `At most ${maxCount} secrets may be carried by one deployment, counting those inherited from another`;
+  const messages: Record<SdlSecretsOrigin, string> = {
+    supplied: `At most ${maxCount} secrets may be supplied for one deployment`,
+    carried: `At most ${maxCount} secrets may be carried by one deployment, counting those inherited from another`,
+    stored: `At most ${maxCount} secrets may be stored for one deployment`
+  };
+
+  return messages[origin];
 }
 
 /** The two ways a reference can already be answered when a create is received: by this request, or by the deployment it inherits from. */
@@ -117,8 +121,8 @@ export class SdlSecretsService {
   }
 
   /** Bounds the whole set a deployment would carry, because measuring one request alone would let a merge grow the stored token past the ceiling one request at a time. */
-  assertStorable(secrets: SdlSecrets): void {
-    this.#assertWithinLimits(secrets, "carried");
+  assertStorable(secrets: SdlSecrets, origin: Exclude<SdlSecretsOrigin, "supplied">): void {
+    this.#assertWithinLimits(secrets, origin);
   }
 
   /** Returns null when nothing was supplied, so a create always has a value to write and a retry cannot inherit an abandoned attempt's token. */

--- a/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets/sdl-secrets.service.ts
@@ -27,6 +27,23 @@ export type ReceiveSdlSecretsResult = { ok: true; value: SdlSecrets } | { ok: fa
 
 const NOTHING_SUPPLIED: SdlSecrets = {};
 
+/** Which set broke a limit, because a redeploy that inherits its values supplied none of them and must not be told to supply fewer. */
+type SdlSecretsOrigin = "supplied" | "carried";
+
+function countExceededMessage(origin: SdlSecretsOrigin, maxCount: number): string {
+  return origin === "supplied"
+    ? `At most ${maxCount} secrets may be supplied for one deployment`
+    : `At most ${maxCount} secrets may be carried by one deployment, counting those inherited from another`;
+}
+
+/** The two ways a reference can already be answered when a create is received: by this request, or by the deployment it inherits from. */
+type ReceivedSdlSecretSets = { supplied: SdlSecrets; inherited: SdlSecrets };
+
+/** Each set is asked separately, so a non-string sitting under a name in one of them cannot shadow a usable value in the other. */
+function isCovered(sets: ReceivedSdlSecretSets, name: string): boolean {
+  return typeof ownValue(sets.supplied, name) === "string" || typeof ownValue(sets.inherited, name) === "string";
+}
+
 /** An unreachable key service answers 503 and will succeed on retry, so it is not evidence that anything moved the stored data. */
 function isRetryable(error: unknown): boolean {
   return isHttpError(error) && error.status === 503;
@@ -69,33 +86,39 @@ export class SdlSecretsService {
   }
 
   /** Takes the parsed document, because an SDL that does not parse has already been refused by the manifest generator and this must not report it twice. */
-  async receive(input: { sdl: SDLInput; rawSdl: string; sealedSecrets?: string }): Promise<ReceiveSdlSecretsResult> {
+  async receive(input: { sdl: SDLInput; rawSdl: string; sealedSecrets?: string; inherited?: SdlSecrets }): Promise<ReceiveSdlSecretsResult> {
     const declarations = this.sdlReferenceService.declarationsOf(input.sdl, SECRET_REFERENCE_KIND);
+    const inherited = input.inherited ?? NOTHING_SUPPLIED;
+    const supplied = input.sealedSecrets ? await this.#openSupplied(input.sealedSecrets, input.rawSdl) : NOTHING_SUPPLIED;
 
-    if (!input.sealedSecrets) {
-      return declarations.length === 0 ? { ok: true, value: NOTHING_SUPPLIED } : { ok: false, value: declarations.map(missingSdlReferenceValueError) };
-    }
-
-    const supplied = await this.unsealerService.open({ seal: input.sealedSecrets, sdl: input.rawSdl });
-    this.#assertWithinLimits(supplied);
-
-    const errors = this.#mismatchesBetween(declarations, supplied);
+    const errors = this.#mismatchesBetween(declarations, { supplied, inherited });
 
     if (errors.length > 0) return { ok: false, value: errors };
 
-    this.#loggerService.info({
-      event: "SDL_SECRETS_RECEIVED",
-      suppliedCount: Object.keys(supplied).length,
-      referencedNames: [...new Set(declarations.map(declaration => declaration.name))],
-      serviceCount: new Set(declarations.map(declaration => declaration.serviceName)).size
-    });
+    if (declarations.length > 0 || Object.keys(supplied).length > 0) {
+      this.#loggerService.info({
+        event: "SDL_SECRETS_RECEIVED",
+        suppliedCount: Object.keys(supplied).length,
+        inheritedCount: Object.keys(inherited).length,
+        referencedNames: [...new Set(declarations.map(declaration => declaration.name))],
+        serviceCount: new Set(declarations.map(declaration => declaration.serviceName)).size
+      });
+    }
 
     return { ok: true, value: supplied };
   }
 
+  /** Opening is what costs a key-service call, so it stays behind the check for a seal rather than inside the one pass that reads both sets. */
+  async #openSupplied(seal: string, rawSdl: string): Promise<SdlSecrets> {
+    const supplied = await this.unsealerService.open({ seal, sdl: rawSdl });
+    this.#assertWithinLimits(supplied, "supplied");
+
+    return supplied;
+  }
+
   /** Bounds the whole set a deployment would carry, because measuring one request alone would let a merge grow the stored token past the ceiling one request at a time. */
   assertStorable(secrets: SdlSecrets): void {
-    this.#assertWithinLimits(secrets);
+    this.#assertWithinLimits(secrets, "carried");
   }
 
   /** Returns null when nothing was supplied, so a create always has a value to write and a retry cannot inherit an abandoned attempt's token. */
@@ -114,7 +137,7 @@ export class SdlSecretsService {
   /** Opens a client's seal without holding it to what the SDL declares, because a patch supplies only what changed and the rest resolves from what is stored. */
   async receiveForMerge(input: { rawSdl: string; sealedSecrets: string }): Promise<SdlSecrets> {
     const supplied = await this.unsealerService.open({ seal: input.sealedSecrets, sdl: input.rawSdl });
-    this.#assertWithinLimits(supplied);
+    this.#assertWithinLimits(supplied, "supplied");
 
     this.#loggerService.info({ event: "SDL_SECRETS_RECEIVED_FOR_MERGE", suppliedCount: Object.keys(supplied).length });
 
@@ -156,12 +179,12 @@ export class SdlSecretsService {
   }
 
   /** Both directions are reported from one pass, so a request that gets each side wrong hears about both at once. */
-  #mismatchesBetween(declarations: SdlReferenceDeclaration[], supplied: SdlSecrets): ValidationError[] {
+  #mismatchesBetween(declarations: SdlReferenceDeclaration[], sets: ReceivedSdlSecretSets): ValidationError[] {
     const errors: ValidationError[] = [];
     const referenced = new Set<string>();
 
     for (const declaration of declarations) {
-      if (typeof ownValue(supplied, declaration.name) === "string") {
+      if (isCovered(sets, declaration.name)) {
         referenced.add(declaration.name);
         continue;
       }
@@ -169,7 +192,7 @@ export class SdlSecretsService {
       errors.push(missingSdlReferenceValueError(declaration));
     }
 
-    for (const name of Object.keys(supplied)) {
+    for (const name of Object.keys(sets.supplied)) {
       if (!referenced.has(name)) errors.push(unreferencedNameError(name));
     }
 
@@ -177,12 +200,12 @@ export class SdlSecretsService {
   }
 
   /** Every bound is measured as `jsonEncodedBytes`, matching the seal budget, because a raw-length check would let a payload pass here and die on the body limit. */
-  #assertWithinLimits(supplied: SdlSecrets): void {
+  #assertWithinLimits(supplied: SdlSecrets, origin: SdlSecretsOrigin): void {
     const maxCount = this.config.get("SDL_SECRETS_MAX_COUNT");
     const names = Object.keys(supplied);
 
     if (names.length > maxCount) {
-      throw this.#reject("SDL_SECRETS_COUNT_EXCEEDED", `At most ${maxCount} secrets may be supplied for one deployment`, { suppliedCount: names.length });
+      throw this.#reject("SDL_SECRETS_COUNT_EXCEEDED", countExceededMessage(origin, maxCount), { suppliedCount: names.length, origin });
     }
 
     const maxValueBytes = this.config.get("SDL_SECRETS_MAX_VALUE_BYTES");

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4938,36 +4938,55 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "Custom domains. Replaces the existing list."
+                                    "description": "Custom domains. Replaces the existing list. Emptying it is rejected by providers that do not generate a hostname of their own, which leaves the patch recorded but undeployed."
                                   },
                                   "httpOptions": {
                                     "type": "object",
                                     "properties": {
                                       "maxBodySize": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 1,
+                                        "maximum": 104857600
                                       },
                                       "readTimeout": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 1,
+                                        "maximum": 4294967295
                                       },
                                       "sendTimeout": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 1,
+                                        "maximum": 4294967295
                                       },
                                       "nextTries": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "maximum": 4294967295
                                       },
                                       "nextTimeout": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "maximum": 4294967295
                                       },
                                       "nextCases": {
                                         "type": "array",
                                         "items": {
-                                          "type": "string"
-                                        }
+                                          "type": "string",
+                                          "enum": [
+                                            "error",
+                                            "timeout",
+                                            "500",
+                                            "502",
+                                            "503",
+                                            "504",
+                                            "403",
+                                            "404",
+                                            "429",
+                                            "off"
+                                          ]
+                                        },
+                                        "minItems": 1,
+                                        "description": "Conditions the proxy retries on. Replaces the existing list; \"off\" disables retrying and stands alone."
                                       }
                                     }
                                   }
@@ -4994,8 +5013,14 @@
                         },
                         "description": "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
                       },
+                      "sealedSecrets": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Compact JWE sealing a flat name-to-value map, as on create, but holding only the names this patch replaces. Omitted names keep the values the deployment already stores."
+                      },
                       "ifManifestVersion": {
                         "type": "string",
+                        "minLength": 1,
                         "maxLength": 64,
                         "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."
                       }
@@ -5571,6 +5596,16 @@
                         "type": "string",
                         "maxLength": 524288
                       },
+                      "sealedSecrets": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Compact JWE sealing a flat name-to-value map of the secrets this SDL references, encrypted to the console's public sealing key. Fetch that key and the claims to sign from GET /v1/sdl-secrets-context. Values are never returned by any endpoint once sealed."
+                      },
+                      "inheritSecretsFrom": {
+                        "type": "string",
+                        "pattern": "^0*[1-9]\\d*$",
+                        "description": "Dseq of one of your own deployments whose stored secrets this deployment starts from, for redeploying an SDL without re-entering its values. The source may be closed. A name also present in `sealedSecrets` takes precedence over the inherited one."
+                      },
                       "deposit": {
                         "type": "number",
                         "description": "Deprecated and ignored. The platform funds every deployment automatically from your account credits.",
@@ -5642,6 +5677,126 @@
                   },
                   "required": [
                     "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, or would carry more secrets than one deployment may hold",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No deployment of yours matches `inheritSecretsFrom`. Deliberately says nothing about whether that deployment exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 409 above",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
                   ]
                 }
               }

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -5683,7 +5683,37 @@
             }
           },
           "400": {
-            "description": "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, or would carry more secrets than one deployment may hold",
+            "description": "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, would carry more secrets than one deployment may hold, or carries a `sealedSecrets` value that is malformed, tampered with, expired or not a flat object of string values",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The `sealedSecrets` value was sealed for a different user, or bound to a different SDL than the one submitted",
             "content": {
               "application/json": {
                 "schema": {
@@ -5743,7 +5773,7 @@
             }
           },
           "409": {
-            "description": "The secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
+            "description": "Either the `sealedSecrets` value was sealed to a key the console no longer holds — refetch `GET /v1/sdl-secrets-context` and seal again — or, with `code` `inherited_secrets_unreadable`, the secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted. The second is permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -6965,6 +6965,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "description": "Deprecated and ignored. The platform funds every deployment automatically from your account credits.",
                         "type": "number",
                       },
+                      "inheritSecretsFrom": {
+                        "description": "Dseq of one of your own deployments whose stored secrets this deployment starts from, for redeploying an SDL without re-entering its values. The source may be closed. A name also present in \`sealedSecrets\` takes precedence over the inherited one.",
+                        "pattern": "^0*[1-9]\\d*$",
+                        "type": "string",
+                      },
                       "runtimeLimitHours": {
                         "description": "Optional runtime limit in hours (1 to 48), counted from lease start. Automatic funding keeps the deployment running until the limit, then the deployment is closed automatically and unused funds are returned. Extend a limit with PATCH /v2/deployment-settings/{dseq}. Omit for always-on funding.",
                         "maximum": 48,
@@ -6973,6 +6978,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       },
                       "sdl": {
                         "maxLength": 524288,
+                        "type": "string",
+                      },
+                      "sealedSecrets": {
+                        "description": "Compact JWE sealing a flat name-to-value map of the secrets this SDL references, encrypted to the console's public sealing key. Fetch that key and the claims to sign from GET /v1/sdl-secrets-context. Values are never returned by any endpoint once sealed.",
+                        "minLength": 1,
                         "type": "string",
                       },
                     },
@@ -7041,6 +7051,156 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
               },
             },
             "description": "Create deployment successfully",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The SDL leaves a secret reference with no value from either \`sealedSecrets\` or the deployment named by \`inheritSecretsFrom\`, supplies a name no service references, would carry more secrets than one deployment may hold, or carries a \`sealedSecrets\` value that is malformed, tampered with, expired or not a flat object of string values",
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The \`sealedSecrets\` value was sealed for a different user, or bound to a different SDL than the one submitted",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "No deployment of yours matches \`inheritSecretsFrom\`. Deliberately says nothing about whether that deployment exists",
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Either the \`sealedSecrets\` value was sealed to a key the console no longer holds — refetch \`GET /v1/sdl-secrets-context\` and seal again — or, with \`code\` \`inherited_secrets_unreadable\`, the secrets recorded for the deployment named by \`inheritSecretsFrom\` can no longer be decrypted. The second is permanent rather than transient, so a retry cannot help; supply the values in \`sealedSecrets\` instead",
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 409 above",
           },
         },
         "security": [
@@ -7562,6 +7722,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "ifManifestVersion": {
                         "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it.",
                         "maxLength": 64,
+                        "minLength": 1,
+                        "type": "string",
+                      },
+                      "sealedSecrets": {
+                        "description": "Compact JWE sealing a flat name-to-value map, as on create, but holding only the names this patch replaces. Omitted names keep the values the deployment already stores.",
                         "minLength": 1,
                         "type": "string",
                       },

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -60,6 +60,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     const response = await patch(apiKey, { services: { web: { image: "nginx" } } });
 
     expect(response.status).toBe(404);
+    expect(await response.text()).toContain("nothing to patch");
   });
 
   it("refuses a body naming no services before it reaches the controller", async () => {

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -21,6 +21,8 @@ import { DeploymentSettingRepository } from "@src/deployment/repositories/deploy
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
 import { app } from "@src/rest-app";
+import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyService } from "@src/secret/services/data-key/data-key.service";
 import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
 
@@ -80,6 +82,8 @@ describe("Deployment sealed secrets", () => {
   const blockHttpService = container.resolve(BlockHttpService);
   const signerService = container.resolve(ManagedSignerService);
   const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+  const dataKeyRepository = container.resolve(DataKeyRepository);
+  const dataKeyService = container.resolve(DataKeyService);
 
   let knownUsers: Record<string, UserOutput>;
   let knownApiKeys: Record<string, ReturnType<typeof createApiKey>>;
@@ -661,6 +665,222 @@ describe("Deployment sealed secrets", () => {
     await expect(openStoredToken(user, dseq.toString(), replaced!.sealedSecrets!)).resolves.toEqual(retriedSecrets);
   });
 
+  describe("carrying secrets forward on redeploy", () => {
+    it("stores a token that opens to the source deployment's values, spending one data key unwrap", async () => {
+      const { apiKey, user } = await persistedUser();
+      const secrets = { API_TOKEN: randomUUID(), DATABASE_URL: `postgres://app:${randomUUID()}@db.internal/app` };
+      const source = await persistedSource(apiKey, user, secrets);
+
+      const response = await postDeployment(apiKey, source.sdl, undefined, undefined, { inheritSecretsFrom: source.setting.dseq });
+
+      expect(response.status).toBe(201);
+      expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(1);
+      const setting = await settingOf(user, response);
+      await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual(secrets);
+    });
+
+    it("carries forward only the names the new sdl references", async () => {
+      const { apiKey, user } = await persistedUser();
+      const spare = randomUUID();
+      const secrets = { API_TOKEN: randomUUID(), SPARE: spare };
+      const source = await persistedSource(apiKey, user, secrets);
+
+      const response = await postDeployment(apiKey, sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN"] }), undefined, undefined, {
+        inheritSecretsFrom: source.setting.dseq
+      });
+
+      expect(response.status).toBe(201);
+      const setting = await settingOf(user, response);
+      await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({ API_TOKEN: secrets.API_TOKEN });
+      expect(setting!.sealedSecrets).not.toContain(spare);
+    });
+
+    it("binds the token it writes to the new deployment, leaving the source's own token unopenable under it", async () => {
+      const { apiKey, user } = await persistedUser();
+      const secrets = { API_TOKEN: randomUUID() };
+      const source = await persistedSource(apiKey, user, secrets);
+
+      const response = await postDeployment(apiKey, source.sdl, undefined, undefined, { inheritSecretsFrom: source.setting.dseq });
+
+      const setting = await settingOf(user, response);
+      expect(setting!.dseq).not.toBe(source.setting.dseq);
+      expect(setting!.sealedSecrets).not.toBe(source.sealedSecrets);
+      expect(decodeProtectedHeader(setting!.sealedSecrets!)).toMatchObject({ sub: user.id, dseq: setting!.dseq });
+      await expect(openStoredToken(user, setting!.dseq, source.sealedSecrets)).rejects.toMatchObject({ status: 500 });
+    });
+
+    it("prefers a supplied value to the inherited one of the same name, and commits the manifest carrying it", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await persistedSource(apiKey, user, { API_TOKEN: randomUUID(), DATABASE_URL: `postgres://app:${randomUUID()}@old/app` });
+      const replaced = `postgres://app:${randomUUID()}@new/app`;
+      const inheritedToken = await openStoredToken(user, source.setting.dseq, source.sealedSecrets);
+
+      const response = await postDeployment(apiKey, source.sdl, { DATABASE_URL: replaced }, undefined, {
+        inheritSecretsFrom: source.setting.dseq
+      });
+
+      expect(response.status).toBe(201);
+      const setting = await settingOf(user, response);
+      await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({
+        API_TOKEN: inheritedToken.API_TOKEN,
+        DATABASE_URL: replaced
+      });
+      expect(broadcastHash(1)).toEqual(await manifestVersionOfDocument(resolvedDocumentOf(setting!.sdl!, { ...inheritedToken, DATABASE_URL: replaced })));
+    });
+
+    it("spends one key-service call on the supplied seal and one on the data key, however much it inherits", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await persistedSource(apiKey, user, { API_TOKEN: randomUUID(), DATABASE_URL: `postgres://app:${randomUUID()}@old/app` });
+
+      const response = await postDeployment(apiKey, source.sdl, { DATABASE_URL: `postgres://app:${randomUUID()}@new/app` }, undefined, {
+        inheritSecretsFrom: source.setting.dseq
+      });
+
+      expect(response.status).toBe(201);
+      expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(2);
+    });
+
+    it("inherits from a closed deployment, closing one deliberately keeping its secrets", async () => {
+      const { apiKey, user } = await persistedUser();
+      const secrets = { API_TOKEN: randomUUID() };
+      const source = await persistedSource(apiKey, user, secrets);
+      await deploymentSettingRepository.updateById(source.setting.id, { closed: true });
+
+      const response = await postDeployment(apiKey, source.sdl, undefined, undefined, { inheritSecretsFrom: source.setting.dseq });
+
+      expect(response.status).toBe(201);
+      const setting = await settingOf(user, response);
+      await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual(secrets);
+      const closed = await deploymentSettingRepository.findById(source.setting.id);
+      expect(closed!.sealedSecrets).toBe(source.sealedSecrets);
+    });
+
+    it("answers not found for another user's deployment, recording nothing and broadcasting nothing", async () => {
+      const owner = await persistedUser();
+      const other = await persistedUser();
+      const source = await persistedSource(owner.apiKey, owner.user, { API_TOKEN: randomUUID() });
+
+      const response = await postDeployment(other.apiKey, source.sdl, undefined, undefined, { inheritSecretsFrom: source.setting.dseq });
+
+      expect(response.status).toBe(404);
+      expect(await deploymentSettingRepository.count({ userId: other.user.id })).toBe(0);
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    });
+
+    it("says nothing about the source of another user in the refusal it returns", async () => {
+      const owner = await persistedUser();
+      const other = await persistedUser();
+      const secret = randomUUID();
+      const source = await persistedSource(owner.apiKey, owner.user, { API_TOKEN: secret });
+
+      const response = await postDeployment(other.apiKey, source.sdl, undefined, undefined, { inheritSecretsFrom: source.setting.dseq });
+      const body = await response.text();
+
+      expect(body).not.toContain(secret);
+      expect(body).not.toContain(source.setting.dseq);
+    });
+
+    it("refuses a reference neither the inherited nor the supplied set answers, before recording or broadcasting anything", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await persistedSource(apiKey, user, { API_TOKEN: randomUUID() });
+
+      const response = await postDeployment(
+        apiKey,
+        sdlWith({ web: ["API_TOKEN=ac-secret://API_TOKEN", "MISSING=ac-secret://MISSING"] }),
+        undefined,
+        undefined,
+        { inheritSecretsFrom: source.setting.dseq }
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("MISSING");
+      expect(await deploymentSettingRepository.count({ userId: user.id })).toBe(1);
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    });
+
+    it("refuses a redeploy that would chain more values into one token than a deployment may hold", async () => {
+      const { apiKey, user } = await persistedUser();
+      const inheritedNames = Array.from({ length: MAX_COUNT }, (_, index) => `INHERITED_${index}`);
+      const source = await persistedSource(apiKey, user, Object.fromEntries(inheritedNames.map(name => [name, randomUUID()])));
+      const addedNames = Array.from({ length: MAX_COUNT }, (_, index) => `ADDED_${index}`);
+      const added = Object.fromEntries(addedNames.map(name => [name, randomUUID()]));
+
+      const response = await postDeployment(
+        apiKey,
+        sdlWith({ web: [...inheritedNames, ...addedNames].map(name => `${name}=ac-secret://${name}`) }),
+        added,
+        undefined,
+        { inheritSecretsFrom: source.setting.dseq }
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain(`At most ${MAX_COUNT} secrets may be carried by one deployment, counting those inherited from another`);
+      expect(await deploymentSettingRepository.count({ userId: user.id })).toBe(1);
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    });
+
+    it("inherits one name from a source holding far more than a deployment may carry", async () => {
+      const { apiKey, user } = await persistedUser();
+      const values = Object.fromEntries(Array.from({ length: MAX_COUNT + 50 }, (_, index) => [`SETTING_${index}`, randomUUID()]));
+      const sourceResponse = await postDeployment(apiKey, sdlWith({ web: Object.entries(values).map(([name, value]) => `${name}=${value}`) }));
+      expect(sourceResponse.status).toBe(201);
+      const sourceSetting = await settingOf(user, sourceResponse);
+      const stored = await openStoredToken(user, sourceSetting!.dseq, sourceSetting!.sealedSecrets!);
+      expect(Object.keys(stored)).toHaveLength(MAX_COUNT + 50);
+
+      const response = await postDeployment(apiKey, sdlWith({ web: ["SETTING_0=ac-secret://s0_e0"] }), undefined, undefined, {
+        inheritSecretsFrom: sourceSetting!.dseq
+      });
+
+      expect(response.status).toBe(201);
+      const setting = await settingOf(user, response);
+      await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual({ s0_e0: stored.s0_e0 });
+    });
+
+    it("answers conflict when the source's token is beyond the data key the user now holds", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await persistedSource(apiKey, user, { API_TOKEN: randomUUID() });
+      const held = await dataKeyRepository.findByUserId(user.id);
+      vi.spyOn(dataKeyService, "ensureDataKey").mockResolvedValue({ ...held!, id: randomUUID() });
+
+      const response = await postDeployment(apiKey, source.sdl, undefined, undefined, { inheritSecretsFrom: source.setting.dseq });
+
+      expect(response.status).toBe(409);
+      expect(await deploymentSettingRepository.count({ userId: user.id })).toBe(1);
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    });
+
+    it("tells a client the conflict is about the secrets it inherits rather than its own stored state", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await persistedSource(apiKey, user, { API_TOKEN: randomUUID() });
+      const held = await dataKeyRepository.findByUserId(user.id);
+      vi.spyOn(dataKeyService, "ensureDataKey").mockResolvedValue({ ...held!, id: randomUUID() });
+
+      const response = await postDeployment(apiKey, source.sdl, undefined, undefined, { inheritSecretsFrom: source.setting.dseq });
+
+      expect(await response.json()).toMatchObject({ code: "inherited_secrets_unreadable" });
+    });
+
+    it("leaves the source's own token untouched by a redeploy it refused", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await persistedSource(apiKey, user, { API_TOKEN: randomUUID() });
+
+      await postDeployment(apiKey, sdlWith({ web: ["MISSING=ac-secret://MISSING"] }), undefined, undefined, {
+        inheritSecretsFrom: source.setting.dseq
+      });
+
+      const unchanged = await deploymentSettingRepository.findById(source.setting.id);
+      expect(unchanged!.sealedSecrets).toBe(source.sealedSecrets);
+    });
+
+    it("accepts the field even though no document announces it", async () => {
+      const response = await app.request("/v1/doc?scope=console");
+      const document = await response.text();
+
+      expect(document).not.toContain("inheritSecretsFrom");
+    });
+  });
+
   async function openStoredToken(user: UserOutput, dseq: string, sealedSecrets: string) {
     const executionContextService = container.resolve(ExecutionContextService);
     const authService = container.resolve(AuthService);
@@ -672,8 +892,8 @@ describe("Deployment sealed secrets", () => {
     });
   }
 
-  function broadcastHash(): Uint8Array {
-    const [, messages] = vi.mocked(signerService.executeDerivedDecodedTxByUserId).mock.calls[0];
+  function broadcastHash(call = 0): Uint8Array {
+    const [, messages] = vi.mocked(signerService.executeDerivedDecodedTxByUserId).mock.calls[call];
 
     return (messages[0] as unknown as { value: { hash: Uint8Array } }).value.hash;
   }
@@ -715,14 +935,27 @@ describe("Deployment sealed secrets", () => {
       .encrypt(publicKey);
   }
 
-  async function postDeployment(apiKey: string, sdl: string, secrets?: Record<string, string>, seal?: string) {
+  async function postDeployment(apiKey: string, sdl: string, secrets?: Record<string, string>, seal?: string, options?: { inheritSecretsFrom?: string }) {
     const sealedSecrets = seal ?? (secrets ? await sealFor(knownUsers[knownApiKeys[apiKey].userId], secrets) : undefined);
 
     return await app.request("/v1/deployments", {
       method: "POST",
-      body: JSON.stringify({ data: { sdl, sealedSecrets } }),
+      body: JSON.stringify({ data: { sdl, sealedSecrets, inheritSecretsFrom: options?.inheritSecretsFrom } }),
       headers: new Headers({ "Content-Type": "application/json", "x-api-key": apiKey })
     });
+  }
+
+  /** A deployment whose token is what a later create inherits: sealed through the route, so the token under test is one the console really wrote. */
+  async function persistedSource(apiKey: string, user: UserOutput, secrets: Record<string, string>) {
+    const sdl = sdlWith({ web: Object.keys(secrets).map(name => `${name}=ac-secret://${name}`) });
+    const response = await postDeployment(apiKey, sdl, secrets);
+
+    expect(response.status).toBe(201);
+    const setting = await settingOf(user, response);
+    expect(setting!.sealedSecrets).toEqual(expect.any(String));
+    kmsClient.asymmetricDecrypt.mockClear();
+
+    return { sdl, setting: setting!, sealedSecrets: setting!.sealedSecrets! };
   }
 
   async function persistedUser() {

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -34,7 +34,7 @@ import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 interface OpenApiPaths {
   paths: Record<
     string,
-    Record<string, { requestBody: { content: Record<string, { schema: { properties: { data: { properties: Record<string, unknown> } } } }> } }>
+    Record<string, { requestBody: { content: Record<string, { schema: { properties: { data: { properties: Record<string, { description?: string }> } } } }> } }>
   >;
 }
 
@@ -537,15 +537,24 @@ describe("Deployment sealed secrets", () => {
     expect(broadcastHash()).toEqual(await manifestVersionOf(sdlWith({ web: [`API_TOKEN=${token}`] })));
   });
 
-  it("publishes no mention of the field in the document callers read", async () => {
+  it("publishes both halves of the capability in the document callers read", async () => {
     const response = await app.request("/v1/doc?scope=console");
     const document = await response.text();
 
     expect(response.status).toBe(200);
-    expect(document).not.toContain("sealedSecrets");
     const createBody = (JSON.parse(document) as OpenApiPaths).paths["/v1/deployments"].post.requestBody.content["application/json"].schema.properties.data
       .properties;
-    expect(Object.keys(createBody)).toEqual(["sdl", "deposit", "runtimeLimitHours"]);
+    expect(Object.keys(createBody)).toEqual(["sdl", "sealedSecrets", "inheritSecretsFrom", "deposit", "runtimeLimitHours"]);
+  });
+
+  it("describes the seal on both routes that accept one, so neither reads as create-only", async () => {
+    const response = await app.request("/v1/doc?scope=console");
+    const paths = (JSON.parse(await response.text()) as OpenApiPaths).paths;
+
+    const createSeal = paths["/v1/deployments"].post.requestBody.content["application/json"].schema.properties.data.properties.sealedSecrets;
+    const patchSeal = paths["/v1/deployments/{dseq}"].patch.requestBody.content["application/json"].schema.properties.data.properties.sealedSecrets;
+    expect(createSeal).toMatchObject({ description: expect.stringContaining("Compact JWE") });
+    expect(patchSeal).toMatchObject({ description: expect.stringContaining("Compact JWE") });
   });
 
   it("refuses a submitted sdl above the allowance a request has always had for one", async () => {
@@ -873,11 +882,12 @@ describe("Deployment sealed secrets", () => {
       expect(unchanged!.sealedSecrets).toBe(source.sealedSecrets);
     });
 
-    it("accepts the field even though no document announces it", async () => {
+    it("describes what the field does for a client reading the document", async () => {
       const response = await app.request("/v1/doc?scope=console");
-      const document = await response.text();
+      const createBody = (JSON.parse(await response.text()) as OpenApiPaths).paths["/v1/deployments"].post.requestBody.content["application/json"].schema
+        .properties.data.properties;
 
-      expect(document).not.toContain("inheritSecretsFrom");
+      expect(createBody.inheritSecretsFrom).toMatchObject({ description: expect.stringContaining("may be closed") });
     });
   });
 

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -831,6 +831,7 @@ describe("Deployments API", () => {
       const response = await postOversizedDeployment(userApiKeySecret);
 
       expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ error: "Error", code: "bad_request", type: "client_error" });
     });
 
     it("says nothing about the sdl in the 400 it returns", async () => {


### PR DESCRIPTION
## Why

A create overlays what the client sealed onto what the console derived from the submitted document. A patch overlays a third set — the token the deployment already held — and prunes the result to the names its document still references. Two spellings of the same rule sat side by side, so a change to one could silently diverge from the other.

Carrying secrets forward on redeploy needs a create to overlay a third set too, which is what makes the duplication worth removing now rather than later.

Part of CON-866. First of a four-PR stack; nothing here changes behaviour.

## What

- Extracts `prunedOverlayOf` as the single statement of that precedence — carried, then supplied, then derived — and routes both writers through it.
- Adds `#referencedNamesOf`, which both use to read a document's secret references.
- `#storedSdlOf` now hands back the document it stored, named `storedDocument` because it is the post-derivation one and the prune depends on that: derivation replaces plaintext with references, so the stored document references strictly more names than the submitted one.
- `#storedSecretsOf` takes its two sets as one object, so a third can join them without another positional parameter.

### Why this is behaviour-neutral

- **For a create the prune is a no-op.** `receive` already guarantees every supplied name is referenced by the submitted document, and derivation only ever adds references. So nothing a create stores can fall outside the stored document's referenced set.
- **For a patch nothing moves at all.** The overlay order is the same, so the resulting key order — and therefore the sealed token's bytes — is identical. `#assertEverySuppliedNameIsReferenced` still runs before the prune, and `assertStorable` still runs after it on the same set.
- The only reordering is that the overlay object is now built after the supplied-names assertion rather than before. Both are pure, so a refusal simply skips work it used to do and throw away.

### The one changed test

`seals what the client supplied together with the credentials it took out itself` supplied `TOKEN` against an SDL that never references it — a request the real intake refuses with an unreferenced-name error, so the fixture described a state that cannot reach this code. The prune correctly dropped the value, which is what surfaced it. The test now uses a document that does reference what it supplies, which makes the assertion mean what it always claimed to.

No other test expectation changed: the suite reports the same 3116 tests as `main`.
