### PR TITLE
refactor(deployment): let a stored definition serve a redeploy

### DIFF
--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -144,28 +144,6 @@ export const CreateDeploymentResponseSchema = z.object({
   })
 });
 
-/** Both fields are overrides, so a body of `{}` redeploys the source exactly as the console stored it. */
-export const RedeployDeploymentRequestSchema = z.object({
-  data: z
-    .object({
-      sealedSecrets: SealedSecretsSchema.optional().openapi({
-        description:
-          "Compact JWE sealing a flat name-to-value map, as on create. A name present here replaces the value the source deployment holds for it; every other name is carried forward untouched."
-      }),
-      runtimeLimitHours: z
-        .number()
-        .int()
-        .min(1)
-        .max(MAX_RUNTIME_LIMIT_INCREMENT_HOURS)
-        .optional()
-        .openapi({
-          description: `Optional runtime limit in hours (1 to ${MAX_RUNTIME_LIMIT_INCREMENT_HOURS}) for the new deployment. Omit to carry the source deployment's own limit forward.`
-        })
-    })
-    .optional()
-    .default({})
-});
-
 export const CloseDeploymentParamsSchema = z.object({
   dseq: DseqSchema.describe("Deployment sequence number")
 });
@@ -470,7 +448,6 @@ export type DepositDeploymentResponse = z.infer<typeof DepositDeploymentResponse
 export type UpdateDeploymentRequest = z.infer<typeof UpdateDeploymentRequestSchema>;
 export type PatchService = z.infer<typeof PatchServiceSchema>;
 export type PatchDeploymentRequest = z.infer<typeof PatchDeploymentRequestSchema>;
-export type RedeployDeploymentRequest = z.infer<typeof RedeployDeploymentRequestSchema>;
 export type PatchDeploymentResponse = z.infer<typeof PatchDeploymentResponseSchema>;
 export type UpdateDeploymentResponse = z.infer<typeof UpdateDeploymentResponseSchema>;
 export type ListWithResourcesParams = z.infer<typeof ListWithResourcesParamsSchema>;

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -144,6 +144,28 @@ export const CreateDeploymentResponseSchema = z.object({
   })
 });
 
+/** Both fields are overrides, so a body of `{}` redeploys the source exactly as the console stored it. */
+export const RedeployDeploymentRequestSchema = z.object({
+  data: z
+    .object({
+      sealedSecrets: SealedSecretsSchema.optional().openapi({
+        description:
+          "Compact JWE sealing a flat name-to-value map, as on create. A name present here replaces the value the source deployment holds for it; every other name is carried forward untouched."
+      }),
+      runtimeLimitHours: z
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_RUNTIME_LIMIT_INCREMENT_HOURS)
+        .optional()
+        .openapi({
+          description: `Optional runtime limit in hours (1 to ${MAX_RUNTIME_LIMIT_INCREMENT_HOURS}) for the new deployment. Omit to carry the source deployment's own limit forward.`
+        })
+    })
+    .optional()
+    .default({})
+});
+
 export const CloseDeploymentParamsSchema = z.object({
   dseq: DseqSchema.describe("Deployment sequence number")
 });
@@ -448,6 +470,7 @@ export type DepositDeploymentResponse = z.infer<typeof DepositDeploymentResponse
 export type UpdateDeploymentRequest = z.infer<typeof UpdateDeploymentRequestSchema>;
 export type PatchService = z.infer<typeof PatchServiceSchema>;
 export type PatchDeploymentRequest = z.infer<typeof PatchDeploymentRequestSchema>;
+export type RedeployDeploymentRequest = z.infer<typeof RedeployDeploymentRequestSchema>;
 export type PatchDeploymentResponse = z.infer<typeof PatchDeploymentResponseSchema>;
 export type UpdateDeploymentResponse = z.infer<typeof UpdateDeploymentResponseSchema>;
 export type ListWithResourcesParams = z.infer<typeof ListWithResourcesParamsSchema>;

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -18,6 +18,7 @@ import type { CreateLogger, JobQueueService, TxService } from "@src/core";
 import { JOB_NAME } from "@src/core";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
