### PR TITLE
refactor(deployment): announce the sealed secrets a request may carry

### DIFF
--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -144,28 +144,6 @@ export const CreateDeploymentResponseSchema = z.object({
   })
 });
 
-/** Both fields are overrides, so a body of `{}` redeploys the source exactly as the console stored it. */
-export const RedeployDeploymentRequestSchema = z.object({
-  data: z
-    .object({
-      sealedSecrets: SealedSecretsSchema.optional().openapi({
-        description:
-          "Compact JWE sealing a flat name-to-value map, as on create. A name present here replaces the value the source deployment holds for it; every other name is carried forward untouched."
-      }),
-      runtimeLimitHours: z
-        .number()
-        .int()
-        .min(1)
-        .max(MAX_RUNTIME_LIMIT_INCREMENT_HOURS)
-        .optional()
-        .openapi({
-          description: `Optional runtime limit in hours (1 to ${MAX_RUNTIME_LIMIT_INCREMENT_HOURS}) for the new deployment. Omit to carry the source deployment's own limit forward.`
-        })
-    })
-    .optional()
-    .default({})
-});
-
 export const CloseDeploymentParamsSchema = z.object({
   dseq: DseqSchema.describe("Deployment sequence number")
 });
@@ -470,7 +448,6 @@ export type DepositDeploymentResponse = z.infer<typeof DepositDeploymentResponse
 export type UpdateDeploymentRequest = z.infer<typeof UpdateDeploymentRequestSchema>;
 export type PatchService = z.infer<typeof PatchServiceSchema>;
 export type PatchDeploymentRequest = z.infer<typeof PatchDeploymentRequestSchema>;
-export type RedeployDeploymentRequest = z.infer<typeof RedeployDeploymentRequestSchema>;
 export type PatchDeploymentResponse = z.infer<typeof PatchDeploymentResponseSchema>;
 export type UpdateDeploymentResponse = z.infer<typeof UpdateDeploymentResponseSchema>;
 export type ListWithResourcesParams = z.infer<typeof ListWithResourcesParamsSchema>;

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -144,6 +144,28 @@ export const CreateDeploymentResponseSchema = z.object({
   })
 });
 
+/** Both fields are overrides, so a body of `{}` redeploys the source exactly as the console stored it. */
+export const RedeployDeploymentRequestSchema = z.object({
+  data: z
+    .object({
+      sealedSecrets: SealedSecretsSchema.optional().openapi({
+        description:
+          "Compact JWE sealing a flat name-to-value map, as on create. A name present here replaces the value the source deployment holds for it; every other name is carried forward untouched."
+      }),
+      runtimeLimitHours: z
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_RUNTIME_LIMIT_INCREMENT_HOURS)
+        .optional()
+        .openapi({
+          description: `Optional runtime limit in hours (1 to ${MAX_RUNTIME_LIMIT_INCREMENT_HOURS}) for the new deployment. Omit to carry the source deployment's own limit forward.`
+        })
+    })
+    .optional()
+    .default({})
+});
+
 export const CloseDeploymentParamsSchema = z.object({
   dseq: DseqSchema.describe("Deployment sequence number")
 });
@@ -448,6 +470,7 @@ export type DepositDeploymentResponse = z.infer<typeof DepositDeploymentResponse
 export type UpdateDeploymentRequest = z.infer<typeof UpdateDeploymentRequestSchema>;
 export type PatchService = z.infer<typeof PatchServiceSchema>;
 export type PatchDeploymentRequest = z.infer<typeof PatchDeploymentRequestSchema>;
