### PR TITLE
fix(user): ask for fair use policy acceptance before the trial wallet exists

### DIFF
--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
@@ -24,6 +24,13 @@ describe(RequireFairUsePolicy.name, () => {
     expect(screen.getByTestId("fair-use-policy-modal")).toBeInTheDocument();
   });
 
+  it("keeps the page and skips the prompt when the wallet lookup has failed", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: null, isTrialing: false, hasWallet: false, isWalletLookupFailed: true });
+
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
+  });
+
   it("renders only the page once the user has accepted", () => {
     setup({ userId: "u1", fairUsePolicyAcceptedAt: ACCEPTED_AT });
 
@@ -76,6 +83,7 @@ describe(RequireFairUsePolicy.name, () => {
     loggedOut?: boolean;
     isTrialing?: boolean;
     hasWallet?: boolean;
+    isWalletLookupFailed?: boolean;
     isGateEnabled?: boolean;
     hasAccepted?: boolean;
   }) {
@@ -88,7 +96,12 @@ describe(RequireFairUsePolicy.name, () => {
             : mock<CustomUserProfile>({ userId: input.userId ?? "u1", fairUsePolicyAcceptedAt: input.fairUsePolicyAcceptedAt ?? null }),
           isLoading: false
         })) as typeof DEPENDENCIES.useUser,
-      useWallet: () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? true, hasWallet: input.hasWallet ?? true }),
+      useWallet: () =>
+        mock<ReturnType<typeof DEPENDENCIES.useWallet>>({
+          isTrialing: input.isTrialing ?? true,
+          hasWallet: input.hasWallet ?? true,
+          isWalletLookupFailed: input.isWalletLookupFailed ?? false
+        }),
       useFlag: flag => flag === "fair_use_policy_gate" && (input.isGateEnabled ?? true),
       useAcceptFairUsePolicy: () => ({ accept, isAccepting: false, hasAccepted: input.hasAccepted ?? false }),
       FairUsePolicyModal: ({ onAccept }) => (

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
@@ -10,10 +10,17 @@ import { fireEvent, render, screen } from "@testing-library/react";
 const ACCEPTED_AT = "2026-09-06T00:00:00.000Z";
 
 describe(RequireFairUsePolicy.name, () => {
-  it("shows the modal over the page for a trialing user who has not accepted", () => {
+  it("shows the modal instead of the page for a trialing user who has not accepted", () => {
     setup({ userId: "u1", fairUsePolicyAcceptedAt: null });
 
-    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.queryByText("child")).not.toBeInTheDocument();
+    expect(screen.getByTestId("fair-use-policy-modal")).toBeInTheDocument();
+  });
+
+  it("demands acceptance before the trial wallet exists", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: null, isTrialing: false, hasWallet: false });
+
+    expect(screen.queryByText("child")).not.toBeInTheDocument();
     expect(screen.getByTestId("fair-use-policy-modal")).toBeInTheDocument();
   });
 
@@ -68,6 +75,7 @@ describe(RequireFairUsePolicy.name, () => {
     isPublic?: boolean;
     loggedOut?: boolean;
     isTrialing?: boolean;
+    hasWallet?: boolean;
     isGateEnabled?: boolean;
     hasAccepted?: boolean;
   }) {
@@ -80,7 +88,7 @@ describe(RequireFairUsePolicy.name, () => {
             : mock<CustomUserProfile>({ userId: input.userId ?? "u1", fairUsePolicyAcceptedAt: input.fairUsePolicyAcceptedAt ?? null }),
           isLoading: false
         })) as typeof DEPENDENCIES.useUser,
-      useWallet: () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? true }),
+      useWallet: () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? true, hasWallet: input.hasWallet ?? true }),
       useFlag: flag => flag === "fair_use_policy_gate" && (input.isGateEnabled ?? true),
       useAcceptFairUsePolicy: () => ({ accept, isAccepting: false, hasAccepted: input.hasAccepted ?? false }),
       FairUsePolicyModal: ({ onAccept }) => (

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
@@ -22,7 +22,7 @@ type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-/** Holds the page back until acceptance, so an auto-started deployment cannot fire behind the modal; a user whose trial wallet is still provisioning is asked too, since that wallet will be a trial one. */
+/** Holds the page back until acceptance, so an auto-started deployment cannot fire behind the modal. */
 export function RequireFairUsePolicy({ children, isPublic, dependencies: d = DEPENDENCIES }: Props) {
   const { user } = d.useUser();
   const { isTrialing, hasWallet, isWalletLookupFailed } = d.useWallet();

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
@@ -22,21 +22,16 @@ type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-/**
- * Keeps the page mounted behind a non-dismissible modal until a trialing user has accepted the Fair Use Policy once.
- * Mirrors the server gate, which only refuses deployments from trial wallets and only while the same flag is on.
- */
+/** Holds the page back until acceptance, so an auto-started deployment cannot fire behind the modal; a user whose trial wallet is still provisioning is asked too, since that wallet will be a trial one. */
 export function RequireFairUsePolicy({ children, isPublic, dependencies: d = DEPENDENCIES }: Props) {
   const { user } = d.useUser();
-  const { isTrialing } = d.useWallet();
+  const { isTrialing, hasWallet } = d.useWallet();
   const isGateEnabled = d.useFlag("fair_use_policy_gate");
   const { accept, isAccepting, hasAccepted } = d.useAcceptFairUsePolicy();
-  const mustAccept = !isPublic && isGateEnabled && isTrialing && !!user?.userId && !user.fairUsePolicyAcceptedAt && !hasAccepted;
+  const isTrialingOrAwaitingWallet = isTrialing || !hasWallet;
+  const mustAccept = !isPublic && isGateEnabled && isTrialingOrAwaitingWallet && !!user?.userId && !user.fairUsePolicyAcceptedAt && !hasAccepted;
 
-  return (
-    <>
-      {children}
-      {mustAccept && <d.FairUsePolicyModal onAccept={accept} isAccepting={isAccepting} />}
-    </>
-  );
+  if (mustAccept) return <d.FairUsePolicyModal onAccept={accept} isAccepting={isAccepting} />;
+
+  return <>{children}</>;
 }

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
@@ -25,11 +25,11 @@ type Props = {
 /** Holds the page back until acceptance, so an auto-started deployment cannot fire behind the modal; a user whose trial wallet is still provisioning is asked too, since that wallet will be a trial one. */
 export function RequireFairUsePolicy({ children, isPublic, dependencies: d = DEPENDENCIES }: Props) {
   const { user } = d.useUser();
-  const { isTrialing, hasWallet } = d.useWallet();
+  const { isTrialing, hasWallet, isWalletLookupFailed } = d.useWallet();
   const isGateEnabled = d.useFlag("fair_use_policy_gate");
   const { accept, isAccepting, hasAccepted } = d.useAcceptFairUsePolicy();
-  const isTrialingOrAwaitingWallet = isTrialing || !hasWallet;
-  const mustAccept = !isPublic && isGateEnabled && isTrialingOrAwaitingWallet && !!user?.userId && !user.fairUsePolicyAcceptedAt && !hasAccepted;
+  const isAwaitingTrialWallet = !hasWallet && !isWalletLookupFailed;
+  const mustAccept = !isPublic && isGateEnabled && (isTrialing || isAwaitingTrialWallet) && !!user?.userId && !user.fairUsePolicyAcceptedAt && !hasAccepted;
 
   if (mustAccept) return <d.FairUsePolicyModal onAccept={accept} isAccepting={isAccepting} />;
 

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.spec.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.spec.tsx
@@ -75,6 +75,12 @@ describe(WalletProvider.name, () => {
     });
   });
 
+  it("reports a failed wallet lookup through useWallet", () => {
+    const { probed } = setup({ user: registeredUser(), managedWallet: { isInitializing: false, wallet: undefined, isLookupFailed: true } });
+
+    expect(probed.current).toMatchObject({ hasWallet: false, isWalletLookupFailed: true });
+  });
+
   function registeredUser() {
     return mock<CustomUserProfile>({ id: "internal-id", userId: "auth-user-id" });
   }
@@ -89,6 +95,7 @@ describe(WalletProvider.name, () => {
       isLoading: false,
       isInitializing: false,
       isFetching: false,
+      isLookupFailed: false,
       ...overrides
     });
   }

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -29,6 +29,8 @@ export type ContextType = {
   address: string;
   /** True once the server-side wallet record exists. The address may still be empty while provisioning. */
   hasWallet: boolean;
+  /** True once the wallet lookup has failed for good, which `hasWallet` alone cannot tell apart from a wallet still being provisioned. */
+  isWalletLookupFailed: boolean;
   signAndBroadcastTx: (msgs: EncodeObject[]) => Promise<boolean>;
   denom: string;
   isTrialing: boolean;
@@ -52,7 +54,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode; dependencies?
 
   const [, setSettingsId] = useAtom(settingsIdAtom);
   const { user } = d.useUser();
-  const { wallet: managedWallet, isInitializing: isManagedWalletInitializing } = d.useManagedWallet();
+  const { wallet: managedWallet, isInitializing: isManagedWalletInitializing, isLookupFailed: isManagedWalletLookupFailed } = d.useManagedWallet();
   const walletAddress = managedWallet?.address;
   const hasWallet = !!managedWallet;
   const { refetch: refetchBalances } = d.useBalances(walletAddress);
@@ -97,6 +99,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode; dependencies?
       value={{
         address: walletAddress as string,
         hasWallet,
+        isWalletLookupFailed: isManagedWalletLookupFailed,
         signAndBroadcastTx,
         denom: managedWallet?.denom ?? "",
         isTrialing: !!managedWallet?.isTrialing,

--- a/apps/deploy-web/src/hooks/useManagedWallet.spec.tsx
+++ b/apps/deploy-web/src/hooks/useManagedWallet.spec.tsx
@@ -26,6 +26,14 @@ describe(useManagedWallet.name, () => {
     });
   });
 
+  it("reports a failed wallet lookup", async () => {
+    const { result } = setup({ userId: "user-failed", lookupError: new Error("wallet service down") });
+
+    await vi.waitFor(() => {
+      expect(result.current.managed.isLookupFailed).toBe(true);
+    });
+  });
+
   function buildApiWallet(overrides: { userId: string; address: string; creditAmount?: number }) {
     return {
       ...mock<ApiManagedWalletOutput>(),
@@ -36,9 +44,9 @@ describe(useManagedWallet.name, () => {
     };
   }
 
-  function setup(input?: { userId?: string; apiWallet?: ApiManagedWalletOutput }) {
+  function setup(input?: { userId?: string; apiWallet?: ApiManagedWalletOutput; lookupError?: Error }) {
     const managedWalletService = mock<ManagedWalletHttpService>({
-      getWallet: vi.fn().mockResolvedValue(input?.apiWallet ?? null)
+      getWallet: input?.lookupError ? vi.fn().mockRejectedValue(input.lookupError) : vi.fn().mockResolvedValue(input?.apiWallet ?? null)
     });
 
     const user = { email: "test@akash.network", id: input?.userId, userId: input?.userId } as UserProfile;

--- a/apps/deploy-web/src/hooks/useManagedWallet.ts
+++ b/apps/deploy-web/src/hooks/useManagedWallet.ts
@@ -7,7 +7,7 @@ import { ensureUserManagedWalletOwnership, updateStorageManagedWallet } from "@s
 
 export const useManagedWallet = () => {
   const { user } = useUser();
-  const { data: queried, isLoading: isInitialLoading, isFetching, refetch } = useManagedWalletQuery(user?.id);
+  const { data: queried, isLoading: isInitialLoading, isFetching, isError: isLookupFailed, refetch } = useManagedWalletQuery(user?.id);
   const wallet = queried as ApiManagedWalletOutput | undefined;
 
   useEffect(() => {
@@ -31,7 +31,8 @@ export const useManagedWallet = () => {
        */
       isInitializing: isInitialLoading,
       isFetching,
+      isLookupFailed,
       refetch
     };
-  }, [wallet, isInitialLoading, isFetching, refetch]);
+  }, [wallet, isInitialLoading, isFetching, isLookupFailed, refetch]);
 };

--- a/apps/deploy-web/tests/ui/actions/fair-use-policy.ts
+++ b/apps/deploy-web/tests/ui/actions/fair-use-policy.ts
@@ -1,17 +1,20 @@
-import type { Page } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
 
 const PROMPT_TIMEOUT_MS = 30_000;
 
-/** A freshly registered user is asked to accept the Fair Use Policy before any page renders, so registration is only complete once that prompt is answered. */
+/** A freshly registered user is asked to accept the Fair Use Policy before any page renders, so registration is only complete once that prompt is answered; the onboarding heading is what renders instead when the gate is off. */
 export async function acceptFairUsePolicyIfPrompted(page: Page): Promise<void> {
   const prompt = page.getByRole("dialog", { name: /fair use policy/i });
-  const isPrompted = await prompt.waitFor({ state: "visible", timeout: PROMPT_TIMEOUT_MS }).then(
-    () => true,
-    () => false
-  );
+  const onboardingHeading = page.getByRole("heading", { name: /deploy your first app/i });
 
-  if (!isPrompted) return;
+  await Promise.race([waitForVisible(prompt), waitForVisible(onboardingHeading)]);
+
+  if (!(await prompt.isVisible())) return;
 
   await prompt.getByRole("button", { name: /i agree to the fair use policy/i }).click();
   await prompt.waitFor({ state: "hidden", timeout: PROMPT_TIMEOUT_MS });
+}
+
+function waitForVisible(locator: Locator): Promise<void> {
+  return locator.waitFor({ state: "visible", timeout: PROMPT_TIMEOUT_MS }).catch(() => undefined);
 }

--- a/apps/deploy-web/tests/ui/actions/fair-use-policy.ts
+++ b/apps/deploy-web/tests/ui/actions/fair-use-policy.ts
@@ -1,0 +1,17 @@
+import type { Page } from "@playwright/test";
+
+const PROMPT_TIMEOUT_MS = 30_000;
+
+/** A freshly registered user is asked to accept the Fair Use Policy before any page renders, so registration is only complete once that prompt is answered. */
+export async function acceptFairUsePolicyIfPrompted(page: Page): Promise<void> {
+  const prompt = page.getByRole("dialog", { name: /fair use policy/i });
+  const isPrompted = await prompt.waitFor({ state: "visible", timeout: PROMPT_TIMEOUT_MS }).then(
+    () => true,
+    () => false
+  );
+
+  if (!isPrompted) return;
+
+  await prompt.getByRole("button", { name: /i agree to the fair use policy/i }).click();
+  await prompt.waitFor({ state: "hidden", timeout: PROMPT_TIMEOUT_MS });
+}

--- a/apps/deploy-web/tests/ui/actions/fair-use-policy.ts
+++ b/apps/deploy-web/tests/ui/actions/fair-use-policy.ts
@@ -2,7 +2,7 @@ import type { Locator, Page } from "@playwright/test";
 
 const PROMPT_TIMEOUT_MS = 30_000;
 
-/** A freshly registered user is asked to accept the Fair Use Policy before any page renders, so registration is only complete once that prompt is answered; the onboarding heading is what renders instead when the gate is off. */
+/** Races the prompt against the onboarding heading, because the heading is what a new user sees instead when the gate is off. */
 export async function acceptFairUsePolicyIfPrompted(page: Page): Promise<void> {
   const prompt = page.getByRole("dialog", { name: /fair use policy/i });
   const onboardingHeading = page.getByRole("heading", { name: /deploy your first app/i });

--- a/apps/deploy-web/tests/ui/fixture/base-test.ts
+++ b/apps/deploy-web/tests/ui/fixture/base-test.ts
@@ -3,6 +3,7 @@ import { test as baseTest } from "@playwright/test";
 
 import { loginExistingUser, registerNewUser } from "../actions/auth";
 import { closeAllActiveDeployments } from "../actions/deployment-janitor";
+import { acceptFairUsePolicyIfPrompted } from "../actions/fair-use-policy";
 import { Auth0ManagementService } from "../services/auth0-management.service";
 import { createEmailVerificationStrategy, type EmailVerificationStrategy } from "../services/email-verification";
 import { testEnvConfig } from "./test-env.config";
@@ -45,6 +46,7 @@ export const test = baseTest.extend<Fixtures>({
       await loginExistingUser(page);
     } else if (userType === "new") {
       createdUserId = (await registerNewUser(page, { auth0, emailVerification })).userId;
+      await acceptFairUsePolicyIfPrompted(page);
     }
 
     await use(page);

--- a/apps/deploy-web/tests/ui/fixture/base-test.ts
+++ b/apps/deploy-web/tests/ui/fixture/base-test.ts
@@ -42,21 +42,23 @@ export const test = baseTest.extend<Fixtures>({
     await routeTestingClientToken(page);
 
     let createdUserId: string | undefined;
-    if (userType === "existing") {
-      await loginExistingUser(page);
-    } else if (userType === "new") {
-      createdUserId = (await registerNewUser(page, { auth0, emailVerification })).userId;
-      await acceptFairUsePolicyIfPrompted(page);
-    }
+    try {
+      if (userType === "existing") {
+        await loginExistingUser(page);
+      } else if (userType === "new") {
+        createdUserId = (await registerNewUser(page, { auth0, emailVerification })).userId;
+        await acceptFairUsePolicyIfPrompted(page);
+      }
 
-    await use(page);
+      await use(page);
 
-    if (userType) {
-      await closeDeploymentsLeftBehind(page);
-    }
-
-    if (createdUserId) {
-      await auth0.deleteUser(createdUserId).catch(() => undefined);
+      if (userType) {
+        await closeDeploymentsLeftBehind(page);
+      }
+    } finally {
+      if (createdUserId) {
+        await auth0.deleteUser(createdUserId).catch(() => undefined);
+      }
     }
   }
 });


### PR DESCRIPTION
## Why

Right after registration the Fair Use Policy prompt did not appear on the onboarding page. It only showed once the managed wallet reported a trial, and the wallet is provisioned by a background job after sign-up. A user who clicked "Deploy now" before that landed on the auto-deploying configure view, where the deployment started, the server refused it with the policy 403, and the user saw an error toast instead of the prompt. The modal also rendered alongside the page, so even once it was up it could not stop the autopilot.

## What

- `RequireFairUsePolicy` now demands acceptance when the user is trialing **or is still waiting on a wallet**. A registered user without a wallet is about to become a trial user, so the prompt appears the moment the onboarding page loads.
- A wallet that is missing because the lookup failed is not the same as one still provisioning. The wallet context now exposes `isWalletLookupFailed` from the query's error state, and the gate only waits on a wallet when the lookup has not failed, so an outage never hides the app behind the modal for paying users.
- While acceptance is pending the gate renders the modal instead of the page, so nothing auto-fires behind it. The server 403 remains as the backstop.
- The e2e fixture accepts the prompt right after registering a new user, since the new-user journeys would otherwise stall on it at their first click. It moves on when the gate flag is off.
- Specs: gate cases for the no-wallet-yet and lookup-failed states, provider and hook cases for the new flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fair Use Policy prompts now block page access until the policy is accepted.
  - Users with trial wallets still provisioning are correctly prompted, while failed wallet lookups are handled separately.
  - Wallet lookup failures are now surfaced consistently to the application.

- **Tests**
  - Expanded coverage for missing wallets, provisioning states, failed lookups, and policy acceptance flows.
  - UI tests now automatically accept the Fair Use Policy when prompted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->