### PR TITLE
feat(deployment): redeploy an existing deployment over http

### DIFF
--- a/apps/api/src/deployment/controllers/deployment/deployment.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/deployment.controller.ts
@@ -19,6 +19,7 @@ import {
   ListWithResourcesResponse,
   PatchDeploymentRequest,
   PatchDeploymentResponse,
+  RedeployDeploymentRequest,
   UpdateDeploymentRequest,
   UpdateDeploymentResponse
 } from "@src/deployment/http-schemas/deployment.schema";
@@ -72,6 +73,12 @@ export class DeploymentController {
   @Protected([{ action: "sign", subject: "UserWallet" }])
   async patch(dseq: string, input: PatchDeploymentRequest["data"]): Promise<PatchDeploymentResponse> {
     const result = await this.deploymentWriterService.patchByUserIdAndDseq(this.authService.currentUser.id, dseq, input, this.authService.ability);
+    return { data: result };
+  }
+
+  @Protected([{ action: "sign", subject: "UserWallet" }])
+  async redeploy(dseq: string, input: RedeployDeploymentRequest["data"]): Promise<CreateDeploymentResponse> {
+    const result = await this.deploymentWriterService.redeployByUserIdAndDseq(this.authService.currentUser.id, dseq, input, this.authService.ability);
     return { data: result };
   }
 

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -144,6 +144,10 @@ export const CreateDeploymentResponseSchema = z.object({
   })
 });
 