+export type RedeployDeploymentRequest = z.infer<typeof RedeployDeploymentRequestSchema>;
 export type PatchDeploymentResponse = z.infer<typeof PatchDeploymentResponseSchema>;
 export type UpdateDeploymentResponse = z.infer<typeof UpdateDeploymentResponseSchema>;
 export type ListWithResourcesParams = z.infer<typeof ListWithResourcesParamsSchema>;

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -112,10 +112,14 @@ const SealedSecretsSchema = z.string().min(1);
 export const CreateDeploymentRequestSchema = z.object({
   data: z.object({
     sdl: z.string().max(MAX_SUBMITTED_SDL_LENGTH),
-    /** Accepted and validated but withheld from every generated document by the route's `undocumentedRequestFields`, so the capability works before it is announced. */
-    sealedSecrets: SealedSecretsSchema.optional(),
-    /** Withheld alongside `sealedSecrets`, whose values it carries forward, so both halves of the capability are announced together. */
-    inheritSecretsFrom: DseqSchema.optional(),
+    sealedSecrets: SealedSecretsSchema.optional().openapi({
+      description:
+        "Compact JWE sealing a flat name-to-value map of the secrets this SDL references, encrypted to the console's public sealing key. Fetch that key and the claims to sign from GET /v1/sdl-secrets-context. Values are never returned by any endpoint once sealed."
+    }),
+    inheritSecretsFrom: DseqSchema.optional().openapi({
+      description:
+        "Dseq of one of your own deployments whose stored secrets this deployment starts from, for redeploying an SDL without re-entering its values. The source may be closed. A name also present in `sealedSecrets` takes precedence over the inherited one."
+    }),
     deposit: z.number().optional().openapi({
       deprecated: true,
       description: "Deprecated and ignored. The platform funds every deployment automatically from your account credits."
@@ -274,7 +278,10 @@ export const PatchDeploymentRequestSchema = z.object({
         .openapi({
           description: "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
         }),
-      sealedSecrets: SealedSecretsSchema.optional(),
+      sealedSecrets: SealedSecretsSchema.optional().openapi({
+        description:
+          "Compact JWE sealing a flat name-to-value map, as on create, but holding only the names this patch replaces. Omitted names keep the values the deployment already stores."
+      }),
       ifManifestVersion: z.string().min(1).max(MAX_MANIFEST_VERSION_LENGTH).optional().openapi({
         description:
           "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -39,6 +39,14 @@ import { FallbackDeploymentReaderService } from "@src/deployment/services/fallba
 
 export const deploymentsRouter = new OpenApiHonoHandler();
 
+/** What `HonoErrorHandlerService` actually returns for a refused request, rather than the `message` alone the first draft of this route declared. */
+const ErrorResponseSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+  code: z.string(),
+  type: z.string()
+});
+
 const getRoute = createRoute({
   method: "get",
   path: "/v1/deployments/{dseq}",
@@ -75,8 +83,6 @@ const postRoute = createRoute({
   security: SECURITY_BEARER_OR_API_KEY,
   /** The only route that can carry a seal, sized so the stated secret limits are reachable rather than shadowed by the default allowance. */
   bodyLimit: { maxSize: CREATE_DEPLOYMENT_BODY_LIMIT_BYTES },
-  /** Accepted and validated in full; unpublished because sealed secrets are not announced yet, and reverting this line is what announces them. */
-  undocumentedRequestFields: ["sealedSecrets", "inheritSecretsFrom"],
   request: {
     body: {
       content: {
@@ -92,6 +98,40 @@ const postRoute = createRoute({
       content: {
         "application/json": {
           schema: CreateDeploymentResponseSchema
+        }
+      }
+    },
+    400: {
+      description:
+        "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, or would carry more secrets than one deployment may hold",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    404: {
+      description: "No deployment of yours matches `inheritSecretsFrom`. Deliberately says nothing about whether that deployment exists",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    409: {
+      description:
+        "The secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    503: {
+      description: "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 409 above",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
         }
       }
     }
@@ -203,14 +243,6 @@ deploymentsRouter.openapi(updateRoute, async function routeUpdateDeployment(c) {
   return c.json(result, 200);
 });
 
-/** What `HonoErrorHandlerService` actually returns for a refused request, rather than the `message` alone the first draft of this route declared. */
-const ErrorResponseSchema = z.object({
-  error: z.string(),
-  message: z.string(),
-  code: z.string(),
-  type: z.string()
-});
-
 const patchRoute = createRoute({
   method: "patch",
   path: "/v1/deployments/{dseq}",
@@ -222,8 +254,6 @@ const patchRoute = createRoute({
   security: SECURITY_BEARER_OR_API_KEY,
   /** Sized like the create route, because a patch may carry a seal and the default allowance would shadow the stated secret limits. */
   bodyLimit: { maxSize: CREATE_DEPLOYMENT_BODY_LIMIT_BYTES },
-  /** Accepted and validated in full; unpublished because sealed secrets are not announced yet, matching the create route. */
-  undocumentedRequestFields: ["sealedSecrets"],
   request: {
     params: PatchDeploymentParamsSchema,
     body: {

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -103,7 +103,15 @@ const postRoute = createRoute({
     },
     400: {
       description:
-        "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, or would carry more secrets than one deployment may hold",
+        "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, would carry more secrets than one deployment may hold, or carries a `sealedSecrets` value that is malformed, tampered with, expired or not a flat object of string values",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    403: {
+      description: "The `sealedSecrets` value was sealed for a different user, or bound to a different SDL than the one submitted",
       content: {
         "application/json": {
           schema: ErrorResponseSchema
@@ -120,7 +128,7 @@ const postRoute = createRoute({
     },
     409: {
       description:
-        "The secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
+        "Either the `sealedSecrets` value was sealed to a key the console no longer holds — refetch `GET /v1/sdl-secrets-context` and seal again — or, with `code` `inherited_secrets_unreadable`, the secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted. The second is permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
       content: {
         "application/json": {
           schema: ErrorResponseSchema

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -18,6 +18,7 @@ import type { CreateLogger, JobQueueService, TxService } from "@src/core";
 import { JOB_NAME } from "@src/core";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
+import { MAX_RUNTIME_LIMIT_HOURS, MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { GenerateResolvedManifestResult, SdlManifest, SdlService } from "@src/deployment/services/sdl/sdl.service";
@@ -160,6 +161,9 @@ const SDL_OF_A_REDEPLOY_WITH_PLAINTEXT = sdlAround(`    env:
       - API_TOKEN=ac-secret://API_TOKEN
       - LOG_LEVEL=${ENV_VALUE}
 `);
+
+/** Short cleartext values lengthen when re-derived into references, so enough of them fit in storage yet cannot be redeployed. */
+const SDL_TOO_LARGE_ONCE_REDERIVED = sdlAround(`    env:\n${Array.from({ length: 6000 }, (_, index) => `      - E${index}=x\n`).join("")}`);
 
 describe(DeploymentWriterService.name, () => {
   const wallet: WalletInitialized = {
@@ -1067,6 +1071,166 @@ describe(DeploymentWriterService.name, () => {
           expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
           expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
         });
+      });
+    });
+  });
+
+  describe("redeployByUserIdAndDseq", () => {
+    it("deploys the sdl the console stored for the source, never one from the request", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedSdl: SDL_OF_A_REDEPLOY, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
+      expect(recorded.sdl).toContain("API_TOKEN=ac-secret://API_TOKEN");
+    });
+
+    it("mints a dseq of its own rather than writing over the source", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
+      expect(recorded.dseq).toBe("1748400000000");
+      expect(recorded.dseq).not.toBe(SOURCE_DSEQ);
+    });
+
+    it("inherits the source's secrets by naming it, so no value passes through the request", async () => {
+      const { service, sdlSecretsInheritanceService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(sdlSecretsInheritanceService.open).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
+    });
+
+    it("carries the source's runtime limit forward", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(5);
+    });
+
+    it("prefers an explicitly supplied runtime limit to the carried one", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { runtimeLimitHours: 9 }, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(9);
+    });
+
+    it("carries no runtime limit when the source has none", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: null, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBeUndefined();
+    });
+
+    it("hands a supplied seal to the intake, so its names replace what the source holds", async () => {
+      const { service, sdlSecretsService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { sealedSecrets: CLIENT_SEAL }, ability);
+
+      expect(sdlSecretsService.receive).toHaveBeenCalledWith(expect.objectContaining({ sealedSecrets: CLIENT_SEAL }));
+    });
+
+    it("reads the source through the caller's own ability", async () => {
+      const { service, deploymentSettingRepository, scopedSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(ability, "read");
+      expect(scopedSettingRepository.findOneBy).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
+    });
+
+    it("reduces a carried runtime limit longer than one request may grant to that increment", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({
+        storedRuntimeLimitHours: MAX_RUNTIME_LIMIT_HOURS,
+        inherited: { API_TOKEN: "a", DATABASE_URL: "b" }
+      });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
+    });
+
+    describe("a stored sdl the console cannot redeploy", () => {
+      it("blames itself rather than the caller for one that will not parse", async () => {
+        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
+          status: 500,
+          errorCode: "stored_sdl_unreadable"
+        });
+      });
+
+      it("tells the caller nothing about a document they could not have written", async () => {
+        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
+
+        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
+
+        expect(thrown.message).toBe("The SDL recorded for this deployment cannot be read");
+        expect(thrown.data).toBeUndefined();
+        expect(thrownTextOf(thrown)).not.toContain("LEAKED");
+        expect(thrownTextOf(thrown)).not.toContain(MALFORMED_SDL_VALUE);
+        expect(thrownTextOf(thrown)).not.toMatch(/line \d+, column \d+/);
+      });
+
+      it("blames itself rather than the caller for one too large once its values are re-derived", async () => {
+        const { service, ability } = setup({ storedSdl: SDL_TOO_LARGE_ONCE_REDERIVED, inherited: { API_TOKEN: "a" } });
+
+        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
+
+        expect(thrown).toMatchObject({ status: 500, errorCode: "redeployed_sdl_too_large" });
+        expect(thrown.data).toBeUndefined();
+        expect(thrownTextOf(thrown)).not.toContain("ac-secret://");
+      });
+
+      it("records nothing and broadcasts nothing for either", async () => {
+        const { service, deploymentSettingRepository, signerService, ability } = setup({
+          storedSdl: "this: is: not: yaml:",
+          inherited: { API_TOKEN: "a" }
+        });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
+
+        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("a source the console recorded no sdl for", () => {
+      it("answers not found", async () => {
+        const { service, ability } = setup({ sourceSetting: undefined });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
+      });
+
+      it("says there is nothing to redeploy rather than nothing to patch", async () => {
+        const { service, ability } = setup({ sourceSetting: undefined });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
+          message: "This deployment has no SDL recorded by the console, so there is nothing to redeploy"
+        });
+      });
+
+      it("mints no dseq, records nothing and broadcasts nothing", async () => {
+        const { service, deploymentSettingRepository, signerService, ability } = setup({ sourceSetting: undefined });
+        const now = vi.spyOn(Date, "now");
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
+
+        expect(now).not.toHaveBeenCalled();
+        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      });
+
+      it("answers not found for a row that exists but holds no sdl", async () => {
+        const { service, ability } = setup({ sourceSetting: mock<DeploymentSettingsOutput>({ sdl: null }) });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
       });
     });
   });
@@ -2057,6 +2221,9 @@ describe(DeploymentWriterService.name, () => {
     inheritanceError?: Error;
     maxCount?: number;
     sealedSecrets?: string | null;
+    storedSdl?: string;
+    storedRuntimeLimitHours?: number | null;
+    sourceSetting?: DeploymentSettingsOutput;
   }) {
     const signerService = mock<ManagedSignerService>();
     const rpcMessageService = mock<RpcMessageService>();
@@ -2080,6 +2247,17 @@ describe(DeploymentWriterService.name, () => {
     });
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.upsertDefinition.mockResolvedValue(DEPLOYMENT_SETTING_ID);
+    const scopedSettingRepository = mock<DeploymentSettingRepository>();
+    scopedSettingRepository.findOneBy.mockResolvedValue(
+      "sourceSetting" in (input ?? {})
+        ? input!.sourceSetting
+        : mock<DeploymentSettingsOutput>({
+            sdl: input?.storedSdl ?? SDL_OF_A_REDEPLOY,
+            runtimeLimitHours: input?.storedRuntimeLimitHours ?? null,
+            sealedSecrets: "stored.token.aaa.bbb.ccc"
+          })
+    );
+    deploymentSettingRepository.accessibleBy.mockReturnValue(scopedSettingRepository);
     const txService = mock<TxService>();
     txService.transaction.mockImplementation(async cb => (input?.transactionRuns === false ? (undefined as never) : await cb()));
     const jobQueueService = mock<JobQueueService>();
@@ -2156,6 +2334,8 @@ describe(DeploymentWriterService.name, () => {
       jobQueueService,
       sdlSecretsService,
       sdlSecretsInheritanceService,
+      scopedSettingRepository,
+      ability: mock<AnyAbility>(),
       storedSecrets
     };
   }

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -18,7 +18,6 @@ import type { CreateLogger, JobQueueService, TxService } from "@src/core";
 import { JOB_NAME } from "@src/core";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
-import { MAX_RUNTIME_LIMIT_HOURS, MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { GenerateResolvedManifestResult, SdlManifest, SdlService } from "@src/deployment/services/sdl/sdl.service";
@@ -161,9 +160,6 @@ const SDL_OF_A_REDEPLOY_WITH_PLAINTEXT = sdlAround(`    env:
       - API_TOKEN=ac-secret://API_TOKEN
       - LOG_LEVEL=${ENV_VALUE}
 `);
-
-/** Short cleartext values lengthen when re-derived into references, so enough of them fit in storage yet cannot be redeployed. */
-const SDL_TOO_LARGE_ONCE_REDERIVED = sdlAround(`    env:\n${Array.from({ length: 6000 }, (_, index) => `      - E${index}=x\n`).join("")}`);
 
 describe(DeploymentWriterService.name, () => {
   const wallet: WalletInitialized = {
@@ -1071,166 +1067,6 @@ describe(DeploymentWriterService.name, () => {
           expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
           expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
         });
-      });
-    });
-  });
-
-  describe("redeployByUserIdAndDseq", () => {
-    it("deploys the sdl the console stored for the source, never one from the request", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedSdl: SDL_OF_A_REDEPLOY, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
-      expect(recorded.sdl).toContain("API_TOKEN=ac-secret://API_TOKEN");
-    });
-
-    it("mints a dseq of its own rather than writing over the source", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
-      expect(recorded.dseq).toBe("1748400000000");
-      expect(recorded.dseq).not.toBe(SOURCE_DSEQ);
-    });
-
-    it("inherits the source's secrets by naming it, so no value passes through the request", async () => {
-      const { service, sdlSecretsInheritanceService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(sdlSecretsInheritanceService.open).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
-    });
-
-    it("carries the source's runtime limit forward", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(5);
-    });
-
-    it("prefers an explicitly supplied runtime limit to the carried one", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { runtimeLimitHours: 9 }, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(9);
-    });
-
-    it("carries no runtime limit when the source has none", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: null, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBeUndefined();
-    });
-
-    it("hands a supplied seal to the intake, so its names replace what the source holds", async () => {
-      const { service, sdlSecretsService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { sealedSecrets: CLIENT_SEAL }, ability);
-
-      expect(sdlSecretsService.receive).toHaveBeenCalledWith(expect.objectContaining({ sealedSecrets: CLIENT_SEAL }));
-    });
-
-    it("reads the source through the caller's own ability", async () => {
-      const { service, deploymentSettingRepository, scopedSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(ability, "read");
-      expect(scopedSettingRepository.findOneBy).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
-    });
-
-    it("reduces a carried runtime limit longer than one request may grant to that increment", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({
-        storedRuntimeLimitHours: MAX_RUNTIME_LIMIT_HOURS,
-        inherited: { API_TOKEN: "a", DATABASE_URL: "b" }
-      });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
-    });
-
-    describe("a stored sdl the console cannot redeploy", () => {
-      it("blames itself rather than the caller for one that will not parse", async () => {
-        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
-          status: 500,
-          errorCode: "stored_sdl_unreadable"
-        });
-      });
-
-      it("tells the caller nothing about a document they could not have written", async () => {
-        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
-
-        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
-
-        expect(thrown.message).toBe("The SDL recorded for this deployment cannot be read");
-        expect(thrown.data).toBeUndefined();
-        expect(thrownTextOf(thrown)).not.toContain("LEAKED");
-        expect(thrownTextOf(thrown)).not.toContain(MALFORMED_SDL_VALUE);
-        expect(thrownTextOf(thrown)).not.toMatch(/line \d+, column \d+/);
-      });
-
-      it("blames itself rather than the caller for one too large once its values are re-derived", async () => {
-        const { service, ability } = setup({ storedSdl: SDL_TOO_LARGE_ONCE_REDERIVED, inherited: { API_TOKEN: "a" } });
-
-        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
-
-        expect(thrown).toMatchObject({ status: 500, errorCode: "redeployed_sdl_too_large" });
-        expect(thrown.data).toBeUndefined();
-        expect(thrownTextOf(thrown)).not.toContain("ac-secret://");
-      });
-
-      it("records nothing and broadcasts nothing for either", async () => {
-        const { service, deploymentSettingRepository, signerService, ability } = setup({
-          storedSdl: "this: is: not: yaml:",
-          inherited: { API_TOKEN: "a" }
-        });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
-
-        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
-        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("a source the console recorded no sdl for", () => {
-      it("answers not found", async () => {
-        const { service, ability } = setup({ sourceSetting: undefined });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
-      });
-
-      it("says there is nothing to redeploy rather than nothing to patch", async () => {
-        const { service, ability } = setup({ sourceSetting: undefined });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
-          message: "This deployment has no SDL recorded by the console, so there is nothing to redeploy"
-        });
-      });
-
-      it("mints no dseq, records nothing and broadcasts nothing", async () => {
-        const { service, deploymentSettingRepository, signerService, ability } = setup({ sourceSetting: undefined });
-        const now = vi.spyOn(Date, "now");
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
-
-        expect(now).not.toHaveBeenCalled();
-        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
-        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
-      });
-
-      it("answers not found for a row that exists but holds no sdl", async () => {
-        const { service, ability } = setup({ sourceSetting: mock<DeploymentSettingsOutput>({ sdl: null }) });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
       });
     });
   });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -19,8 +19,10 @@ import {
   DeploymentResponse,
   PatchDeploymentRequest,
   PatchDeploymentResponse,
+  RedeployDeploymentRequest,
   UpdateDeploymentRequest
 } from "@src/deployment/http-schemas/deployment.schema";
+import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import {
   DeleteUnbackedDeploymentSetting,
@@ -47,8 +49,14 @@ const SECRET_REFERENCE_KIND = "secret";
 /** Distinct from the sealed-secret failure so a client can tell which half of the stored state it cannot read, both being permanent. */
 const STORED_SDL_UNREADABLE_ERROR_CODE = "stored_sdl_unreadable";
 
+/** Redeploying re-derives cleartext values into references, which lengthens the document, so a source can be stored yet be too large to redeploy. */
+const REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE = "redeployed_sdl_too_large";
+
 /** A deployment the console never recorded an SDL for has nothing to patch, and the SDL is deliberately not accepted from the request. */
 const NOT_PATCHABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to patch";
+
+/** Its own wording rather than the one above, because the patch endpoint's 404 message is a shipped behaviour its callers already read. */
+const NOT_REDEPLOYABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to redeploy";
 
 /** What becomes of the values a submitted document carries in the clear. There is no longer a way to say "dropped": every writer can seal, so a value is never lost to be safe. */
 type StoredSdlValues =
@@ -56,6 +64,30 @@ type StoredSdlValues =
   | "every-value-sealed"
   /** Only a registry credential is, a seal having already said which of the rest are secret. */
   | "only-credentials-sealed";
+
+/**
+ * A 400 by default, so every caller that submitted the document keeps answering exactly as it did, while a
+ * caller that submitted none can catch this and answer for the console instead. `name` must stay unset:
+ * the error handler echoes it into the response body, so assigning it would change a shipped 400.
+ */
+class UnstorableSdlError extends HTTPException {
+  readonly refusal: StoredSdlRefusal;
+
+  constructor(refusal: StoredSdlRefusal, message: string) {
+    super(400, { message });
+    this.refusal = refusal;
+  }
+}
+
+/**
+ * A redeploy creates a deployment that has none, so the most one request may grant it is the same first
+ * increment every other entry point allows; a longer limit stays reachable by extending after the redeploy.
+ */
+function carriedRuntimeLimitOf(storedRuntimeLimitHours: number | null | undefined) {
+  if (typeof storedRuntimeLimitHours !== "number") return undefined;
+
+  return Math.min(storedRuntimeLimitHours, MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
+}
 
 /** Lowest precedence first: what the deployment carried in, then what the request supplied, then what the document gave up. */
 function prunedOverlayOf(sets: { carried: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, referenced: ReadonlySet<string>): SdlSecrets {
@@ -281,12 +313,32 @@ export class DeploymentWriterService {
     if (refusal === "unparseable") {
       this.logger.warn({ event: "DEPLOYMENT_SDL_UNPARSEABLE", ...loggable, line: at?.line, column: at?.column });
 
-      return new HTTPException(400, { message: at ? `SDL is not valid YAML: line ${at.line}, column ${at.column}` : "SDL is not valid YAML" });
+      return new UnstorableSdlError(refusal, at ? `SDL is not valid YAML: line ${at.line}, column ${at.column}` : "SDL is not valid YAML");
     }
 
     this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE", ...loggable, maxLength: SDL_MAX_LENGTH });
 
-    return new HTTPException(400, { message: `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored` });
+    return new UnstorableSdlError(refusal, `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored`);
+  }
+
+  /**
+   * Built from the refusal kind alone and never from the error carrying it, so no line, column or fragment of
+   * the console's own document reaches a caller who could not have written it.
+   */
+  #rejectUnredeployableStoredSdl(refusal: StoredSdlRefusal, key: { userId: string; dseq: string }) {
+    if (refusal === "unparseable") {
+      this.logger.error({ event: "DEPLOYMENT_STORED_SDL_UNPARSEABLE", ...key });
+
+      return createError(500, "The SDL recorded for this deployment cannot be read", { errorCode: STORED_SDL_UNREADABLE_ERROR_CODE });
+    }
+
+    this.logger.error({ event: "DEPLOYMENT_REDEPLOYED_SDL_TOO_LARGE", ...key, maxLength: SDL_MAX_LENGTH });
+
+    return createError(
+      500,
+      `The SDL recorded for this deployment cannot be redeployed: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once its values are re-derived`,
+      { errorCode: REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE }
+    );
   }
 
   /**
@@ -392,7 +444,10 @@ export class DeploymentWriterService {
     input: PatchDeploymentRequest["data"],
     ability: AnyAbility
   ): Promise<PatchDeploymentResponse["data"]> {
-    const [wallet, stored] = await Promise.all([this.walletReaderService.getWalletByUserId(userId), this.#findStoredDefinition({ userId, dseq }, ability)]);
+    const [wallet, stored] = await Promise.all([
+      this.walletReaderService.getWalletByUserId(userId),
+      this.#findStoredDefinition({ userId, dseq }, ability, NOT_PATCHABLE_MESSAGE)
+    ]);
     const parsed = this.#parseStored(stored.sdl, { userId, dseq });
     const document = parsed.document;
 
@@ -445,18 +500,61 @@ export class DeploymentWriterService {
     return { ...(await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq)), manifestVersion: recordedVersion };
   }
 
+  /**
+   * Deploys again what the console stored for a deployment — its SDL, its secrets and its runtime limit —
+   * as a new deployment of its own. The SDL is never accepted from the request, and the secrets are carried
+   * by the same inheritance a create performs, so nothing about them passes through the client.
+   *
+   * The definition is read here and its token read again inside `create`. A patch landing between the two
+   * can only pair the older SDL with a newer token, which either resolves — a value the patch changed being
+   * what a caller would want anyway — or is refused when the token no longer covers what the SDL references.
+   * The worst a race produces is a spurious refusal, never a deployment of something other than the source.
+   */
+  public async redeployByUserIdAndDseq(
+    userId: string,
+    dseq: string,
+    input: RedeployDeploymentRequest["data"],
+    ability: AnyAbility
+  ): Promise<CreateDeploymentResponse["data"]> {
+    const stored = await this.#findStoredDefinition({ userId, dseq }, ability, NOT_REDEPLOYABLE_MESSAGE);
+
+    this.logger.info({ event: "DEPLOYMENT_REDEPLOY_STARTED", userId, dseq, overridesRuntimeLimit: input.runtimeLimitHours !== undefined });
+
+    try {
+      return await this.create({
+        userId,
+        sdl: stored.sdl,
+        inheritSecretsFrom: dseq,
+        sealedSecrets: input.sealedSecrets,
+        runtimeLimitHours: input.runtimeLimitHours ?? carriedRuntimeLimitOf(stored.runtimeLimitHours)
+      });
+    } catch (error) {
+      if (error instanceof UnstorableSdlError) {
+        throw this.#rejectUnredeployableStoredSdl(error.refusal, { userId, dseq });
+      }
+
+      throw error;
+    }
+  }
+
   /** Read through the caller's own ability as well as their id, so a definition is unreachable by anyone the ability excludes even before the write re-checks it. */
   async #findStoredDefinition(
     key: { userId: string; dseq: string },
-    ability: AnyAbility
-  ): Promise<{ sdl: string; sealedSecrets: string | null; manifestVersion?: string }> {
+    ability: AnyAbility,
+    notFoundMessage: string
+  ): Promise<{ sdl: string; sealedSecrets: string | null; manifestVersion?: string; runtimeLimitHours?: number }> {
     const setting = await this.deploymentSettingRepository.accessibleBy(ability, "read").findOneBy(key);
 
     if (!setting?.sdl) {
-      throw createError(404, NOT_PATCHABLE_MESSAGE);
+      throw createError(404, notFoundMessage);
     }
 
-    return { sdl: setting.sdl, sealedSecrets: setting.sealedSecrets, manifestVersion: setting.manifestVersion ?? undefined };
+    return {
+      sdl: setting.sdl,
+      sealedSecrets: setting.sealedSecrets,
+      manifestVersion: setting.manifestVersion ?? undefined,
+      runtimeLimitHours: setting.runtimeLimitHours ?? undefined
+    };
   }
 
   /** The caller did not supply this document, so an unparseable one is the console's fault and never a 400. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -19,10 +19,8 @@ import {
   DeploymentResponse,
   PatchDeploymentRequest,
   PatchDeploymentResponse,
-  RedeployDeploymentRequest,
   UpdateDeploymentRequest
 } from "@src/deployment/http-schemas/deployment.schema";
-import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import {
   DeleteUnbackedDeploymentSetting,
@@ -49,14 +47,8 @@ const SECRET_REFERENCE_KIND = "secret";
 /** Distinct from the sealed-secret failure so a client can tell which half of the stored state it cannot read, both being permanent. */
 const STORED_SDL_UNREADABLE_ERROR_CODE = "stored_sdl_unreadable";
 
-/** Redeploying re-derives cleartext values into references, which lengthens the document, so a source can be stored yet be too large to redeploy. */
-const REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE = "redeployed_sdl_too_large";
-
 /** A deployment the console never recorded an SDL for has nothing to patch, and the SDL is deliberately not accepted from the request. */
 const NOT_PATCHABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to patch";
-
-/** Its own wording rather than the one above, because the patch endpoint's 404 message is a shipped behaviour its callers already read. */
-const NOT_REDEPLOYABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to redeploy";
 
 /** What becomes of the values a submitted document carries in the clear. There is no longer a way to say "dropped": every writer can seal, so a value is never lost to be safe. */
 type StoredSdlValues =
@@ -77,16 +69,6 @@ class UnstorableSdlError extends HTTPException {
     super(400, { message });
     this.refusal = refusal;
   }
-}
-
-/**
- * A redeploy creates a deployment that has none, so the most one request may grant it is the same first
- * increment every other entry point allows; a longer limit stays reachable by extending after the redeploy.
- */
-function carriedRuntimeLimitOf(storedRuntimeLimitHours: number | null | undefined) {
-  if (typeof storedRuntimeLimitHours !== "number") return undefined;
-
-  return Math.min(storedRuntimeLimitHours, MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
 }
 
 /** Lowest precedence first: what the deployment carried in, then what the request supplied, then what the document gave up. */
@@ -322,26 +304,6 @@ export class DeploymentWriterService {
   }
 
   /**
-   * Built from the refusal kind alone and never from the error carrying it, so no line, column or fragment of
-   * the console's own document reaches a caller who could not have written it.
-   */
-  #rejectUnredeployableStoredSdl(refusal: StoredSdlRefusal, key: { userId: string; dseq: string }) {
-    if (refusal === "unparseable") {
-      this.logger.error({ event: "DEPLOYMENT_STORED_SDL_UNPARSEABLE", ...key });
-
-      return createError(500, "The SDL recorded for this deployment cannot be read", { errorCode: STORED_SDL_UNREADABLE_ERROR_CODE });
-    }
-
-    this.logger.error({ event: "DEPLOYMENT_REDEPLOYED_SDL_TOO_LARGE", ...key, maxLength: SDL_MAX_LENGTH });
-
-    return createError(
-      500,
-      `The SDL recorded for this deployment cannot be redeployed: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once its values are re-derived`,
-      { errorCode: REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE }
-    );
-  }
-
-  /**
    * Reclaims escrow from a trial wallet's orphaned (open, lease-less) deployments before a new create, so a stranded
    * trial user whose earlier close failed can deploy again without waiting for the periodic cleanup job. It runs
    * before the create tx so the freed deployment allowance is available when the create's balance check runs.
@@ -498,43 +460,6 @@ export class DeploymentWriterService {
     });
 
     return { ...(await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq)), manifestVersion: recordedVersion };
-  }
-
-  /**
-   * Deploys again what the console stored for a deployment — its SDL, its secrets and its runtime limit —
-   * as a new deployment of its own. The SDL is never accepted from the request, and the secrets are carried
-   * by the same inheritance a create performs, so nothing about them passes through the client.
-   *
-   * The definition is read here and its token read again inside `create`. A patch landing between the two
-   * can only pair the older SDL with a newer token, which either resolves — a value the patch changed being
-   * what a caller would want anyway — or is refused when the token no longer covers what the SDL references.
-   * The worst a race produces is a spurious refusal, never a deployment of something other than the source.
-   */
-  public async redeployByUserIdAndDseq(
-    userId: string,
-    dseq: string,
-    input: RedeployDeploymentRequest["data"],
-    ability: AnyAbility
-  ): Promise<CreateDeploymentResponse["data"]> {
-    const stored = await this.#findStoredDefinition({ userId, dseq }, ability, NOT_REDEPLOYABLE_MESSAGE);
-
-    this.logger.info({ event: "DEPLOYMENT_REDEPLOY_STARTED", userId, dseq, overridesRuntimeLimit: input.runtimeLimitHours !== undefined });
-
-    try {
-      return await this.create({
-        userId,
-        sdl: stored.sdl,
-        inheritSecretsFrom: dseq,
-        sealedSecrets: input.sealedSecrets,
-        runtimeLimitHours: input.runtimeLimitHours ?? carriedRuntimeLimitOf(stored.runtimeLimitHours)
-      });
-    } catch (error) {
-      if (error instanceof UnstorableSdlError) {
-        throw this.#rejectUnredeployableStoredSdl(error.refusal, { userId, dseq });
-      }
-
-      throw error;
-    }
   }
 
   /** Read through the caller's own ability as well as their id, so a definition is unreachable by anyone the ability excludes even before the write re-checks it. */

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4938,36 +4938,55 @@
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "Custom domains. Replaces the existing list."
+                                    "description": "Custom domains. Replaces the existing list. Emptying it is rejected by providers that do not generate a hostname of their own, which leaves the patch recorded but undeployed."
                                   },
                                   "httpOptions": {
                                     "type": "object",
                                     "properties": {
                                       "maxBodySize": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 1,
+                                        "maximum": 104857600
                                       },
                                       "readTimeout": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 1,
+                                        "maximum": 4294967295
                                       },
                                       "sendTimeout": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 1,
+                                        "maximum": 4294967295
                                       },
                                       "nextTries": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "maximum": 4294967295
                                       },
                                       "nextTimeout": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "maximum": 4294967295
                                       },
                                       "nextCases": {
                                         "type": "array",
                                         "items": {
-                                          "type": "string"
-                                        }
+                                          "type": "string",
+                                          "enum": [
+                                            "error",
+                                            "timeout",
+                                            "500",
+                                            "502",
+                                            "503",
+                                            "504",
+                                            "403",
+                                            "404",
+                                            "429",
+                                            "off"
+                                          ]
+                                        },
+                                        "minItems": 1,
+                                        "description": "Conditions the proxy retries on. Replaces the existing list; \"off\" disables retrying and stands alone."
                                       }
                                     }
                                   }
@@ -4994,8 +5013,14 @@
                         },
                         "description": "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
                       },
+                      "sealedSecrets": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Compact JWE sealing a flat name-to-value map, as on create, but holding only the names this patch replaces. Omitted names keep the values the deployment already stores."
+                      },
                       "ifManifestVersion": {
                         "type": "string",
+                        "minLength": 1,
                         "maxLength": 64,
                         "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."
                       }
@@ -5571,6 +5596,16 @@
                         "type": "string",
                         "maxLength": 524288
                       },
+                      "sealedSecrets": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Compact JWE sealing a flat name-to-value map of the secrets this SDL references, encrypted to the console's public sealing key. Fetch that key and the claims to sign from GET /v1/sdl-secrets-context. Values are never returned by any endpoint once sealed."
+                      },
+                      "inheritSecretsFrom": {
+                        "type": "string",
+                        "pattern": "^0*[1-9]\\d*$",
+                        "description": "Dseq of one of your own deployments whose stored secrets this deployment starts from, for redeploying an SDL without re-entering its values. The source may be closed. A name also present in `sealedSecrets` takes precedence over the inherited one."
+                      },
                       "deposit": {
                         "type": "number",
                         "description": "Deprecated and ignored. The platform funds every deployment automatically from your account credits.",
@@ -5642,6 +5677,126 @@
                   },
                   "required": [
                     "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, or would carry more secrets than one deployment may hold",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No deployment of yours matches `inheritSecretsFrom`. Deliberately says nothing about whether that deployment exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 409 above",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
                   ]
                 }
               }

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -5683,7 +5683,37 @@
             }
           },
           "400": {
-            "description": "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, or would carry more secrets than one deployment may hold",
+            "description": "The SDL leaves a secret reference with no value from either `sealedSecrets` or the deployment named by `inheritSecretsFrom`, supplies a name no service references, would carry more secrets than one deployment may hold, or carries a `sealedSecrets` value that is malformed, tampered with, expired or not a flat object of string values",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The `sealedSecrets` value was sealed for a different user, or bound to a different SDL than the one submitted",
             "content": {
               "application/json": {
                 "schema": {
@@ -5743,7 +5773,7 @@
             }
           },
           "409": {
-            "description": "The secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
+            "description": "Either the `sealedSecrets` value was sealed to a key the console no longer holds — refetch `GET /v1/sdl-secrets-context` and seal again — or, with `code` `inherited_secrets_unreadable`, the secrets recorded for the deployment named by `inheritSecretsFrom` can no longer be decrypted. The second is permanent rather than transient, so a retry cannot help; supply the values in `sealedSecrets` instead",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -6965,6 +6965,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "description": "Deprecated and ignored. The platform funds every deployment automatically from your account credits.",
                         "type": "number",
                       },
+                      "inheritSecretsFrom": {
+                        "description": "Dseq of one of your own deployments whose stored secrets this deployment starts from, for redeploying an SDL without re-entering its values. The source may be closed. A name also present in \`sealedSecrets\` takes precedence over the inherited one.",
+                        "pattern": "^0*[1-9]\\d*$",
+                        "type": "string",
+                      },
                       "runtimeLimitHours": {
                         "description": "Optional runtime limit in hours (1 to 48), counted from lease start. Automatic funding keeps the deployment running until the limit, then the deployment is closed automatically and unused funds are returned. Extend a limit with PATCH /v2/deployment-settings/{dseq}. Omit for always-on funding.",
                         "maximum": 48,
@@ -6973,6 +6978,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       },
                       "sdl": {
                         "maxLength": 524288,
+                        "type": "string",
+                      },
+                      "sealedSecrets": {
+                        "description": "Compact JWE sealing a flat name-to-value map of the secrets this SDL references, encrypted to the console's public sealing key. Fetch that key and the claims to sign from GET /v1/sdl-secrets-context. Values are never returned by any endpoint once sealed.",
+                        "minLength": 1,
                         "type": "string",
                       },
                     },
@@ -7041,6 +7051,156 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
               },
             },
             "description": "Create deployment successfully",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The SDL leaves a secret reference with no value from either \`sealedSecrets\` or the deployment named by \`inheritSecretsFrom\`, supplies a name no service references, would carry more secrets than one deployment may hold, or carries a \`sealedSecrets\` value that is malformed, tampered with, expired or not a flat object of string values",
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The \`sealedSecrets\` value was sealed for a different user, or bound to a different SDL than the one submitted",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "No deployment of yours matches \`inheritSecretsFrom\`. Deliberately says nothing about whether that deployment exists",
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Either the \`sealedSecrets\` value was sealed to a key the console no longer holds — refetch \`GET /v1/sdl-secrets-context\` and seal again — or, with \`code\` \`inherited_secrets_unreadable\`, the secrets recorded for the deployment named by \`inheritSecretsFrom\` can no longer be decrypted. The second is permanent rather than transient, so a retry cannot help; supply the values in \`sealedSecrets\` instead",
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 409 above",
           },
         },
         "security": [
@@ -7562,6 +7722,11 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "ifManifestVersion": {
                         "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it.",
                         "maxLength": 64,
+                        "minLength": 1,
+                        "type": "string",
+                      },
+                      "sealedSecrets": {
+                        "description": "Compact JWE sealing a flat name-to-value map, as on create, but holding only the names this patch replaces. Omitted names keep the values the deployment already stores.",
                         "minLength": 1,
                         "type": "string",
                       },

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -60,6 +60,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     const response = await patch(apiKey, { services: { web: { image: "nginx" } } });
 
     expect(response.status).toBe(404);
+    expect(await response.text()).toContain("nothing to patch");
   });
 
   it("refuses a body naming no services before it reaches the controller", async () => {

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -34,7 +34,7 @@ import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 interface OpenApiPaths {
   paths: Record<
     string,
-    Record<string, { requestBody: { content: Record<string, { schema: { properties: { data: { properties: Record<string, unknown> } } } }> } }>
+    Record<string, { requestBody: { content: Record<string, { schema: { properties: { data: { properties: Record<string, { description?: string }> } } } }> } }>
   >;
 }
 
@@ -537,15 +537,24 @@ describe("Deployment sealed secrets", () => {
     expect(broadcastHash()).toEqual(await manifestVersionOf(sdlWith({ web: [`API_TOKEN=${token}`] })));
   });
 
-  it("publishes no mention of the field in the document callers read", async () => {
+  it("publishes both halves of the capability in the document callers read", async () => {
     const response = await app.request("/v1/doc?scope=console");
     const document = await response.text();
 
     expect(response.status).toBe(200);
-    expect(document).not.toContain("sealedSecrets");
     const createBody = (JSON.parse(document) as OpenApiPaths).paths["/v1/deployments"].post.requestBody.content["application/json"].schema.properties.data
       .properties;
-    expect(Object.keys(createBody)).toEqual(["sdl", "deposit", "runtimeLimitHours"]);
+    expect(Object.keys(createBody)).toEqual(["sdl", "sealedSecrets", "inheritSecretsFrom", "deposit", "runtimeLimitHours"]);
+  });
+
+  it("describes the seal on both routes that accept one, so neither reads as create-only", async () => {
+    const response = await app.request("/v1/doc?scope=console");
+    const paths = (JSON.parse(await response.text()) as OpenApiPaths).paths;
+
+    const createSeal = paths["/v1/deployments"].post.requestBody.content["application/json"].schema.properties.data.properties.sealedSecrets;
+    const patchSeal = paths["/v1/deployments/{dseq}"].patch.requestBody.content["application/json"].schema.properties.data.properties.sealedSecrets;
+    expect(createSeal).toMatchObject({ description: expect.stringContaining("Compact JWE") });
+    expect(patchSeal).toMatchObject({ description: expect.stringContaining("Compact JWE") });
   });
 
   it("refuses a submitted sdl above the allowance a request has always had for one", async () => {
@@ -873,11 +882,12 @@ describe("Deployment sealed secrets", () => {
       expect(unchanged!.sealedSecrets).toBe(source.sealedSecrets);
     });
 
-    it("accepts the field even though no document announces it", async () => {
+    it("describes what the field does for a client reading the document", async () => {
       const response = await app.request("/v1/doc?scope=console");
-      const document = await response.text();
+      const createBody = (JSON.parse(await response.text()) as OpenApiPaths).paths["/v1/deployments"].post.requestBody.content["application/json"].schema
+        .properties.data.properties;
 
-      expect(document).not.toContain("inheritSecretsFrom");
+      expect(createBody.inheritSecretsFrom).toMatchObject({ description: expect.stringContaining("may be closed") });
     });
   });
 

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -831,6 +831,7 @@ describe("Deployments API", () => {
       const response = await postOversizedDeployment(userApiKeySecret);
 
       expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ error: "Error", code: "bad_request", type: "client_error" });
     });
 
     it("says nothing about the sdl in the 400 it returns", async () => {


### PR DESCRIPTION
## Why

`sealedSecrets` has been accepted and validated but withheld from every generated document since it landed, so the capability could work before it was announced. `inheritSecretsFrom` joined it on the same terms in #C. This publishes both.

Closes CON-866. Last of a four-PR stack, on top of #C.

## What

Drops `undocumentedRequestFields` from **both** the create and the patch route, so `sealedSecrets` and `inheritSecretsFrom` appear in the OpenAPI document and Swagger UI.

Both routes, not just create: it is one field, one shared `SealedSecretsSchema` and one capability, and publishing it on create while withholding it on patch would leave the document describing a secret write that only half exists. The comment the patch route carried — "matching the create route" — is itself the argument that the two move together.

- **`sealedSecrets`** is described on both routes: what it is, that the key and claims come from `GET /v1/sdl-secrets-context`, and that values are never returned by any endpoint once sealed. Naming that endpoint matters — how to build a seal is the one thing about this field a client cannot guess, and the endpoint is already published.
- **`inheritSecretsFrom`** is described with the two things a caller cannot infer — that the source may be closed, and that a name also present in `sealedSecrets` takes precedence.
- **The create route documents its refusals**: 400, 404, 409 (with its code) and 503, mirroring what the patch route already documents. The 409-versus-503 split is the one a client needs to decide whether retrying can help.
- `ErrorResponseSchema` moves above the create route, since it is now used by the first route in the file.

### No behaviour change

`undocumentedRequestFields` strips properties from the generated *document*, not from the zod schema — `OpenApiDocsService` deletes them after the fact precisely so `zValidator` keeps seeing the full schema. Removing it cannot change what the endpoint accepts or how it validates.

### On the generated artifacts

`apps/api/swagger/openapi.json` is regenerated and carries both fields; its path count is unchanged at 107.

The `console-api-types` half of `sdk:gen` is **deliberately not included**. Running it here reformats every file from two-space to four-space indentation *and* drops operations the committed copy still declares — `getWalletSettings`, `createWalletSettings` and others — against an `openapi.json` that still contains them. That is pre-existing drift in that generator, not something this change causes, and shipping it would silently remove real API surface from the SDK types. It wants its own chore PR.

## Tests

The two functional tests that asserted the fields were *absent* from `/v1/doc?scope=console` are inverted: the create body's published property list is asserted exactly, both routes are asserted to describe `sealedSecrets`, and `inheritSecretsFrom`'s description is asserted to mention that the source may be closed. Asserting the exact list rather than mere presence is what catches a field being published by accident later.
