### PR TITLE
fix(user): show the app header behind the fair use policy prompt

### DIFF
--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
@@ -10,11 +10,11 @@ import { fireEvent, render, screen } from "@testing-library/react";
 const ACCEPTED_AT = "2026-09-06T00:00:00.000Z";
 
 describe(RequireFairUsePolicy.name, () => {
-  it("shows the modal instead of the page for a trialing user who has not accepted", () => {
+  it("shows the modal inside the app shell instead of the page for a trialing user who has not accepted", () => {
     setup({ userId: "u1", fairUsePolicyAcceptedAt: null });
 
     expect(screen.queryByText("child")).not.toBeInTheDocument();
-    expect(screen.getByTestId("fair-use-policy-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("layout")).toContainElement(screen.getByTestId("fair-use-policy-modal"));
   });
 
   it("demands acceptance before the trial wallet exists", () => {
@@ -36,6 +36,7 @@ describe(RequireFairUsePolicy.name, () => {
 
     expect(screen.getByText("child")).toBeInTheDocument();
     expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("layout")).not.toBeInTheDocument();
   });
 
   it("stops demanding acceptance once it is confirmed, even while the profile still lacks the timestamp", () => {
@@ -104,6 +105,7 @@ describe(RequireFairUsePolicy.name, () => {
         }),
       useFlag: flag => flag === "fair_use_policy_gate" && (input.isGateEnabled ?? true),
       useAcceptFairUsePolicy: () => ({ accept, isAccepting: false, hasAccepted: input.hasAccepted ?? false }),
+      Layout: ({ children }) => <div data-testid="layout">{children}</div>,
       FairUsePolicyModal: ({ onAccept }) => (
         <div data-testid="fair-use-policy-modal">
           <button data-testid="fair-use-policy-accept-button" onClick={onAccept}>

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
@@ -2,6 +2,7 @@
 import type { ReactNode } from "react";
 
 import { FairUsePolicyModal } from "@src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal";
+import Layout from "@src/components/layout/Layout";
 import { useWallet } from "@src/context/WalletProvider";
 import { useAcceptFairUsePolicy } from "@src/hooks/useAcceptFairUsePolicy";
 import { useFlag } from "@src/hooks/useFlag";
@@ -12,6 +13,7 @@ export const DEPENDENCIES = {
   useWallet,
   useFlag,
   useAcceptFairUsePolicy,
+  Layout,
   FairUsePolicyModal
 };
 
@@ -22,7 +24,7 @@ type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-/** Holds the page back until acceptance, so an auto-started deployment cannot fire behind the modal. */
+/** Holds the page back until acceptance, so an auto-started deployment cannot fire behind the modal, and renders the shell the withheld page would have. */
 export function RequireFairUsePolicy({ children, isPublic, dependencies: d = DEPENDENCIES }: Props) {
   const { user } = d.useUser();
   const { isTrialing, hasWallet, isWalletLookupFailed } = d.useWallet();
@@ -31,7 +33,13 @@ export function RequireFairUsePolicy({ children, isPublic, dependencies: d = DEP
   const isAwaitingTrialWallet = !hasWallet && !isWalletLookupFailed;
   const mustAccept = !isPublic && isGateEnabled && (isTrialing || isAwaitingTrialWallet) && !!user?.userId && !user.fairUsePolicyAcceptedAt && !hasAccepted;
 
-  if (mustAccept) return <d.FairUsePolicyModal onAccept={accept} isAccepting={isAccepting} />;
+  if (mustAccept) {
+    return (
+      <d.Layout>
+        <d.FairUsePolicyModal onAccept={accept} isAccepting={isAccepting} />
+      </d.Layout>
+    );
+  }
 
   return <>{children}</>;
 }


### PR DESCRIPTION
## Why

The fair use policy prompt rendered on a blank white page, with no logo and no header above it. The gate holds back the page component, and in deploy-web each page renders the app shell itself, so holding the page back removed the shell too.

## What

The gate now renders the shell and puts the prompt inside it. The header and logo stay visible while the page content is still held back. Since the dialog is portalled to the body, the content area behind it stays empty, and nothing on the page can be reached before acceptance. `ResumeDeploymentGuard` already composes `Layout` this way when it blocks the configure screen.

Two specs cover it: the held-back state checks that the prompt renders inside the shell, and the accepted state checks that the gate does not add a second shell around the page.