+import { MAX_RUNTIME_LIMIT_HOURS, MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { GenerateResolvedManifestResult, SdlManifest, SdlService } from "@src/deployment/services/sdl/sdl.service";
@@ -160,6 +161,9 @@ const SDL_OF_A_REDEPLOY_WITH_PLAINTEXT = sdlAround(`    env:
       - API_TOKEN=ac-secret://API_TOKEN
       - LOG_LEVEL=${ENV_VALUE}
 `);
+
+/** Short cleartext values lengthen when re-derived into references, so enough of them fit in storage yet cannot be redeployed. */
+const SDL_TOO_LARGE_ONCE_REDERIVED = sdlAround(`    env:\n${Array.from({ length: 6000 }, (_, index) => `      - E${index}=x\n`).join("")}`);
 
 describe(DeploymentWriterService.name, () => {
   const wallet: WalletInitialized = {
@@ -1067,6 +1071,166 @@ describe(DeploymentWriterService.name, () => {
           expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
           expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
         });
+      });
+    });
+  });
+
+  describe("redeployByUserIdAndDseq", () => {
+    it("deploys the sdl the console stored for the source, never one from the request", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedSdl: SDL_OF_A_REDEPLOY, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
+      expect(recorded.sdl).toContain("API_TOKEN=ac-secret://API_TOKEN");
+    });
+
+    it("mints a dseq of its own rather than writing over the source", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
+      expect(recorded.dseq).toBe("1748400000000");
+      expect(recorded.dseq).not.toBe(SOURCE_DSEQ);
+    });
+
+    it("inherits the source's secrets by naming it, so no value passes through the request", async () => {
+      const { service, sdlSecretsInheritanceService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(sdlSecretsInheritanceService.open).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
+    });
+
+    it("carries the source's runtime limit forward", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(5);
+    });
+
+    it("prefers an explicitly supplied runtime limit to the carried one", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { runtimeLimitHours: 9 }, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(9);
+    });
+
+    it("carries no runtime limit when the source has none", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: null, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBeUndefined();
+    });
+
+    it("hands a supplied seal to the intake, so its names replace what the source holds", async () => {
+      const { service, sdlSecretsService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { sealedSecrets: CLIENT_SEAL }, ability);
+
+      expect(sdlSecretsService.receive).toHaveBeenCalledWith(expect.objectContaining({ sealedSecrets: CLIENT_SEAL }));
+    });
+
+    it("reads the source through the caller's own ability", async () => {
+      const { service, deploymentSettingRepository, scopedSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(ability, "read");
+      expect(scopedSettingRepository.findOneBy).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
+    });
+
+    it("reduces a carried runtime limit longer than one request may grant to that increment", async () => {
+      const { service, deploymentSettingRepository, ability } = setup({
+        storedRuntimeLimitHours: MAX_RUNTIME_LIMIT_HOURS,
+        inherited: { API_TOKEN: "a", DATABASE_URL: "b" }
+      });
+
+      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
+
+      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
+    });
+
+    describe("a stored sdl the console cannot redeploy", () => {
+      it("blames itself rather than the caller for one that will not parse", async () => {
+        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
+          status: 500,
+          errorCode: "stored_sdl_unreadable"
+        });
+      });
+
+      it("tells the caller nothing about a document they could not have written", async () => {
+        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
+
+        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
+
+        expect(thrown.message).toBe("The SDL recorded for this deployment cannot be read");
+        expect(thrown.data).toBeUndefined();
+        expect(thrownTextOf(thrown)).not.toContain("LEAKED");
+        expect(thrownTextOf(thrown)).not.toContain(MALFORMED_SDL_VALUE);
+        expect(thrownTextOf(thrown)).not.toMatch(/line \d+, column \d+/);
+      });
+
+      it("blames itself rather than the caller for one too large once its values are re-derived", async () => {
+        const { service, ability } = setup({ storedSdl: SDL_TOO_LARGE_ONCE_REDERIVED, inherited: { API_TOKEN: "a" } });
+
+        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
+
+        expect(thrown).toMatchObject({ status: 500, errorCode: "redeployed_sdl_too_large" });
+        expect(thrown.data).toBeUndefined();
+        expect(thrownTextOf(thrown)).not.toContain("ac-secret://");
+      });
+
+      it("records nothing and broadcasts nothing for either", async () => {
+        const { service, deploymentSettingRepository, signerService, ability } = setup({
+          storedSdl: "this: is: not: yaml:",
+          inherited: { API_TOKEN: "a" }
+        });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
+
+        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("a source the console recorded no sdl for", () => {
+      it("answers not found", async () => {
+        const { service, ability } = setup({ sourceSetting: undefined });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
+      });
+
+      it("says there is nothing to redeploy rather than nothing to patch", async () => {
+        const { service, ability } = setup({ sourceSetting: undefined });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
+          message: "This deployment has no SDL recorded by the console, so there is nothing to redeploy"
+        });
+      });
+
+      it("mints no dseq, records nothing and broadcasts nothing", async () => {
+        const { service, deploymentSettingRepository, signerService, ability } = setup({ sourceSetting: undefined });
+        const now = vi.spyOn(Date, "now");
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
+
+        expect(now).not.toHaveBeenCalled();
+        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      });
+
+      it("answers not found for a row that exists but holds no sdl", async () => {
+        const { service, ability } = setup({ sourceSetting: mock<DeploymentSettingsOutput>({ sdl: null }) });
+
+        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
       });
     });
   });
