### PR TITLE
fix(deployment): run the trial deployment probe sweep on staging sandbox

### DIFF
--- a/.helm/console-api-staging-sandbox-values.yaml
+++ b/.helm/console-api-staging-sandbox-values.yaml
@@ -52,6 +52,15 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - close-unreachable-deployments
+  # Offset from the sweeps above so no two of them hit deployment_settings on the same minute.
+  - name: probe-trial-deployments
+    schedule: "13,43 * * * *" # every 30 minutes
+    command:
+      - node
+      - --require
+      - ./dist/instrumentation.js
+      - ./dist/console.js
+      - probe-trial-deployments
 
 replicas: 2
 


### PR DESCRIPTION
## Why

The `probe-trial-deployments` sweep runs on prod mainnet every 30 minutes and gives any live trial deployment without a pending probe a new one. It was never added to the staging sandbox values, so on beta a deployment whose probe chain ends is never revisited, and the follow-up work a later probe would queue never happens. Staging mainnet defines no cron jobs at all, so it is left as is.

## What

- Adds the `probe-trial-deployments` cron to `.helm/console-api-staging-sandbox-values.yaml` with the same schedule and offset as prod mainnet.
- Values-only change. It takes effect on the next console-api deploy to staging sandbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scheduled job that checks trial deployments every 30 minutes in the staging sandbox environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->