### PR TITLE
chore(repo): ignore the local .codex directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ profile-results.json
 
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
+.codex/
 .github/workflows/test*.yml
 
 .stryker-tmp/


### PR DESCRIPTION
## Why

Codex writes a per-developer `.codex/config.toml` in the repo root, and it can hold live credentials. Mine currently has a Grafana service account token in it. Nothing in `.gitignore` covered the path, so a `git add -A` from the repo root would have committed it.

Sits next to the existing `.claude/settings.local.json` entry, which is there for the same reason.

## What

One line in `.gitignore`.