+export const RedeployDeploymentParamsSchema = z.object({
+  dseq: DseqSchema.describe("Deployment sequence number of the deployment to redeploy")
+});
+
 /** Both fields are overrides, so a body of `{}` redeploys the source exactly as the console stored it. */
 export const RedeployDeploymentRequestSchema = z.object({
   data: z

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -26,6 +26,8 @@ import {
   PatchDeploymentParamsSchema,
   PatchDeploymentRequestSchema,
   PatchDeploymentResponseSchema,
+  RedeployDeploymentParamsSchema,
+  RedeployDeploymentRequestSchema,
   UpdateDeploymentRequestSchema,
   UpdateDeploymentResponseSchema
 } from "@src/deployment/http-schemas/deployment.schema";
@@ -331,6 +333,91 @@ deploymentsRouter.openapi(patchRoute, async function routePatchDeployment(c) {
   const { data } = c.req.valid("json");
   const result = await container.resolve(DeploymentController).patch(dseq, data);
   return c.json(result, 200);
+});
+
+const redeployRoute = createRoute({
+  method: "post",
+  path: "/v1/deployments/{dseq}/redeploy",
+  summary: "Redeploy an existing deployment",
+  description:
+    "Creates a new deployment from what the console stored for this one: its SDL, its secrets and its runtime limit. The SDL is never accepted from the request. Secrets are carried forward in the process and never pass through the client; a name supplied in `sealedSecrets` replaces the value the source holds for it. A source whose stored SDL still carries values in the clear has them sealed for the new deployment, so the new SDL is equivalent to the source's rather than byte-identical to it. A carried runtime limit longer than one request may grant is reduced to that increment, and can be extended after the redeploy.",
+  // eslint-disable-next-line akash/operation-id-format
+  operationId: "redeployDeployment",
+  tags: ["Deployments"],
+  security: SECURITY_BEARER_OR_API_KEY,
+  /** Sized like the create route, because the body may carry a seal and the default allowance would shadow the stated secret limits. */
+  bodyLimit: { maxSize: CREATE_DEPLOYMENT_BODY_LIMIT_BYTES },
+  request: {
+    params: RedeployDeploymentParamsSchema,
+    /** Required although every field within it is optional, because the request needs a `Content-Type` and an absent body has none. */
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: RedeployDeploymentRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: "Redeployed successfully, answering exactly as a create does",
+      content: {
+        "application/json": {
+          schema: CreateDeploymentResponseSchema
+        }
+      }
+    },
+    400: {
+      description:
+        "The stored SDL leaves a secret reference no value answers, `sealedSecrets` supplies a name it does not reference, or the source carries more secrets than one deployment may hold",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    404: {
+      description: "No deployment of yours matches this dseq, or the console recorded no SDL for it. Says nothing about whether the deployment exists",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    409: {
+      description:
+        "The secrets recorded for this deployment can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    500: {
+      description:
+        "The SDL recorded for this deployment cannot be redeployed: `code` is `stored_sdl_unreadable` when it would not parse and `redeployed_sdl_too_large` when re-deriving its cleartext values into references would exceed the maximum length. Both are permanent rather than transient, so a retry cannot help, and neither is anything the request can correct",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    },
+    503: {
+      description: "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 409 and 500 above",
+      content: {
+        "application/json": {
+          schema: ErrorResponseSchema
+        }
+      }
+    }
+  }
+});
+deploymentsRouter.openapi(redeployRoute, async function routeRedeployDeployment(c) {
+  const { dseq } = c.req.valid("param");
+  const { data } = c.req.valid("json");
+  const result = await container.resolve(DeploymentController).redeploy(dseq, data);
+  return c.json(result, 201);
 });
 
 const listRoute = createRoute({

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -6589,6 +6589,269 @@
         }
       }
     },
+    "/v1/deployments/{dseq}/redeploy": {
+      "post": {
+        "summary": "Redeploy an existing deployment",
+        "description": "Creates a new deployment from what the console stored for this one: its SDL, its secrets and its runtime limit. The SDL is never accepted from the request. Secrets are carried forward in the process and never pass through the client; a name supplied in `sealedSecrets` replaces the value the source holds for it. A source whose stored SDL still carries values in the clear has them sealed for the new deployment, so the new SDL is equivalent to the source's rather than byte-identical to it. A carried runtime limit longer than one request may grant is reduced to that increment, and can be extended after the redeploy.",
+        "operationId": "redeployDeployment",
+        "tags": [
+          "Deployments"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^0*[1-9]\\d*$",
+              "description": "Deployment sequence number of the deployment to redeploy"
+            },
+            "required": true,
+            "description": "Deployment sequence number of the deployment to redeploy",
+            "name": "dseq",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "sealedSecrets": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Compact JWE sealing a flat name-to-value map, as on create. A name present here replaces the value the source deployment holds for it; every other name is carried forward untouched."
+                      },
+                      "runtimeLimitHours": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 48,
+                        "description": "Optional runtime limit in hours (1 to 48) for the new deployment. Omit to carry the source deployment's own limit forward."
+                      }
+                    },
+                    "default": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Redeployed successfully, answering exactly as a create does",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "dseq": {
+                          "type": "string",
+                          "pattern": "^0*[1-9]\\d*$"
+                        },
+                        "manifest": {
+                          "type": "string"
+                        },
+                        "signTx": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "number"
+                            },
+                            "transactionHash": {
+                              "type": "string"
+                            },
+                            "rawLog": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "code",
+                            "transactionHash",
+                            "rawLog"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "dseq",
+                        "manifest",
+                        "signTx"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The stored SDL leaves a secret reference no value answers, `sealedSecrets` supplies a name it does not reference, or the source carries more secrets than one deployment may hold",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No deployment of yours matches this dseq, or the console recorded no SDL for it. Says nothing about whether the deployment exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The secrets recorded for this deployment can no longer be decrypted, with `code` `inherited_secrets_unreadable`. Permanent rather than transient, so a retry cannot help",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The SDL recorded for this deployment cannot be redeployed: `code` is `stored_sdl_unreadable` when it would not parse and `redeployed_sdl_too_large` when re-deriving its cleartext values into references would exceed the maximum length. Both are permanent rather than transient, so a retry cannot help, and neither is anything the request can correct",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 409 and 500 above",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/addresses/{address}/deployments/{skip}/{limit}": {
       "get": {
         "summary": "Get a list of deployments by owner address.",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -8853,6 +8853,269 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/v1/deployments/{dseq}/redeploy": {
+      "post": {
+        "description": "Creates a new deployment from what the console stored for this one: its SDL, its secrets and its runtime limit. The SDL is never accepted from the request. Secrets are carried forward in the process and never pass through the client; a name supplied in \`sealedSecrets\` replaces the value the source holds for it. A source whose stored SDL still carries values in the clear has them sealed for the new deployment, so the new SDL is equivalent to the source's rather than byte-identical to it. A carried runtime limit longer than one request may grant is reduced to that increment, and can be extended after the redeploy.",
+        "operationId": "redeployDeployment",
+        "parameters": [
+          {
+            "description": "Deployment sequence number of the deployment to redeploy",
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "description": "Deployment sequence number of the deployment to redeploy",
+              "pattern": "^0*[1-9]\\d*$",
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "default": {},
+                    "properties": {
+                      "runtimeLimitHours": {
+                        "description": "Optional runtime limit in hours (1 to 48) for the new deployment. Omit to carry the source deployment's own limit forward.",
+                        "maximum": 48,
+                        "minimum": 1,
+                        "type": "integer",
+                      },
+                      "sealedSecrets": {
+                        "description": "Compact JWE sealing a flat name-to-value map, as on create. A name present here replaces the value the source deployment holds for it; every other name is carried forward untouched.",
+                        "minLength": 1,
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "dseq": {
+                          "pattern": "^0*[1-9]\\d*$",
+                          "type": "string",
+                        },
+                        "manifest": {
+                          "type": "string",
+                        },
+                        "signTx": {
+                          "properties": {
+                            "code": {
+                              "type": "number",
+                            },
+                            "rawLog": {
+                              "type": "string",
+                            },
+                            "transactionHash": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "code",
+                            "transactionHash",
+                            "rawLog",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "dseq",
+                        "manifest",
+                        "signTx",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Redeployed successfully, answering exactly as a create does",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The stored SDL leaves a secret reference no value answers, \`sealedSecrets\` supplies a name it does not reference, or the source carries more secrets than one deployment may hold",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "No deployment of yours matches this dseq, or the console recorded no SDL for it. Says nothing about whether the deployment exists",
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The secrets recorded for this deployment can no longer be decrypted, with \`code\` \`inherited_secrets_unreadable\`. Permanent rather than transient, so a retry cannot help",
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The SDL recorded for this deployment cannot be redeployed: \`code\` is \`stored_sdl_unreadable\` when it would not parse and \`redeployed_sdl_too_large\` when re-deriving its cleartext values into references would exceed the maximum length. Both are permanent rather than transient, so a retry cannot help, and neither is anything the request can correct",
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "type": "string",
+                    },
+                    "message": {
+                      "type": "string",
+                    },
+                    "type": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                    "message",
+                    "code",
+                    "type",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "The key management service is temporarily unreachable. Transient and worth retrying, unlike the 409 and 500 above",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+          {
+            "ApiKeyAuth": [],
+          },
+        ],
+        "summary": "Redeploy an existing deployment",
+        "tags": [
+          "Deployments",
+        ],
+      },
+    },
     "/v1/deposit-deployment": {
       "post": {
         "deprecated": true,

--- a/apps/api/test/functional/deployment-redeploy.spec.ts
+++ b/apps/api/test/functional/deployment-redeploy.spec.ts
@@ -1,0 +1,378 @@
+import { faker } from "@faker-js/faker";
+import { CompactEncrypt } from "jose";
+import nock from "nock";
+import { randomUUID } from "node:crypto";
+import { container } from "tsyringe";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { startJobQueues } from "@src/app/providers/jobs.provider";
+import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
+import { AuthService } from "@src/auth/services/auth.service";
+import type { UserWalletOutput } from "@src/billing/repositories";
+import { UserWalletRepository } from "@src/billing/repositories";
+import { ManagedSignerService } from "@src/billing/services";
+import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import { SDL_SECRETS_CONTENT_ENCRYPTION, SDL_SECRETS_SEAL_ALGORITHM } from "@src/deployment/config/sdl-secrets.config";
+import { MAX_RUNTIME_LIMIT_HOURS, MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "@src/deployment/http-schemas/runtime-limit";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import { app } from "@src/rest-app";
+import type { UserOutput } from "@src/user/repositories";
+import { UserRepository } from "@src/user/repositories";
+
+import { registerFakeSdlSecretsKms, SDL_SECRETS_KID, warmSealingKeyAsBootWould } from "@test/mocks/sdl-secrets-kms.mock";
+import { createApiKey } from "@test/seeders/api-key.seeder";
+import { createUser } from "@test/seeders/user.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const MAX_COUNT = 100;
+
+const { client: kmsClient, publicKey } = registerFakeSdlSecretsKms();
+
+function sdlWith(env: string[]) {
+  const body = `  web:\n    image: nginx\n    env:\n${env.map(entry => `      - ${JSON.stringify(entry)}\n`).join("")}`;
+
+  return `version: "2.0"\nservices:\n${body}profiles:\n  compute:\n    web:\n      resources:\n        cpu:\n          units: 0.1\n        memory:\n          size: 128Mi\n        storage:\n          - size: 128Mi\n  placement:\n    dcloud:\n      pricing:\n        web:\n          denom: uakt\n          amount: 1000\ndeployment:\n  web:\n    dcloud:\n      profile: web\n      count: 1\n`;
+}
+
+describe("Deployment redeploy", () => {
+  const userRepository = container.resolve(UserRepository);
+  const apiKeyAuthService = container.resolve(ApiKeyAuthService);
+  const userWalletRepository = container.resolve(UserWalletRepository);
+  const blockHttpService = container.resolve(BlockHttpService);
+  const signerService = container.resolve(ManagedSignerService);
+  const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+
+  let knownUsers: Record<string, UserOutput>;
+  let knownApiKeys: Record<string, ReturnType<typeof createApiKey>>;
+  let knownWallets: Record<string, UserWalletOutput[]>;
+
+  beforeAll(async () => {
+    await startJobQueues();
+    await warmSealingKeyAsBootWould();
+  }, 20_000);
+
+  beforeEach(() => {
+    knownUsers = {};
+    knownApiKeys = {};
+    knownWallets = {};
+
+    vi.spyOn(userRepository, "findById").mockImplementation(async id =>
+      knownUsers[id] ? { ...knownUsers[id], trial: false, userWallets: { isTrialing: false } } : undefined
+    );
+    vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async key => knownApiKeys[key!]);
+    vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(faker.number.int({ min: 1000000, max: 10000000 }));
+    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue({
+      findByUserId: async (id: string) => knownWallets[id],
+      findOneByUserId: async (id: string) => knownWallets[id][0]
+    } as unknown as UserWalletRepository);
+    vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
+      code: 200,
+      transactionHash: "fake-transaction-hash",
+      hash: "fake-transaction-hash",
+      rawLog: "fake-raw-log"
+    });
+    kmsClient.asymmetricDecrypt.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  afterAll(async () => {
+    await container.dispose();
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  describe("a source whose stored sdl is already all references", () => {
+    it("records an sdl byte-identical to the source's", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID() });
+
+      const response = await postRedeploy(apiKey, source.setting.dseq);
+
+      expect(response.status).toBe(201);
+      expect((await settingOf(user, response))!.sdl).toBe(source.setting.sdl);
+    });
+
+    it("opens its token to exactly the source's plaintexts", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID(), DATABASE_URL: `postgres://a:${randomUUID()}@db/app` });
+
+      const response = await postRedeploy(apiKey, source.setting.dseq);
+
+      const setting = await settingOf(user, response);
+      await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual(source.secrets);
+    });
+
+    it("binds the new token to the new deployment, leaving the source's unopenable under it", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID() });
+
+      const response = await postRedeploy(apiKey, source.setting.dseq);
+
+      const setting = await settingOf(user, response);
+      expect(setting!.dseq).not.toBe(source.setting.dseq);
+      await expect(openStoredToken(user, setting!.dseq, source.setting.sealedSecrets!)).rejects.toMatchObject({ status: 500 });
+    });
+  });
+
+  describe("a source whose stored sdl still carries values in the clear", () => {
+    it("seals what the source left in the clear rather than recording an identical sdl", async () => {
+      const { apiKey, user } = await persistedUser();
+      const plain = randomUUID();
+      const sealed = randomUUID();
+      const source = await sourceFromSeal(apiKey, user, { API_TOKEN: sealed }, [`LOG_LEVEL=${plain}`]);
+
+      const response = await postRedeploy(apiKey, source.setting.dseq);
+
+      expect(response.status).toBe(201);
+      const setting = await settingOf(user, response);
+      expect(setting!.sdl).not.toBe(source.setting.sdl);
+      expect(setting!.sdl).not.toContain(plain);
+    });
+
+    it("loses none of the source's values in doing so", async () => {
+      const { apiKey, user } = await persistedUser();
+      const plain = randomUUID();
+      const sealed = randomUUID();
+      const source = await sourceFromSeal(apiKey, user, { API_TOKEN: sealed }, [`LOG_LEVEL=${plain}`]);
+
+      const response = await postRedeploy(apiKey, source.setting.dseq);
+
+      const setting = await settingOf(user, response);
+      const opened = await openStoredToken(user, setting!.dseq, setting!.sealedSecrets!);
+      expect(Object.values(opened)).toEqual(expect.arrayContaining([sealed, plain]));
+    });
+
+    it("settles after one redeploy, the next one deriving nothing further", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await sourceFromSeal(apiKey, user, { API_TOKEN: randomUUID() }, [`LOG_LEVEL=${randomUUID()}`]);
+      const first = await settingOf(user, await postRedeploy(apiKey, source.setting.dseq));
+
+      const second = await settingOf(user, await postRedeploy(apiKey, first!.dseq));
+
+      expect(second!.sdl).toBe(first!.sdl);
+      await expect(openStoredToken(user, second!.dseq, second!.sealedSecrets!)).resolves.toEqual(
+        await openStoredToken(user, first!.dseq, first!.sealedSecrets!)
+      );
+    });
+  });
+
+  describe("the runtime limit", () => {
+    it("carries the source's forward", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID() }, 5);
+
+      const response = await postRedeploy(apiKey, source.setting.dseq);
+
+      expect((await settingOf(user, response))!.runtimeLimitHours).toBe(5);
+    });
+
+    it("reduces one longer than a single request may grant to that increment", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID() }, 5);
+      await deploymentSettingRepository.updateById(source.setting.id, { runtimeLimitHours: MAX_RUNTIME_LIMIT_HOURS });
+
+      const response = await postRedeploy(apiKey, source.setting.dseq);
+
+      expect((await settingOf(user, response))!.runtimeLimitHours).toBe(MAX_RUNTIME_LIMIT_INCREMENT_HOURS);
+    });
+
+    it("carries none forward when the source has none", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID() });
+
+      const response = await postRedeploy(apiKey, source.setting.dseq);
+
+      expect((await settingOf(user, response))!.runtimeLimitHours).toBeNull();
+    });
+
+    it("prefers an explicitly supplied one", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID() }, 5);
+
+      const response = await postRedeploy(apiKey, source.setting.dseq, { runtimeLimitHours: 9 });
+
+      expect((await settingOf(user, response))!.runtimeLimitHours).toBe(9);
+    });
+  });
+
+  it("prefers a supplied secret to the source's value of the same name", async () => {
+    const { apiKey, user } = await persistedUser();
+    const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID(), DATABASE_URL: `postgres://a:${randomUUID()}@old/app` });
+    const replaced = `postgres://a:${randomUUID()}@new/app`;
+    const [, databaseUrlName] = Object.keys(source.secrets);
+
+    const response = await postRedeploy(apiKey, source.setting.dseq, { secrets: { [databaseUrlName]: replaced } });
+
+    expect(response.status).toBe(201);
+    const setting = await settingOf(user, response);
+    const opened = await openStoredToken(user, setting!.dseq, setting!.sealedSecrets!);
+    expect(opened[databaseUrlName]).toBe(replaced);
+    expect(Object.values(opened)).not.toContain(source.secrets[databaseUrlName]);
+  });
+
+  it("redeploys a closed deployment, closing one deliberately keeping its secrets", async () => {
+    const { apiKey, user } = await persistedUser();
+    const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID() });
+    await deploymentSettingRepository.updateById(source.setting.id, { closed: true });
+
+    const response = await postRedeploy(apiKey, source.setting.dseq);
+
+    expect(response.status).toBe(201);
+    const setting = await settingOf(user, response);
+    await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual(source.secrets);
+  });
+
+  it("redeploys a source holding exactly as many secrets as a deployment may carry", async () => {
+    const { apiKey, user } = await persistedUser();
+    const values = Object.fromEntries(Array.from({ length: MAX_COUNT }, (_, index) => [`SETTING_${index}`, randomUUID()]));
+    const source = await sourceFromPlaintext(apiKey, user, values);
+    expect(Object.keys(source.secrets)).toHaveLength(MAX_COUNT);
+
+    const response = await postRedeploy(apiKey, source.setting.dseq);
+
+    expect(response.status).toBe(201);
+    const setting = await settingOf(user, response);
+    await expect(openStoredToken(user, setting!.dseq, setting!.sealedSecrets!)).resolves.toEqual(source.secrets);
+  });
+
+  it("refuses a source holding one more secret than a deployment may carry", async () => {
+    const { apiKey, user } = await persistedUser();
+    const values = Object.fromEntries(Array.from({ length: MAX_COUNT + 1 }, (_, index) => [`SETTING_${index}`, randomUUID()]));
+    const source = await sourceFromPlaintext(apiKey, user, values);
+
+    const response = await postRedeploy(apiKey, source.setting.dseq);
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain(`At most ${MAX_COUNT} secrets may be carried by one deployment`);
+  });
+
+  describe("a source the caller may not redeploy", () => {
+    it("answers not found for another user's deployment, recording nothing and broadcasting nothing", async () => {
+      const owner = await persistedUser();
+      const other = await persistedUser();
+      const source = await sourceFromPlaintext(owner.apiKey, owner.user, { API_TOKEN: randomUUID() });
+
+      const response = await postRedeploy(other.apiKey, source.setting.dseq);
+
+      expect(response.status).toBe(404);
+      expect(await deploymentSettingRepository.count({ userId: other.user.id })).toBe(0);
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    });
+
+    it("answers not found for a deployment the console recorded no sdl for", async () => {
+      const { apiKey, user } = await persistedUser();
+      const dseq = Date.now().toString();
+      await deploymentSettingRepository.createDefaultIfMissing({ userId: user.id, dseq });
+
+      const response = await postRedeploy(apiKey, dseq);
+
+      expect(response.status).toBe(404);
+      expect(await response.text()).toContain("nothing to redeploy");
+    });
+
+    it("refuses a source whose sdl references values its row no longer holds", async () => {
+      const { apiKey, user } = await persistedUser();
+      const source = await sourceFromPlaintext(apiKey, user, { API_TOKEN: randomUUID() });
+      await deploymentSettingRepository.updateById(source.setting.id, { sealedSecrets: null });
+
+      const response = await postRedeploy(apiKey, source.setting.dseq);
+
+      expect(response.status).toBe(400);
+      expect(await response.text()).toContain("no value supplied for SDL Reference");
+    });
+  });
+
+  async function openStoredToken(user: UserOutput, dseq: string, sealedSecrets: string) {
+    const executionContextService = container.resolve(ExecutionContextService);
+    const authService = container.resolve(AuthService);
+
+    return await executionContextService.runWithContext(async () => {
+      authService.currentUser = user;
+
+      return await container.resolve(SdlSecretsService).openStored({ userId: user.id, dseq, sealedSecrets });
+    });
+  }
+
+  async function settingOf(user: UserOutput, response: Response) {
+    const { data } = (await response.clone().json()) as { data: { dseq: string } };
+
+    return await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: data.dseq });
+  }
+
+  async function sealFor(user: UserOutput, secrets: Record<string, string>) {
+    return await new CompactEncrypt(new TextEncoder().encode(JSON.stringify(secrets)))
+      .setProtectedHeader({
+        alg: SDL_SECRETS_SEAL_ALGORITHM,
+        enc: SDL_SECRETS_CONTENT_ENCRYPTION,
+        kid: SDL_SECRETS_KID,
+        sub: user.id,
+        exp: Math.floor(Date.now() / 1000) + 300
+      })
+      .encrypt(publicKey);
+  }
+
+  /** Sealing nothing leaves the console to derive every value, so the stored sdl comes back fully de-referenced. */
+  async function sourceFromPlaintext(apiKey: string, user: UserOutput, values: Record<string, string>, runtimeLimitHours?: number) {
+    const response = await postCreate(apiKey, {
+      sdl: sdlWith(Object.entries(values).map(([name, value]) => `${name}=${value}`)),
+      runtimeLimitHours
+    });
+
+    expect(response.status).toBe(201);
+    const setting = (await settingOf(user, response))!;
+
+    return { setting, secrets: await openStoredToken(user, setting.dseq, setting.sealedSecrets!) };
+  }
+
+  /** A seal says which values are secret, so the console leaves every other one in the clear in the stored sdl. */
+  async function sourceFromSeal(apiKey: string, user: UserOutput, secrets: Record<string, string>, plaintextEnv: string[]) {
+    const response = await postCreate(apiKey, {
+      sdl: sdlWith([...Object.keys(secrets).map(name => `${name}=ac-secret://${name}`), ...plaintextEnv]),
+      sealedSecrets: await sealFor(user, secrets)
+    });
+
+    expect(response.status).toBe(201);
+
+    return { setting: (await settingOf(user, response))! };
+  }
+
+  async function postCreate(apiKey: string, data: Record<string, unknown>) {
+    return await app.request("/v1/deployments", {
+      method: "POST",
+      body: JSON.stringify({ data }),
+      headers: new Headers({ "Content-Type": "application/json", "x-api-key": apiKey })
+    });
+  }
+
+  async function postRedeploy(apiKey: string, dseq: string, options?: { runtimeLimitHours?: number; secrets?: Record<string, string> }) {
+    const user = knownUsers[knownApiKeys[apiKey].userId];
+    const data: Record<string, unknown> = {};
+
+    if (options?.runtimeLimitHours !== undefined) data.runtimeLimitHours = options.runtimeLimitHours;
+    if (options?.secrets) data.sealedSecrets = await sealFor(user, options.secrets);
+
+    return await app.request(`/v1/deployments/${dseq}/redeploy`, {
+      method: "POST",
+      body: JSON.stringify({ data }),
+      headers: new Headers({ "Content-Type": "application/json", "x-api-key": apiKey })
+    });
+  }
+
+  async function persistedUser() {
+    const dbUser = await userRepository.create({ userId: faker.string.uuid() });
+    const apiKey = faker.string.alphanumeric(24);
+    const user = createUser({ id: dbUser.id, userId: dbUser.userId ?? undefined });
+
+    knownUsers[dbUser.id] = user;
+    knownApiKeys[apiKey] = createApiKey({ userId: dbUser.id });
+    knownWallets[dbUser.id] = [createUserWallet({ userId: dbUser.id, address: "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm" })];
+
+    return { user, apiKey };
+  }
+});


