### PR TITLE
refactor(deployment): update a deployment through the console api

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetail.tsx
@@ -211,7 +211,6 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq, dependencies
                     onManifestChange={setEditedManifest}
                     isRemoteDeploy={isRemoteDeploy}
                     deployment={deployment}
-                    leases={leases}
                     onRedeploy={storedDeployment?.manifest ? redeployFromStoredManifest : undefined}
                     closeManifestEditor={() => {
                       changeTab("DETAILS");

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -15,6 +15,11 @@ import { buildWallet } from "@tests/seeders/wallet";
 import { MockComponents } from "@tests/unit/mocks";
 import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
+const PROVIDER_UNAVAILABLE = new ApiError(503, { message: "Provider service is temporarily unavailable" }, "PUT /v1/deployments/{dseq} → 503");
+const BAD_SDL = new ApiError(400, { message: "SDL is not valid YAML: line 3, column 5" }, "PUT /v1/deployments/{dseq} → 400");
+const BAD_PROVIDER_CREDENTIALS = new ApiError(400, { message: "Invalid provider jwt credentials" }, "PUT /v1/deployments/{dseq} → 400");
+const OUT_OF_CREDITS = new ApiError(402, { message: "Insufficient balance: top up to keep deploying" }, "PUT /v1/deployments/{dseq} → 402");
+
 describe(ManifestUpdate.name, () => {
   it("shows outside deployment message when no local manifest exists", () => {
     setup({ storedManifest: null });
@@ -100,21 +105,21 @@ describe(ManifestUpdate.name, () => {
 
   it("submits the edited sdl to the console api instead of signing and sending it from the browser", async () => {
     const signAndBroadcastTx = vi.fn(() => Promise.resolve(true));
-    const { mutate, providerProxy, dependencies } = setup({
+    const handles = setup({
       editedManifest: "version: '2.0'",
       deployment: { dseq: "123", state: "active", hash: "different-hash" },
       wallet: { signAndBroadcastTx }
     });
 
-    await clickUpdate(dependencies);
+    await clickUpdate(handles);
 
-    expect(mutate).toHaveBeenCalledWith({ dseq: "123", data: { sdl: "version: '2.0'" } }, expect.anything());
+    expect(handles.mutate).toHaveBeenCalledWith({ dseq: "123", data: { sdl: "version: '2.0'" } }, expect.anything());
     expect(signAndBroadcastTx).not.toHaveBeenCalled();
-    expect(providerProxy.sendManifest).not.toHaveBeenCalled();
+    expect(handles.providerProxy.sendManifest).not.toHaveBeenCalled();
   });
 
   it("submits to the console api even when the local manifest version already matches the chain", async () => {
-    const { mutate, dependencies } = setup({
+    const handles = setup({
       editedManifest: "version: '2.0'",
       deployment: { dseq: "123", state: "active", hash: "matching-hash" },
       dependencies: {
@@ -124,93 +129,206 @@ describe(ManifestUpdate.name, () => {
       }
     });
 
-    await clickUpdate(dependencies);
+    await clickUpdate(handles);
 
-    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(handles.mutate).toHaveBeenCalledTimes(1);
   });
 
   it("caches the submitted sdl under the deployment without a manifest version", async () => {
-    const { mutate, deploymentLocalStorage, dependencies } = setup({ editedManifest: "version: '2.0'", wallet: { address: "akash1abc" } });
+    const handles = setup({ editedManifest: "version: '2.0'", wallet: { address: "akash1abc" } });
 
-    await clickUpdate(dependencies);
-    await succeed(mutate);
+    await clickUpdate(handles);
+    await succeed(handles);
 
-    expect(deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "123", { manifest: "version: '2.0'" });
+    expect(handles.deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "123", { manifest: "version: '2.0'" });
+  });
+
+  it("caches the submitted sdl even when the editor closes before the api answers", async () => {
+    const handles = setup({ editedManifest: "version: '2.0'", wallet: { address: "akash1abc" } });
+
+    await clickUpdate(handles);
+    handles.unmount();
+    await settleAfterClose(handles, { outcome: "success" });
+
+    expect(handles.deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "123", { manifest: "version: '2.0'" });
+  });
+
+  it("surfaces the failure even when the editor closes before the api answers", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    handles.unmount();
+    await settleAfterClose(handles, { outcome: "failure", cause: PROVIDER_UNAVAILABLE });
+
+    expect(handles.enqueueSnackbar).toHaveBeenCalled();
   });
 
   it("tracks the update and the successful transaction once the api accepts it", async () => {
-    const { mutate, analyticsService, dependencies } = setup();
+    const handles = setup();
 
-    await clickUpdate(dependencies);
-    await succeed(mutate);
+    await clickUpdate(handles);
+    await succeed(handles);
 
-    expect(analyticsService.track).toHaveBeenCalledWith("update_deployment", { category: "deployments", label: "Update deployment" });
-    expect(analyticsService.track).toHaveBeenCalledWith("successful_tx", { category: "transactions", label: "Successful transaction" });
+    expect(handles.analyticsService.track).toHaveBeenCalledWith("update_deployment", { category: "deployments", label: "Update deployment" });
+    expect(handles.analyticsService.track).toHaveBeenCalledWith("successful_tx", { category: "transactions", label: "Successful transaction" });
   });
 
   it("refreshes the balances once the api accepts the update", async () => {
-    const { mutate, refetchBalances, dependencies } = setup();
+    const handles = setup();
 
-    await clickUpdate(dependencies);
-    await succeed(mutate);
+    await clickUpdate(handles);
+    await succeed(handles);
 
-    expect(refetchBalances).toHaveBeenCalled();
+    expect(handles.refetchBalances).toHaveBeenCalled();
+  });
+
+  it("refreshes the balances when the api refuses the update for payment", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, OUT_OF_CREDITS);
+
+    expect(handles.refetchBalances).toHaveBeenCalled();
   });
 
   it("closes the editor once the api accepts the update", async () => {
     const closeManifestEditor = vi.fn();
-    const { mutate, dependencies } = setup({ closeManifestEditor });
+    const handles = setup({ closeManifestEditor });
 
-    await clickUpdate(dependencies);
-    await succeed(mutate);
+    await clickUpdate(handles);
+    await succeed(handles);
 
     expect(closeManifestEditor).toHaveBeenCalled();
   });
 
   it("shows the sdl the api refused inline and leaves the editor open", async () => {
     const closeManifestEditor = vi.fn();
-    const { mutate, deploymentLocalStorage, dependencies } = setup({ closeManifestEditor });
+    const handles = setup({ closeManifestEditor });
 
-    await clickUpdate(dependencies);
-    await fail(mutate, new ApiError(400, { message: "SDL is not valid YAML: line 3, column 5" }, "PUT /v1/deployments/{dseq} → 400"));
+    await clickUpdate(handles);
+    await fail(handles, BAD_SDL);
 
     expect(screen.getByText("SDL is not valid YAML: line 3, column 5")).toBeInTheDocument();
     expect(closeManifestEditor).not.toHaveBeenCalled();
-    expect(deploymentLocalStorage.update).not.toHaveBeenCalled();
+    expect(handles.deploymentLocalStorage.update).not.toHaveBeenCalled();
+  });
+
+  it("lets the user retry after editing the sdl the api refused", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, BAD_SDL);
+
+    expect(updateButtonOf(handles.dependencies)?.disabled).toBe(true);
+
+    await act(async () => {
+      handles.dependencies.SDLEditor.mock.calls[0][0].onChange?.("version: '2.0'\nfixed: true", editorChangeEvent());
+    });
+
+    expect(screen.queryByText("SDL is not valid YAML: line 3, column 5")).not.toBeInTheDocument();
+    expect(updateButtonOf(handles.dependencies)?.disabled).toBe(false);
+  });
+
+  it("lets the user retry after editing in the remote deploy editor", async () => {
+    const handles = setup({ isRemoteDeploy: true });
+
+    await clickUpdate(handles);
+    await fail(handles, BAD_SDL);
+
+    expect(screen.getByText("SDL is not valid YAML: line 3, column 5")).toBeInTheDocument();
+
+    await act(async () => {
+      handles.dependencies.RemoteDeployUpdate.mock.calls[0][0].onManifestChange("version: '2.0'\nfixed: true");
+    });
+
+    expect(screen.queryByText("SDL is not valid YAML: line 3, column 5")).not.toBeInTheDocument();
+    expect(updateButtonOf(handles.dependencies)?.disabled).toBe(false);
+  });
+
+  it("keeps a refused provider credential out of the editor's inline alert", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, BAD_PROVIDER_CREDENTIALS);
+
+    expect(screen.queryByText("Invalid provider jwt credentials")).not.toBeInTheDocument();
+    expect(handles.enqueueSnackbar).toHaveBeenCalled();
+    expect(updateButtonOf(handles.dependencies)?.disabled).toBe(false);
   });
 
   it("surfaces the provider failure the api reports in a snackbar that does not auto hide", async () => {
-    const { mutate, enqueueSnackbar, dependencies } = setup();
+    const handles = setup();
 
-    await clickUpdate(dependencies);
-    await fail(mutate, new ApiError(503, { message: "Provider service is temporarily unavailable" }, "PUT /v1/deployments/{dseq} → 503"));
+    await clickUpdate(handles);
+    await fail(handles, PROVIDER_UNAVAILABLE);
 
-    const [element, options] = enqueueSnackbar.mock.calls[0];
-    expect(element.type).toBe(dependencies.Snackbar);
+    const [element, options] = handles.enqueueSnackbar.mock.calls[0];
+    expect(element.type).toBe(handles.dependencies.Snackbar);
     expect(element.props.subTitle).toBe("Provider service is temporarily unavailable");
     expect(options).toEqual({ variant: "error", autoHideDuration: null });
   });
 
+  it("re-enables the update and redeploy actions after a failed update", async () => {
+    const onRedeploy = vi.fn();
+    const handles = setup({ onRedeploy });
+
+    await clickUpdate(handles);
+    await fail(handles, PROVIDER_UNAVAILABLE);
+
+    expect(updateButtonOf(handles.dependencies)?.disabled).toBe(false);
+    expect(redeployButtonOf(handles.dependencies, onRedeploy)?.disabled).toBe(false);
+  });
+
   it("offers the add credits action when the api refuses the update for payment", async () => {
-    const { mutate, enqueueSnackbar, dependencies } = setup();
+    const handles = setup();
 
-    await clickUpdate(dependencies);
-    await fail(mutate, new ApiError(402, { message: "Insufficient balance: top up to keep deploying" }, "PUT /v1/deployments/{dseq} → 402"));
+    await clickUpdate(handles);
+    await fail(handles, OUT_OF_CREDITS);
 
-    const [element, options] = enqueueSnackbar.mock.calls[0];
+    const [element, options] = handles.enqueueSnackbar.mock.calls[0];
     expect(element.props.title).toBe("Insufficient balance");
-    expect(element.props.subTitle.type).toBe(dependencies.AddCreditsSnackbarContent);
+    expect(element.props.subTitle.type).toBe(handles.dependencies.AddCreditsSnackbarContent);
     expect(element.props.subTitle.props.message).toBe("top up to keep deploying");
     expect(options).toEqual({ variant: "warning", autoHideDuration: 10000 });
   });
 
+  it("dismisses the add credits snackbar once the user acts on it", async () => {
+    const handles = setup();
+    handles.enqueueSnackbar.mockReturnValue("snackbar-key");
+
+    await clickUpdate(handles);
+    await fail(handles, OUT_OF_CREDITS);
+
+    handles.enqueueSnackbar.mock.calls[0][0].props.subTitle.props.onAction();
+
+    expect(handles.closeSnackbar).toHaveBeenCalledWith("snackbar-key");
+  });
+
+  it("re-enables the update action after the api refuses the update for payment", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, OUT_OF_CREDITS);
+
+    expect(updateButtonOf(handles.dependencies)?.disabled).toBe(false);
+  });
+
   it("tracks a failed transaction when the api refuses the update", async () => {
-    const { mutate, analyticsService, dependencies } = setup();
+    const handles = setup();
 
-    await clickUpdate(dependencies);
-    await fail(mutate, new ApiError(503, { message: "Provider service is temporarily unavailable" }, "PUT /v1/deployments/{dseq} → 503"));
+    await clickUpdate(handles);
+    await fail(handles, PROVIDER_UNAVAILABLE);
 
-    expect(analyticsService.track).toHaveBeenCalledWith("failed_tx", { category: "transactions", label: "Failed transaction" });
+    expect(handles.analyticsService.track).toHaveBeenCalledWith("failed_tx", { category: "transactions", label: "Failed transaction" });
+  });
+
+  it("tracks no failed transaction when the api refuses the sdl before attempting one", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, BAD_SDL);
+
+    expect(handles.analyticsService.track).not.toHaveBeenCalledWith("failed_tx", expect.anything());
   });
 
   it("clears deployment version when text changes in editor", async () => {
@@ -222,10 +340,7 @@ describe(ManifestUpdate.name, () => {
     });
 
     act(() => {
-      dependencies.SDLEditor.mock.calls[0][0].onChange?.(
-        "updated manifest",
-        mock<Parameters<NonNullable<Parameters<typeof DEPENDENCIES.SDLEditor>[0]["onChange"]>>[1]>()
-      );
+      dependencies.SDLEditor.mock.calls[0][0].onChange?.("updated manifest", editorChangeEvent());
     });
 
     expect(onManifestChange).toHaveBeenCalledWith("updated manifest");
@@ -240,13 +355,12 @@ describe(ManifestUpdate.name, () => {
 
   it("disables the redeploy action while an update is in flight", async () => {
     const onRedeploy = vi.fn();
-    const { dependencies } = setup({ onRedeploy });
+    const handles = setup({ onRedeploy });
 
-    await clickUpdate(dependencies);
+    await clickUpdate(handles);
 
     await waitFor(() => {
-      const redeployRenders = dependencies.Button.mock.calls.filter(call => call[0].onClick === onRedeploy);
-      expect(redeployRenders[redeployRenders.length - 1][0].disabled).toBe(true);
+      expect(redeployButtonOf(handles.dependencies, onRedeploy)?.disabled).toBe(true);
     });
   });
 
@@ -256,33 +370,50 @@ describe(ManifestUpdate.name, () => {
     expect(dependencies.Button.mock.calls.map(call => call[0].children)).toEqual(["Update Deployment"]);
   });
 
-  it("wires no transaction message builder, so nothing can sign an update from the browser", () => {
-    expect(Object.keys(DEPENDENCIES)).not.toContain("TransactionMessageData");
-  });
+  type Handles = ReturnType<typeof setup>;
+  type Dependencies = Handles["dependencies"];
 
-  type Dependencies = ReturnType<typeof setup>["dependencies"];
-
-  function updateButtonOf(dependencies: Dependencies) {
-    return dependencies.Button.mock.calls.find(call => call[0].children === "Update Deployment")?.[0];
+  function editorChangeEvent() {
+    return mock<Parameters<NonNullable<Parameters<typeof DEPENDENCIES.SDLEditor>[0]["onChange"]>>[1]>();
   }
 
-  async function clickUpdate(dependencies: Dependencies) {
-    const updateButton = updateButtonOf(dependencies);
+  function updateButtonOf(dependencies: Dependencies) {
+    return dependencies.Button.mock.calls.filter(call => call[0].children === "Update Deployment").at(-1)?.[0];
+  }
+
+  function redeployButtonOf(dependencies: Dependencies, onRedeploy: () => void) {
+    return dependencies.Button.mock.calls.filter(call => call[0].onClick === onRedeploy).at(-1)?.[0];
+  }
+
+  async function clickUpdate(handles: Handles) {
+    const updateButton = updateButtonOf(handles.dependencies);
 
     await act(async () => {
       updateButton?.onClick?.(mock<MouseEvent<HTMLButtonElement>>());
     });
   }
 
-  async function succeed(mutate: ReturnType<typeof vi.fn>) {
+  async function succeed(handles: Handles) {
     await act(async () => {
-      mutate.mock.calls[0][1].onSuccess({ data: {} });
+      handles.mutationOptions.current?.onSuccess?.({ data: {} });
+      handles.mutate.mock.calls[0][1]?.onSuccess?.({ data: {} });
     });
   }
 
-  async function fail(mutate: ReturnType<typeof vi.fn>, cause: unknown) {
+  async function fail(handles: Handles, cause: unknown) {
     await act(async () => {
-      mutate.mock.calls[0][1].onError(cause);
+      handles.mutationOptions.current?.onError?.(cause);
+      handles.mutate.mock.calls[0][1]?.onError?.(cause);
+    });
+  }
+
+  async function settleAfterClose(handles: Handles, outcome: { outcome: "success" } | { outcome: "failure"; cause: unknown }) {
+    await act(async () => {
+      if (outcome.outcome === "success") {
+        handles.mutationOptions.current?.onSuccess?.({ data: {} });
+        return;
+      }
+      handles.mutationOptions.current?.onError?.(outcome.cause);
     });
   }
 
@@ -300,19 +431,19 @@ describe(ManifestUpdate.name, () => {
   }) {
     const providerProxy = mock<ProviderProxyService>();
     const analyticsService = mock<AnalyticsService>();
-    const deploymentLocalStorage = {
-      get: vi
-        .fn<DeploymentStorageService["get"]>()
-        .mockReturnValue(input?.storedManifest === null ? null : { manifest: input?.storedManifest ?? "version: '2.0'" }),
-      set: vi.fn<DeploymentStorageService["set"]>(),
-      update: vi.fn<DeploymentStorageService["update"]>()
-    };
+    const deploymentLocalStorage = mock<DeploymentStorageService>();
+    deploymentLocalStorage.get.mockReturnValue(input?.storedManifest === null ? null : { manifest: input?.storedManifest ?? "version: '2.0'" });
 
     const mutate = vi.fn();
+    const mutationOptions: { current?: { onSuccess?: (data: unknown) => void; onError?: (cause: unknown) => void } } = {};
     const api = mockDeep<AppDIContainer["api"]>();
-    api.v1.updateDeployment.useMutation.mockReturnValue(mock<ReturnType<typeof api.v1.updateDeployment.useMutation>>({ mutate }));
+    api.v1.updateDeployment.useMutation.mockImplementation(options => {
+      mutationOptions.current = options as typeof mutationOptions.current;
+      return mock<ReturnType<typeof api.v1.updateDeployment.useMutation>>({ mutate });
+    });
 
     const enqueueSnackbar = vi.fn();
+    const closeSnackbar = vi.fn();
     const balances = mock<ReturnType<typeof DEPENDENCIES.useBalances>>();
 
     const useWallet: typeof DEPENDENCIES.useWallet = () =>
@@ -334,7 +465,7 @@ describe(ManifestUpdate.name, () => {
       ensureToken: vi.fn().mockResolvedValue("test-token")
     });
 
-    const useSnackbar: typeof DEPENDENCIES.useSnackbar = () => ({ enqueueSnackbar, closeSnackbar: vi.fn() });
+    const useSnackbar: typeof DEPENDENCIES.useSnackbar = () => ({ enqueueSnackbar, closeSnackbar });
 
     const useBlockchainStatus: typeof DEPENDENCIES.useBlockchainStatus = () =>
       mock<ReturnType<typeof DEPENDENCIES.useBlockchainStatus>>({ isBlockchainDown: false });
@@ -351,13 +482,13 @@ describe(ManifestUpdate.name, () => {
       ...input?.dependencies
     });
 
-    render(
+    const { unmount } = render(
       <TestContainerProvider
         services={{
           api: () => api,
           providerProxy: () => providerProxy,
           analyticsService: () => analyticsService,
-          deploymentLocalStorage: () => deploymentLocalStorage as unknown as DeploymentStorageService
+          deploymentLocalStorage: () => deploymentLocalStorage
         }}
       >
         <ManifestUpdate
@@ -379,6 +510,17 @@ describe(ManifestUpdate.name, () => {
       </TestContainerProvider>
     );
 
-    return { providerProxy, analyticsService, deploymentLocalStorage, dependencies, mutate, enqueueSnackbar, refetchBalances: balances.refetch };
+    return {
+      providerProxy,
+      analyticsService,
+      deploymentLocalStorage,
+      dependencies,
+      mutate,
+      mutationOptions,
+      enqueueSnackbar,
+      closeSnackbar,
+      refetchBalances: balances.refetch,
+      unmount
+    };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -67,6 +67,25 @@ describe(ManifestUpdate.name, () => {
     });
   });
 
+  it("enables the update button for an active deployment the user can still change", async () => {
+    const { dependencies } = setup();
+
+    await waitFor(() => {
+      expect(updateButtonOf(dependencies)?.disabled).toBe(false);
+    });
+  });
+
+  it("treats a cleared editor as an empty manifest", () => {
+    const onManifestChange = vi.fn();
+    const { dependencies } = setup({ onManifestChange });
+
+    act(() => {
+      dependencies.SDLEditor.mock.calls[0][0].onChange?.(undefined, editorChangeEvent());
+    });
+
+    expect(onManifestChange).toHaveBeenCalledWith("");
+  });
+
   it("disables update button when manifest is empty", () => {
     const { dependencies } = setup({ editedManifest: "" });
 
@@ -211,6 +230,7 @@ describe(ManifestUpdate.name, () => {
     expect(screen.getByText("SDL is not valid YAML: line 3, column 5")).toBeInTheDocument();
     expect(closeManifestEditor).not.toHaveBeenCalled();
     expect(handles.deploymentLocalStorage.update).not.toHaveBeenCalled();
+    expect(handles.enqueueSnackbar).not.toHaveBeenCalled();
   });
 
   it("lets the user retry after editing the sdl the api refused", async () => {
@@ -302,6 +322,15 @@ describe(ManifestUpdate.name, () => {
     handles.enqueueSnackbar.mock.calls[0][0].props.subTitle.props.onAction();
 
     expect(handles.closeSnackbar).toHaveBeenCalledWith("snackbar-key");
+  });
+
+  it("names the add credits snackbar itself when the api sends no message with the refusal", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, new ApiError(402, {}, "PUT /v1/deployments/{dseq} → 402"));
+
+    expect(handles.enqueueSnackbar.mock.calls[0][0].props.title).toBe("Add credits to continue");
   });
 
   it("re-enables the update action after the api refuses the update for payment", async () => {

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -19,6 +19,17 @@ const PROVIDER_UNAVAILABLE = new ApiError(503, { message: "Provider service is t
 const BAD_SDL = new ApiError(400, { message: "SDL is not valid YAML: line 3, column 5" }, "PUT /v1/deployments/{dseq} → 400");
 const BAD_PROVIDER_CREDENTIALS = new ApiError(400, { message: "Invalid provider jwt credentials" }, "PUT /v1/deployments/{dseq} → 400");
 const OUT_OF_CREDITS = new ApiError(402, { message: "Insufficient balance: top up to keep deploying" }, "PUT /v1/deployments/{dseq} → 402");
+const UNRESOLVED_REFERENCE = new ApiError(
+  400,
+  { message: 'Invalid SDL: no value supplied for SDL Reference "ac-secret://TOKEN"' },
+  "PUT /v1/deployments/{dseq} → 400"
+);
+const OVERSIZE_SDL = new ApiError(
+  400,
+  { message: "SDL is too large: it exceeds the maximum of 60000 characters once stored" },
+  "PUT /v1/deployments/{dseq} → 400"
+);
+const SDL_SHAPED_SERVER_FAILURE = new ApiError(500, { message: "Invalid SDL: the console could not read it" }, "PUT /v1/deployments/{dseq} → 500");
 
 describe(ManifestUpdate.name, () => {
   it("shows outside deployment message when no local manifest exists", () => {
@@ -163,13 +174,15 @@ describe(ManifestUpdate.name, () => {
   });
 
   it("caches the submitted sdl even when the editor closes before the api answers", async () => {
-    const handles = setup({ editedManifest: "version: '2.0'", wallet: { address: "akash1abc" } });
+    const closeManifestEditor = vi.fn();
+    const handles = setup({ editedManifest: "version: '2.0'", wallet: { address: "akash1abc" }, closeManifestEditor });
 
     await clickUpdate(handles);
     handles.unmount();
     await settleAfterClose(handles, { outcome: "success" });
 
     expect(handles.deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "123", { manifest: "version: '2.0'" });
+    expect(closeManifestEditor).not.toHaveBeenCalled();
   });
 
   it("surfaces the failure even when the editor closes before the api answers", async () => {
@@ -218,6 +231,7 @@ describe(ManifestUpdate.name, () => {
     await succeed(handles);
 
     expect(closeManifestEditor).toHaveBeenCalled();
+    expect(updateButtonOf(handles.dependencies)?.disabled).toBe(false);
   });
 
   it("shows the sdl the api refused inline and leaves the editor open", async () => {
@@ -263,6 +277,36 @@ describe(ManifestUpdate.name, () => {
 
     expect(screen.queryByText("SDL is not valid YAML: line 3, column 5")).not.toBeInTheDocument();
     expect(updateButtonOf(handles.dependencies)?.disabled).toBe(false);
+  });
+
+  it("shows a refused sdl reference inline", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, UNRESOLVED_REFERENCE);
+
+    expect(screen.getByText('Invalid SDL: no value supplied for SDL Reference "ac-secret://TOKEN"')).toBeInTheDocument();
+    expect(handles.enqueueSnackbar).not.toHaveBeenCalled();
+  });
+
+  it("shows an oversize sdl inline", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, OVERSIZE_SDL);
+
+    expect(screen.getByText("SDL is too large: it exceeds the maximum of 60000 characters once stored")).toBeInTheDocument();
+    expect(handles.enqueueSnackbar).not.toHaveBeenCalled();
+  });
+
+  it("keeps a server failure out of the inline alert even when it reads like an sdl refusal", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, SDL_SHAPED_SERVER_FAILURE);
+
+    expect(screen.queryByText("Invalid SDL: the console could not read it")).not.toBeInTheDocument();
+    expect(handles.enqueueSnackbar).toHaveBeenCalled();
   });
 
   it("keeps a refused provider credential out of the editor's inline alert", async () => {

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -30,6 +30,12 @@ const OVERSIZE_SDL = new ApiError(
   "PUT /v1/deployments/{dseq} → 400"
 );
 const SDL_SHAPED_SERVER_FAILURE = new ApiError(500, { message: "Invalid SDL: the console could not read it" }, "PUT /v1/deployments/{dseq} → 500");
+const TRIAL_GATED_SDL = new ApiError(
+  400,
+  { message: "Invalid SDL: rtx4090 not available on free trial: Add funds to unlock GPU access" },
+  "PUT /v1/deployments/{dseq} → 400"
+);
+const UNTITLED_OUT_OF_CREDITS = new ApiError(402, { message: "Not enough funds to cover the transaction fee" }, "PUT /v1/deployments/{dseq} → 402");
 
 describe(ManifestUpdate.name, () => {
   it("shows outside deployment message when no local manifest exists", () => {
@@ -109,16 +115,6 @@ describe(ManifestUpdate.name, () => {
     expect(updateButtonOf(dependencies)?.disabled).toBe(true);
   });
 
-  it("disables update button when credentials are not usable", () => {
-    const { dependencies } = setup({
-      providerCredentials: {
-        details: { usable: false, isExpired: true, type: "jwt" as const, value: null, error: null }
-      }
-    });
-
-    expect(updateButtonOf(dependencies)?.disabled).toBe(true);
-  });
-
   it("renders SDLEditor when not remote deploy", () => {
     const { dependencies } = setup({ isRemoteDeploy: false, editedManifest: "some-manifest" });
 
@@ -171,6 +167,31 @@ describe(ManifestUpdate.name, () => {
     await succeed(handles);
 
     expect(handles.deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "123", { manifest: "version: '2.0'" });
+  });
+
+  it("caches the sdl it submitted, not the one edited while the update was in flight", async () => {
+    const handles = setup({ editedManifest: "version: '2.0'", wallet: { address: "akash1abc" } });
+
+    await clickUpdate(handles);
+    handles.rerenderWith({ editedManifest: "version: '3.0'" });
+    await succeed(handles);
+
+    expect(handles.deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "123", { manifest: "version: '2.0'" });
+  });
+
+  it("finishes the accepted update even when caching the manifest locally fails", async () => {
+    const closeManifestEditor = vi.fn();
+    const handles = setup({ closeManifestEditor });
+    handles.deploymentLocalStorage.update.mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+
+    await clickUpdate(handles);
+    await succeed(handles);
+
+    expect(handles.analyticsService.track).toHaveBeenCalledWith("successful_tx", { category: "transactions", label: "Successful transaction" });
+    expect(closeManifestEditor).toHaveBeenCalled();
+    expect(handles.enqueueSnackbar).not.toHaveBeenCalled();
   });
 
   it("caches the submitted sdl even when the editor closes before the api answers", async () => {
@@ -356,6 +377,40 @@ describe(ManifestUpdate.name, () => {
     expect(options).toEqual({ variant: "warning", autoHideDuration: 10000 });
   });
 
+  it("offers the add credits action when the trial refuses the gpu the sdl requests", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, TRIAL_GATED_SDL);
+
+    const [element, options] = handles.enqueueSnackbar.mock.calls[0];
+    expect(element.props.title).toBe("rtx4090 not available on free trial");
+    expect(element.props.subTitle.type).toBe(handles.dependencies.AddCreditsSnackbarContent);
+    expect(element.props.subTitle.props.message).toBe("Add funds to unlock GPU access");
+    expect(options).toEqual({ variant: "warning", autoHideDuration: 10000 });
+  });
+
+  it("keeps the trial gating refusal out of the editor's inline alert", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, TRIAL_GATED_SDL);
+
+    expect(screen.queryByText(/not available on free trial/)).not.toBeInTheDocument();
+    expect(updateButtonOf(handles.dependencies)?.disabled).toBe(false);
+  });
+
+  it("shows the whole refusal in the add credits snackbar body when it carries no title of its own", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, UNTITLED_OUT_OF_CREDITS);
+
+    const [element] = handles.enqueueSnackbar.mock.calls[0];
+    expect(element.props.title).toBe("Add credits to continue");
+    expect(element.props.subTitle.props.message).toBe("Not enough funds to cover the transaction fee");
+  });
+
   it("dismisses the add credits snackbar once the user acts on it", async () => {
     const handles = setup();
     handles.enqueueSnackbar.mockReturnValue("snackbar-key");
@@ -400,6 +455,15 @@ describe(ManifestUpdate.name, () => {
 
     await clickUpdate(handles);
     await fail(handles, BAD_SDL);
+
+    expect(handles.analyticsService.track).not.toHaveBeenCalledWith("failed_tx", expect.anything());
+  });
+
+  it("tracks no failed transaction when the api refuses the update for payment", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    await fail(handles, OUT_OF_CREDITS);
 
     expect(handles.analyticsService.track).not.toHaveBeenCalledWith("failed_tx", expect.anything());
   });
@@ -466,9 +530,13 @@ describe(ManifestUpdate.name, () => {
     });
   }
 
+  function submittedVariablesOf(handles: Handles) {
+    return handles.mutate.mock.calls[0][0];
+  }
+
   async function succeed(handles: Handles) {
     await act(async () => {
-      handles.mutationOptions.current?.onSuccess?.({ data: {} });
+      handles.mutationOptions.current?.onSuccess?.({ data: {} }, submittedVariablesOf(handles));
       handles.mutate.mock.calls[0][1]?.onSuccess?.({ data: {} });
     });
   }
@@ -483,7 +551,7 @@ describe(ManifestUpdate.name, () => {
   async function settleAfterClose(handles: Handles, outcome: { outcome: "success" } | { outcome: "failure"; cause: unknown }) {
     await act(async () => {
       if (outcome.outcome === "success") {
-        handles.mutationOptions.current?.onSuccess?.({ data: {} });
+        handles.mutationOptions.current?.onSuccess?.({ data: {} }, submittedVariablesOf(handles));
         return;
       }
       handles.mutationOptions.current?.onError?.(outcome.cause);
@@ -499,7 +567,6 @@ describe(ManifestUpdate.name, () => {
     onManifestChange?: (value: string) => void;
     onRedeploy?: () => void;
     wallet?: Partial<{ address: string; signAndBroadcastTx: ContextType["signAndBroadcastTx"] }>;
-    providerCredentials?: Partial<{ details: { usable: boolean; isExpired: boolean; type: "jwt"; value: string | null; error: Error | null } }>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const providerProxy = mock<ProviderProxyService>();
@@ -508,7 +575,9 @@ describe(ManifestUpdate.name, () => {
     deploymentLocalStorage.get.mockReturnValue(input?.storedManifest === null ? null : { manifest: input?.storedManifest ?? "version: '2.0'" });
 
     const mutate = vi.fn();
-    const mutationOptions: { current?: { onSuccess?: (data: unknown) => void; onError?: (cause: unknown) => void } } = {};
+    const mutationOptions: {
+      current?: { onSuccess?: (data: unknown, variables: { dseq: string; data: { sdl: string } }) => void; onError?: (cause: unknown) => void };
+    } = {};
     const api = mockDeep<AppDIContainer["api"]>();
     api.v1.updateDeployment.useMutation.mockImplementation(options => {
       mutationOptions.current = options as typeof mutationOptions.current;
@@ -527,17 +596,6 @@ describe(ManifestUpdate.name, () => {
 
     const useBalances: typeof DEPENDENCIES.useBalances = () => balances;
 
-    const useProviderCredentials: typeof DEPENDENCIES.useProviderCredentials = () => ({
-      details: input?.providerCredentials?.details || {
-        usable: true,
-        isExpired: false,
-        type: "jwt" as const,
-        value: "test-token",
-        error: null
-      },
-      ensureToken: vi.fn().mockResolvedValue("test-token")
-    });
-
     const useSnackbar: typeof DEPENDENCIES.useSnackbar = () => ({ enqueueSnackbar, closeSnackbar });
 
     const useBlockchainStatus: typeof DEPENDENCIES.useBlockchainStatus = () =>
@@ -546,7 +604,6 @@ describe(ManifestUpdate.name, () => {
     const dependencies = MockComponents(DEPENDENCIES, {
       useWallet,
       useBalances,
-      useProviderCredentials,
       useSnackbar,
       useBlockchainStatus,
       deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
@@ -555,7 +612,10 @@ describe(ManifestUpdate.name, () => {
       ...input?.dependencies
     });
 
-    const { unmount } = render(
+    const closeManifestEditor = input?.closeManifestEditor || vi.fn();
+    const onManifestChange = input?.onManifestChange || vi.fn();
+
+    const componentWith = (overrides?: { editedManifest: string }) => (
       <TestContainerProvider
         services={{
           api: () => api,
@@ -573,17 +633,20 @@ describe(ManifestUpdate.name, () => {
               ...input?.deployment
             } as Parameters<typeof ManifestUpdate>[0]["deployment"]
           }
-          closeManifestEditor={input?.closeManifestEditor || vi.fn()}
+          closeManifestEditor={closeManifestEditor}
           isRemoteDeploy={input?.isRemoteDeploy ?? false}
-          editedManifest={input?.editedManifest ?? "version: '2.0'"}
-          onManifestChange={input?.onManifestChange || vi.fn()}
+          editedManifest={overrides?.editedManifest ?? input?.editedManifest ?? "version: '2.0'"}
+          onManifestChange={onManifestChange}
           onRedeploy={input?.onRedeploy}
           dependencies={dependencies}
         />
       </TestContainerProvider>
     );
 
+    const { unmount, rerender } = render(componentWith());
+
     return {
+      rerenderWith: (overrides: { editedManifest: string }) => rerender(componentWith(overrides)),
       providerProxy,
       analyticsService,
       deploymentLocalStorage,

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -191,7 +191,7 @@ describe(ManifestUpdate.name, () => {
 
     expect(handles.analyticsService.track).toHaveBeenCalledWith("successful_tx", { category: "transactions", label: "Successful transaction" });
     expect(closeManifestEditor).toHaveBeenCalled();
-    expect(handles.enqueueSnackbar).not.toHaveBeenCalled();
+    expect(handles.enqueueSnackbar).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "error" }));
   });
 
   it("caches the submitted sdl even when the editor closes before the api answers", async () => {
@@ -612,6 +612,12 @@ describe(ManifestUpdate.name, () => {
       mock<ReturnType<typeof DEPENDENCIES.useBlockchainStatus>>({ isBlockchainDown: false });
 
     const dependencies = MockComponents(DEPENDENCIES, {
+      DeploymentTabHeader: vi.fn(({ actions, children }) => (
+        <>
+          {children}
+          {actions}
+        </>
+      )),
       useWallet,
       useBalances,
       useSnackbar,

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -1,7 +1,9 @@
 import type { MouseEvent } from "react";
+import { ApiError } from "@akashnetwork/openapi-sdk";
 import { describe, expect, it, vi } from "vitest";
-import { mock } from "vitest-mock-extended";
+import { mock, mockDeep } from "vitest-mock-extended";
 
+import type { AppDIContainer } from "@src/context/ServicesProvider/ServicesProvider";
 import type { ContextType } from "@src/context/WalletProvider";
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
@@ -10,37 +12,25 @@ import { DEPENDENCIES, ManifestUpdate } from "./ManifestUpdate";
 
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { buildWallet } from "@tests/seeders/wallet";
-import { ComponentMock, MockComponents } from "@tests/unit/mocks";
+import { MockComponents } from "@tests/unit/mocks";
 import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
 describe(ManifestUpdate.name, () => {
   it("shows outside deployment message when no local manifest exists", () => {
-    setup({
-      deploymentLocalStorage: {
-        get: vi.fn().mockReturnValue(null)
-      }
-    });
+    setup({ storedManifest: null });
 
     expect(screen.getByText(/it looks like this deployment was created using another deploy tool/i)).toBeInTheDocument();
   });
 
   it("hides outside deployment message and shows editor after clicking Continue", async () => {
-    const ButtonMock = vi.fn(ComponentMock);
-    setup({
-      deploymentLocalStorage: {
-        get: vi.fn().mockReturnValue(null)
-      },
-      dependencies: {
-        Button: ButtonMock
-      }
-    });
+    const { dependencies } = setup({ storedManifest: null });
 
     expect(screen.getByText(/it looks like this deployment was created using another deploy tool/i)).toBeInTheDocument();
 
-    const continueButton = ButtonMock.mock.calls.find(call => call[0].children === "Continue");
+    const continueButton = dependencies.Button.mock.calls.find(call => call[0].children === "Continue");
 
     await act(() => {
-      continueButton?.[0].onClick();
+      continueButton?.[0].onClick?.(mock<MouseEvent<HTMLButtonElement>>());
     });
 
     await waitFor(() => {
@@ -50,17 +40,7 @@ describe(ManifestUpdate.name, () => {
 
   it("loads manifest from local storage and calls onManifestChange", async () => {
     const onManifestChange = vi.fn();
-    setup({
-      onManifestChange,
-      deploymentLocalStorage: {
-        get: vi.fn().mockReturnValue({ manifest: "version: '2.0'" })
-      },
-      dependencies: {
-        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
-          getManifestVersion: vi.fn().mockResolvedValue("abc123")
-        })
-      }
-    });
+    setup({ onManifestChange, storedManifest: "version: '2.0'" });
 
     await waitFor(() => {
       expect(onManifestChange).toHaveBeenCalledWith("version: '2.0'");
@@ -69,9 +49,7 @@ describe(ManifestUpdate.name, () => {
 
   it("shows parsing error when manifest version retrieval fails", async () => {
     setup({
-      deploymentLocalStorage: {
-        get: vi.fn().mockReturnValue({ manifest: "version: '2.0'" })
-      },
+      storedManifest: "version: '2.0'",
       dependencies: {
         deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
           getManifestVersion: vi.fn().mockRejectedValue(new Error("parse error"))
@@ -85,218 +63,169 @@ describe(ManifestUpdate.name, () => {
   });
 
   it("disables update button when manifest is empty", () => {
-    const ButtonMock = vi.fn(ComponentMock);
-    setup({
-      editedManifest: "",
-      dependencies: {
-        Button: ButtonMock
-      }
-    });
+    const { dependencies } = setup({ editedManifest: "" });
 
-    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
-    expect(updateButton?.[0].disabled).toBe(true);
+    expect(updateButtonOf(dependencies)?.disabled).toBe(true);
   });
 
   it("disables update button when deployment is not active", () => {
-    const ButtonMock = vi.fn(ComponentMock);
-    setup({
-      deployment: { dseq: "123", state: "closed", hash: "abc" },
-      dependencies: {
-        Button: ButtonMock
-      }
-    });
+    const { dependencies } = setup({ deployment: { dseq: "123", state: "closed", hash: "abc" } });
 
-    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
-    expect(updateButton?.[0].disabled).toBe(true);
+    expect(updateButtonOf(dependencies)?.disabled).toBe(true);
   });
 
   it("disables update button when credentials are not usable", () => {
-    const ButtonMock = vi.fn(ComponentMock);
-    setup({
+    const { dependencies } = setup({
       providerCredentials: {
         details: { usable: false, isExpired: true, type: "jwt" as const, value: null, error: null }
-      },
-      dependencies: {
-        Button: ButtonMock
       }
     });
 
-    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
-    expect(updateButton?.[0].disabled).toBe(true);
+    expect(updateButtonOf(dependencies)?.disabled).toBe(true);
   });
 
   it("renders SDLEditor when not remote deploy", () => {
-    const SDLEditorMock = vi.fn(ComponentMock);
-    setup({
-      isRemoteDeploy: false,
-      editedManifest: "some-manifest",
-      dependencies: {
-        SDLEditor: SDLEditorMock
-      }
-    });
+    const { dependencies } = setup({ isRemoteDeploy: false, editedManifest: "some-manifest" });
 
-    expect(SDLEditorMock).toHaveBeenCalled();
-    expect(SDLEditorMock.mock.calls[0][0].value).toBe("some-manifest");
+    expect(dependencies.SDLEditor).toHaveBeenCalled();
+    expect(dependencies.SDLEditor.mock.calls[0][0].value).toBe("some-manifest");
   });
 
   it("renders RemoteDeployUpdate when remote deploy", () => {
-    const RemoteDeployUpdateMock = vi.fn(ComponentMock);
-    setup({
-      isRemoteDeploy: true,
-      editedManifest: "some-manifest",
-      dependencies: {
-        RemoteDeployUpdate: RemoteDeployUpdateMock
-      }
-    });
+    const { dependencies } = setup({ isRemoteDeploy: true, editedManifest: "some-manifest" });
 
-    expect(RemoteDeployUpdateMock).toHaveBeenCalled();
-    expect(RemoteDeployUpdateMock.mock.calls[0][0].sdlString).toBe("some-manifest");
+    expect(dependencies.RemoteDeployUpdate).toHaveBeenCalled();
+    expect(dependencies.RemoteDeployUpdate.mock.calls[0][0].sdlString).toBe("some-manifest");
   });
 
-  it("sends update transaction and manifest when hash differs", async () => {
-    const ButtonMock = vi.fn(ComponentMock);
-    const closeManifestEditor = vi.fn();
+  it("submits the edited sdl to the console api instead of signing and sending it from the browser", async () => {
     const signAndBroadcastTx = vi.fn(() => Promise.resolve(true));
-    const { providerProxy, analyticsService } = setup({
+    const { mutate, providerProxy, dependencies } = setup({
       editedManifest: "version: '2.0'",
       deployment: { dseq: "123", state: "active", hash: "different-hash" },
-      leases: [{ provider: "provider1" }],
-      closeManifestEditor,
-      providers: [{ owner: "provider1", hostUri: "https://provider1.com" }],
-      wallet: {
-        address: "akash1abc",
-        signAndBroadcastTx
-      },
+      wallet: { signAndBroadcastTx }
+    });
+
+    await clickUpdate(dependencies);
+
+    expect(mutate).toHaveBeenCalledWith({ dseq: "123", data: { sdl: "version: '2.0'" } }, expect.anything());
+    expect(signAndBroadcastTx).not.toHaveBeenCalled();
+    expect(providerProxy.sendManifest).not.toHaveBeenCalled();
+  });
+
+  it("submits to the console api even when the local manifest version already matches the chain", async () => {
+    const { mutate, dependencies } = setup({
+      editedManifest: "version: '2.0'",
+      deployment: { dseq: "123", state: "active", hash: "matching-hash" },
       dependencies: {
-        Button: ButtonMock,
         deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
-          NewDeploymentData: vi.fn().mockResolvedValue({
-            hash: Buffer.from("new-hash"),
-            deploymentId: { dseq: "123" }
-          }),
-          getManifest: vi.fn().mockReturnValue([])
-        }),
-        TransactionMessageData: {
-          getUpdateDeploymentMsg: vi.fn().mockReturnValue({ typeUrl: "/update", value: {} })
-        }
+          getManifestVersion: vi.fn().mockResolvedValue("matching-hash")
+        })
       }
     });
 
-    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
+    await clickUpdate(dependencies);
 
-    await act(async () => {
-      await updateButton?.[0].onClick();
-    });
-
-    await waitFor(() => {
-      expect(signAndBroadcastTx).toHaveBeenCalled();
-    });
-    await waitFor(() => {
-      expect(providerProxy.sendManifest).toHaveBeenCalled();
-    });
-    await waitFor(() => {
-      expect(analyticsService.track).toHaveBeenCalledWith("update_deployment", {
-        category: "deployments",
-        label: "Update deployment"
-      });
-    });
-    await waitFor(() => {
-      expect(closeManifestEditor).toHaveBeenCalled();
-    });
+    expect(mutate).toHaveBeenCalledTimes(1);
   });
 
-  it("skips transaction when hash matches and only sends manifest", async () => {
-    const hashBytes = Buffer.from("matching-hash");
-    const base64Hash = hashBytes.toString("base64");
-    const ButtonMock = vi.fn(ComponentMock);
+  it("caches the submitted sdl under the deployment without a manifest version", async () => {
+    const { mutate, deploymentLocalStorage, dependencies } = setup({ editedManifest: "version: '2.0'", wallet: { address: "akash1abc" } });
+
+    await clickUpdate(dependencies);
+    await succeed(mutate);
+
+    expect(deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "123", { manifest: "version: '2.0'" });
+  });
+
+  it("tracks the update and the successful transaction once the api accepts it", async () => {
+    const { mutate, analyticsService, dependencies } = setup();
+
+    await clickUpdate(dependencies);
+    await succeed(mutate);
+
+    expect(analyticsService.track).toHaveBeenCalledWith("update_deployment", { category: "deployments", label: "Update deployment" });
+    expect(analyticsService.track).toHaveBeenCalledWith("successful_tx", { category: "transactions", label: "Successful transaction" });
+  });
+
+  it("refreshes the balances once the api accepts the update", async () => {
+    const { mutate, refetchBalances, dependencies } = setup();
+
+    await clickUpdate(dependencies);
+    await succeed(mutate);
+
+    expect(refetchBalances).toHaveBeenCalled();
+  });
+
+  it("closes the editor once the api accepts the update", async () => {
     const closeManifestEditor = vi.fn();
-    const signAndBroadcastTx = vi.fn(() => Promise.resolve(true));
-    const { providerProxy } = setup({
-      editedManifest: "version: '2.0'",
-      deployment: { dseq: "123", state: "active", hash: base64Hash },
-      leases: [{ provider: "provider1" }],
-      closeManifestEditor,
-      providers: [{ owner: "provider1", hostUri: "https://provider1.com" }],
-      wallet: {
-        address: "akash1abc",
-        signAndBroadcastTx
-      },
-      dependencies: {
-        Button: ButtonMock,
-        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
-          NewDeploymentData: vi.fn().mockResolvedValue({
-            hash: hashBytes,
-            deploymentId: { dseq: "123" }
-          }),
-          getManifest: vi.fn().mockReturnValue([]),
-          getManifestVersion: vi.fn().mockResolvedValue(base64Hash)
-        })
-      }
-    });
+    const { mutate, dependencies } = setup({ closeManifestEditor });
 
-    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
+    await clickUpdate(dependencies);
+    await succeed(mutate);
 
-    await act(async () => {
-      await updateButton?.[0].onClick();
-    });
-
-    await waitFor(() => {
-      expect(signAndBroadcastTx).not.toHaveBeenCalled();
-    });
-    await waitFor(() => {
-      expect(providerProxy.sendManifest).toHaveBeenCalled();
-    });
-    await waitFor(() => {
-      expect(closeManifestEditor).toHaveBeenCalled();
-    });
+    expect(closeManifestEditor).toHaveBeenCalled();
   });
 
-  it("shows YAML parsing error on update failure", async () => {
-    const ButtonMock = vi.fn(ComponentMock);
-    setup({
-      editedManifest: "version: '2.0'",
-      dependencies: {
-        Button: ButtonMock,
-        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
-          NewDeploymentData: vi.fn().mockRejectedValue(Object.assign(new Error("bad yaml"), { name: "YAMLException" })),
-          getManifest: vi.fn()
-        })
-      }
-    });
+  it("shows the sdl the api refused inline and leaves the editor open", async () => {
+    const closeManifestEditor = vi.fn();
+    const { mutate, deploymentLocalStorage, dependencies } = setup({ closeManifestEditor });
 
-    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
+    await clickUpdate(dependencies);
+    await fail(mutate, new ApiError(400, { message: "SDL is not valid YAML: line 3, column 5" }, "PUT /v1/deployments/{dseq} → 400"));
 
-    await act(async () => {
-      await updateButton?.[0].onClick();
-    });
+    expect(screen.getByText("SDL is not valid YAML: line 3, column 5")).toBeInTheDocument();
+    expect(closeManifestEditor).not.toHaveBeenCalled();
+    expect(deploymentLocalStorage.update).not.toHaveBeenCalled();
+  });
 
-    await waitFor(() => {
-      expect(screen.getByText("bad yaml")).toBeInTheDocument();
-    });
+  it("surfaces the provider failure the api reports in a snackbar that does not auto hide", async () => {
+    const { mutate, enqueueSnackbar, dependencies } = setup();
+
+    await clickUpdate(dependencies);
+    await fail(mutate, new ApiError(503, { message: "Provider service is temporarily unavailable" }, "PUT /v1/deployments/{dseq} → 503"));
+
+    const [element, options] = enqueueSnackbar.mock.calls[0];
+    expect(element.type).toBe(dependencies.Snackbar);
+    expect(element.props.subTitle).toBe("Provider service is temporarily unavailable");
+    expect(options).toEqual({ variant: "error", autoHideDuration: null });
+  });
+
+  it("offers the add credits action when the api refuses the update for payment", async () => {
+    const { mutate, enqueueSnackbar, dependencies } = setup();
+
+    await clickUpdate(dependencies);
+    await fail(mutate, new ApiError(402, { message: "Insufficient balance: top up to keep deploying" }, "PUT /v1/deployments/{dseq} → 402"));
+
+    const [element, options] = enqueueSnackbar.mock.calls[0];
+    expect(element.props.title).toBe("Insufficient balance");
+    expect(element.props.subTitle.type).toBe(dependencies.AddCreditsSnackbarContent);
+    expect(element.props.subTitle.props.message).toBe("top up to keep deploying");
+    expect(options).toEqual({ variant: "warning", autoHideDuration: 10000 });
+  });
+
+  it("tracks a failed transaction when the api refuses the update", async () => {
+    const { mutate, analyticsService, dependencies } = setup();
+
+    await clickUpdate(dependencies);
+    await fail(mutate, new ApiError(503, { message: "Provider service is temporarily unavailable" }, "PUT /v1/deployments/{dseq} → 503"));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("failed_tx", { category: "transactions", label: "Failed transaction" });
   });
 
   it("clears deployment version when text changes in editor", async () => {
-    const SDLEditorMock = vi.fn(ComponentMock);
     const onManifestChange = vi.fn();
-    setup({
-      onManifestChange,
-      dependencies: {
-        SDLEditor: SDLEditorMock,
-        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
-          getManifestVersion: vi.fn().mockResolvedValue("version123")
-        })
-      },
-      deploymentLocalStorage: {
-        get: vi.fn().mockReturnValue({ manifest: "version: '2.0'" })
-      }
-    });
+    const { dependencies } = setup({ onManifestChange, storedManifest: "version: '2.0'" });
 
     await waitFor(() => {
       expect(onManifestChange).toHaveBeenCalledWith("version: '2.0'");
     });
 
     act(() => {
-      SDLEditorMock.mock.calls[0][0].onChange("updated manifest");
+      dependencies.SDLEditor.mock.calls[0][0].onChange?.(
+        "updated manifest",
+        mock<Parameters<NonNullable<Parameters<typeof DEPENDENCIES.SDLEditor>[0]["onChange"]>>[1]>()
+      );
     });
 
     expect(onManifestChange).toHaveBeenCalledWith("updated manifest");
@@ -309,23 +238,11 @@ describe(ManifestUpdate.name, () => {
     expect(dependencies.Button.mock.calls.some(call => call[0].onClick === onRedeploy)).toBe(true);
   });
 
-  it("disables the redeploy action while a manifest update is in flight", async () => {
+  it("disables the redeploy action while an update is in flight", async () => {
     const onRedeploy = vi.fn();
-    const { providerProxy, dependencies } = setup({
-      onRedeploy,
-      editedManifest: "version: '2.0'",
-      deployment: { dseq: "123", state: "active", hash: "different-hash" },
-      leases: [{ provider: "provider1" }],
-      providers: [{ owner: "provider1", hostUri: "https://provider1.com" }]
-    });
+    const { dependencies } = setup({ onRedeploy });
 
-    providerProxy.sendManifest.mockReturnValue(new Promise(() => {}));
-
-    const updateButton = dependencies.Button.mock.calls.find(call => call[0].children === "Update Deployment");
-
-    await act(async () => {
-      updateButton?.[0].onClick?.(mock<MouseEvent<HTMLButtonElement>>());
-    });
+    await clickUpdate(dependencies);
 
     await waitFor(() => {
       const redeployRenders = dependencies.Button.mock.calls.filter(call => call[0].onClick === onRedeploy);
@@ -339,27 +256,64 @@ describe(ManifestUpdate.name, () => {
     expect(dependencies.Button.mock.calls.map(call => call[0].children)).toEqual(["Update Deployment"]);
   });
 
+  it("wires no transaction message builder, so nothing can sign an update from the browser", () => {
+    expect(Object.keys(DEPENDENCIES)).not.toContain("TransactionMessageData");
+  });
+
+  type Dependencies = ReturnType<typeof setup>["dependencies"];
+
+  function updateButtonOf(dependencies: Dependencies) {
+    return dependencies.Button.mock.calls.find(call => call[0].children === "Update Deployment")?.[0];
+  }
+
+  async function clickUpdate(dependencies: Dependencies) {
+    const updateButton = updateButtonOf(dependencies);
+
+    await act(async () => {
+      updateButton?.onClick?.(mock<MouseEvent<HTMLButtonElement>>());
+    });
+  }
+
+  async function succeed(mutate: ReturnType<typeof vi.fn>) {
+    await act(async () => {
+      mutate.mock.calls[0][1].onSuccess({ data: {} });
+    });
+  }
+
+  async function fail(mutate: ReturnType<typeof vi.fn>, cause: unknown) {
+    await act(async () => {
+      mutate.mock.calls[0][1].onError(cause);
+    });
+  }
+
   function setup(input?: {
     deployment?: Partial<{ dseq: string; state: string; hash: string }>;
-    leases?: Array<Partial<{ provider: string }>>;
     editedManifest?: string;
     isRemoteDeploy?: boolean;
+    storedManifest?: string | null;
     closeManifestEditor?: () => void;
     onManifestChange?: (value: string) => void;
     onRedeploy?: () => void;
-    providers?: Array<Partial<{ owner: string; hostUri: string }>>;
     wallet?: Partial<{ address: string; signAndBroadcastTx: ContextType["signAndBroadcastTx"] }>;
     providerCredentials?: Partial<{ details: { usable: boolean; isExpired: boolean; type: "jwt"; value: string | null; error: Error | null } }>;
-    deploymentLocalStorage?: Partial<{ get: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> }>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const providerProxy = mock<ProviderProxyService>();
     const analyticsService = mock<AnalyticsService>();
     const deploymentLocalStorage = {
-      get: input?.deploymentLocalStorage?.get || vi.fn().mockReturnValue({ manifest: "version: '2.0'" }),
-      set: vi.fn(),
-      update: input?.deploymentLocalStorage?.update || vi.fn()
+      get: vi
+        .fn<DeploymentStorageService["get"]>()
+        .mockReturnValue(input?.storedManifest === null ? null : { manifest: input?.storedManifest ?? "version: '2.0'" }),
+      set: vi.fn<DeploymentStorageService["set"]>(),
+      update: vi.fn<DeploymentStorageService["update"]>()
     };
+
+    const mutate = vi.fn();
+    const api = mockDeep<AppDIContainer["api"]>();
+    api.v1.updateDeployment.useMutation.mockReturnValue(mock<ReturnType<typeof api.v1.updateDeployment.useMutation>>({ mutate }));
+
+    const enqueueSnackbar = vi.fn();
+    const balances = mock<ReturnType<typeof DEPENDENCIES.useBalances>>();
 
     const useWallet: typeof DEPENDENCIES.useWallet = () =>
       buildWallet({
@@ -367,10 +321,7 @@ describe(ManifestUpdate.name, () => {
         signAndBroadcastTx: input?.wallet?.signAndBroadcastTx || vi.fn(() => Promise.resolve(true))
       });
 
-    const useProviderList: typeof DEPENDENCIES.useProviderList = () =>
-      ({
-        data: input?.providers || [{ owner: "provider1", hostUri: "https://provider1.com" }]
-      }) as ReturnType<typeof DEPENDENCIES.useProviderList>;
+    const useBalances: typeof DEPENDENCIES.useBalances = () => balances;
 
     const useProviderCredentials: typeof DEPENDENCIES.useProviderCredentials = () => ({
       details: input?.providerCredentials?.details || {
@@ -383,37 +334,27 @@ describe(ManifestUpdate.name, () => {
       ensureToken: vi.fn().mockResolvedValue("test-token")
     });
 
-    const useSnackbar: typeof DEPENDENCIES.useSnackbar = () => ({
-      enqueueSnackbar: vi.fn(),
-      closeSnackbar: vi.fn()
-    });
+    const useSnackbar: typeof DEPENDENCIES.useSnackbar = () => ({ enqueueSnackbar, closeSnackbar: vi.fn() });
 
     const useBlockchainStatus: typeof DEPENDENCIES.useBlockchainStatus = () =>
       mock<ReturnType<typeof DEPENDENCIES.useBlockchainStatus>>({ isBlockchainDown: false });
 
     const dependencies = MockComponents(DEPENDENCIES, {
       useWallet,
-      useProviderList,
+      useBalances,
       useProviderCredentials,
       useSnackbar,
       useBlockchainStatus,
-      deploymentData: {
-        getManifestVersion: vi.fn().mockResolvedValue("test-version"),
-        getManifest: vi.fn().mockReturnValue([]),
-        NewDeploymentData: vi.fn().mockResolvedValue({
-          hash: Buffer.from("test-hash"),
-          deploymentId: { dseq: "123" }
-        })
-      } as unknown as typeof DEPENDENCIES.deploymentData,
-      TransactionMessageData: {
-        getUpdateDeploymentMsg: vi.fn().mockReturnValue({ typeUrl: "/update", value: {} })
-      } as unknown as typeof DEPENDENCIES.TransactionMessageData,
+      deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
+        getManifestVersion: vi.fn().mockResolvedValue("test-version")
+      }),
       ...input?.dependencies
     });
 
     render(
       <TestContainerProvider
         services={{
+          api: () => api,
           providerProxy: () => providerProxy,
           analyticsService: () => analyticsService,
           deploymentLocalStorage: () => deploymentLocalStorage as unknown as DeploymentStorageService
@@ -428,7 +369,6 @@ describe(ManifestUpdate.name, () => {
               ...input?.deployment
             } as Parameters<typeof ManifestUpdate>[0]["deployment"]
           }
-          leases={(input?.leases || [{ provider: "provider1" }]) as Parameters<typeof ManifestUpdate>[0]["leases"]}
           closeManifestEditor={input?.closeManifestEditor || vi.fn()}
           isRemoteDeploy={input?.isRemoteDeploy ?? false}
           editedManifest={input?.editedManifest ?? "version: '2.0'"}
@@ -439,11 +379,6 @@ describe(ManifestUpdate.name, () => {
       </TestContainerProvider>
     );
 
-    return {
-      providerProxy,
-      analyticsService,
-      deploymentLocalStorage,
-      dependencies
-    };
+    return { providerProxy, analyticsService, deploymentLocalStorage, dependencies, mutate, enqueueSnackbar, refetchBalances: balances.refetch };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -216,6 +216,16 @@ describe(ManifestUpdate.name, () => {
     expect(handles.enqueueSnackbar).toHaveBeenCalled();
   });
 
+  it("falls back to a snackbar when an sdl refusal arrives after the editor closes", async () => {
+    const handles = setup();
+
+    await clickUpdate(handles);
+    handles.unmount();
+    await settleAfterClose(handles, { outcome: "failure", cause: BAD_SDL });
+
+    expect(handles.enqueueSnackbar).toHaveBeenCalled();
+  });
+
   it("tracks the update and the successful transaction once the api accepts it", async () => {
     const handles = setup();
 

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import type { Manifest } from "@akashnetwork/chain-sdk/web";
+import { extractApiErrorMessage, isApiError } from "@akashnetwork/openapi-sdk";
 import { Alert, Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
 import { InfoCircle, Upload, WarningCircle } from "iconoir-react";
 import yaml from "js-yaml";
@@ -12,15 +12,13 @@ import { ViewPanel } from "@src/components/shared/ViewPanel";
 import { useBlockchainStatus as useBlockchainStatusOriginal } from "@src/context/BlockchainStatusProvider";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet as useWalletOriginal } from "@src/context/WalletProvider";
+import { AddCreditsSnackbarContent } from "@src/context/WalletProvider/useSignAndBroadcast";
 import { useProviderCredentials as useProviderCredentialsOriginal } from "@src/hooks/useProviderCredentials/useProviderCredentials";
-import { useProviderList as useProviderListOriginal } from "@src/queries/useProvidersQuery";
-import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
-import type { ApiProviderList } from "@src/types/provider";
+import { useBalances as useBalancesOriginal } from "@src/queries/useBalancesQuery";
+import type { DeploymentDto } from "@src/types/deployment";
 import { deploymentData as deploymentDataOriginal } from "@src/utils/deploymentData";
-import { TransactionMessageData as TransactionMessageDataOriginal } from "@src/utils/TransactionMessageData";
 import RemoteDeployUpdate from "../../remote-deploy/update/RemoteDeployUpdate";
 import { SDLEditor } from "../../sdl/SDLEditor/SDLEditor";
-import { ManifestErrorSnackbar } from "../../shared/ManifestErrorSnackbar/ManifestErrorSnackbar";
 import { DeploymentTabHeader } from "../DeploymentDetail/DeploymentTabHeader";
 
 export const DEPENDENCIES = {
@@ -28,27 +26,29 @@ export const DEPENDENCIES = {
   Button,
   CustomTooltip,
   Snackbar,
+  AddCreditsSnackbarContent,
   LinearLoadingSkeleton,
   LinkTo,
   ViewPanel,
   RemoteDeployUpdate,
   SDLEditor,
-  ManifestErrorSnackbar,
   InfoCircle,
   WarningCircle,
   useWallet: useWalletOriginal,
-  useProviderList: useProviderListOriginal,
+  useBalances: useBalancesOriginal,
   useProviderCredentials: useProviderCredentialsOriginal,
   useSnackbar: useSnackbarOriginal,
   useBlockchainStatus: useBlockchainStatusOriginal,
   // eslint-disable-next-line akash/dependencies-component-or-hook
-  deploymentData: deploymentDataOriginal,
-  TransactionMessageData: TransactionMessageDataOriginal
+  deploymentData: deploymentDataOriginal
 };
+
+const REFUSED_SDL_MESSAGE = "The console could not accept this SDL.";
+const UPDATE_FAILURE_MESSAGE = "Something went wrong while updating the deployment. Please try again.";
+const ADD_CREDITS_TITLE = "Add credits to continue";
 
 type Props = {
   deployment: DeploymentDto;
-  leases: LeaseDto[];
   closeManifestEditor: () => void;
   isRemoteDeploy: boolean;
   editedManifest: string;
@@ -60,7 +60,6 @@ type Props = {
 
 export const ManifestUpdate: React.FunctionComponent<Props> = ({
   deployment,
-  leases,
   closeManifestEditor,
   isRemoteDeploy,
   editedManifest,
@@ -68,16 +67,17 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   onRedeploy,
   dependencies: d = DEPENDENCIES
 }) => {
-  const { providerProxy, analyticsService, deploymentLocalStorage } = useServices();
+  const { api, analyticsService, deploymentLocalStorage } = useServices();
   const [parsingError, setParsingError] = useState<string | null>(null);
   const [deploymentVersion, setDeploymentVersion] = useState<string | null>(null);
   const [showOutsideDeploymentMessage, setShowOutsideDeploymentMessage] = useState(false);
-  const [isSendingManifest, setIsSendingManifest] = useState(false);
-  const { address, signAndBroadcastTx } = d.useWallet();
-  const { data: providers } = d.useProviderList();
+  const [isUpdating, setIsUpdating] = useState(false);
+  const { address } = d.useWallet();
+  const { refetch: refetchBalances } = d.useBalances(address);
   const providerCredentials = d.useProviderCredentials();
   const { enqueueSnackbar } = d.useSnackbar();
   const { isBlockchainDown } = d.useBlockchainStatus();
+  const updateDeployment = api.v1.updateDeployment.useMutation();
 
   useEffect(() => {
     const init = async () => {
@@ -116,67 +116,51 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     window.open("https://akash.network/docs/deployments/akash-cli/installation/#update-the-deployment", "_blank");
   }
 
-  async function sendManifest(providerInfo: ApiProviderList, manifest: Manifest) {
-    try {
-      return await providerProxy.sendManifest(providerInfo, manifest, {
-        dseq: deployment.dseq,
-        ensureToken: providerCredentials.ensureToken
-      });
-    } catch (err) {
-      enqueueSnackbar(<d.ManifestErrorSnackbar err={err} />, { variant: "error", autoHideDuration: null });
-      throw err;
-    }
+  function handleUpdateClick() {
+    setParsingError(null);
+    setIsUpdating(true);
+    updateDeployment.mutate({ dseq: deployment.dseq, data: { sdl: editedManifest } }, { onSuccess: finishUpdate, onError: reportUpdateFailure });
   }
 
-  async function handleUpdateClick() {
-    let response;
+  function finishUpdate() {
+    deploymentLocalStorage.update(address, deployment.dseq, { manifest: editedManifest });
+    analyticsService.track("update_deployment", { category: "deployments", label: "Update deployment" });
+    analyticsService.track("successful_tx", { category: "transactions", label: "Successful transaction" });
+    refetchBalances();
+    setIsUpdating(false);
+    closeManifestEditor();
+  }
 
-    try {
-      const doc = yaml.load(editedManifest);
+  function reportUpdateFailure(cause: unknown) {
+    setIsUpdating(false);
+    analyticsService.track("failed_tx", { category: "transactions", label: "Failed transaction" });
 
-      const dd = await d.deploymentData.NewDeploymentData(editedManifest, deployment.dseq, address);
-      const mani = d.deploymentData.getManifest(doc);
-
-      // If it's actual update, send a transaction, else just send the manifest
-      if (Buffer.from(dd.hash).toString("base64") !== deployment.hash) {
-        const message = d.TransactionMessageData.getUpdateDeploymentMsg(dd);
-        response = await signAndBroadcastTx([message]);
-      } else {
-        response = true;
-      }
-
-      if (response) {
-        setIsSendingManifest(true);
-
-        deploymentLocalStorage.update(address, dd.deploymentId.dseq, {
-          manifest: editedManifest,
-          manifestVersion: dd.hash
-        });
-
-        const leaseProviders = leases.map(lease => lease.provider).filter((v, i, s) => s.indexOf(v) === i);
-
-        for (const provider of leaseProviders) {
-          const providerInfo = providers?.find(x => x.owner === provider);
-          await sendManifest(providerInfo as ApiProviderList, mani);
-        }
-
-        analyticsService.track("update_deployment", {
-          category: "deployments",
-          label: "Update deployment"
-        });
-
-        setIsSendingManifest(false);
-        closeManifestEditor();
-      }
-    } catch (error: any) {
-      if (error.name === "YAMLException" || error.name === "CustomValidationError") {
-        setParsingError(error.message);
-      } else {
-        setParsingError("Error while parsing SDL file");
-        console.error(error);
-      }
-      setIsSendingManifest(false);
+    if (isApiError(cause) && cause.status === 400) {
+      setParsingError(extractApiErrorMessage(cause) ?? REFUSED_SDL_MESSAGE);
+      return;
     }
+
+    if (isApiError(cause) && cause.status === 402) {
+      offerCredits(cause);
+      return;
+    }
+
+    enqueueSnackbar(<d.Snackbar title="Couldn't update deployment" subTitle={extractApiErrorMessage(cause) ?? UPDATE_FAILURE_MESSAGE} iconVariant="error" />, {
+      variant: "error",
+      autoHideDuration: null
+    });
+  }
+
+  function offerCredits(cause: unknown) {
+    const [title, message] = (extractApiErrorMessage(cause) ?? "").split(": ");
+
+    enqueueSnackbar(
+      <d.Snackbar title={title || message || ADD_CREDITS_TITLE} subTitle={<d.AddCreditsSnackbarContent message={message} />} iconVariant="warning" />,
+      {
+        variant: "warning",
+        autoHideDuration: 10000
+      }
+    );
   }
 
   return (
@@ -201,7 +185,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
               actions={
                 <div className="flex items-center gap-2">
                   {onRedeploy && (
-                    <d.Button variant="outline" size="md" className="gap-1" type="button" disabled={isSendingManifest} onClick={onRedeploy}>
+                    <d.Button variant="outline" size="md" className="gap-1" type="button" disabled={isUpdating} onClick={onRedeploy}>
                       <Upload className="text-xs" />
                       Redeploy
                     </d.Button>
@@ -211,8 +195,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
                       !providerCredentials.details.usable ||
                       !!parsingError ||
                       !editedManifest ||
-                      !providers ||
-                      isSendingManifest ||
+                      isUpdating ||
                       deployment.state !== "active" ||
                       isBlockchainDown
                     }
@@ -252,7 +235,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
 
             {parsingError && <d.Alert variant="warning">{parsingError}</d.Alert>}
 
-            <d.LinearLoadingSkeleton isLoading={isSendingManifest} />
+            <d.LinearLoadingSkeleton isLoading={isUpdating} />
 
             <d.ViewPanel stickToBottom style={{ overflow: isRemoteDeploy ? "unset" : "hidden" }}>
               {isRemoteDeploy ? (

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -135,7 +135,6 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   }
 
   function handleUpdateClick() {
-    setParsingError(null);
     setIsUpdating(true);
     updateDeployment.mutate({ dseq: deployment.dseq, data: { sdl: editedManifest } }, { onSuccess: closeAfterUpdate, onError: releaseAfterFailure });
   }

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -34,6 +34,7 @@ export const DEPENDENCIES = {
   SDLEditor,
   InfoCircle,
   WarningCircle,
+  DeploymentTabHeader,
   useWallet: useWalletOriginal,
   useBalances: useBalancesOriginal,
   useSnackbar: useSnackbarOriginal,
@@ -189,6 +190,9 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     analyticsService.track("update_deployment", { category: "deployments", label: "Update deployment" });
     analyticsService.track("successful_tx", { category: "transactions", label: "Successful transaction" });
     refetchBalances();
+    enqueueSnackbar(<d.Snackbar title="Success" subTitle="Deployment updated successfully" iconVariant="success" />, {
+      variant: "success"
+    });
   }
 
   /** A full or corrupted browser storage must not turn an update the api already accepted into a reported failure. */
@@ -220,7 +224,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
       return;
     }
 
-    enqueueSnackbar(<d.Snackbar title="Couldn't update deployment" subTitle={extractApiErrorMessage(cause) ?? UPDATE_FAILURE_MESSAGE} iconVariant="error" />, {
+    enqueueSnackbar(<d.Snackbar title="Error" subTitle={extractApiErrorMessage(cause) ?? UPDATE_FAILURE_MESSAGE} iconVariant="error" />, {
       variant: "error",
       autoHideDuration: null
     });
@@ -260,7 +264,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
       ) : (
         <>
           <div>
-            <DeploymentTabHeader
+            <d.DeploymentTabHeader
               title="Update Deployment"
               actions={
                 <div className="flex items-center gap-2">
@@ -304,7 +308,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
                   <d.WarningCircle className="text-xs text-warning" />
                 </d.CustomTooltip>
               )}
-            </DeploymentTabHeader>
+            </d.DeploymentTabHeader>
 
             {parsingError && <d.Alert variant="warning">{parsingError}</d.Alert>}
 

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { LoggerService } from "@akashnetwork/logging";
 import { extractApiErrorMessage, isApiError } from "@akashnetwork/openapi-sdk";
 import { Alert, Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
 import { InfoCircle, Upload, WarningCircle } from "iconoir-react";
@@ -13,7 +14,6 @@ import { useBlockchainStatus as useBlockchainStatusOriginal } from "@src/context
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet as useWalletOriginal } from "@src/context/WalletProvider";
 import { AddCreditsSnackbarContent } from "@src/context/WalletProvider/useSignAndBroadcast";
-import { useProviderCredentials as useProviderCredentialsOriginal } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useBalances as useBalancesOriginal } from "@src/queries/useBalancesQuery";
 import type { DeploymentDto } from "@src/types/deployment";
 import { deploymentData as deploymentDataOriginal } from "@src/utils/deploymentData";
@@ -36,15 +36,18 @@ export const DEPENDENCIES = {
   WarningCircle,
   useWallet: useWalletOriginal,
   useBalances: useBalancesOriginal,
-  useProviderCredentials: useProviderCredentialsOriginal,
   useSnackbar: useSnackbarOriginal,
   useBlockchainStatus: useBlockchainStatusOriginal,
   // eslint-disable-next-line akash/dependencies-component-or-hook
   deploymentData: deploymentDataOriginal
 };
 
+const logger = new LoggerService({ name: "ManifestUpdate" });
+
 /** The api answers 400 for provider-credential and schema failures too, and only a refusal of the document itself belongs in the editor's inline alert. */
 const SDL_REFUSAL_PREFIXES = ["Invalid SDL:", "SDL is not valid YAML", "SDL is too large"];
+/** The api wraps trial fair-use gating in the same "Invalid SDL:" 400 as document refusals, yet only adding credits resolves it. */
+const TRIAL_GATE_MARK = "not available on free trial";
 const UPDATE_FAILURE_MESSAGE = "Something went wrong while updating the deployment. Please try again.";
 const ADD_CREDITS_TITLE = "Add credits to continue";
 
@@ -52,12 +55,41 @@ function isBadRequest(cause: unknown): boolean {
   return isApiError(cause) && cause.status === 400;
 }
 
+function isPaymentRequired(cause: unknown): boolean {
+  return isApiError(cause) && cause.status === 402;
+}
+
+/** Mirrors signAndBroadcast, which keeps client-side refusals out of the failed_tx metric. */
+function isClientRefusal(cause: unknown): boolean {
+  return isBadRequest(cause) || isPaymentRequired(cause);
+}
+
 function sdlRefusalOf(cause: unknown): string | null {
-  if (!isBadRequest(cause)) return null;
+  if (!isBadRequest(cause) || trialGateRefusalOf(cause) !== null) return null;
 
   const message = extractApiErrorMessage(cause);
 
   return message && SDL_REFUSAL_PREFIXES.some(prefix => message.startsWith(prefix)) ? message : null;
+}
+
+function trialGateRefusalOf(cause: unknown): string | null {
+  if (!isBadRequest(cause)) return null;
+
+  const message = extractApiErrorMessage(cause);
+
+  return message?.includes(TRIAL_GATE_MARK) ? message.replace(/^Invalid SDL: /, "") : null;
+}
+
+function creditsRefusalOf(cause: unknown): string | null {
+  return isPaymentRequired(cause) ? extractApiErrorMessage(cause) ?? "" : trialGateRefusalOf(cause);
+}
+
+function addCreditsContentOf(refusal: string): { title: string; message?: string } {
+  const separatorAt = refusal.indexOf(": ");
+
+  if (separatorAt === -1) return { title: ADD_CREDITS_TITLE, message: refusal || undefined };
+
+  return { title: refusal.slice(0, separatorAt), message: refusal.slice(separatorAt + 2) };
 }
 
 type Props = {
@@ -87,10 +119,12 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   const [isUpdating, setIsUpdating] = useState(false);
   const { address } = d.useWallet();
   const { refetch: refetchBalances } = d.useBalances(address);
-  const providerCredentials = d.useProviderCredentials();
   const { enqueueSnackbar, closeSnackbar } = d.useSnackbar();
   const { isBlockchainDown } = d.useBlockchainStatus();
-  const updateDeployment = api.v1.updateDeployment.useMutation({ onSuccess: recordUpdate, onError: reportUpdateFailure });
+  const updateDeployment = api.v1.updateDeployment.useMutation({
+    onSuccess: (_data, variables) => recordUpdate(variables.data.sdl),
+    onError: reportUpdateFailure
+  });
 
   useEffect(() => {
     const init = async () => {
@@ -139,11 +173,20 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     updateDeployment.mutate({ dseq: deployment.dseq, data: { sdl: editedManifest } }, { onSuccess: closeAfterUpdate, onError: releaseAfterFailure });
   }
 
-  function recordUpdate() {
-    deploymentLocalStorage.update(address, deployment.dseq, { manifest: editedManifest });
+  function recordUpdate(submittedSdl: string) {
+    cacheSubmittedManifest(submittedSdl);
     analyticsService.track("update_deployment", { category: "deployments", label: "Update deployment" });
     analyticsService.track("successful_tx", { category: "transactions", label: "Successful transaction" });
     refetchBalances();
+  }
+
+  /** A full or corrupted browser storage must not turn an update the api already accepted into a reported failure. */
+  function cacheSubmittedManifest(manifest: string) {
+    try {
+      deploymentLocalStorage.update(address, deployment.dseq, { manifest });
+    } catch (error) {
+      logger.error({ event: "DEPLOYMENT_MANIFEST_CACHE_FAILED", error });
+    }
   }
 
   function closeAfterUpdate() {
@@ -154,14 +197,15 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   function reportUpdateFailure(cause: unknown) {
     refetchBalances();
 
-    if (!isBadRequest(cause)) {
+    if (!isClientRefusal(cause)) {
       analyticsService.track("failed_tx", { category: "transactions", label: "Failed transaction" });
     }
 
     if (sdlRefusalOf(cause)) return;
 
-    if (isApiError(cause) && cause.status === 402) {
-      offerCredits(cause);
+    const creditsRefusal = creditsRefusalOf(cause);
+    if (creditsRefusal !== null) {
+      offerCredits(creditsRefusal);
       return;
     }
 
@@ -176,15 +220,11 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     setParsingError(sdlRefusalOf(cause));
   }
 
-  function offerCredits(cause: unknown) {
-    const [title, message] = (extractApiErrorMessage(cause) ?? "").split(": ");
+  function offerCredits(refusal: string) {
+    const { title, message } = addCreditsContentOf(refusal);
 
     const key = enqueueSnackbar(
-      <d.Snackbar
-        title={title || message || ADD_CREDITS_TITLE}
-        subTitle={<d.AddCreditsSnackbarContent message={message} onAction={() => closeSnackbar(key)} />}
-        iconVariant="warning"
-      />,
+      <d.Snackbar title={title} subTitle={<d.AddCreditsSnackbarContent message={message} onAction={() => closeSnackbar(key)} />} iconVariant="warning" />,
       {
         variant: "warning",
         autoHideDuration: 10000
@@ -220,14 +260,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
                     </d.Button>
                   )}
                   <d.Button
-                    disabled={
-                      !providerCredentials.details.usable ||
-                      !!parsingError ||
-                      !editedManifest ||
-                      isUpdating ||
-                      deployment.state !== "active" ||
-                      isBlockchainDown
-                    }
+                    disabled={!!parsingError || !editedManifest || isUpdating || deployment.state !== "active" || isBlockchainDown}
                     onClick={() => handleUpdateClick()}
                     size="md"
                     type="button"

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -43,9 +43,22 @@ export const DEPENDENCIES = {
   deploymentData: deploymentDataOriginal
 };
 
-const REFUSED_SDL_MESSAGE = "The console could not accept this SDL.";
+/** The api answers 400 for provider-credential and schema failures too, and only a refusal of the document itself belongs in the editor's inline alert. */
+const SDL_REFUSAL_PREFIXES = ["Invalid SDL:", "SDL is not valid YAML", "SDL is too large"];
 const UPDATE_FAILURE_MESSAGE = "Something went wrong while updating the deployment. Please try again.";
 const ADD_CREDITS_TITLE = "Add credits to continue";
+
+function isBadRequest(cause: unknown): boolean {
+  return isApiError(cause) && cause.status === 400;
+}
+
+function sdlRefusalOf(cause: unknown): string | null {
+  if (!isBadRequest(cause)) return null;
+
+  const message = extractApiErrorMessage(cause);
+
+  return message && SDL_REFUSAL_PREFIXES.some(prefix => message.startsWith(prefix)) ? message : null;
+}
 
 type Props = {
   deployment: DeploymentDto;
@@ -75,9 +88,9 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   const { address } = d.useWallet();
   const { refetch: refetchBalances } = d.useBalances(address);
   const providerCredentials = d.useProviderCredentials();
-  const { enqueueSnackbar } = d.useSnackbar();
+  const { enqueueSnackbar, closeSnackbar } = d.useSnackbar();
   const { isBlockchainDown } = d.useBlockchainStatus();
-  const updateDeployment = api.v1.updateDeployment.useMutation();
+  const updateDeployment = api.v1.updateDeployment.useMutation({ onSuccess: recordUpdate, onError: reportUpdateFailure });
 
   useEffect(() => {
     const init = async () => {
@@ -102,8 +115,13 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     init();
   }, [deployment, address, deploymentLocalStorage]);
 
+  function handleManifestChange(value: string) {
+    setParsingError(null);
+    onManifestChange(value);
+  }
+
   function handleTextChange(value: string | undefined) {
-    onManifestChange(value || "");
+    handleManifestChange(value || "");
 
     if (deploymentVersion) {
       setDeploymentVersion(null);
@@ -119,26 +137,29 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   function handleUpdateClick() {
     setParsingError(null);
     setIsUpdating(true);
-    updateDeployment.mutate({ dseq: deployment.dseq, data: { sdl: editedManifest } }, { onSuccess: finishUpdate, onError: reportUpdateFailure });
+    updateDeployment.mutate({ dseq: deployment.dseq, data: { sdl: editedManifest } }, { onSuccess: closeAfterUpdate, onError: releaseAfterFailure });
   }
 
-  function finishUpdate() {
+  function recordUpdate() {
     deploymentLocalStorage.update(address, deployment.dseq, { manifest: editedManifest });
     analyticsService.track("update_deployment", { category: "deployments", label: "Update deployment" });
     analyticsService.track("successful_tx", { category: "transactions", label: "Successful transaction" });
     refetchBalances();
+  }
+
+  function closeAfterUpdate() {
     setIsUpdating(false);
     closeManifestEditor();
   }
 
   function reportUpdateFailure(cause: unknown) {
-    setIsUpdating(false);
-    analyticsService.track("failed_tx", { category: "transactions", label: "Failed transaction" });
+    refetchBalances();
 
-    if (isApiError(cause) && cause.status === 400) {
-      setParsingError(extractApiErrorMessage(cause) ?? REFUSED_SDL_MESSAGE);
-      return;
+    if (!isBadRequest(cause)) {
+      analyticsService.track("failed_tx", { category: "transactions", label: "Failed transaction" });
     }
+
+    if (sdlRefusalOf(cause)) return;
 
     if (isApiError(cause) && cause.status === 402) {
       offerCredits(cause);
@@ -151,11 +172,20 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     });
   }
 
+  function releaseAfterFailure(cause: unknown) {
+    setIsUpdating(false);
+    setParsingError(sdlRefusalOf(cause));
+  }
+
   function offerCredits(cause: unknown) {
     const [title, message] = (extractApiErrorMessage(cause) ?? "").split(": ");
 
-    enqueueSnackbar(
-      <d.Snackbar title={title || message || ADD_CREDITS_TITLE} subTitle={<d.AddCreditsSnackbarContent message={message} />} iconVariant="warning" />,
+    const key = enqueueSnackbar(
+      <d.Snackbar
+        title={title || message || ADD_CREDITS_TITLE}
+        subTitle={<d.AddCreditsSnackbarContent message={message} onAction={() => closeSnackbar(key)} />}
+        iconVariant="warning"
+      />,
       {
         variant: "warning",
         autoHideDuration: 10000
@@ -239,7 +269,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
 
             <d.ViewPanel stickToBottom style={{ overflow: isRemoteDeploy ? "unset" : "hidden" }}>
               {isRemoteDeploy ? (
-                <d.RemoteDeployUpdate sdlString={editedManifest} onManifestChange={onManifestChange} />
+                <d.RemoteDeployUpdate sdlString={editedManifest} onManifestChange={handleManifestChange} />
               ) : (
                 <d.SDLEditor value={editedManifest} onChange={handleTextChange} onValidate={() => setParsingError(null)} />
               )}

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LoggerService } from "@akashnetwork/logging";
 import { extractApiErrorMessage, isApiError } from "@akashnetwork/openapi-sdk";
 import { Alert, Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
@@ -126,6 +126,17 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     onError: reportUpdateFailure
   });
 
+  /** The inline alert only exists while the editor is mounted, so a refusal arriving after it closes has to fall back to a snackbar. */
+  const isEditorMounted = useRef(true);
+
+  useEffect(function trackEditorMount() {
+    isEditorMounted.current = true;
+
+    return function markEditorUnmounted() {
+      isEditorMounted.current = false;
+    };
+  }, []);
+
   useEffect(() => {
     const init = async () => {
       const localDeploymentData = deploymentLocalStorage.get(address, deployment.dseq);
@@ -201,7 +212,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
       analyticsService.track("failed_tx", { category: "transactions", label: "Failed transaction" });
     }
 
-    if (sdlRefusalOf(cause)) return;
+    if (sdlRefusalOf(cause) && isEditorMounted.current) return;
 
     const creditsRefusal = creditsRefusalOf(cause);
     if (creditsRefusal !== null) {

--- a/apps/deploy-web/src/utils/TransactionMessageData.ts
+++ b/apps/deploy-web/src/utils/TransactionMessageData.ts
@@ -1,5 +1,5 @@
 import { Source } from "@akashnetwork/chain-sdk/private-types/akash.v1";
-import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
 import { MsgSend } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 
@@ -33,16 +33,6 @@ export class TransactionMessageData {
           sources: [Source.grant, Source.balance]
         },
         reclamation: deploymentData.reclamation
-      })
-    };
-  }
-
-  static getUpdateDeploymentMsg(deploymentData: NewDeploymentData) {
-    return {
-      typeUrl: `/${MsgUpdateDeployment.$type}`,
-      value: MsgUpdateDeployment.fromPartial({
-        id: deploymentData.deploymentId,
-        hash: deploymentData.hash
       })
     };
   }


### PR DESCRIPTION
## Why

Fixes CON-869.

The manifest-update flow built the Akash manifest in the browser, decided for itself whether the manifest hash had changed, broadcast the update transaction and then sent the manifest straight to each lease provider. The console API's update endpoint already does that whole job server-side, and — since it parses and resolves the SDL — it is the only place that can substitute `ac-secret://NAME` reference values. Moving the flow onto `PUT /v1/deployments/{dseq}` puts the manifest on the one code path that can resolve.

The hash comparison inside the endpoint stays correct because both sides are then resolved manifests: the one it derives and the one committed on chain.

Browser wallets are out of scope, and there is nothing to preserve for them: `WalletProvider` sources wallets solely from `useManagedWallet`, and `signAndBroadcastTx` already went through the console API's tx endpoint rather than a browser signer. The removal is unconditional.

## What

`ManifestUpdate` now calls `api.v1.updateDeployment` and drops its own signing and provider calls.

- Submits `{ dseq, data: { sdl } }` to `PUT /v1/deployments/{dseq}`; the endpoint parses the SDL, records the definition, broadcasts only when the manifest hash differs from chain, and sends the manifest to every lease's provider.
- Removed from the browser: `signAndBroadcastTx`, `TransactionMessageData.getUpdateDeploymentMsg` (deleted — it had no other caller), `deploymentData.NewDeploymentData`, `providerProxy.sendManifest`, the unique-provider loop, `useProviderList`, and the `leases` prop. `sendManifest`, `NewDeploymentData` and `useProviderCredentials` all stay in the codebase for their other callers.
- Rebuilt, so the browser path's affordances are not lost: the 402 → **Add Funds** call to action, the balance refresh after a successful update, and the `successful_tx` / `failed_tx` analytics alongside the retained `update_deployment`.
- Error mapping: a 400 renders inline in the same warning `Alert` that YAML errors always used (the API's message is more specific than the old "Error while parsing SDL file"); a 402 offers Add Funds; anything else raises a snackbar carrying the API's message with `autoHideDuration: null`, as provider errors did before.
- The local-storage write drops `manifestVersion`, which nothing in the app has ever read back.

### Please read before approving

**AC3 is satisfied by construction, not by resolution.** The update editor is fed only from `deploymentLocalStorage`, so the SDL it submits is always plaintext and always resolves. Nothing in deploy-web reads `consoleSettings.sdl` or `/v2/deployment-settings`, and `useDeploymentDetail` reads the chain REST API, which carries no SDL — so a reference-bearing document never reaches the editor. **The moment any surface hands the user their stored SDL, this path returns 400**, because `updateByUserIdAndDseq` resolves with no `secrets` and will not open the deployment's own sealed token (deliberately — `deployment-writer.service.ts:330` vs `:372`, pinned by *"refuses an update that resubmits the sdl it stored, whose references it holds no values for"*). CON-864's move to PATCH is the real fix; this PR does not change that behaviour and does not touch `apps/api`.

**Forward hazard for CON-864.** Error routing keys off the SDL-refusal message prefixes `Invalid SDL:`, `SDL is not valid YAML` and `SDL is too large`, which is the complete set PUT can emit. PATCH emits a fourth the gate does not match — `The patched SDL is too large: …` (`deployment-writer.service.ts:445`) — so whoever moves deploy-web to PATCH must add that prefix, or an oversize SDL will misroute from the inline alert to a snackbar. Relatedly, none of these messages is pinned by a test on either side, so a reword would move a refusal between surfaces silently; recorded as a follow-up rather than fixed here, since this PR leaves `apps/api` untouched.

**This knowingly adds a steady consumer to a deprecated endpoint.** `PUT /v1/deployments/{dseq}` is marked `deprecated: true`, and `updateByUserIdAndDseq` logs `DEPRECATED_UPDATE_DEPLOYMENT_ENDPOINT_USED` at warn on every call. That warn is **left in place deliberately**, as pressure to finish CON-864, rather than demoted or gated. Expect warn-level volume proportional to update usage. PUT (not PATCH) is right for this use case: the editor resubmits a whole document, whereas PATCH only touches named services.

**Accepted losses.** The `TransactionModal` "updatingDeployment" overlay is gone; the loading skeleton and the disabled button already report progress. A multi-provider failure no longer names *which* provider failed — the API's error does not carry it. Both are deliberate.

**Two new failure modes**, neither of which the browser path had:
- Trial fair-use now gates updates. `#resolveSdl` runs with `isTrialing`, so a trialing wallet updating into a blocked GPU or GPU interconnect gets a 400 ("Add funds to unlock GPU access"). Almost certainly a fix, but it is a change.
- An update can now fail on the AKT price feed. `restatePricesInGrantDenom` calls the exchange rate service, so an update can be refused with "the AKT price is unavailable".

**Server-side ordering caveat.** The endpoint records the deployment definition *before* it broadcasts, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs it: it recomputes the same manifest version and goes on to broadcast and push the manifest. This is the endpoint's existing behaviour, documented on the PATCH route, and is inherited rather than introduced here.

### Verification

`apps/deploy-web`: `npm test` 378 files / 3793 tests passed · `npm run lint -- --quiet` clean · `npx tsc --noEmit` 84 errors, all pre-existing (down from 94 on `main` — the 10 in `ManifestUpdate.spec.tsx` are cleared, none added) · `npm run knip -- --workspace apps/deploy-web` clean.

AC2 is verified server-side by existing coverage rather than here, because the client no longer has a hash or a say: `deployment-writer.service.spec.ts` *"skips update tx when manifest hash matches"*. The client-side guarantee added instead is that it always calls the API and can never short-circuit.

---

## Demo


Before this change, the Update tab in deploy-web built the Akash manifest in the browser, decided for itself whether the manifest hash had changed, broadcast the update transaction, and then `PUT` the manifest to every lease provider directly. Now it hands the SDL to the console API and the API does all of it server-side.

What follows drives the **real** `ManifestUpdate` component through its DI seam, with the **real** generated API SDK (`createApiSdk` + `createProxy`) and the **real** `Alert` / `Button` / `Snackbar` / `AddCreditsSnackbarContent` UI components. Only the network boundary is faked, so the request shown below is the actual HTTP request the browser would put on the wire, and the text shown is the actual text rendered into the DOM.

A live end-to-end demo against a running console API is not achievable here: the endpoint signs with a managed wallet and needs an authenticated user, an API key and a funded wallet, none of which I have. No browser screenshot for the same reason. This is the closest honest thing.

```bash
set -e
ROOT=$(git rev-parse --show-toplevel)
H="$ROOT/apps/deploy-web/src/components/deployments/ManifestUpdate/__demo.spec.tsx"
trap 'rm -f "$H"' EXIT
cp "$ROOT/.work/con-869-update-through-api/demo-harness.spec.tsx" "$H"
cd "$ROOT/apps/deploy-web"
NODE_ENV=test DEPLOYMENT_ENV=staging npx vitest run src/components/deployments/ManifestUpdate/__demo.spec.tsx --disable-console-intercept 2>&1 \
  | grep -v "^npm warn" | grep -v "\"level\":\"info\"" | grep -vE "^\s*$" | grep -vE "RUN  v|Start at|Duration"

```

```output
--- HTTP request the browser actually made ---
method : PUT
url    : https://console-api.example/v1/deployments/123
body   : {"data":{"sdl":"version: \"2.0\"\nservices:\n  web:\n    image: nginx:1.27\n    env:\n      - API_TOKEN=PLAINTEXT_TOKEN_PLACEHOLDER\n    expose:\n      - port: 80\n        as: 80\n        to:\n          - global: true\n"}}
browser-side signing calls : 0
browser->provider calls    : 0
SDL sent on the wire carries the real env value, not a reference:
  contains 'PLAINTEXT_TOKEN_PLACEHOLDER' : true
  contains 'ac-secret://'           : false
--- inline alert the user sees ---
SDL is not valid YAML: line 4, column 7
--- snackbar the user sees ---
title   : Couldn't update deployment
message : Provider service is temporarily unavailable
--- snackbar the user sees ---
title       : Insufficient balance
message     : top up to keep deploying
call to action: Add Funds
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Reading that output:

- **Scenario A (AC1, AC3).** One `PUT https://console-api.example/v1/deployments/123`, body `{"data":{"sdl":...}}`. `signAndBroadcastTx` was called **0** times and `providerProxy.sendManifest` **0** times: the browser neither signs nor talks to a provider any more. The SDL on the wire carries the plaintext env value and contains no `ac-secret://` reference — that is the AC3 evidence available on this side. AC2 is now the endpoint decision rather than the client one: the client always calls, and the API skips the transaction when the manifest hash is unchanged.
- **Scenario B (AC4).** A 400 renders inline in the same warning `Alert` that YAML errors always used, and the editor stays open. The API message is more specific than the old client-side "Error while parsing SDL file".
- **Scenario C (AC4).** A provider failure relayed by the API becomes a snackbar carrying the provider own message, and it does not auto-hide — same as the old browser path.
- **Scenario D (AC4).** A 402 still offers a working **Add Funds** call to action, rebuilt from what `signAndBroadcast` used to do.

```bash
cd "$(git rev-parse --show-toplevel)"
echo "=== browser-side signing and provider path is gone from the component ==="
for sym in signAndBroadcastTx providerProxy sendManifest TransactionMessageData getUpdateDeploymentMsg NewDeploymentData useProviderList; do
  printf "%-24s occurrences in ManifestUpdate.tsx: %s\n" "$sym" "$(grep -c "$sym" apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx)"
done
echo
echo "=== getUpdateDeploymentMsg deleted repo-wide (it had no other caller) ==="
grep -rn "getUpdateDeploymentMsg" apps/deploy-web/src || echo "no occurrences"
echo
echo "=== still alive for other callers, so NOT dead code ==="
grep -rln "providerProxy.sendManifest\|deploymentData.NewDeploymentData\|useProviderCredentials" apps/deploy-web/src --include=*.tsx --include=*.ts | grep -v spec | sort
```

```output
=== browser-side signing and provider path is gone from the component ===
signAndBroadcastTx       occurrences in ManifestUpdate.tsx: 0
providerProxy            occurrences in ManifestUpdate.tsx: 0
sendManifest             occurrences in ManifestUpdate.tsx: 0
TransactionMessageData   occurrences in ManifestUpdate.tsx: 0
getUpdateDeploymentMsg   occurrences in ManifestUpdate.tsx: 0
NewDeploymentData        occurrences in ManifestUpdate.tsx: 0
useProviderList          occurrences in ManifestUpdate.tsx: 0

=== getUpdateDeploymentMsg deleted repo-wide (it had no other caller) ===
no occurrences

=== still alive for other callers, so NOT dead code ===
apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.ts
apps/deploy-web/src/hooks/useProviderApiActions.tsx
apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
apps/deploy-web/src/queries/useLeaseQuery.ts
```

The harness driving the scenarios above is a throwaway scratch file, deliberately not committed: it is demo scaffolding, not a test the suite should carry. What it asserts is covered for real by `ManifestUpdate.spec.tsx` in this PR; its job here was only to prove the behaviour against the real SDK and the real UI components rather than against doubles.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manifest updates now use the Console API for submission.
  - Added clearer handling for SDL validation errors, payment or credit requirements, and update failures.
  - Update controls reflect active deployment and in-progress states.
  - Manifest edits are cached safely and restored when appropriate.
  - Balance information refreshes after updates.

- **Bug Fixes**
  - Editing the manifest clears previous parsing errors.
  - Improved retry behavior and deployment update state handling.
  - Delayed validation failures now provide feedback through notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->