### PR TITLE
fix(config): allow the first-party origins the CSP blocks today

### DIFF
--- a/apps/deploy-web/src/lib/csp/csp.spec.ts
+++ b/apps/deploy-web/src/lib/csp/csp.spec.ts
@@ -115,6 +115,7 @@ describe("csp", () => {
     it("allows any https image source because template logos point at arbitrary origins", () => {
       const { imgSrc } = setup({});
 
+      expect(imgSrc).toContain("'self'");
       expect(imgSrc).toContain("https:");
       expect(imgSrc).toContain("data:");
       expect(imgSrc).toContain("blob:");

--- a/apps/deploy-web/src/lib/csp/csp.spec.ts
+++ b/apps/deploy-web/src/lib/csp/csp.spec.ts
@@ -106,10 +106,32 @@ describe("csp", () => {
       expect(connectSrc).toContain("'self'");
     });
 
-    it("derives the templates img-src origin from the provided value", () => {
-      const { imgSrc } = setup({ templatesUrl: "https://akash-templates.pages.dev" });
+    it("derives the templates connect-src origin from the provided value", () => {
+      const { connectSrc } = setup({ templatesUrl: "https://akash-templates.pages.dev" });
 
-      expect(imgSrc).toContain("https://akash-templates.pages.dev");
+      expect(connectSrc).toContain("https://akash-templates.pages.dev");
+    });
+
+    it("allows any https image source because template logos point at arbitrary origins", () => {
+      const { imgSrc } = setup({});
+
+      expect(imgSrc).toContain("https:");
+      expect(imgSrc).toContain("data:");
+      expect(imgSrc).toContain("blob:");
+    });
+
+    it("allows the bare analytics.google.com host the subdomain wildcard cannot match", () => {
+      const { connectSrc } = setup({});
+
+      expect(connectSrc).toContain("https://analytics.google.com");
+      expect(connectSrc).toContain("https://*.analytics.google.com");
+      expect(connectSrc).toContain("https://*.google-analytics.com");
+    });
+
+    it("allows the jsDelivr origin the provider map fetches its topology from", () => {
+      const { connectSrc } = setup({});
+
+      expect(connectSrc).toContain("https://cdn.jsdelivr.net");
     });
 
     it("always allows Amplitude endpoints since Session Replay is not routed through the proxy", () => {

--- a/apps/deploy-web/src/lib/csp/csp.ts
+++ b/apps/deploy-web/src/lib/csp/csp.ts
@@ -13,8 +13,11 @@ const isDevelopment = process.env.NODE_ENV !== "production";
  */
 export const THEME_SCRIPT_HASH = "'sha256-eMuh8xiwcX72rRYNAGENurQBAcH7kLlAUQcoOri3BIo='";
 
+/** GA4 also calls the bare host, which `*.analytics.google.com` cannot match: a CSP wildcard requires at least one subdomain label. */
+const GOOGLE_ANALYTICS_ORIGINS = ["https://*.google-analytics.com", "https://*.analytics.google.com", "https://analytics.google.com"];
+
 /**
- * Third-party endpoints the app connects to directly (Stripe, Cloudflare, Google, Growth Channel, Amplitude); these never vary by environment.
+ * Third-party endpoints the app connects to directly (Stripe, Cloudflare, Google, Growth Channel, Amplitude, jsDelivr); these never vary by environment.
  * Amplitude core events are proxied via NEXT_PUBLIC_AMPLITUDE_PROXY_URL, but Session Replay (config + ingest) and the no-proxy fallback hit
  * `*.amplitude.com` subdomains directly, so the wildcard is required regardless of the proxy setting.
  */
@@ -23,21 +26,14 @@ const FIXED_VENDOR_CONNECT_ORIGINS = [
   "https://m.stripe.network",
   "https://challenges.cloudflare.com",
   "https://www.googletagmanager.com",
-  "https://*.google-analytics.com",
-  "https://*.analytics.google.com",
+  ...GOOGLE_ANALYTICS_ORIGINS,
   "https://pxl.growth-channel.net",
-  "https://*.amplitude.com"
+  "https://*.amplitude.com",
+  "https://cdn.jsdelivr.net"
 ];
 
-/** Image hosts that never vary by environment (inline data/blob URIs, GitHub avatars/raw content, Google). */
-const FIXED_IMG_SRC = [
-  "data:",
-  "blob:",
-  "https://raw.githubusercontent.com",
-  "https://avatars.githubusercontent.com",
-  "https://www.googletagmanager.com",
-  "https://*.google-analytics.com"
-];
+/** Template logos are community-supplied and point at arbitrary origins, so img-src cannot be a host allowlist. */
+const FIXED_IMG_SRC = ["data:", "blob:", "https:"];
 
 export interface ContentSecurityPolicyInput {
   mainnetApiUrl?: string;
@@ -110,11 +106,12 @@ export function buildContentSecurityPolicy(input: ContentSecurityPolicyInput) {
     toOrigin(input.amplitudeProxyUrl),
     toOrigin(input.unleashFrontendApiUrl),
     toOrigin(input.sentryDsn),
+    toOrigin(input.templatesUrl),
     ...(input.networkRpcAndApiUrls ?? []).map(toOrigin)
   ];
 
   const connectSrc = dedupeOrigins(["'self'", ...envConnectOrigins, ...FIXED_VENDOR_CONNECT_ORIGINS]);
-  const imgSrc = dedupeOrigins(["'self'", ...FIXED_IMG_SRC, toOrigin(input.templatesUrl)]);
+  const imgSrc = dedupeOrigins(["'self'", ...FIXED_IMG_SRC]);
   const sentrySecurityReportUri = toSentrySecurityReportUri(input.sentryDsn);
 
   if (isDevelopment) {


### PR DESCRIPTION
## Why

The deploy-web Sentry project takes roughly 16k CSP violation reports every 30 days, which buries everything else. A large share of them are things the app genuinely does that the policy forbids.

CSP is still report-only in production (`CSP_MODE` is not set anywhere, so `getContentSecurityPolicyHeaderName()` falls through to `Content-Security-Policy-Report-Only`). Nothing is broken today. Each of these becomes an outage the day we flip to enforce.

## What

Four gaps closed in `apps/deploy-web/src/lib/csp/csp.ts`, with 30-day report counts:

**`analytics.google.com`, 1,392 reports.** The loudest issue in the whole project. GA4 calls the bare host, and `https://*.analytics.google.com` cannot match it, because a CSP wildcard needs at least one subdomain label to consume. The bare host now sits next to the wildcard.

**`cdn.jsdelivr.net`, 296.** `ProviderMap` fetches `world-atlas@2/land-110m.json` from there, so it needs to be in `connect-src`.

**`akash-templates.pages.dev`, 165.** The templates origin was only ever fed into `img-src`, so fetching the gallery itself was blocked. It now goes into `connect-src` as well.

**Template logos, about 1,220 across a dozen hosts** (`github.com`, `user-images.githubusercontent.com`, `qdrant.tech`, `zfnd.org`, `seed.radicle.xyz`, `neo4j.design`, `unsloth.ai`, `react.dev`, `img.shields.io`, `cdn.zeroheight.com`, `cdn.jsdelivr.net`). `logoUrl` comes from community-contributed templates and can point anywhere, so a host allowlist cannot work here. `img-src` now takes `https:`, which makes the previous explicit host entries redundant.

That last one is the judgement call worth a look. Images do not execute, so it widens the weakest directive rather than `script-src`, and `img-src` is a poor exfiltration control regardless. The alternative is proxying every template logo through our own endpoint, which is a lot more work; `AvatarImage` is a Radix primitive rendering a plain `img`, so these do not go through `next/image` today either.

`CSP_MODE` is untouched. Enforcing is a separate decision once the reports are quiet.

Two things deliberately left out: `script inline:` (591 reports) needs the `script-sample` read off the Sentry issue before anyone touches `script-src`, and `script blob:` (17) needs its source identified first.

## Verification

`npm run test:unit`: 379 files, 3803 tests pass. Lint clean. `tsc` shows 95 errors on this branch and 95 on `origin/main`, none in the touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated content security settings to support template connections and analytics requests.
  - Enabled images from HTTPS, data, and blob sources.
  - Added support for jsDelivr and the required Google Analytics host.
  - Removed template origins from image source rules and aligned them with connection rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->