### PR DESCRIPTION
## Why

Part of CON-866. Redeploying an existing deployment currently means re-submitting its SDL and
re-entering every secret by hand. This exposes the seam added in the previous PR as an endpoint, so
a caller can redeploy by dseq alone.

## What

`POST /v1/deployments/{dseq}/redeploy` answers exactly as a create does, taking the SDL, the secrets
and the runtime limit from what the console stored for the source rather than from the request body.
The SDL is never accepted from the request.

Both body fields are overrides, so a body of `{}` redeploys the source exactly as stored:

- `sealedSecrets` — a compact JWE whose names replace the source's values of the same name.
- `runtimeLimitHours` — replaces the limit carried forward from the source.

Behaviour worth calling out:

- A source the console fully de-referenced redeploys to a **byte-identical** SDL under a new dseq.
- A source created *with* a seal redeploys to an SDL that differs from the source's, while resolving
  to the same values. This is the AC-1 departure below, not a defect.
- Secret tokens stay bound to the deployment they were minted for — the source's token does not open
  under the new deployment.
- A closed source is still redeployable, keeping its secrets.
- Another user's deployment answers 404 before any write or any chain traffic, and says nothing
  about whether the deployment exists.

`akash/operation-id-format` is suppressed on the one `operationId` line rather than taught a new
collection verb, since `redeploy` is specific to this endpoint. The rule's own message offers that
as the intended route for a one-off.