@@ -2057,6 +2221,9 @@ describe(DeploymentWriterService.name, () => {
     inheritanceError?: Error;
     maxCount?: number;
     sealedSecrets?: string | null;
+    storedSdl?: string;
+    storedRuntimeLimitHours?: number | null;
+    sourceSetting?: DeploymentSettingsOutput;
   }) {
     const signerService = mock<ManagedSignerService>();
     const rpcMessageService = mock<RpcMessageService>();
@@ -2080,6 +2247,17 @@ describe(DeploymentWriterService.name, () => {
     });
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.upsertDefinition.mockResolvedValue(DEPLOYMENT_SETTING_ID);
+    const scopedSettingRepository = mock<DeploymentSettingRepository>();
+    scopedSettingRepository.findOneBy.mockResolvedValue(
+      "sourceSetting" in (input ?? {})
+        ? input!.sourceSetting
+        : mock<DeploymentSettingsOutput>({
+            sdl: input?.storedSdl ?? SDL_OF_A_REDEPLOY,
+            runtimeLimitHours: input?.storedRuntimeLimitHours ?? null,
+            sealedSecrets: "stored.token.aaa.bbb.ccc"
+          })
+    );
+    deploymentSettingRepository.accessibleBy.mockReturnValue(scopedSettingRepository);
     const txService = mock<TxService>();
     txService.transaction.mockImplementation(async cb => (input?.transactionRuns === false ? (undefined as never) : await cb()));
     const jobQueueService = mock<JobQueueService>();
@@ -2156,6 +2334,8 @@ describe(DeploymentWriterService.name, () => {
       jobQueueService,
       sdlSecretsService,
       sdlSecretsInheritanceService,
+      scopedSettingRepository,
+      ability: mock<AnyAbility>(),
       storedSecrets
     };
   }

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -18,7 +18,6 @@ import type { CreateLogger, JobQueueService, TxService } from "@src/core";
 import { JOB_NAME } from "@src/core";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import type { DeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
-import { MAX_RUNTIME_LIMIT_HOURS, MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeleteUnbackedDeploymentSetting } from "@src/deployment/services/delete-unbacked-deployment-setting/delete-unbacked-deployment-setting.handler";
 import type { GenerateResolvedManifestResult, SdlManifest, SdlService } from "@src/deployment/services/sdl/sdl.service";
@@ -161,9 +160,6 @@ const SDL_OF_A_REDEPLOY_WITH_PLAINTEXT = sdlAround(`    env:
       - API_TOKEN=ac-secret://API_TOKEN
       - LOG_LEVEL=${ENV_VALUE}
 `);
-
-/** Short cleartext values lengthen when re-derived into references, so enough of them fit in storage yet cannot be redeployed. */
-const SDL_TOO_LARGE_ONCE_REDERIVED = sdlAround(`    env:\n${Array.from({ length: 6000 }, (_, index) => `      - E${index}=x\n`).join("")}`);
 
 describe(DeploymentWriterService.name, () => {
   const wallet: WalletInitialized = {
@@ -1071,166 +1067,6 @@ describe(DeploymentWriterService.name, () => {
           expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
           expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
         });
-      });
-    });
-  });
-
-  describe("redeployByUserIdAndDseq", () => {
-    it("deploys the sdl the console stored for the source, never one from the request", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedSdl: SDL_OF_A_REDEPLOY, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
-      expect(recorded.sdl).toContain("API_TOKEN=ac-secret://API_TOKEN");
-    });
-
-    it("mints a dseq of its own rather than writing over the source", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-      vi.spyOn(Date, "now").mockReturnValue(1748400000000);
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      const [recorded] = vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0];
-      expect(recorded.dseq).toBe("1748400000000");
-      expect(recorded.dseq).not.toBe(SOURCE_DSEQ);
-    });
-
-    it("inherits the source's secrets by naming it, so no value passes through the request", async () => {
-      const { service, sdlSecretsInheritanceService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(sdlSecretsInheritanceService.open).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
-    });
-
-    it("carries the source's runtime limit forward", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(5);
-    });
-
-    it("prefers an explicitly supplied runtime limit to the carried one", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: 5, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { runtimeLimitHours: 9 }, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(9);
-    });
-
-    it("carries no runtime limit when the source has none", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({ storedRuntimeLimitHours: null, inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBeUndefined();
-    });
-
-    it("hands a supplied seal to the intake, so its names replace what the source holds", async () => {
-      const { service, sdlSecretsService, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, { sealedSecrets: CLIENT_SEAL }, ability);
-
-      expect(sdlSecretsService.receive).toHaveBeenCalledWith(expect.objectContaining({ sealedSecrets: CLIENT_SEAL }));
-    });
-
-    it("reads the source through the caller's own ability", async () => {
-      const { service, deploymentSettingRepository, scopedSettingRepository, ability } = setup({ inherited: { API_TOKEN: "a", DATABASE_URL: "b" } });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(deploymentSettingRepository.accessibleBy).toHaveBeenCalledWith(ability, "read");
-      expect(scopedSettingRepository.findOneBy).toHaveBeenCalledWith({ userId: "user-1", dseq: SOURCE_DSEQ });
-    });
-
-    it("reduces a carried runtime limit longer than one request may grant to that increment", async () => {
-      const { service, deploymentSettingRepository, ability } = setup({
-        storedRuntimeLimitHours: MAX_RUNTIME_LIMIT_HOURS,
-        inherited: { API_TOKEN: "a", DATABASE_URL: "b" }
-      });
-
-      await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability);
-
-      expect(vi.mocked(deploymentSettingRepository.upsertDefinition).mock.calls[0][0].runtimeLimitHours).toBe(MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
-    });
-
-    describe("a stored sdl the console cannot redeploy", () => {
-      it("blames itself rather than the caller for one that will not parse", async () => {
-        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
-          status: 500,
-          errorCode: "stored_sdl_unreadable"
-        });
-      });
-
-      it("tells the caller nothing about a document they could not have written", async () => {
-        const { service, ability } = setup({ storedSdl: MALFORMED_SDL_CARRYING_A_VALUE, inherited: { API_TOKEN: "a" } });
-
-        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
-
-        expect(thrown.message).toBe("The SDL recorded for this deployment cannot be read");
-        expect(thrown.data).toBeUndefined();
-        expect(thrownTextOf(thrown)).not.toContain("LEAKED");
-        expect(thrownTextOf(thrown)).not.toContain(MALFORMED_SDL_VALUE);
-        expect(thrownTextOf(thrown)).not.toMatch(/line \d+, column \d+/);
-      });
-
-      it("blames itself rather than the caller for one too large once its values are re-derived", async () => {
-        const { service, ability } = setup({ storedSdl: SDL_TOO_LARGE_ONCE_REDERIVED, inherited: { API_TOKEN: "a" } });
-
-        const thrown = await service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability).catch(error => error);
-
-        expect(thrown).toMatchObject({ status: 500, errorCode: "redeployed_sdl_too_large" });
-        expect(thrown.data).toBeUndefined();
-        expect(thrownTextOf(thrown)).not.toContain("ac-secret://");
-      });
-
-      it("records nothing and broadcasts nothing for either", async () => {
-        const { service, deploymentSettingRepository, signerService, ability } = setup({
-          storedSdl: "this: is: not: yaml:",
-          inherited: { API_TOKEN: "a" }
-        });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
-
-        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
-        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("a source the console recorded no sdl for", () => {
-      it("answers not found", async () => {
-        const { service, ability } = setup({ sourceSetting: undefined });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
-      });
-
-      it("says there is nothing to redeploy rather than nothing to patch", async () => {
-        const { service, ability } = setup({ sourceSetting: undefined });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({
-          message: "This deployment has no SDL recorded by the console, so there is nothing to redeploy"
-        });
-      });
-
-      it("mints no dseq, records nothing and broadcasts nothing", async () => {
-        const { service, deploymentSettingRepository, signerService, ability } = setup({ sourceSetting: undefined });
-        const now = vi.spyOn(Date, "now");
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toThrow();
-
-        expect(now).not.toHaveBeenCalled();
-        expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
-        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
-      });
-
-      it("answers not found for a row that exists but holds no sdl", async () => {
-        const { service, ability } = setup({ sourceSetting: mock<DeploymentSettingsOutput>({ sdl: null }) });
-
-        await expect(service.redeployByUserIdAndDseq("user-1", SOURCE_DSEQ, {}, ability)).rejects.toMatchObject({ status: 404 });
       });
     });
   });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -19,8 +19,10 @@ import {
   DeploymentResponse,
   PatchDeploymentRequest,
   PatchDeploymentResponse,
+  RedeployDeploymentRequest,
   UpdateDeploymentRequest
 } from "@src/deployment/http-schemas/deployment.schema";
