### PR TITLE
fix(observability): stop reporting cancellations and double-reporting mutations

### DIFF
--- a/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
@@ -50,7 +50,12 @@ describe(Turnstile.name, () => {
       await wait(0);
     });
 
-    expect(errorHandler.reportError).toHaveBeenCalledWith(expect.objectContaining({ error: "network-error", tags: { event: "TURNSTILE_CHALLENGE_FAILED" } }));
+    expect(errorHandler.reportError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({ message: "Turnstile challenge failed with code network-error" }),
+        tags: { event: "TURNSTILE_CHALLENGE_FAILED" }
+      })
+    );
   });
 
   it("reports only the first failure of a run so Cloudflare's retries cannot storm Sentry", async () => {

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -175,7 +175,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
               options={{ execution: "execute", size: "normal", ...RECOVERY_OPTIONS }}
               onError={error => {
                 setStatus("error");
-                reportChallengeFailure(error, "TURNSTILE_CHALLENGE_FAILED");
+                reportChallengeFailure(new Error(`Turnstile challenge failed with code ${error}`), "TURNSTILE_CHALLENGE_FAILED");
                 eventBus.current.dispatchEvent(new CustomEvent("error", { detail: { error, reason: "error" } }));
               }}
               onExpire={() => setStatus("expired")}

--- a/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
+++ b/apps/deploy-web/src/hooks/useAcceptFairUsePolicy.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useUser } from "@src/hooks/useUser";
+import { SKIP_REPORTING_HANDLED_BY_CALLER } from "@src/services/query-error-policy/query-error-policy";
 
 export const DEPENDENCIES = {
   useUser
@@ -22,7 +23,8 @@ export function useAcceptFairUsePolicy(dependencies: typeof DEPENDENCIES = DEPEN
       setHasAccepted(true);
       await checkSession();
     },
-    onError: error => errorHandler.reportError({ error, tags: { category: "user" } })
+    onError: error => errorHandler.reportError({ error, tags: { category: "user" } }),
+    meta: SKIP_REPORTING_HANDLED_BY_CALLER
   });
 
   const accept = useCallback(async () => {

--- a/apps/deploy-web/src/hooks/useSkipOnboarding.ts
+++ b/apps/deploy-web/src/hooks/useSkipOnboarding.ts
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useUser } from "@src/hooks/useUser";
+import { SKIP_REPORTING_HANDLED_BY_CALLER } from "@src/services/query-error-policy/query-error-policy";
 
 export type SkipOnboardingSource = "picker" | "auto_deploy";
 
@@ -35,7 +36,8 @@ export function useSkipOnboarding(dependencies: typeof DEPENDENCIES = DEPENDENCI
       await checkSession();
     },
     onSuccess: () => setIsAwaitingSkippedProfile(true),
-    onError: error => errorHandler.reportError({ error, tags: { category: "onboarding" } })
+    onError: error => errorHandler.reportError({ error, tags: { category: "onboarding" } }),
+    meta: SKIP_REPORTING_HANDLED_BY_CALLER
   });
 
   useEffect(

--- a/apps/deploy-web/src/middleware.spec.ts
+++ b/apps/deploy-web/src/middleware.spec.ts
@@ -37,6 +37,30 @@ describe("middleware", () => {
     expect(response.headers.get("Content-Security-Policy-Report-Only")).toBeNull();
   });
 
+  it.each(["/sw.js", "/workbox-4754cb34.js", "/manifest.json"])("serves %s during maintenance instead of redirecting it", path => {
+    vi.stubEnv("MAINTENANCE_MODE", "true");
+
+    const { response } = setup({ path });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("still applies the CSP header to the service worker script", () => {
+    const { response } = setup({ path: "/sw.js" });
+
+    expect(response.headers.get("Content-Security-Policy-Report-Only")).toContain("script-src 'self'");
+  });
+
+  it("redirects an ordinary page during maintenance", () => {
+    vi.stubEnv("MAINTENANCE_MODE", "true");
+
+    const { response } = setup({ path: "/deployments" });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("/maintenance");
+  });
+
   function setup(input: { path: string }) {
     const request = new NextRequest(new URL(`http://localhost${input.path}`));
     const response = middleware(request);

--- a/apps/deploy-web/src/middleware.spec.ts
+++ b/apps/deploy-web/src/middleware.spec.ts
@@ -52,13 +52,36 @@ describe("middleware", () => {
     expect(response.headers.get("Content-Security-Policy-Report-Only")).toContain("script-src 'self'");
   });
 
-  it("redirects an ordinary page during maintenance", () => {
+  it("carries the original path and query into the maintenance return param", () => {
     vi.stubEnv("MAINTENANCE_MODE", "true");
 
-    const { response } = setup({ path: "/deployments" });
+    const { response } = setup({ path: "/deployments?network=sandbox" });
 
     expect(response.status).toBe(307);
-    expect(response.headers.get("location")).toContain("/maintenance");
+    expect(response.headers.get("location")).toBe(`http://localhost/maintenance?return=${encodeURIComponent("/deployments?network=sandbox")}`);
+  });
+
+  it("leaves an ordinary page alone while maintenance mode is off", () => {
+    const { response } = setup({ path: "/deployments" });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it.each(["/maintenance", "/maintenance/details"])("serves %s itself while maintenance mode is on", path => {
+    vi.stubEnv("MAINTENANCE_MODE", "true");
+
+    const { response } = setup({ path });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it.each(["/maintenance", "/maintenance/details"])("redirects away from %s once maintenance mode is off", path => {
+    const { response } = setup({ path: `${path}?return=%2Fdeployments` });
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost/deployments");
   });
 
   function setup(input: { path: string }) {

--- a/apps/deploy-web/src/middleware.ts
+++ b/apps/deploy-web/src/middleware.ts
@@ -88,6 +88,7 @@ function getReturnPath(request: NextRequest) {
   }
 }
 
+/** A service worker script served behind the maintenance redirect fails registration outright, so PWA assets skip the middleware. */
 export const config = {
-  matcher: ["/((?!_next|api/auth).*)(.+)", "/"]
+  matcher: ["/((?!_next|api/auth|sw\\.js|workbox-|manifest\\.json).*)(.+)", "/"]
 };

--- a/apps/deploy-web/src/middleware.ts
+++ b/apps/deploy-web/src/middleware.ts
@@ -5,10 +5,12 @@ import { NextResponse } from "next/server";
 
 import { buildContentSecurityPolicy, getContentSecurityPolicyHeaderName, getContentSecurityPolicyReportHeaders } from "./lib/csp/csp";
 
-const { MAINTENANCE_MODE } = process.env;
 const logger = new LoggerService({ name: "middleware" });
 
 const networkRpcAndApiUrls = netConfig.getSupportedNetworks().flatMap(network => [netConfig.getBaseRpcUrl(network), netConfig.getBaseAPIUrl(network)]);
+
+/** A service worker script served as a redirect fails registration outright, so the maintenance redirect has to let the PWA assets through. */
+const PWA_ASSET_PATHNAME = /^\/(sw\.js|workbox-[^/]+\.js|manifest\.json)$/;
 
 export function middleware(request: NextRequest) {
   const contentSecurityPolicyInput = {
@@ -27,15 +29,18 @@ export function middleware(request: NextRequest) {
   const contentSecurityPolicyReportHeaders = getContentSecurityPolicyReportHeaders(contentSecurityPolicyInput);
 
   const maintenancePage = "/maintenance";
-  const isMaintenanceMode = MAINTENANCE_MODE === "true";
-  if (isMaintenanceMode && !request.nextUrl.pathname.startsWith(maintenancePage)) {
-    const fromPath = request.nextUrl.pathname + request.nextUrl.search;
+  const { pathname } = request.nextUrl;
+  const isMaintenanceMode = process.env.MAINTENANCE_MODE === "true";
+  const shouldRedirectToMaintenance = isMaintenanceMode && !pathname.startsWith(maintenancePage) && !PWA_ASSET_PATHNAME.test(pathname);
+
+  if (shouldRedirectToMaintenance) {
+    const fromPath = pathname + request.nextUrl.search;
     logger.info({ message: `Redirecting to maintenance page from ${fromPath}` });
 
     const redirectResponse = NextResponse.redirect(new URL(`${maintenancePage}?return=${encodeURIComponent(fromPath)}`, request.url), 307); // 307 - temporary redirect
     setContentSecurityPolicyHeaders(redirectResponse, contentSecurityPolicyHeaderName, contentSecurityPolicy, contentSecurityPolicyReportHeaders);
     return redirectResponse;
-  } else if (!isMaintenanceMode && request.nextUrl.pathname.startsWith(maintenancePage)) {
+  } else if (!isMaintenanceMode && pathname.startsWith(maintenancePage)) {
     const returnPath = getReturnPath(request);
     logger.info({ message: `Redirecting from maintenance page to ${returnPath}` });
 
@@ -88,7 +93,6 @@ function getReturnPath(request: NextRequest) {
   }
 }
 
-/** A service worker script served behind the maintenance redirect fails registration outright, so PWA assets skip the middleware. */
 export const config = {
-  matcher: ["/((?!_next|api/auth|sw\\.js|workbox-|manifest\\.json).*)(.+)", "/"]
+  matcher: ["/((?!_next|api/auth).*)(.+)", "/"]
 };

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -13,6 +13,7 @@ import type { UseQueryOptions, UseQueryResult } from "@tanstack/react-query";
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useServices } from "@src/context/ServicesProvider";
+import { SKIP_REPORTING_HANDLED_BY_CALLER } from "@src/services/query-error-policy/query-error-policy";
 import { walletProvisioningRetry } from "@src/utils/walletProvisioning";
 import { QueryKeys } from "./queryKeys";
 
@@ -78,7 +79,8 @@ export const useSetupIntentMutation = () => {
     },
     onError: error => {
       errorHandler.reportError({ error, tags: { category: "billing" } });
-    }
+    },
+    meta: SKIP_REPORTING_HANDLED_BY_CALLER
   });
 };
 

--- a/apps/deploy-web/src/queries/useSaveSettings.ts
+++ b/apps/deploy-web/src/queries/useSaveSettings.ts
@@ -5,6 +5,7 @@ import { useSnackbar } from "notistack";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
+import { SKIP_REPORTING_HANDLED_BY_CALLER } from "@src/services/query-error-policy/query-error-policy";
 import type { DepositParams, RpcDeploymentParams } from "@src/types/deployment";
 import type { UserSettings } from "@src/types/user";
 import { ApiUrlService } from "@src/utils/apiUtils";
@@ -31,7 +32,8 @@ export function useSaveSettings() {
       }
       enqueueSnackbar(message, { variant: "error" });
       errorHandler.reportError({ error, tags: { category: "user-settings" } });
-    }
+    },
+    meta: SKIP_REPORTING_HANDLED_BY_CALLER
   });
 }
 

--- a/apps/deploy-web/src/services/app-di-container/app-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/app-di-container.ts
@@ -19,7 +19,7 @@ import type { Axios, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } 
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import { UrlReturnToStack } from "@src/hooks/useReturnTo/UrlReturnToStack";
 import { AnalyticsService } from "@src/services/analytics/analytics.service";
-import { retryOnServerError, shouldReportQueryError } from "@src/services/query-error-policy/query-error-policy";
+import { retryOnServerError, shouldReportError } from "@src/services/query-error-policy/query-error-policy";
 import networkStore from "@src/store/networkStore";
 import { registry } from "@src/utils/customRegistry";
 import { UrlService } from "@src/utils/urlUtils";
@@ -162,12 +162,15 @@ export const createAppRootContainer = (config: ServicesConfig) => {
         },
         queryCache: new QueryCache({
           onError: (error, query) => {
-            if (!shouldReportQueryError(error, query.meta)) return;
+            if (!shouldReportError(error, query.meta)) return;
             container.errorHandler.reportError({ error });
           }
         }),
         mutationCache: new MutationCache({
-          onError: error => container.errorHandler.reportError({ error })
+          onError: (error, _variables, _context, mutation) => {
+            if (!shouldReportError(error, mutation.meta)) return;
+            container.errorHandler.reportError({ error });
+          }
         })
       }),
     errorHandler: () => new ErrorHandlerService(container.logger),

--- a/apps/deploy-web/src/services/error-handler/error-handler.service.spec.ts
+++ b/apps/deploy-web/src/services/error-handler/error-handler.service.spec.ts
@@ -66,6 +66,34 @@ describe(ErrorHandlerService.name, () => {
     });
   });
 
