### PR TITLE
fix(deployment): keep fair use enforcement consistent with payments and retry stalled runs

### DIFF
--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -93,7 +93,7 @@ program
 
 program
   .command("probe-trial-deployments")
-  .description("Schedule a workload probe for every live trial deployment that has none pending")
+  .description("Schedule a workload probe for every live trial deployment that has none pending and queue stuck wipes again")
   .option("-d, --dry-run", "Log which deployments would be probed without enqueuing", false)
   .action(async (options, command) => {
     await executeCliHandler(command.name(), async () => {

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -39,6 +39,22 @@ describe(RefillService.name, () => {
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up", expect.objectContaining({ amount_cents: amountUsd, amount_usd: 1 }));
     });
 
+    it("holds the wallet row before touching the chain, so a concurrent abuse wipe waits for the settlement", async () => {
+      const { service, userWalletRepository, managedUserWalletService, walletInitializerService, balancesService } = setup();
+      const existingWallet = createInitializedUserWallet({ userId });
+      walletInitializerService.ensureWallet.mockResolvedValue(existingWallet);
+      userWalletRepository.claimActivation.mockResolvedValue(undefined);
+      userWalletRepository.findOneByAndLock.mockResolvedValue(existingWallet);
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+
+      await service.topUpWallet(amountUsd, userId);
+
+      expect(userWalletRepository.findOneByAndLock).toHaveBeenCalledWith({ id: existingWallet.id });
+      expect(userWalletRepository.findOneByAndLock.mock.invocationCallOrder[0]).toBeLessThan(
+        managedUserWalletService.authorizeSpending.mock.invocationCallOrder[0]
+      );
+    });
+
     it("asks to clear the abuse lock on every payment, so a lock applied after the wallet was read is still cleared", async () => {
       const { service, userWalletRepository, walletInitializerService, balancesService, logger } = setup();
       const unlockedWallet = createInitializedUserWallet({ userId, abuseLockedAt: null, abuseLockedReason: null });

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -77,7 +77,7 @@ export class RefillService {
     userId: UserWalletOutput["userId"],
     options: { endTrial?: boolean; payment?: PaymentAnalyticsContext } = {}
   ): Promise<ToppedUpWallet> {
-    const userWallet = await this.ensureActivatedWallet(userId);
+    const userWallet = await this.lockActivatedWallet(userId);
     const currentLimit = await this.balancesService.retrieveDeploymentLimit(userWallet);
 
     const nextLimit = currentLimit + amountUsd * 10000;
@@ -150,6 +150,13 @@ export class RefillService {
     } catch (error) {
       this.logger.error({ event: "WALLET_ABUSE_LOCK_CLEAR_FAILED", walletId: userWallet.id, userId: userWallet.userId, error });
     }
+  }
+
+  /** Holds the wallet row until the settlement commits, so an abuse wipe of the same wallet waits for it instead of revoking between this grant and its bookkeeping. */
+  private async lockActivatedWallet(userId: UserWalletOutput["userId"]) {
+    const userWallet = await this.ensureActivatedWallet(userId);
+
+    return (await this.userWalletRepository.findOneByAndLock({ id: userWallet.id })) ?? userWallet;
   }
 
   /**

--- a/apps/api/src/workload-abuse/controllers/workload-abuse.controller.spec.ts
+++ b/apps/api/src/workload-abuse/controllers/workload-abuse.controller.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { TrialAbuseEnforcementJobService } from "@src/workload-abuse/services/trial-abuse-enforcement-job/trial-abuse-enforcement-job.service";
+import type { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
+import { WorkloadAbuseController } from "./workload-abuse.controller";
+
+describe(WorkloadAbuseController.name, () => {
+  it("runs the probe sweep and the enforcement sweep with the same options", async () => {
+    const { controller, probeJobService, enforcementJobService } = setup();
+
+    await controller.probeTrialDeployments({ dryRun: true });
+
+    expect(probeJobService.reconcile).toHaveBeenCalledWith({ dryRun: true });
+    expect(enforcementJobService.reconcile).toHaveBeenCalledWith({ dryRun: true });
+  });
+
+  it("still runs the enforcement sweep when the probe sweep fails, then reports that failure", async () => {
+    const { controller, probeJobService, enforcementJobService } = setup();
+    const error = new Error("db down");
+    probeJobService.reconcile.mockRejectedValue(error);
+
+    await expect(controller.probeTrialDeployments({ dryRun: false })).rejects.toBe(error);
+
+    expect(enforcementJobService.reconcile).toHaveBeenCalledWith({ dryRun: false });
+  });
+
+  function setup() {
+    const probeJobService = mock<TrialWorkloadProbeJobService>();
+    probeJobService.reconcile.mockResolvedValue();
+    const enforcementJobService = mock<TrialAbuseEnforcementJobService>();
+    enforcementJobService.reconcile.mockResolvedValue();
+    const controller = new WorkloadAbuseController(probeJobService, enforcementJobService);
+
+    return { controller, probeJobService, enforcementJobService };
+  }
+});

--- a/apps/api/src/workload-abuse/controllers/workload-abuse.controller.spec.ts
+++ b/apps/api/src/workload-abuse/controllers/workload-abuse.controller.spec.ts
@@ -25,6 +25,16 @@ describe(WorkloadAbuseController.name, () => {
     expect(enforcementJobService.reconcile).toHaveBeenCalledWith({ dryRun: false });
   });
 
+  it("reports both failures when both sweeps fail", async () => {
+    const { controller, probeJobService, enforcementJobService } = setup();
+    const probeError = new Error("probe db down");
+    const enforcementError = new Error("queue down");
+    probeJobService.reconcile.mockRejectedValue(probeError);
+    enforcementJobService.reconcile.mockRejectedValue(enforcementError);
+
+    await expect(controller.probeTrialDeployments({ dryRun: false })).rejects.toMatchObject({ errors: [probeError, enforcementError] });
+  });
+
   function setup() {
     const probeJobService = mock<TrialWorkloadProbeJobService>();
     probeJobService.reconcile.mockResolvedValue();

--- a/apps/api/src/workload-abuse/controllers/workload-abuse.controller.ts
+++ b/apps/api/src/workload-abuse/controllers/workload-abuse.controller.ts
@@ -14,8 +14,9 @@ export class WorkloadAbuseController {
   /** Each sweep runs whether or not the other fails, so a probe outage does not leave stuck wipes waiting another run. */
   async probeTrialDeployments(options: DryRunOptions): Promise<void> {
     const sweeps = await Promise.allSettled([this.probeJobService.reconcile(options), this.enforcementJobService.reconcile(options)]);
-    const failure = sweeps.find((sweep): sweep is PromiseRejectedResult => sweep.status === "rejected");
+    const failures = sweeps.filter((sweep): sweep is PromiseRejectedResult => sweep.status === "rejected").map(sweep => sweep.reason);
 
-    if (failure) throw failure.reason;
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) throw new AggregateError(failures, "Both the probe sweep and the enforcement sweep failed");
   }
 }

--- a/apps/api/src/workload-abuse/controllers/workload-abuse.controller.ts
+++ b/apps/api/src/workload-abuse/controllers/workload-abuse.controller.ts
@@ -1,13 +1,18 @@
 import { singleton } from "tsyringe";
 
 import type { DryRunOptions } from "@src/core/types/console";
+import { TrialAbuseEnforcementJobService } from "@src/workload-abuse/services/trial-abuse-enforcement-job/trial-abuse-enforcement-job.service";
 import { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
 
 @singleton()
 export class WorkloadAbuseController {
-  constructor(private readonly probeJobService: TrialWorkloadProbeJobService) {}
+  constructor(
+    private readonly probeJobService: TrialWorkloadProbeJobService,
+    private readonly enforcementJobService: TrialAbuseEnforcementJobService
+  ) {}
 
   async probeTrialDeployments(options: DryRunOptions): Promise<void> {
     await this.probeJobService.reconcile(options);
+    await this.enforcementJobService.reconcile(options);
   }
 }

--- a/apps/api/src/workload-abuse/controllers/workload-abuse.controller.ts
+++ b/apps/api/src/workload-abuse/controllers/workload-abuse.controller.ts
@@ -11,8 +11,11 @@ export class WorkloadAbuseController {
     private readonly enforcementJobService: TrialAbuseEnforcementJobService
   ) {}
 
+  /** Each sweep runs whether or not the other fails, so a probe outage does not leave stuck wipes waiting another run. */
   async probeTrialDeployments(options: DryRunOptions): Promise<void> {
-    await this.probeJobService.reconcile(options);
-    await this.enforcementJobService.reconcile(options);
+    const sweeps = await Promise.allSettled([this.probeJobService.reconcile(options), this.enforcementJobService.reconcile(options)]);
+    const failure = sweeps.find((sweep): sweep is PromiseRejectedResult => sweep.status === "rejected");
+
+    if (failure) throw failure.reason;
   }
 }

--- a/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.ts
+++ b/apps/api/src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository.ts
@@ -1,6 +1,7 @@
-import { and, eq, gt, ne } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, isNull, lt, ne } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
+import { UserWallets } from "@src/billing/model-schemas";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
@@ -28,6 +29,24 @@ export class WorkloadAbuseDetectionRepository extends BaseRepository<Table, Work
       .selectDistinct({ walletId: this.table.walletId, dseq: this.table.dseq })
       .from(this.table)
       .where(and(eq(this.table.verdict, "hard"), gt(this.table.createdAt, since)));
+  }
+
+  /** One detection per wallet, since the wipe covers the whole wallet whichever of its detections re-queues it. */
+  async findStalledEnforcements({ updatedBefore }: { updatedBefore: Date }): Promise<Array<{ walletId: number; detectionId: string }>> {
+    return await this.cursor
+      .selectDistinctOn([this.table.walletId], { walletId: this.table.walletId, detectionId: this.table.id })
+      .from(this.table)
+      .innerJoin(UserWallets, eq(UserWallets.id, this.table.walletId))
+      .where(
+        and(
+          eq(this.table.verdict, "hard"),
+          inArray(this.table.action, ["enforcing", "enforcement_failed"]),
+          lt(this.table.updatedAt, updatedBefore),
+          eq(UserWallets.isTrialing, true),
+          isNull(UserWallets.abuseLockedAt)
+        )
+      )
+      .orderBy(this.table.walletId, desc(this.table.updatedAt));
   }
 
   /** A locked wallet settles every confirmed detection it has, including the ones whose own enforcement job never ran or failed. */

--- a/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.integration.ts
+++ b/apps/api/src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler.integration.ts
@@ -1,5 +1,6 @@
 import { AuthzHttpService, LeaseHttpService, type RpcLease } from "@akashnetwork/http-sdk";
 import { addHours } from "date-fns";
+import { eq } from "drizzle-orm";
 import { container } from "tsyringe";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -7,7 +8,7 @@ import { mock } from "vitest-mock-extended";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
-import { JOB_NAME } from "@src/core";
+import { type ApiPgDatabase, JOB_NAME, POSTGRES_DB, resolveTable } from "@src/core";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
 import { ProbeTrialDeploymentHandler } from "@src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler";
@@ -75,6 +76,23 @@ describe(EnforceTrialAbuseHandler.name, () => {
     expect(executeFundingTx).not.toHaveBeenCalled();
   });
 
+  it("waits for a payment holding the wallet row and leaves the wallet alone once that payment has ended its trial", async () => {
+    const { handler, wallet, detection, close, executeFundingTx, findWallet, findDetection, holdWalletRowUntil } = await setup({ liveDseqs: ["11"] });
+    let wipe: Promise<void> | undefined;
+
+    await holdWalletRowUntil(async ({ wipeWaitsForRow, endTrial }) => {
+      wipe = handler.handle({ walletId: wallet.id, detectionId: detection.id, version: 1 });
+      await wipeWaitsForRow;
+      await endTrial();
+    });
+    await wipe;
+
+    expect(await findDetection(detection.id)).toMatchObject({ action: "detected", enforcementError: null });
+    expect(await findWallet()).toMatchObject({ abuseLockedAt: null, isTrialing: false, deploymentAllowance: 10_000_000 });
+    expect(close).not.toHaveBeenCalled();
+    expect(executeFundingTx).not.toHaveBeenCalled();
+  });
+
   it("records the failure on the detection and keeps the wallet unlocked and monitored when a revoke fails", async () => {
     const { handler, wallet, detection, findWallet, findDetection, findProbeJob } = await setup({
       liveDseqs: ["11"],
@@ -135,7 +153,29 @@ describe(EnforceTrialAbuseHandler.name, () => {
     else executeFundingTx.mockResolvedValue(mock<Awaited<ReturnType<ManagedSignerService["executeFundingTx"]>>>());
     const close = vi.spyOn(container.resolve(DeploymentWriterService), "close").mockResolvedValue(true);
 
+    async function holdWalletRowUntil(cb: (payment: { wipeWaitsForRow: Promise<void>; endTrial: () => Promise<void> }) => Promise<void>) {
+      const userWallets = resolveTable("UserWallets");
+      const lockWalletRow = userWalletRepository.findOneByAndLock.bind(userWalletRepository);
+      const wipeWaitsForRow = new Promise<void>(resolve => {
+        vi.spyOn(userWalletRepository, "findOneByAndLock").mockImplementation(async query => {
+          resolve();
+          return await lockWalletRow(query);
+        });
+      });
+
+      await container.resolve<ApiPgDatabase>(POSTGRES_DB).transaction(async tx => {
+        await tx.select().from(userWallets).where(eq(userWallets.id, wallet.id)).for("update");
+        await cb({
+          wipeWaitsForRow,
+          endTrial: async () => {
+            await tx.update(userWallets).set({ isTrialing: false }).where(eq(userWallets.id, wallet.id));
+          }
+        });
+      });
+    }
+
     return {
+      holdWalletRowUntil,
       handler: container.resolve(EnforceTrialAbuseHandler),
       wallet,
       detection,

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement-job/trial-abuse-enforcement-job.service.integration.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement-job/trial-abuse-enforcement-job.service.integration.ts
@@ -1,0 +1,135 @@
+import { addHours, subMinutes } from "date-fns";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { JOB_NAME } from "@src/core";
+import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import {
+  EnforceTrialAbuse,
+  EnforceTrialAbuseHandler,
+  enforceTrialAbuseKeyFor
+} from "@src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler";
+import { ABUSE_LOCK_REASON } from "@src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { TrialAbuseEnforcementJobService } from "./trial-abuse-enforcement-job.service";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
+import { findJobRows, useJobWorkers } from "@test/services/job-queue-harness";
+
+const STALLED_MINUTES_AGO = 90;
+const RECENT_MINUTES_AGO = 10;
+
+const jobWorkers = useJobWorkers(() => [container.resolve(EnforceTrialAbuseHandler)]);
+
+describe(TrialAbuseEnforcementJobService.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("queues the wipe again for a trial wallet whose enforcement failed or died more than an hour ago", async () => {
+    const { reconcile, seedDetection, findEnforcementJob } = await setup({ mode: "enforce" });
+    const failed = await seedDetection({ action: "enforcement_failed", minutesAgo: STALLED_MINUTES_AGO });
+    const died = await seedDetection({ action: "enforcing", minutesAgo: STALLED_MINUTES_AGO });
+    const stillRetrying = await seedDetection({ action: "enforcement_failed", minutesAgo: RECENT_MINUTES_AGO });
+    const done = await seedDetection({ action: "enforced", minutesAgo: STALLED_MINUTES_AGO });
+
+    await reconcile();
+
+    expect(await findEnforcementJob(failed.walletId)).toMatchObject({ state: "created", data: { walletId: failed.walletId, detectionId: failed.id } });
+    expect(await findEnforcementJob(died.walletId)).toMatchObject({ state: "created", data: { walletId: died.walletId, detectionId: died.id } });
+    expect(await findEnforcementJob(stillRetrying.walletId)).toBeUndefined();
+    expect(await findEnforcementJob(done.walletId)).toBeUndefined();
+  });
+
+  it("leaves a wallet that has paid or is already locked alone", async () => {
+    const { reconcile, seedDetection, findEnforcementJob } = await setup({ mode: "enforce" });
+    const paid = await seedDetection({ action: "enforcement_failed", minutesAgo: STALLED_MINUTES_AGO, wallet: { isTrialing: false } });
+    const locked = await seedDetection({
+      action: "enforcement_failed",
+      minutesAgo: STALLED_MINUTES_AGO,
+      wallet: { abuseLockedAt: new Date(), abuseLockedReason: ABUSE_LOCK_REASON }
+    });
+
+    await reconcile();
+
+    expect(await findEnforcementJob(paid.walletId)).toBeUndefined();
+    expect(await findEnforcementJob(locked.walletId)).toBeUndefined();
+  });
+
+  it("queues one wipe per wallet, naming its latest detection", async () => {
+    const { reconcile, seedDetection, findEnforcementJobs } = await setup({ mode: "enforce" });
+    const older = await seedDetection({ action: "enforcement_failed", minutesAgo: STALLED_MINUTES_AGO * 2 });
+    const latest = await seedDetection({ action: "enforcement_failed", minutesAgo: STALLED_MINUTES_AGO, walletId: older.walletId });
+
+    await reconcile();
+
+    const jobs = await findEnforcementJobs(older.walletId);
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].data).toEqual({ walletId: older.walletId, detectionId: latest.id, version: 1 });
+  });
+
+  it("does not queue a second wipe while one is still pending for the wallet", async () => {
+    const { reconcile, seedDetection, enqueuePending, findEnforcementJobs } = await setup({ mode: "enforce" });
+    const stalled = await seedDetection({ action: "enforcement_failed", minutesAgo: STALLED_MINUTES_AGO });
+    await enqueuePending(stalled.walletId, stalled.id);
+
+    await reconcile();
+
+    expect(await findEnforcementJobs(stalled.walletId)).toHaveLength(1);
+  });
+
+  it("queues nothing in detect mode", async () => {
+    const { reconcile, seedDetection, findEnforcementJob } = await setup({ mode: "detect" });
+    const stalled = await seedDetection({ action: "enforcement_failed", minutesAgo: STALLED_MINUTES_AGO });
+
+    await reconcile();
+
+    expect(await findEnforcementJob(stalled.walletId)).toBeUndefined();
+  });
+
+  async function setup(input: { mode: "detect" | "enforce" }) {
+    const { enqueue } = await jobWorkers();
+    const detectionRepository = container.resolve(WorkloadAbuseDetectionRepository);
+    const config = container.resolve(WorkloadAbuseConfigService);
+    const readConfig = config.get.bind(config);
+    vi.spyOn(config, "get").mockImplementation(key => (key === "WORKLOAD_ABUSE_ENFORCEMENT_MODE" ? input.mode : readConfig(key)));
+
+    async function seedDetection(detection: {
+      action: "enforcing" | "enforced" | "enforcement_failed";
+      minutesAgo: number;
+      walletId?: number;
+      wallet?: { isTrialing?: boolean; abuseLockedAt?: Date; abuseLockedReason?: string };
+    }) {
+      const seeded = detection.walletId ? undefined : await seedUserWithWallet({ isTrialing: true, ...detection.wallet });
+      const walletId = detection.walletId ?? seeded!.wallet.id;
+      const userId = seeded?.user.id ?? (await detectionRepository.findOneBy({ walletId }))!.userId;
+
+      return await detectionRepository.create({
+        userId,
+        walletId,
+        dseq: String(Date.now()),
+        provider: createAkashAddress(),
+        verdict: "hard",
+        probeStatus: "probed",
+        signals: [],
+        evidenceExcerpt: "",
+        action: detection.action,
+        updatedAt: subMinutes(new Date(), detection.minutesAgo)
+      });
+    }
+
+    async function findEnforcementJobs(walletId: number) {
+      return await findJobRows(EnforceTrialAbuse[JOB_NAME], { singletonKey: enforceTrialAbuseKeyFor(walletId) });
+    }
+
+    return {
+      reconcile: () => container.resolve(TrialAbuseEnforcementJobService).reconcile({ dryRun: false }),
+      seedDetection,
+      enqueuePending: (walletId: number, detectionId: string) =>
+        enqueue(new EnforceTrialAbuse({ walletId, detectionId }), { singletonKey: enforceTrialAbuseKeyFor(walletId), startAfter: addHours(new Date(), 1) }),
+      findEnforcementJobs,
+      findEnforcementJob: async (walletId: number) => (await findEnforcementJobs(walletId))[0]
+    };
+  }
+});

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement-job/trial-abuse-enforcement-job.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement-job/trial-abuse-enforcement-job.service.spec.ts
@@ -1,0 +1,110 @@
+import { subMinutes } from "date-fns";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger, JobQueueService } from "@src/core";
+import type { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { EnforceTrialAbuse, enforceTrialAbuseKeyFor } from "@src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler";
+import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { TrialAbuseEnforcementJobService } from "./trial-abuse-enforcement-job.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+const NOW = new Date("2026-01-01T12:00:00.000Z");
+const STALLED = [
+  { walletId: 1, detectionId: "detection-1" },
+  { walletId: 2, detectionId: "detection-2" }
+];
+
+describe(TrialAbuseEnforcementJobService.name, () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("queues nothing while enforcement is in detect mode", async () => {
+    const { service, detectionRepository, jobQueueService, logger } = setup({ mode: "detect" });
+
+    await service.reconcile({ dryRun: false });
+
+    expect(detectionRepository.findStalledEnforcements).not.toHaveBeenCalled();
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_SKIPPED", reason: "DETECT_MODE" });
+  });
+
+  it("queues nothing on a dry run", async () => {
+    const { service, jobQueueService, logger } = setup({});
+
+    await service.reconcile({ dryRun: true });
+
+    expect(jobQueueService.findPendingSingletonKeys).not.toHaveBeenCalled();
+    expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_START", count: 2, dryRun: true });
+  });
+
+  it("looks for wipes whose last state change is more than an hour old", async () => {
+    const { service, detectionRepository } = setup({});
+
+    await service.reconcile({ dryRun: false });
+
+    expect(detectionRepository.findStalledEnforcements).toHaveBeenCalledWith({ updatedBefore: subMinutes(NOW, 60) });
+  });
+
+  it("queues the wipe again only for wallets without one already pending", async () => {
+    const { service, jobQueueService, logger } = setup({ pendingKeys: [enforceTrialAbuseKeyFor(1)] });
+
+    await service.reconcile({ dryRun: false });
+
+    expect(jobQueueService.enqueue).toHaveBeenCalledTimes(1);
+    expect(jobQueueService.enqueue).toHaveBeenCalledWith(new EnforceTrialAbuse({ walletId: 2, detectionId: "detection-2" }), {
+      singletonKey: enforceTrialAbuseKeyFor(2)
+    });
+    expect(logger.info).toHaveBeenCalledWith({
+      event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_END",
+      found: 2,
+      requeued: 1,
+      alreadyQueued: 1,
+      failed: 0
+    });
+  });
+
+  it("counts a wipe the queue refused as already queued", async () => {
+    const { service, jobQueueService, logger } = setup({});
+    jobQueueService.enqueue.mockResolvedValueOnce(null);
+
+    await service.reconcile({ dryRun: false });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_END", requeued: 1, alreadyQueued: 1 })
+    );
+  });
+
+  it("goes on with the other wallets when one wipe cannot be queued", async () => {
+    const { service, jobQueueService, logger } = setup({});
+    const error = new Error("queue down");
+    jobQueueService.enqueue.mockRejectedValueOnce(error);
+
+    await service.reconcile({ dryRun: false });
+
+    expect(jobQueueService.enqueue).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalledWith({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_FAILED", walletId: 1, detectionId: "detection-1", error });
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_END", requeued: 1, failed: 1 }));
+  });
+
+  function setup(input: { mode?: "detect" | "enforce"; stalled?: Array<{ walletId: number; detectionId: string }>; pendingKeys?: string[] }) {
+    vi.useFakeTimers({ now: NOW, toFake: ["Date"] });
+
+    const jobQueueService = mock<JobQueueService>();
+    jobQueueService.enqueue.mockResolvedValue("job-id");
+    jobQueueService.findPendingSingletonKeys.mockResolvedValue(new Set(input.pendingKeys ?? []));
+    const detectionRepository = mock<WorkloadAbuseDetectionRepository>();
+    detectionRepository.findStalledEnforcements.mockResolvedValue(input.stalled ?? STALLED);
+    const config = mockConfigService<WorkloadAbuseConfigService>({ WORKLOAD_ABUSE_ENFORCEMENT_MODE: input.mode ?? "enforce" });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const service = new TrialAbuseEnforcementJobService(jobQueueService, detectionRepository, config, createLogger);
+
+    return { service, jobQueueService, detectionRepository, logger };
+  }
+});

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement-job/trial-abuse-enforcement-job.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement-job/trial-abuse-enforcement-job.service.ts
@@ -1,0 +1,63 @@
+import { subMinutes } from "date-fns";
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, JOB_NAME, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import type { DryRunOptions } from "@src/core/types/console";
+import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
+import { EnforceTrialAbuse, enforceTrialAbuseKeyFor } from "@src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+
+/** The queue's own retries are over within about twenty minutes, so a wipe still not enforced an hour after its last state change is stuck. */
+const STALLED_ENFORCEMENT_AFTER_MIN = 60;
+
+/** Backstops the queue: a confirmed detection whose wipe failed or died gets its job queued again while the wallet is still on trial and unlocked. */
+@singleton()
+export class TrialAbuseEnforcementJobService {
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly jobQueueService: JobQueueService,
+    private readonly detectionRepository: WorkloadAbuseDetectionRepository,
+    private readonly config: WorkloadAbuseConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: TrialAbuseEnforcementJobService.name });
+  }
+
+  async reconcile({ dryRun }: DryRunOptions): Promise<void> {
+    if (this.config.get("WORKLOAD_ABUSE_ENFORCEMENT_MODE") !== "enforce") {
+      this.logger.info({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_SKIPPED", reason: "DETECT_MODE" });
+      return;
+    }
+
+    const stalled = await this.detectionRepository.findStalledEnforcements({ updatedBefore: subMinutes(new Date(), STALLED_ENFORCEMENT_AFTER_MIN) });
+    this.logger.info({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_START", count: stalled.length, dryRun });
+
+    if (dryRun) return;
+
+    const pendingKeys = await this.jobQueueService.findPendingSingletonKeys(EnforceTrialAbuse[JOB_NAME]);
+    let requeued = 0;
+    let alreadyQueued = 0;
+    let failed = 0;
+
+    for (const { walletId, detectionId } of stalled) {
+      const singletonKey = enforceTrialAbuseKeyFor(walletId);
+
+      if (pendingKeys.has(singletonKey)) {
+        alreadyQueued++;
+        continue;
+      }
+
+      try {
+        const jobId = await this.jobQueueService.enqueue(new EnforceTrialAbuse({ walletId, detectionId }), { singletonKey });
+        if (jobId) requeued++;
+        else alreadyQueued++;
+      } catch (error) {
+        this.logger.error({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_FAILED", walletId, detectionId, error });
+        failed++;
+      }
+    }
+
+    this.logger.info({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECONCILE_END", found: stalled.length, requeued, alreadyQueued, failed });
+  }
+}

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
@@ -7,7 +7,7 @@ import type { ChainErrorService } from "@src/billing/services/chain-error/chain-
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
-import type { CreateLogger } from "@src/core";
+import type { CreateLogger, TxService } from "@src/core";
 import type { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import type { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
 import type { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
@@ -27,7 +27,7 @@ describe(TrialAbuseEnforcementService.name, () => {
 
     const outcome = await service.enforce({ wallet, detectionId: DETECTION_ID });
 
-    expect(calls).toEqual(["revoke:deposit", "close:11", "close:22", "revoke:fee", "lock", "cancelProbes"]);
+    expect(calls).toEqual(["tx:begin", "lockRow", "revoke:deposit", "close:11", "close:22", "revoke:fee", "lock", "cancelProbes", "tx:commit"]);
     expect(userWalletRepository.lockForAbuse).toHaveBeenCalledWith(wallet.id, ABUSE_LOCK_REASON);
     expect(outcome).toEqual({ depositGrantRevoked: true, feeGrantRevoked: true, closedDseqs: ["11", "22"] });
     expect(detectionRepository.updateById).toHaveBeenNthCalledWith(1, DETECTION_ID, {
@@ -58,8 +58,26 @@ describe(TrialAbuseEnforcementService.name, () => {
 
     expect(signerService.executeFundingTx).toHaveBeenCalledTimes(1);
     expect(signerService.executeFundingTx).toHaveBeenCalledWith([REVOKE_FEE]);
-    expect(calls).toEqual(["lock", "cancelProbes"]);
+    expect(calls).toEqual(["tx:begin", "lockRow", "lock", "cancelProbes", "tx:commit"]);
     expect(outcome).toEqual({ depositGrantRevoked: false, feeGrantRevoked: true, closedDseqs: [] });
+  });
+
+  it("leaves a wallet that paid while waiting for its row alone and hands the detection back", async () => {
+    const { service, wallet, calls, signerService, deploymentWriterService, userWalletRepository, detectionRepository, instrumentation } = setup({
+      liveDseqs: ["11"],
+      paidUnderLock: true
+    });
+
+    const outcome = await service.enforce({ wallet, detectionId: DETECTION_ID });
+
+    expect(outcome).toBeNull();
+    expect(calls).toEqual(["tx:begin", "lockRow", "tx:commit"]);
+    expect(signerService.executeFundingTx).not.toHaveBeenCalled();
+    expect(deploymentWriterService.close).not.toHaveBeenCalled();
+    expect(userWalletRepository.lockForAbuse).not.toHaveBeenCalled();
+    expect(detectionRepository.markWalletEnforced).not.toHaveBeenCalled();
+    expect(detectionRepository.updateById).toHaveBeenLastCalledWith(DETECTION_ID, { action: "detected", enforcementError: null, updatedAt: expect.any(Date) });
+    expect(instrumentation.recordEnforcement).toHaveBeenCalledWith("skipped");
   });
 
   it("closes each live deployment once even when several leases share it", async () => {
@@ -104,9 +122,17 @@ describe(TrialAbuseEnforcementService.name, () => {
     expect(probeJobService.cancelForWallet).not.toHaveBeenCalled();
   });
 
-  function setup(input: { liveDseqs: string[]; hasDepositGrant?: boolean; hasFeeGrant?: boolean }) {
+  function setup(input: { liveDseqs: string[]; hasDepositGrant?: boolean; hasFeeGrant?: boolean; paidUnderLock?: boolean }) {
     const wallet = createInitializedUserWallet({ isTrialing: true });
     const calls: string[] = [];
+
+    const txService = mock<TxService>();
+    txService.transaction.mockImplementation(async cb => {
+      calls.push("tx:begin");
+      const result = await cb();
+      calls.push("tx:commit");
+      return result;
+    });
 
     const txManagerService = mock<TxManagerService>();
     txManagerService.getFundingWalletAddress.mockResolvedValue(GRANTER);
@@ -134,6 +160,10 @@ describe(TrialAbuseEnforcementService.name, () => {
     const chainErrorService = mock<ChainErrorService>();
     chainErrorService.isUnsettleableDeploymentError.mockReturnValue(false);
     const userWalletRepository = mock<UserWalletRepository>();
+    userWalletRepository.findOneByAndLock.mockImplementation(async () => {
+      calls.push("lockRow");
+      return { ...wallet, isTrialing: !input.paidUnderLock };
+    });
     userWalletRepository.lockForAbuse.mockImplementation(async () => {
       calls.push("lock");
     });
@@ -159,6 +189,7 @@ describe(TrialAbuseEnforcementService.name, () => {
       detectionRepository,
       probeJobService,
       instrumentation,
+      txService,
       createLogger
     );
 

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
@@ -7,7 +7,7 @@ import { ChainErrorService } from "@src/billing/services/chain-error/chain-error
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
-import { type CreateLogger, LOGGER_FACTORY } from "@src/core";
+import { type CreateLogger, LOGGER_FACTORY, TxService } from "@src/core";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
 import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
 import { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
@@ -45,19 +45,20 @@ export class TrialAbuseEnforcementService {
     private readonly detectionRepository: WorkloadAbuseDetectionRepository,
     private readonly probeJobService: TrialWorkloadProbeJobService,
     private readonly instrumentation: WorkloadAbuseInstrumentationService,
+    private readonly txService: TxService,
     @inject(LOGGER_FACTORY) createLogger: CreateLogger
   ) {
     this.logger = createLogger({ context: TrialAbuseEnforcementService.name });
   }
 
-  async enforce(input: { wallet: WalletInitialized; detectionId: string }): Promise<EnforcementOutcome> {
+  async enforce(input: { wallet: WalletInitialized; detectionId: string }): Promise<EnforcementOutcome | null> {
     const { wallet, detectionId } = input;
     await this.detectionRepository.updateById(detectionId, { action: "enforcing", enforcementError: null, updatedAt: new Date() });
 
-    let outcome: EnforcementOutcome;
+    let outcome: EnforcementOutcome | null;
 
     try {
-      outcome = await this.#wipe(wallet);
+      outcome = await this.txService.transaction(() => this.#wipeUnlessPaid(wallet));
     } catch (error) {
       await this.detectionRepository.updateById(detectionId, { action: "enforcement_failed", enforcementError: toErrorMessage(error), updatedAt: new Date() });
       this.instrumentation.recordEnforcement("failed");
@@ -72,6 +73,20 @@ export class TrialAbuseEnforcementService {
       throw error;
     }
 
+    if (!outcome) {
+      await this.detectionRepository.updateById(detectionId, { action: "detected", enforcementError: null, updatedAt: new Date() });
+      this.instrumentation.recordEnforcement("skipped");
+      this.logger.info({
+        event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_SKIPPED",
+        reason: "PAID_DURING_ENFORCEMENT",
+        detectionId,
+        walletId: wallet.id,
+        userId: wallet.userId,
+        owner: wallet.address
+      });
+      return null;
+    }
+
     await this.detectionRepository.markWalletEnforced(wallet.id);
     this.instrumentation.recordEnforcement("enforced");
     this.logger.warn({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCED", detectionId, walletId: wallet.id, userId: wallet.userId, owner: wallet.address, ...outcome });
@@ -79,7 +94,16 @@ export class TrialAbuseEnforcementService {
     return outcome;
   }
 
-  /** The lock commits before the probes are cancelled, so a wipe that fails partway leaves the wallet unlocked and still monitored for the retry. */
+  /** Holds the wallet row for the whole wipe, so a payment settling at the same time waits for it and then clears the lock instead of re-granting between the revokes. */
+  async #wipeUnlessPaid(wallet: WalletInitialized): Promise<EnforcementOutcome | null> {
+    const lockedWallet = await this.userWalletRepository.findOneByAndLock({ id: wallet.id });
+
+    if (!lockedWallet?.isTrialing) return null;
+
+    return await this.#wipe(wallet);
+  }
+
+  /** The lock and the probe cancellations ride the row-lock transaction, so a wipe that fails partway rolls them back and leaves the wallet unlocked and still monitored for the retry. */
   async #wipe(wallet: WalletInitialized): Promise<EnforcementOutcome> {
     const granter = await this.txManagerService.getFundingWalletAddress();
     const depositGrantRevoked = await this.#revokeDepositGrant(granter, wallet.address);


### PR DESCRIPTION
## Why

Two gaps were left open when fair use enforcement on trial deployments shipped:

- An enforcement run and a payment settlement both change a wallet's chain grants over several round trips. Nothing kept them apart, so a payment settling during a run could have its fresh grant revoked and the wallet locked right after the customer was charged.
- Once a deployment is confirmed, no further probe is scheduled for it. An enforcement run that used up its queue retries was therefore never attempted again, and the wallet stayed on trial with its grants intact.

## What

- The enforcement run now executes inside a transaction that holds the wallet row for its whole duration, and the payment settlement takes the same row before it touches the chain. Whichever starts second waits. The run re-reads the wallet under the lock and steps aside, handing the detection back to `detected`, when the wallet has stopped trialing in the meantime. A settlement that waited finds the lock and clears it as before.
- The existing `probe-trial-deployments` sweep now also queues the enforcement job again for confirmed detections whose run failed or died more than an hour ago, as long as the wallet is still trialing and unlocked, and no job for it is already pending. Detect mode is respected, so detections recorded before a mode flip are not acted on by the sweep.
- Unit specs cover the ordering and the paid-under-lock case. Integration tests run the enforcement handler against a concurrent transaction holding the wallet row, and run the sweep against seeded detections in each state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for stalled trial-abuse enforcement tasks.
  * Prevented duplicate recovery tasks and added support for dry-run reconciliation.
  * Probe operations now also queue stuck deployment wipes.
* **Bug Fixes**
  * Improved wallet locking during payments and abuse enforcement to prevent race conditions.
  * Enforcement is skipped when a wallet becomes paid during processing, avoiding unintended access removal.
* **Reliability**
  * Enforcement and wallet updates now complete transactionally, reducing inconsistent states after failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->