Three things a reviewer should know follow: two deliberate departures from the issue as written,
and one stated limitation, each with its reason.

## How much the green ticks are worth

**The test suite has never run in CI for this PR, or for any stacked PR in this series.**
`all-ci.yml` triggers only on pull requests based on `main` or `main-sdk-next`, and every PR in
this stack is based on the one below it. The checks that do run here are Socket, Snyk, the size
labeler and review bots — none of them execute `apps/api` tests.

Every result quoted below was produced locally: `npx tsc --noEmit`, `npm run lint -- --quiet` and
`npm test` in `apps/api`, all green, 302 test files and 4155 tests passing. Saying so explicitly
because a green rollup on this PR does not mean CI vouched for the code, and the suite will not
actually run against it until the stack is retargeted at `main`.

## Deliberate departure: AC-1 was weakened after investigation

AC-1 originally read *"produces a new deployment whose SDL is the source's stored SDL"*. **It was
deliberately weakened, at the plan gate, to "resolves to the same values as the source"** — this PR
does not meet AC-1 as first written, by design.

The reason is that byte-equality is not achievable for every source, and insisting on it would have
meant either storing something wrong or refusing a legitimate redeploy. A source created **with** a
seal keeps the values the caller did not mark secret in the clear in its stored SDL. Redeploying it
seals those values too, replacing each with an `ac-secret://` reference, so the new SDL is
necessarily a different document. The alternative — leaving them in the clear to preserve
byte-equality — would carry plaintext forward into a new deployment, which is the opposite of what
this feature exists to do.