+  it.each([
+    ["a DOM abort", { name: "AbortError" }],
+    ["an axios cancellation by name", { name: "CanceledError" }],
+    ["an axios cancellation by code", { code: "ERR_CANCELED" }],
+    ["a Monaco cancellation", { name: "Canceled" }]
+  ])("does not report %s", (_label, shape) => {
+    const captureException = vi.fn();
+    const errorHandler = setup({ captureException });
+
+    errorHandler.reportError({ error: Object.assign(new Error("cancelled"), shape) });
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("tags http errors that responded 400", () => {
+    const captureException = vi.fn();
+    const errorHandler = setup({ captureException });
+    const config = { method: "post", url: "https://api.example.com/deployments" } as InternalAxiosRequestConfig;
+    const httpError = new AxiosError("Request failed", "400", config, {}, { status: 400, statusText: "Bad Request", headers: {}, data: {}, config });
+
+    errorHandler.reportError({ error: httpError });
+
+    expect(captureException).toHaveBeenCalledWith(
+      httpError,
+      expect.objectContaining({ tags: { status: "400", method: "POST", url: "https://api.example.com/deployments" } })
+    );
+  });
+
   describe("wrapCallback", () => {
     it("wraps synchronous function and reports error", () => {
       const captureException = vi.fn();

--- a/apps/deploy-web/src/services/error-handler/error-handler.service.ts
+++ b/apps/deploy-web/src/services/error-handler/error-handler.service.ts
@@ -21,13 +21,13 @@ export class ErrorHandlerService {
   }
 
   reportError({ severity, error, tags, ...extra }: ErrorContext): void {
-    if (error && typeof error === "object" && "name" in error && error.name === "AbortError") {
+    if (isCancellation(error)) {
       return;
     }
 
     const finalTags: Record<string, string> = { ...tags };
 
-    if (isHttpError(error) && error.response && error.response.status !== 400) {
+    if (isHttpError(error) && error.response) {
       finalTags.status = error.response.status.toString();
       finalTags.method = error.response.config.method?.toUpperCase() || "UNKNOWN";
       finalTags.url = error.response.config.url || "UNKNOWN";
@@ -59,6 +59,14 @@ export class ErrorHandlerService {
       }
     }) as T;
   }
+}
+
+/** Monaco names its cancellations `Canceled` and axios uses `CanceledError`; a cancelled request is not a fault. */
+function isCancellation(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+
+  const { name, code } = error as { name?: unknown; code?: unknown };
+  return name === "AbortError" || name === "CanceledError" || name === "Canceled" || code === "ERR_CANCELED";
 }
 
 export type SeverityLevel = SentrySeverityLevel;

--- a/apps/deploy-web/src/services/query-error-policy/query-error-policy.spec.ts
+++ b/apps/deploy-web/src/services/query-error-policy/query-error-policy.spec.ts
@@ -1,7 +1,13 @@
 import { AxiosError } from "axios";
 import { describe, expect, it, vi } from "vitest";
 
-import { isProviderUnavailableError, retryOnServerError, shouldReportQueryError, SKIP_REPORTING_PROVIDER_UNAVAILABLE } from "./query-error-policy";
+import {
+  isProviderUnavailableError,
+  retryOnServerError,
+  shouldReportError,
+  SKIP_REPORTING_HANDLED_BY_CALLER,
+  SKIP_REPORTING_PROVIDER_UNAVAILABLE
+} from "./query-error-policy";
 
 describe("query-error-policy", () => {
   describe("isProviderUnavailableError", () => {
@@ -38,30 +44,37 @@ describe("query-error-policy", () => {
     });
   });
 
-  describe("shouldReportQueryError", () => {
+  describe("shouldReportError", () => {
     it("reports when the query carries no meta", () => {
-      expect(shouldReportQueryError(httpError(500), undefined)).toBe(true);
+      expect(shouldReportError(httpError(500), undefined)).toBe(true);
     });
 
     it("reports when the query opts out of a different error", () => {
-      expect(shouldReportQueryError(httpError(500), SKIP_REPORTING_PROVIDER_UNAVAILABLE)).toBe(true);
+      expect(shouldReportError(httpError(500), SKIP_REPORTING_PROVIDER_UNAVAILABLE)).toBe(true);
     });
 
     it("stays quiet for the error the query opted out of", () => {
-      expect(shouldReportQueryError(httpError(502), SKIP_REPORTING_PROVIDER_UNAVAILABLE)).toBe(false);
+      expect(shouldReportError(httpError(502), SKIP_REPORTING_PROVIDER_UNAVAILABLE)).toBe(false);
     });
 
     it("passes the error to the predicate", () => {
       const skipErrorReporting = vi.fn().mockReturnValue(false);
       const error = httpError(500);
 
-      shouldReportQueryError(error, { skipErrorReporting });
+      shouldReportError(error, { skipErrorReporting });
 
       expect(skipErrorReporting).toHaveBeenCalledWith(error);
     });
 
     it("reports when meta holds no predicate", () => {
-      expect(shouldReportQueryError(httpError(502), { somethingElse: true })).toBe(true);
+      expect(shouldReportError(httpError(502), { somethingElse: true })).toBe(true);
+    });
+  });
+
+  describe("SKIP_REPORTING_HANDLED_BY_CALLER", () => {
+    it("suppresses cache-level reporting whatever the error", () => {
+      expect(shouldReportError(httpError(500), SKIP_REPORTING_HANDLED_BY_CALLER)).toBe(false);
+      expect(shouldReportError(new Error("boom"), SKIP_REPORTING_HANDLED_BY_CALLER)).toBe(false);
     });
   });
 

--- a/apps/deploy-web/src/services/query-error-policy/query-error-policy.ts
+++ b/apps/deploy-web/src/services/query-error-policy/query-error-policy.ts
@@ -19,12 +19,15 @@ export function isProviderUnavailableError(error: unknown): boolean {
 }
 
 /**
- * Queries opt out of error reporting by putting a predicate on React Query's `meta`, which is the documented
- * way to hand per-query policy to the global cache handler.
+ * Queries and mutations opt out of error reporting by putting a predicate on React Query's `meta`, which is the
+ * documented way to hand per-call policy to the global cache handlers.
  */
-export function shouldReportQueryError(error: unknown, meta: Record<string, unknown> | undefined): boolean {
+export function shouldReportError(error: unknown, meta: Record<string, unknown> | undefined): boolean {
   const skipErrorReporting = meta?.skipErrorReporting;
   return typeof skipErrorReporting === "function" ? !skipErrorReporting(error) : true;
 }
 
 export const SKIP_REPORTING_PROVIDER_UNAVAILABLE = { skipErrorReporting: isProviderUnavailableError };
+
+/** Opt out for call sites whose own onError reports the failure with tags the cache handler has no way to know. */
+export const SKIP_REPORTING_HANDLED_BY_CALLER = { skipErrorReporting: () => true };


### PR DESCRIPTION
## Why

Once the CSP reports are dealt with (#3881, #3882), what is left in deploy-web's Sentry is a few hundred app errors, and some of them are not errors. Cancellations get filed as failures, four mutations are reported twice, 400s group badly because they are missing their tags, and Turnstile failures arrive titled `<unknown>`.

Independent of the CSP work; no shared files.

## What

**Cancellations.** `ErrorHandlerService.reportError` dropped DOM `AbortError` and nothing else. Monaco names its cancellations `Canceled` (that is the `Canceled: Canceled` issue, from the SDL editor) and axios uses `CanceledError` with code `ERR_CANCELED`. All four shapes now short-circuit.

**400 tagging.** HTTP 400s were captured without the `status`, `method` and `url` tags every other status gets, because of a `status !== 400` condition that has been there since the original commit with no note explaining it. That is why the 400 issues group so badly in Sentry. Removed. It also makes the `fetchLeaseStatus` 400s (38 in 7 days, currently unexplained) diagnosable, which is the actual next step there.

**Double reporting.** `mutationCache.onError` reported unconditionally while `queryCache.onError` honoured `meta.skipErrorReporting`. Mutations now get the same say. Four mutations already report with their own `category` tag and were being filed a second time by the cache; they opt out through a new `SKIP_REPORTING_HANDLED_BY_CALLER` rather than losing their tags.

**Turnstile.** `onError` passed Cloudflare's raw error code straight to `reportError`, so failures landed in Sentry titled `<unknown>` with a bare number for a message (19 in 7 days on `/login`, all code 300031). Wrapping it keeps the code and gives the issue a name. Whether 300031 is transient or a real login blocker is a separate question, and one that is easier to answer once the issue is legible.

**Service worker.** The middleware matcher claimed `/sw.js`. In maintenance mode that means the service worker script gets a 307, and a redirected SW script cannot register at all, which is the `Failed to register a ServiceWorker` issue. The maintenance redirect now skips `sw.js`, `workbox-*.js` and `manifest.json`. They stay inside the matcher so they keep getting the CSP header: a worker takes its policy from its own script response and nowhere else.

I left the `ignoreErrors` entry for the leftover SW failures (private browsing, storage disabled) out on purpose. Adding it now would mask the matcher fix before anyone can confirm it worked.

## Verification

`npm run test:unit`: 379 files, 3806 tests pass, including new coverage for the cancellation shapes, 400 tagging and the caller opt-out. Lint clean. `tsc` shows 95 errors on this branch and 95 on `origin/main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting by suppressing expected cancellation errors and avoiding duplicate reports for errors already handled by the app.
  * Added richer metadata to HTTP error reports, including status, method, and URL.
  * Turnstile failures now provide clearer error messages.
  * Updated middleware handling so service-worker and manifest assets load without being redirected.

* **Tests**
  * Expanded coverage for cancellation handling, caller-managed errors, and HTTP error metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