+import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import {
   DeleteUnbackedDeploymentSetting,
@@ -47,8 +49,14 @@ const SECRET_REFERENCE_KIND = "secret";
 /** Distinct from the sealed-secret failure so a client can tell which half of the stored state it cannot read, both being permanent. */
 const STORED_SDL_UNREADABLE_ERROR_CODE = "stored_sdl_unreadable";
 
+/** Redeploying re-derives cleartext values into references, which lengthens the document, so a source can be stored yet be too large to redeploy. */
+const REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE = "redeployed_sdl_too_large";
+
 /** A deployment the console never recorded an SDL for has nothing to patch, and the SDL is deliberately not accepted from the request. */
 const NOT_PATCHABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to patch";
+
+/** Its own wording rather than the one above, because the patch endpoint's 404 message is a shipped behaviour its callers already read. */
+const NOT_REDEPLOYABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to redeploy";
 
 /** What becomes of the values a submitted document carries in the clear. There is no longer a way to say "dropped": every writer can seal, so a value is never lost to be safe. */
 type StoredSdlValues =
@@ -56,6 +64,30 @@ type StoredSdlValues =
   | "every-value-sealed"
   /** Only a registry credential is, a seal having already said which of the rest are secret. */
   | "only-credentials-sealed";
+
+/**
+ * A 400 by default, so every caller that submitted the document keeps answering exactly as it did, while a
+ * caller that submitted none can catch this and answer for the console instead. `name` must stay unset:
+ * the error handler echoes it into the response body, so assigning it would change a shipped 400.
+ */
+class UnstorableSdlError extends HTTPException {
+  readonly refusal: StoredSdlRefusal;
+
+  constructor(refusal: StoredSdlRefusal, message: string) {
+    super(400, { message });
+    this.refusal = refusal;
+  }
+}
+
+/**
+ * A redeploy creates a deployment that has none, so the most one request may grant it is the same first
+ * increment every other entry point allows; a longer limit stays reachable by extending after the redeploy.
+ */
+function carriedRuntimeLimitOf(storedRuntimeLimitHours: number | null | undefined) {
+  if (typeof storedRuntimeLimitHours !== "number") return undefined;
+
+  return Math.min(storedRuntimeLimitHours, MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
+}
 
 /** Lowest precedence first: what the deployment carried in, then what the request supplied, then what the document gave up. */
 function prunedOverlayOf(sets: { carried: SdlSecrets; supplied: SdlSecrets; derived: SdlSecrets }, referenced: ReadonlySet<string>): SdlSecrets {
@@ -281,12 +313,32 @@ export class DeploymentWriterService {
     if (refusal === "unparseable") {
       this.logger.warn({ event: "DEPLOYMENT_SDL_UNPARSEABLE", ...loggable, line: at?.line, column: at?.column });
 
-      return new HTTPException(400, { message: at ? `SDL is not valid YAML: line ${at.line}, column ${at.column}` : "SDL is not valid YAML" });
+      return new UnstorableSdlError(refusal, at ? `SDL is not valid YAML: line ${at.line}, column ${at.column}` : "SDL is not valid YAML");
     }
 
     this.logger.warn({ event: "DEPLOYMENT_SDL_TOO_LARGE", ...loggable, maxLength: SDL_MAX_LENGTH });
 
-    return new HTTPException(400, { message: `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored` });
+    return new UnstorableSdlError(refusal, `SDL is too large: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once stored`);
+  }
+
+  /**
+   * Built from the refusal kind alone and never from the error carrying it, so no line, column or fragment of
+   * the console's own document reaches a caller who could not have written it.
+   */
+  #rejectUnredeployableStoredSdl(refusal: StoredSdlRefusal, key: { userId: string; dseq: string }) {
+    if (refusal === "unparseable") {
+      this.logger.error({ event: "DEPLOYMENT_STORED_SDL_UNPARSEABLE", ...key });
+
+      return createError(500, "The SDL recorded for this deployment cannot be read", { errorCode: STORED_SDL_UNREADABLE_ERROR_CODE });
+    }
+
+    this.logger.error({ event: "DEPLOYMENT_REDEPLOYED_SDL_TOO_LARGE", ...key, maxLength: SDL_MAX_LENGTH });
+
+    return createError(
+      500,
+      `The SDL recorded for this deployment cannot be redeployed: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once its values are re-derived`,
+      { errorCode: REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE }
+    );
   }
 
   /**
@@ -392,7 +444,10 @@ export class DeploymentWriterService {
     input: PatchDeploymentRequest["data"],
     ability: AnyAbility
   ): Promise<PatchDeploymentResponse["data"]> {
-    const [wallet, stored] = await Promise.all([this.walletReaderService.getWalletByUserId(userId), this.#findStoredDefinition({ userId, dseq }, ability)]);
+    const [wallet, stored] = await Promise.all([
+      this.walletReaderService.getWalletByUserId(userId),
+      this.#findStoredDefinition({ userId, dseq }, ability, NOT_PATCHABLE_MESSAGE)
+    ]);
     const parsed = this.#parseStored(stored.sdl, { userId, dseq });
     const document = parsed.document;
 
@@ -445,18 +500,61 @@ export class DeploymentWriterService {
     return { ...(await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq)), manifestVersion: recordedVersion };
   }
 
+  /**
+   * Deploys again what the console stored for a deployment — its SDL, its secrets and its runtime limit —
+   * as a new deployment of its own. The SDL is never accepted from the request, and the secrets are carried
+   * by the same inheritance a create performs, so nothing about them passes through the client.
+   *
+   * The definition is read here and its token read again inside `create`. A patch landing between the two
+   * can only pair the older SDL with a newer token, which either resolves — a value the patch changed being
+   * what a caller would want anyway — or is refused when the token no longer covers what the SDL references.
+   * The worst a race produces is a spurious refusal, never a deployment of something other than the source.
+   */
+  public async redeployByUserIdAndDseq(
+    userId: string,
+    dseq: string,
+    input: RedeployDeploymentRequest["data"],
+    ability: AnyAbility
+  ): Promise<CreateDeploymentResponse["data"]> {
+    const stored = await this.#findStoredDefinition({ userId, dseq }, ability, NOT_REDEPLOYABLE_MESSAGE);
+
+    this.logger.info({ event: "DEPLOYMENT_REDEPLOY_STARTED", userId, dseq, overridesRuntimeLimit: input.runtimeLimitHours !== undefined });
+
+    try {
+      return await this.create({
+        userId,
+        sdl: stored.sdl,
+        inheritSecretsFrom: dseq,
+        sealedSecrets: input.sealedSecrets,
+        runtimeLimitHours: input.runtimeLimitHours ?? carriedRuntimeLimitOf(stored.runtimeLimitHours)
+      });
+    } catch (error) {
+      if (error instanceof UnstorableSdlError) {
+        throw this.#rejectUnredeployableStoredSdl(error.refusal, { userId, dseq });
+      }
+
+      throw error;
+    }
+  }
+
   /** Read through the caller's own ability as well as their id, so a definition is unreachable by anyone the ability excludes even before the write re-checks it. */
   async #findStoredDefinition(
     key: { userId: string; dseq: string },
-    ability: AnyAbility
-  ): Promise<{ sdl: string; sealedSecrets: string | null; manifestVersion?: string }> {
+    ability: AnyAbility,
+    notFoundMessage: string
+  ): Promise<{ sdl: string; sealedSecrets: string | null; manifestVersion?: string; runtimeLimitHours?: number }> {
     const setting = await this.deploymentSettingRepository.accessibleBy(ability, "read").findOneBy(key);
 
     if (!setting?.sdl) {
-      throw createError(404, NOT_PATCHABLE_MESSAGE);
+      throw createError(404, notFoundMessage);
     }
 
-    return { sdl: setting.sdl, sealedSecrets: setting.sealedSecrets, manifestVersion: setting.manifestVersion ?? undefined };
+    return {
+      sdl: setting.sdl,
+      sealedSecrets: setting.sealedSecrets,
+      manifestVersion: setting.manifestVersion ?? undefined,
+      runtimeLimitHours: setting.runtimeLimitHours ?? undefined
+    };
   }
 
   /** The caller did not supply this document, so an unparseable one is the console's fault and never a 400. */

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -19,10 +19,8 @@ import {
   DeploymentResponse,
   PatchDeploymentRequest,
   PatchDeploymentResponse,
-  RedeployDeploymentRequest,
   UpdateDeploymentRequest
 } from "@src/deployment/http-schemas/deployment.schema";
-import { MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import {
   DeleteUnbackedDeploymentSetting,
@@ -49,14 +47,8 @@ const SECRET_REFERENCE_KIND = "secret";
 /** Distinct from the sealed-secret failure so a client can tell which half of the stored state it cannot read, both being permanent. */
 const STORED_SDL_UNREADABLE_ERROR_CODE = "stored_sdl_unreadable";
 
-/** Redeploying re-derives cleartext values into references, which lengthens the document, so a source can be stored yet be too large to redeploy. */
-const REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE = "redeployed_sdl_too_large";
-
 /** A deployment the console never recorded an SDL for has nothing to patch, and the SDL is deliberately not accepted from the request. */
 const NOT_PATCHABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to patch";
-
-/** Its own wording rather than the one above, because the patch endpoint's 404 message is a shipped behaviour its callers already read. */
-const NOT_REDEPLOYABLE_MESSAGE = "This deployment has no SDL recorded by the console, so there is nothing to redeploy";
 
 /** What becomes of the values a submitted document carries in the clear. There is no longer a way to say "dropped": every writer can seal, so a value is never lost to be safe. */
 type StoredSdlValues =
@@ -77,16 +69,6 @@ class UnstorableSdlError extends HTTPException {
     super(400, { message });
     this.refusal = refusal;
   }
-}
-
-/**
- * A redeploy creates a deployment that has none, so the most one request may grant it is the same first
- * increment every other entry point allows; a longer limit stays reachable by extending after the redeploy.
- */
-function carriedRuntimeLimitOf(storedRuntimeLimitHours: number | null | undefined) {
-  if (typeof storedRuntimeLimitHours !== "number") return undefined;
-
-  return Math.min(storedRuntimeLimitHours, MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
 }
 
 /** Lowest precedence first: what the deployment carried in, then what the request supplied, then what the document gave up. */
@@ -322,26 +304,6 @@ export class DeploymentWriterService {
   }
 
   /**
-   * Built from the refusal kind alone and never from the error carrying it, so no line, column or fragment of
-   * the console's own document reaches a caller who could not have written it.
-   */
-  #rejectUnredeployableStoredSdl(refusal: StoredSdlRefusal, key: { userId: string; dseq: string }) {
-    if (refusal === "unparseable") {
-      this.logger.error({ event: "DEPLOYMENT_STORED_SDL_UNPARSEABLE", ...key });
-
-      return createError(500, "The SDL recorded for this deployment cannot be read", { errorCode: STORED_SDL_UNREADABLE_ERROR_CODE });
-    }
-
-    this.logger.error({ event: "DEPLOYMENT_REDEPLOYED_SDL_TOO_LARGE", ...key, maxLength: SDL_MAX_LENGTH });
-
-    return createError(
-      500,
-      `The SDL recorded for this deployment cannot be redeployed: it exceeds the maximum of ${SDL_MAX_LENGTH} characters once its values are re-derived`,
-      { errorCode: REDEPLOYED_SDL_TOO_LARGE_ERROR_CODE }
-    );
-  }
-
-  /**
    * Reclaims escrow from a trial wallet's orphaned (open, lease-less) deployments before a new create, so a stranded
    * trial user whose earlier close failed can deploy again without waiting for the periodic cleanup job. It runs
    * before the create tx so the freed deployment allowance is available when the create's balance check runs.
@@ -498,43 +460,6 @@ export class DeploymentWriterService {
     });
 
     return { ...(await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq)), manifestVersion: recordedVersion };
-  }
-
-  /**
-   * Deploys again what the console stored for a deployment — its SDL, its secrets and its runtime limit —
-   * as a new deployment of its own. The SDL is never accepted from the request, and the secrets are carried
-   * by the same inheritance a create performs, so nothing about them passes through the client.
-   *
-   * The definition is read here and its token read again inside `create`. A patch landing between the two
-   * can only pair the older SDL with a newer token, which either resolves — a value the patch changed being
-   * what a caller would want anyway — or is refused when the token no longer covers what the SDL references.
-   * The worst a race produces is a spurious refusal, never a deployment of something other than the source.
-   */
-  public async redeployByUserIdAndDseq(
-    userId: string,
-    dseq: string,
-    input: RedeployDeploymentRequest["data"],
-    ability: AnyAbility
-  ): Promise<CreateDeploymentResponse["data"]> {
-    const stored = await this.#findStoredDefinition({ userId, dseq }, ability, NOT_REDEPLOYABLE_MESSAGE);
-
-    this.logger.info({ event: "DEPLOYMENT_REDEPLOY_STARTED", userId, dseq, overridesRuntimeLimit: input.runtimeLimitHours !== undefined });
-
-    try {
-      return await this.create({
-        userId,
-        sdl: stored.sdl,
-        inheritSecretsFrom: dseq,
-        sealedSecrets: input.sealedSecrets,
-        runtimeLimitHours: input.runtimeLimitHours ?? carriedRuntimeLimitOf(stored.runtimeLimitHours)
-      });
-    } catch (error) {
-      if (error instanceof UnstorableSdlError) {
-        throw this.#rejectUnredeployableStoredSdl(error.refusal, { userId, dseq });
-      }
-
-      throw error;
-    }
   }
 
   /** Read through the caller's own ability as well as their id, so a definition is unreachable by anyone the ability excludes even before the write re-checks it. */

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -60,6 +60,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     const response = await patch(apiKey, { services: { web: { image: "nginx" } } });
 
     expect(response.status).toBe(404);
+    expect(await response.text()).toContain("nothing to patch");
   });
 
   it("refuses a body naming no services before it reaches the controller", async () => {

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -831,6 +831,7 @@ describe("Deployments API", () => {
       const response = await postOversizedDeployment(userApiKeySecret);
 
       expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ error: "Error", code: "bad_request", type: "client_error" });
     });
 
     it("says nothing about the sdl in the 400 it returns", async () => {


### PR DESCRIPTION
## Why

Part of CON-866. `POST /v1/deployments/{dseq}/redeploy` has to build a new deployment out of what
the console already stored for an existing one. This adds that seam on its own so the route in the
next PR is only wiring, following the same split as #3828.

## What

- `#findStoredDefinition` takes the 404 message as a parameter, so a redeploy can say there is
  nothing to *redeploy* instead of borrowing the patch endpoint's wording — that message is shipped
  behaviour its own callers already read.
- It also returns the stored `runtimeLimitHours`, so a redeploy can carry the source's limit
  forward.
- `redeployByUserIdAndDseq` reads the source through the caller's own ability and deploys what the
  console stored for it, inheriting the secrets by naming the source, so no value passes through the
  request.

No route yet — nothing reaches this from HTTP until the next PR.

---

## Design note: the refusal is caught, not threaded

The SDL-for-storage path refuses with a typed error carrying the *kind* of refusal, and it is still a
400 by default. `redeployByUserIdAndDseq` catches that error and answers 500 instead —
`stored_sdl_unreadable` for a document that will not parse, `redeployed_sdl_too_large` for one that
outgrows the length bound as its cleartext values are re-derived into references. A caller who
submitted no SDL cannot usefully be handed a line and column for it.

An earlier revision threaded an *origin* parameter down through `create` into the storage path
instead. Catching at the boundary is better: `create` stays unaware that redeploy exists, no caller
has to declare an origin it has no opinion about, and the shipped path's safety no longer rests on a
default parameter happening to be the conservative one. The knowledge that the document is the
console's own lives in the one method that actually knows it.

Two properties this deliberately preserves, both covered by tests that were **not** modified:

- **`create`'s 400s are byte-identical** — same statuses and same messages, including the one that
  quotes line and column. The typed error subclasses `HTTPException` and hono does not set `name`,
  so every field the error handler reads is unchanged. `create`'s own signature and the storage
  helper's are byte-identical to their pre-change form.
- **The 400's response body is now pinned by a test.** The class deliberately leaves `name` unset,
  unlike five other error classes in this repo that assign it, because
  `hono-error-handler.service.ts` echoes `name` straight into the body. A consistency pass adding
  `this.name` would silently turn every malformed-or-oversized `POST /v1/deployments` response from
  `{"error":"Error",…}` into `{"error":"UnstorableSdlError",…}` — a shipped body on the
  most-travelled deployment endpoint, and nothing asserted it. The constraint is stated on the class
  and `deployments.spec.ts` now asserts the body's shape. I verified the guard by temporarily
  assigning `name` and confirming the assertion fails with exactly that diff.
- **The 500 leaks nothing** — its message is built from the refusal kind alone, never from the
  caught error, and it carries no `data`. Pinned by a test that plants a marker in the source
  document and asserts the thrown error's whole `cause` chain contains neither the marker nor any
  line/column.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployments can inherit secrets from an existing deployment, with validation and precedence rules applied automatically.
  - Redeployments support stored service definitions and preserve applicable runtime-limit settings.
  - Cleanup recovery can reuse an existing waiting job when a retry is requested.

- **Bug Fixes**
  - Improved handling of missing or malformed stored definitions.
  - Deployment patch errors now provide clearer “nothing to patch” details.
  - Oversized service definitions return structured client error information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->