What holds instead, and is tested:

- Every value survives the redeploy: the new deployment resolves to exactly the source's values.
- No cleartext value the source held in the clear appears in the new SDL.
- The transformation **settles after one hop** — a second redeploy reproduces the first's SDL
  byte-for-byte and opens to the same values, so this does not drift further on each redeploy.
- For a source the console fully de-referenced (created *without* a seal), the SDL **is**
  byte-identical, so the original AC-1 does hold for that case.

## Deliberate departure: a carried runtime limit is clamped

A source's runtime limit is carried forward, but **reduced to the per-request increment (48 hours)
when it exceeds it**. A source sitting at the 8760 hour ceiling redeploys to 48.

This is a deliberate departure from strict carry-forward, decided after review showed 8760 was
reachable — not a bug. The reasoning: the redeploy creates a deployment that "has none" in the
codebase's own words, so the most one request may grant it is the same increment every other entry
point enforces. Carrying 8760 forward would not be carrying a limit forward, it would be granting a
year in a single request, which is exactly what the cap's stated rationale — making the user
re-confirm within a day or two — exists to prevent. Without the clamp the column would also take a
value `POST /v1/deployments` returns 400 for.

A longer limit stays reachable the designed way, by extending after the redeploy. A source with no
limit still carries none. The clamp is stated in the endpoint description, since a silent reduction
is the one thing it must not be.

