### PR TITLE
fix(auth): start the turnstile challenge once cloudflare's script lands

### DIFF
--- a/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.spec.tsx
@@ -161,29 +161,56 @@ describe(Turnstile.name, () => {
 
   describe("renderAndWaitResponse", () => {
     it("resolves with token when challenge is solved", async () => {
-      const turnstileInstance = mock<TurnstileInstance>();
-      let triggerSuccess: ((token: string) => void) | undefined;
-      const ReactTurnstile = forwardRef<TurnstileInstance | undefined, TurnstileProps>((props, ref) => {
-        useForwardedRef(ref, turnstileInstance);
-        triggerSuccess = (token: string) => props.onSuccess?.(token);
-        return <div>Turnstile</div>;
-      });
-
-      const { turnstileRef } = await setup({
-        enabled: true,
-        components: { ReactTurnstile }
-      });
+      const { ReactTurnstile, instance, latestProps } = createTurnstileMock();
+      const { turnstileRef } = await setup({ enabled: true, components: { ReactTurnstile } });
 
       const promise = turnstileRef.current!.renderAndWaitResponse();
       await act(async () => {
-        triggerSuccess?.("test-token");
+        latestProps.current?.onSuccess?.("test-token");
         await wait(0);
       });
 
       await expect(promise).resolves.toEqual({ token: "test-token" });
-      expect(turnstileInstance.remove).toHaveBeenCalled();
-      expect(turnstileInstance.render).toHaveBeenCalled();
-      expect(turnstileInstance.execute).toHaveBeenCalled();
+      expect(instance.remove).toHaveBeenCalled();
+      expect(instance.render).toHaveBeenCalled();
+      expect(instance.execute).toHaveBeenCalled();
+    });
+
+    it("starts a challenge requested before cloudflare's script lands instead of dropping it", async () => {
+      const { ReactTurnstile, instance, latestProps } = createTurnstileMock({ loadsWidget: false });
+      const { turnstileRef } = await setup({ enabled: true, components: { ReactTurnstile } });
+
+      const promise = turnstileRef.current!.renderAndWaitResponse();
+      expect(instance.execute).not.toHaveBeenCalled();
+
+      await act(async () => {
+        latestProps.current?.onWidgetLoad?.("mock-widget-id");
+        await wait(0);
+      });
+      await act(async () => {
+        latestProps.current?.onSuccess?.("late-token");
+        await wait(0);
+      });
+
+      await expect(promise).resolves.toEqual({ token: "late-token" });
+      expect(instance.execute).toHaveBeenCalled();
+    });
+
+    it("does not start an abandoned challenge once cloudflare's script lands", async () => {
+      const { ReactTurnstile, instance, latestProps } = createTurnstileMock({ loadsWidget: false });
+      const { turnstileRef } = await setup({ enabled: true, components: { ReactTurnstile } });
+
+      turnstileRef.current!.renderAndWaitResponse().catch(() => undefined);
+      await act(async () => {
+        turnstileRef.current!.abandonPendingChallenge();
+        await wait(0);
+      });
+      await act(async () => {
+        latestProps.current?.onWidgetLoad?.("mock-widget-id");
+        await wait(0);
+      });
+
+      expect(instance.execute).not.toHaveBeenCalled();
     });
 
     it("rejects with error when challenge fails", async () => {
@@ -416,11 +443,15 @@ describe(Turnstile.name, () => {
     </button>
   ));
 
-  function createTurnstileMock(instance: TurnstileInstance = mock<TurnstileInstance>()) {
+  function createTurnstileMock(input?: { loadsWidget?: boolean }) {
+    const instance = mock<TurnstileInstance>();
     const latestProps: { current: TurnstileProps | undefined } = { current: undefined };
     const ReactTurnstile = forwardRef<TurnstileInstance | undefined, TurnstileProps>((props, ref) => {
       useForwardedRef(ref, instance);
       latestProps.current = props;
+      useEffect(() => {
+        if (input?.loadsWidget ?? true) props.onWidgetLoad?.("mock-widget-id");
+      }, []);
       return <div>Turnstile</div>;
     });
 

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -74,6 +74,17 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
     turnstileRef.current?.render();
     turnstileRef.current?.execute();
   }, []);
+  const isWidgetLoaded = useRef(false);
+  const startChallengeOnWidgetLoad = useRef<(() => void) | undefined>(undefined);
+  /** Cloudflare's api.js can still be in flight when the visitor submits, and it silently drops render and execute calls made before it lands, leaving a challenge that never starts. */
+  const startChallenge = useCallback(() => {
+    if (isWidgetLoaded.current) {
+      resetWidget();
+      return;
+    }
+
+    startChallengeOnWidgetLoad.current = resetWidget;
+  }, [resetWidget]);
   const abandonPendingChallenge = useRef<(() => void) | undefined>(undefined);
   const stopWaitingForChallenge = useRef<(() => void) | undefined>(undefined);
   /** Notifies the parent before rejecting so it can drop the abandoned attempt instead of rendering it as a failure. */
@@ -108,10 +119,11 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
 
         abandonPendingChallenge.current?.();
         hasReportedFailure.current = false;
-        resetWidget();
+        startChallenge();
         return new Promise((resolve, reject) => {
           const stopWaiting = () => {
             clearTimeout(deadline);
+            startChallengeOnWidgetLoad.current = undefined;
             eventBus.current.removeEventListener("success", successListener);
             eventBus.current.removeEventListener("error", errorListener);
             abandonPendingChallenge.current = undefined;
@@ -143,7 +155,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
         });
       }
     }),
-    [resetWidget, enabled, reportChallengeFailure]
+    [startChallenge, enabled, reportChallengeFailure]
   );
 
   if (!enabled) {
@@ -186,6 +198,12 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
                 eventBus.current.dispatchEvent(new CustomEvent("success", { detail: { token } }));
               }}
               onBeforeInteractive={() => setStatus("interactive")}
+              onWidgetLoad={() => {
+                isWidgetLoaded.current = true;
+                const startPendingChallenge = startChallengeOnWidgetLoad.current;
+                startChallengeOnWidgetLoad.current = undefined;
+                startPendingChallenge?.();
+              }}
             />
             <motion.div
               className="flex flex-col items-center"


### PR DESCRIPTION
## Why

Beta e2e failed on the last deploy with 1 failed and 9 flaky specs, all wedged at login. The Slack notification blamed #3882, but that PR only adds origins to a report-only CSP and cannot block anything.

The traces show the real cause. Every failure has the submit button stuck in `Loading...` and no request to `/api/auth/*` at all, preceded by:

```
Turnstile has not been loaded
Turnstile has not been loaded or container not found
Turnstile has not been loaded or container not found
```

That is `resetWidget()` calling `remove()`, `render()` and `execute()` while `window.turnstile` is still undefined: `challenges.cloudflare.com/api.js` had not landed yet (in the traces it arrives ~300ms after the click). `@marsidev/react-turnstile` drops all three calls with those warnings, then auto-renders the widget when the script loads. Because we run with `execution: "execute"`, the challenge itself never starts without another `execute()`, and nothing issues one, so the form waits on a challenge that will never run until the 120s deadline.

This is not e2e-only. Any visitor who submits before Cloudflare's script finishes loading gets the same dead button, which fits the `TURNSTILE_CHALLENGE_WEDGED` reports in Sentry.

## What

- A challenge requested while the widget is still loading is held and started from `onWidgetLoad` instead of being dropped.
- A held challenge is discarded if the caller abandons it or the deadline passes, so a late script load cannot start a challenge nobody is waiting for.
- The "Reload captcha" button keeps calling the widget directly: it is only reachable once the widget is visible, which means it is already loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved challenge startup reliability by waiting for the widget to finish loading before proceeding.
  * Deferred actions during API loading and resumed them automatically once loading completed.
  * Preserved challenge success and reset behavior, including abandoned challenge handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->