### PR TITLE
fix(billing): let the funding wallet revoke a deposit grant through the tx-signer

### DIFF
--- a/apps/tx-signer/src/config/message-urls.config.ts
+++ b/apps/tx-signer/src/config/message-urls.config.ts
@@ -1,7 +1,7 @@
 import { DepositAuthorization, MsgAccountDeposit, MsgCreateCertificate, MsgMintACT } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
-import { MsgGrant, MsgGrantAllowance, MsgRevokeAllowance } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { MsgGrant, MsgGrantAllowance, MsgRevoke, MsgRevokeAllowance } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { BasicAllowance } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 
 /**
@@ -12,6 +12,7 @@ export const FUNDING_WALLET_MESSAGE_TYPE_URLS = [
   `/${MsgGrantAllowance.$type}`,
   `/${MsgRevokeAllowance.$type}`,
   `/${MsgGrant.$type}`,
+  `/${MsgRevoke.$type}`,
   `/${MsgMintACT.$type}`
 ] as const;
 

--- a/apps/tx-signer/src/services/tx-policy/tx-policy.service.spec.ts
+++ b/apps/tx-signer/src/services/tx-policy/tx-policy.service.spec.ts
@@ -1,6 +1,6 @@
 import { DepositAuthorization, MsgAccountDeposit, MsgCreateCertificate, MsgMintACT, Scope } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
-import { BasicAllowance, type Coin, MsgGrant, MsgGrantAllowance, MsgRevokeAllowance } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { BasicAllowance, type Coin, MsgGrant, MsgGrantAllowance, MsgRevoke, MsgRevokeAllowance } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -60,6 +60,20 @@ describe(TxPolicyService.name, () => {
     it("rejects a grant issued by another granter", () => {
       const { service } = setup();
       const message = encodeObject(`/${MsgGrantAllowance.$type}`, MsgGrantAllowance.fromPartial({ granter: OTHER_ADDRESS, grantee: SIGNER_ADDRESS }));
+
+      expect(() => service.assertActingOnBehalfOf([message], SIGNER_ADDRESS)).toThrow(/may not be signed by this wallet/);
+    });
+
+    it("accepts an authz revoke issued by the signing wallet", () => {
+      const { service } = setup();
+      const message = encodeObject(`/${MsgRevoke.$type}`, MsgRevoke.fromPartial({ granter: SIGNER_ADDRESS, grantee: OTHER_ADDRESS }));
+
+      expect(() => service.assertActingOnBehalfOf([message], SIGNER_ADDRESS)).not.toThrow();
+    });
+
+    it("rejects an authz revoke issued by another granter", () => {
+      const { service } = setup();
+      const message = encodeObject(`/${MsgRevoke.$type}`, MsgRevoke.fromPartial({ granter: OTHER_ADDRESS, grantee: SIGNER_ADDRESS }));
 
       expect(() => service.assertActingOnBehalfOf([message], SIGNER_ADDRESS)).toThrow(/may not be signed by this wallet/);
     });

--- a/apps/tx-signer/src/services/tx-policy/tx-policy.service.ts
+++ b/apps/tx-signer/src/services/tx-policy/tx-policy.service.ts
@@ -1,7 +1,7 @@
 import { DepositAuthorization, MsgAccountDeposit, MsgCreateCertificate, MsgMintACT } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
-import { BasicAllowance, type Coin, MsgGrant, MsgGrantAllowance, MsgRevokeAllowance } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
+import { BasicAllowance, type Coin, MsgGrant, MsgGrantAllowance, MsgRevoke, MsgRevokeAllowance } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import { Forbidden } from "http-errors";
 import { inject, singleton } from "tsyringe";
@@ -35,6 +35,7 @@ const ACTOR_ADDRESS_READERS = {
   [`/${MsgGrantAllowance.$type}` as const]: readActorAddresses((m: MsgGrantAllowance) => [m.granter]),
   [`/${MsgRevokeAllowance.$type}` as const]: readActorAddresses((m: MsgRevokeAllowance) => [m.granter]),
   [`/${MsgGrant.$type}` as const]: readActorAddresses((m: MsgGrant) => [m.granter]),
+  [`/${MsgRevoke.$type}` as const]: readActorAddresses((m: MsgRevoke) => [m.granter]),
   [`/${MsgMintACT.$type}` as const]: readActorAddresses((m: MsgMintACT) => [m.owner, m.to])
 } satisfies Record<SignableMessageTypeUrl, ActorAddressReader>;
 

--- a/apps/tx-signer/test/functional/sign-and-broadcast-tx.spec.ts
+++ b/apps/tx-signer/test/functional/sign-and-broadcast-tx.spec.ts
@@ -1,9 +1,10 @@
-import { MsgCreateCertificate } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { MsgAccountDeposit, MsgCreateCertificate } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import {
   BaseAccount,
   BasicAllowance,
   type Coin,
   MsgGrantAllowance,
+  MsgRevoke,
   QueryAccountResponse,
   SimulateResponse,
   TxBody,
@@ -69,6 +70,29 @@ describe(TxController.name, () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ data: { code: 0, hash: txHash, rawLog: "" } });
+  });
+
+  it("signs a funding tx revoking a deposit grant the funding wallet issued", async () => {
+    const { txHash } = mockRpcNode();
+
+    const res = await app.request("/v1/tx/funding", {
+      method: "POST",
+      body: JSON.stringify({ data: { messages: await buildRevokeDepositGrantMessages() } }),
+      headers: authorizedHeaders()
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: { code: 0, hash: txHash, rawLog: "" } });
+  });
+
+  it("rejects a funding tx revoking a deposit grant another granter issued", async () => {
+    const res = await app.request("/v1/tx/funding", {
+      method: "POST",
+      body: JSON.stringify({ data: { messages: await buildRevokeDepositGrantMessages(createAkashAddress()) } }),
+      headers: authorizedHeaders()
+    });
+
+    expect(res.status).toBe(403);
   });
 
   it("retries a gas simulation that failed at the transport with a transaction window opened for the retry", async () => {
@@ -227,6 +251,19 @@ describe(TxController.name, () => {
           typeUrl: `/${BasicAllowance.$type}`,
           value: Uint8Array.from(BasicAllowance.encode(BasicAllowance.fromPartial({ spendLimit })).finish())
         }
+      })
+    });
+  }
+
+  async function buildRevokeDepositGrantMessages(granter?: string) {
+    const txManagerService = container.resolve(TxManagerService);
+
+    return encodeMessages({
+      typeUrl: `/${MsgRevoke.$type}`,
+      value: MsgRevoke.fromPartial({
+        granter: granter ?? (await txManagerService.getFundingWalletAddress()),
+        grantee: await txManagerService.getDerivedWalletAddress(DERIVATION_INDEX),
+        msgTypeUrl: `/${MsgAccountDeposit.$type}`
       })
     });
   }


### PR DESCRIPTION
## Why

The tx-signer's funding wallet allowlist covers granting and revoking fee allowances and granting deposit authorizations, but not revoking a deposit authorization. The api's grant lifecycle now needs that revoke, and the signer rejected it as a validation error before it reached the policy layer, so the calling job failed on every retry.

## What

- Adds `/cosmos.authz.v1beta1.MsgRevoke` to `FUNDING_WALLET_MESSAGE_TYPE_URLS`.
- Adds the matching actor binding rule in `TxPolicyService`, so the revoke may only be signed when the funding wallet is the granter, the same rule the grant has.
- Unit spec covers the accept and reject sides of the binding. Functional spec covers a signed revoke end to end against the mocked RPC node and a 403 for a revoke naming another granter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Funding wallets can now sign authorization revocation transactions.
  - Revocations are supported for the wallet’s own account-deposit grants.

- **Bug Fixes**
  - Transactions attempting to revoke grants issued by another account are now rejected.
  - Transaction validation now ensures the revocation granter matches the signing wallet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->