## Stated limitation: inherited secret names are not discoverable

Overriding a single inherited value requires naming it, and for a source the console
de-referenced there is currently no way for a caller to learn that name.

When a deployment is created **without** a seal, the console seals every value itself and names the
references positionally — `s0_e0`, `s0_e1`, … — so the stored SDL refers to names the caller never
chose and no endpoint returns. Supplying the original environment variable name instead is refused
with a 400 (`a value was supplied for "DATABASE_URL" but no service's SDL references it`).

This does not affect:

- redeploying such a source **unchanged**, which is the common case and needs no names at all; or
- a source created **with** a seal, which keeps the caller's own names and can be overridden by
  them directly.

AC-5 holds as written — a supplied name does override the inherited value of the same name. The gap
is discoverability, and listing the stored reference names is part of the deploy-web work CON-866
deferred. Tracking it there rather than widening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an authenticated redeployment endpoint: `POST /v1/deployments/{dseq}/redeploy`.
  - Redeploy existing deployments, including closed deployments, while preserving deployment data and sealed secrets.
  - Optionally replace sealed secrets and adjust runtime limits during redeployment.
  - Added validation and clear responses for invalid deployments, unavailable resources, secret issues, and service errors.

- **Documentation**
  - Updated the API specification with redeployment parameters, responses, and error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->