### PR TITLE
fix(analytics): let the GTM marketing tags through the CSP

### DIFF
--- a/apps/deploy-web/src/lib/csp/csp.spec.ts
+++ b/apps/deploy-web/src/lib/csp/csp.spec.ts
@@ -135,6 +135,24 @@ describe("csp", () => {
       expect(connectSrc).toContain("https://cdn.jsdelivr.net");
     });
 
+    it("allows the marketing tags the GTM container fires", () => {
+      const { scriptSrc, styleSrc, connectSrc } = setup({});
+
+      expect(scriptSrc).toContain("https://tags.srv.stackadapt.com");
+      expect(scriptSrc).toContain("https://pxl.iqm.com");
+      expect(styleSrc).toContain("https://tags.srv.stackadapt.com");
+      expect(connectSrc).toContain("https://tags.srv.stackadapt.com");
+      expect(connectSrc).toContain("https://*.g.doubleclick.net");
+    });
+
+    it("names Google Ads country endpoints individually because CSP cannot wildcard a TLD", () => {
+      const { connectSrc } = setup({});
+
+      expect(connectSrc).toContain("https://www.google.com");
+      expect(connectSrc).toContain("https://www.google.de");
+      expect(connectSrc).toContain("https://www.google.co.in");
+    });
+
     it("always allows Amplitude endpoints since Session Replay is not routed through the proxy", () => {
       const { connectSrc } = setup({});
 
@@ -200,6 +218,7 @@ describe("csp", () => {
     return {
       policy,
       scriptSrc: directives["script-src"],
+      styleSrc: directives["style-src"],
       connectSrc: directives["connect-src"],
       imgSrc: directives["img-src"],
       reportUri: directives["report-uri"],

--- a/apps/deploy-web/src/lib/csp/csp.spec.ts
+++ b/apps/deploy-web/src/lib/csp/csp.spec.ts
@@ -62,7 +62,7 @@ describe("csp", () => {
       expect(scriptSrc).toContain("https://challenges.cloudflare.com");
       expect(scriptSrc).toContain("https://js.stripe.com");
       expect(scriptSrc).not.toContain("'strict-dynamic'");
-      expect(scriptSrc).not.toContain("'nonce-");
+      expect(scriptSrc.some(source => source.startsWith("'nonce-"))).toBe(false);
       expect(scriptSrc).not.toContain("'unsafe-inline'");
     });
 
@@ -148,9 +148,25 @@ describe("csp", () => {
     it("names Google Ads country endpoints individually because CSP cannot wildcard a TLD", () => {
       const { connectSrc } = setup({});
 
-      expect(connectSrc).toContain("https://www.google.com");
-      expect(connectSrc).toContain("https://www.google.de");
-      expect(connectSrc).toContain("https://www.google.co.in");
+      expect(connectSrc).toEqual(
+        expect.arrayContaining([
+          "https://www.google.com",
+          "https://www.google.be",
+          "https://www.google.co.in",
+          "https://www.google.com.br",
+          "https://www.google.com.pe",
+          "https://www.google.com.ph",
+          "https://www.google.com.pk",
+          "https://www.google.com.ua",
+          "https://www.google.com.vn",
+          "https://www.google.de",
+          "https://www.google.fi",
+          "https://www.google.fr",
+          "https://www.google.kz",
+          "https://www.google.pl",
+          "https://www.google.pt"
+        ])
+      );
     });
 
     it("always allows Amplitude endpoints since Session Replay is not routed through the proxy", () => {
@@ -162,8 +178,8 @@ describe("csp", () => {
     it("adds Sentry CSP reporting directives when a Sentry DSN is configured", () => {
       const { reportUri, reportTo } = setup({ sentryDsn: "https://publicKey@o877251.ingest.sentry.io/4504" });
 
-      expect(reportUri).toBe("report-uri https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey");
-      expect(reportTo).toBe("report-to csp-endpoint");
+      expect(reportUri).toEqual(["https://o877251.ingest.sentry.io/api/4504/security/?sentry_key=publicKey"]);
+      expect(reportTo).toEqual(["csp-endpoint"]);
     });
 
     it("omits Sentry CSP reporting directives when no Sentry DSN is configured", () => {
@@ -214,7 +230,12 @@ describe("csp", () => {
 
   function setup(input: ContentSecurityPolicyInput) {
     const policy = buildContentSecurityPolicy(input);
-    const directives = Object.fromEntries(policy.split("; ").map(directive => [directive.split(" ")[0], directive]));
+    const directives = Object.fromEntries(
+      policy.split("; ").map(directive => {
+        const [name, ...sources] = directive.split(" ");
+        return [name, sources];
+      })
+    );
     return {
       policy,
       scriptSrc: directives["script-src"],

--- a/apps/deploy-web/src/lib/csp/csp.ts
+++ b/apps/deploy-web/src/lib/csp/csp.ts
@@ -35,6 +35,34 @@ const FIXED_VENDOR_CONNECT_ORIGINS = [
 /** Template logos are community-supplied and point at arbitrary origins, so img-src cannot be a host allowlist. */
 const FIXED_IMG_SRC = ["data:", "blob:", "https:"];
 
+const STACKADAPT_ORIGIN = "https://tags.srv.stackadapt.com";
+const IQM_ORIGIN = "https://pxl.iqm.com";
+
+/** CSP cannot wildcard a TLD, so Google Ads' per-country audience endpoints have to be listed one by one. */
+const GOOGLE_ADS_COUNTRY_ORIGINS = [
+  "https://www.google.com",
+  "https://www.google.be",
+  "https://www.google.co.in",
+  "https://www.google.com.br",
+  "https://www.google.com.pe",
+  "https://www.google.com.ph",
+  "https://www.google.com.pk",
+  "https://www.google.com.ua",
+  "https://www.google.com.vn",
+  "https://www.google.de",
+  "https://www.google.fi",
+  "https://www.google.fr",
+  "https://www.google.kz",
+  "https://www.google.pl",
+  "https://www.google.pt"
+];
+
+/**
+ * Retargeting tags the GTM container fires (StackAdapt, IQM, Google Ads); their image pixels already fall under the
+ * blanket https: in img-src, so only the script, style, and connect directives need to name them.
+ */
+const MARKETING_TAG_CONNECT_ORIGINS = [STACKADAPT_ORIGIN, "https://*.g.doubleclick.net", ...GOOGLE_ADS_COUNTRY_ORIGINS];
+
 export interface ContentSecurityPolicyInput {
   mainnetApiUrl?: string;
   testnetApiUrl?: string;
@@ -91,7 +119,9 @@ export function buildContentSecurityPolicy(input: ContentSecurityPolicyInput) {
     "https://*.google-analytics.com",
     "https://pxl.growth-channel.net",
     "https://challenges.cloudflare.com",
-    "https://js.stripe.com"
+    "https://js.stripe.com",
+    STACKADAPT_ORIGIN,
+    IQM_ORIGIN
   ];
 
   const providerProxyOrigin = toOrigin(input.providerProxyUrl);
@@ -110,7 +140,7 @@ export function buildContentSecurityPolicy(input: ContentSecurityPolicyInput) {
     ...(input.networkRpcAndApiUrls ?? []).map(toOrigin)
   ];
 
-  const connectSrc = dedupeOrigins(["'self'", ...envConnectOrigins, ...FIXED_VENDOR_CONNECT_ORIGINS]);
+  const connectSrc = dedupeOrigins(["'self'", ...envConnectOrigins, ...FIXED_VENDOR_CONNECT_ORIGINS, ...MARKETING_TAG_CONNECT_ORIGINS]);
   const imgSrc = dedupeOrigins(["'self'", ...FIXED_IMG_SRC]);
   const sentrySecurityReportUri = toSentrySecurityReportUri(input.sentryDsn);
 
@@ -126,7 +156,7 @@ export function buildContentSecurityPolicy(input: ContentSecurityPolicyInput) {
     "frame-ancestors 'none'",
     "form-action 'self'",
     `script-src ${scriptSrc.join(" ")}`,
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com ${STACKADAPT_ORIGIN}`,
     "style-src-attr 'unsafe-inline'",
     `img-src ${imgSrc.join(" ")}`,
     "font-src 'self' data: https://fonts.gstatic.com",

--- a/apps/deploy-web/src/lib/csp/csp.ts
+++ b/apps/deploy-web/src/lib/csp/csp.ts
@@ -57,10 +57,7 @@ const GOOGLE_ADS_COUNTRY_ORIGINS = [
   "https://www.google.pt"
 ];
 
-/**
- * Retargeting tags the GTM container fires (StackAdapt, IQM, Google Ads); their image pixels already fall under the
- * blanket https: in img-src, so only the script, style, and connect directives need to name them.
- */
+/** The matching image pixels need no img-src entry because the blanket https: already covers them. */
 const MARKETING_TAG_CONNECT_ORIGINS = [STACKADAPT_ORIGIN, "https://*.g.doubleclick.net", ...GOOGLE_ADS_COUNTRY_ORIGINS];
 
 export interface ContentSecurityPolicyInput {


### PR DESCRIPTION
## Why

Stacked on #3881. Review that one first; the diff here is only the second commit.

The StackAdapt, IQM and Google Ads tags in the GTM container have been blocked by CSP since the policy landed. That is about 5k violation reports per 30 days, and it means retargeting has not been attributed for as long as the policy has been live.

Worth being explicit about what these are, because at first glance the report list looks like adware injected by browser extensions. It is not. The tell is the country-localized `www.google.<tld>` pixels, which are the Google Ads remarketing tag, and the fan-out to openx, pubmatic, taboola, outbrain and friends, which is StackAdapt's cookie sync. These are our own tags in GTM-MSF384N3.

## What

`script-src` gains `tags.srv.stackadapt.com` and `pxl.iqm.com`. `style-src` gains StackAdapt. `connect-src` gains StackAdapt, `*.g.doubleclick.net` (one wildcard covers both `cm.` and `stats.`, plus the `googleads.` that will show up eventually), and the Google Ads country endpoints.

The image pixels needed nothing at all. #3881 put a blanket `https:` in `img-src` for template logos, and that already covers every one of them, including the 13 partner sync pixels StackAdapt fans out to. So the header grows by about 500 bytes rather than the 1.5k a full enumeration would have cost: 1385 to 1887 bytes on a staging-shaped config.

Google Ads talks to a per-country endpoint and CSP has no way to wildcard a TLD, so `GOOGLE_ADS_COUNTRY_ORIGINS` lists them one by one. It covers the 15 countries that appear in the `connect` reports. New markets will surface as fresh reports rather than silently working, which is the tradeoff for not carrying all ~40 Google ccTLDs in a header on every response.

## What this does not do

It does not touch `CSP_MODE`, and it does not judge whether these tags should exist. If nobody is actually using StackAdapt or IQM, deleting them from the GTM container is a cleaner fix than this PR and I am happy to close it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated security policies to support additional marketing and advertising integrations.
  * Added support for country-specific Google Ads endpoints.
  * Expanded permitted styling, script, and connection sources for supported marketing services.
* **Tests**
  * Added coverage to verify the updated marketing domains and styling policy directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->