### PR TITLE
fix(provider): temporarily remove provider creation entry points and route

### DIFF
--- a/apps/provider-console/README.md
+++ b/apps/provider-console/README.md
@@ -1,5 +1,7 @@
 ## Provider Console
-Provider console is responsible for creating provider in Akash Network using UI with best practices
+
+Provider Console is the UI for managing providers on Akash Network. Creating and building providers through the UI is currently disabled; see [docs/provider-builds-disabled.md](docs/provider-builds-disabled.md).
+
 ## Getting Started
 
 First, run the development server:
@@ -17,3 +19,7 @@ bun dev
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+
+## Docs
+
+- [Provider builds disabled](docs/provider-builds-disabled.md) — what was removed on 2026-09-09, why, and how to re-enable it.

--- a/apps/provider-console/docs/provider-builds-disabled.md
+++ b/apps/provider-console/docs/provider-builds-disabled.md
@@ -1,0 +1,35 @@
+# Provider builds disabled in Provider Console
+
+Since 2026-09-09, Provider Console no longer lets users create or build a provider. Providers are built with the [Provider Playbook](https://akash.network/docs/providers/setup-and-installation/provider-playbook/) instead. Provider Console remains fully available for dashboards and management of existing providers.
+
+Tracked in Linear as AKHN-441 and shipped in [PR #3891](https://github.com/akash-network/console/pull/3891).
+
+## What changed
+
+- The `/become-provider` route was removed. The wizard still exists as `src/components/become-provider/BecomeProvider.tsx` but nothing mounts it.
+- The "Create Provider" button was removed from the sidebar (`src/components/layout/Sidebar.tsx`).
+- The "Create Provider" link was removed from the final step of the Get Started stepper (`src/components/get-started/GetStartedStepper.tsx`). The step text now says provider creation is unavailable.
+- The "Restart Provider Build" button was removed from the remedies page (`src/pages/remedies/index.tsx`), together with the provider-process reset it triggered.
+- A warning banner (`src/components/layout/ProviderBuildDisabledBanner.tsx`) is rendered by `Layout` above the fixed header on every page and links to the Provider Playbook. It publishes its measured height as the `--top-banner-height` CSS variable, and the header, sidebar drawer, and global body height add that variable to their existing 57px header offset.
+
+No feature flag guards this. The removal is a plain code change so that there is no configuration that could accidentally re-enable builds.
+
+## What did not change
+
+- All wizard step components under `src/components/become-provider/` are untouched. `pages/attributes` and `pages/pricing` still reuse `ProviderAttributes` and `ProviderPricing` from there.
+- `provider-console-api` is a separate repository and was not modified. Its `/build-provider` endpoint is not blocked server-side.
+- Dashboard, nodes, deployments, settings, API keys, and every other management page work as before.
+
+## How to re-enable provider builds
+
+1. Add `src/pages/become-provider/index.tsx` containing:
+
+   ```tsx
+   import { BecomeProvider } from "@src/components/become-provider/BecomeProvider";
+   import { withAuth } from "@src/components/shared/withAuth";
+
+   export default withAuth({ WrappedComponent: BecomeProvider, authLevel: "wallet" });
+   ```
+
+2. Restore the three entry points removed in PR #3891: the sidebar button, the Get Started stepper link, and the remedies "Restart Provider Build" button. The PR diff is the reference.
+3. Remove `ProviderBuildDisabledBanner` from `Layout.tsx` and delete the component and its spec. The `--top-banner-height` offsets in `Nav.tsx`, `Sidebar.tsx`, `Layout.tsx`, and `src/styles/index.css` can stay (they resolve to 0px) or be reverted to the plain 57px values.

--- a/apps/provider-console/src/components/become-provider/BecomeProvider.tsx
+++ b/apps/provider-console/src/components/become-provider/BecomeProvider.tsx
@@ -11,13 +11,12 @@ import { ServerAccess } from "@src/components/become-provider/ServerAccess";
 import { CustomizedSteppers } from "@src/components/become-provider/Stepper";
 import { WalletImport } from "@src/components/become-provider/WalletImport";
 import { Layout } from "@src/components/layout/Layout";
-import { withAuth } from "@src/components/shared/withAuth";
 import { useWallet } from "@src/context/WalletProvider";
 import providerProcessStore from "@src/store/providerProcessStore";
 import { hasRequiredCertManagerSecrets } from "@src/types/certManager";
 import { migrateProviderStorage } from "@src/utils/migrateProviderStorage";
 
-const BecomeProvider: React.FC = () => {
+export const BecomeProvider: React.FC = () => {
   const [activeStep, setActiveStep] = useState<number>(0);
   const [providerProcess, setProviderProcess] = useAtom(providerProcessStore.providerProcessAtom);
   const [certManagerSecrets] = useAtom(providerProcessStore.certManagerSecretsAtom);
@@ -104,5 +103,3 @@ const BecomeProvider: React.FC = () => {
     </Layout>
   );
 };
-
-export default withAuth({ WrappedComponent: BecomeProvider, authLevel: "wallet" });

--- a/apps/provider-console/src/components/get-started/GetStartedStepper.tsx
+++ b/apps/provider-console/src/components/get-started/GetStartedStepper.tsx
@@ -249,12 +249,9 @@ export const GetStartedStepper: React.FunctionComponent = () => {
               </ul>
             </li>
           </ol>
-          <p>Once you understand the process, you can create a provider.</p>
+          <p>Provider creation through Provider Console is temporarily unavailable.</p>
           <div className="my-4 flex items-center space-x-4">
             <div className="my-4 space-x-2">
-              <Link className={cn("space-x-2", buttonVariants({ variant: "default" }))} href={UrlService.becomeProvider()}>
-                <span>Create Provider</span>
-              </Link>
               <Button onClick={handleReset} className="space-x-2" variant="ghost">
                 <span>Reset</span>
                 <MdRestartAlt />

--- a/apps/provider-console/src/components/layout/Layout.tsx
+++ b/apps/provider-console/src/components/layout/Layout.tsx
@@ -4,10 +4,11 @@ import React, { useEffect, useState } from "react";
 import { IntlProvider } from "react-intl";
 import { useMediaQuery, useTheme as useMuiTheme } from "@mui/material";
 
-import { accountBarHeight } from "@src/utils/constants";
+import { accountBarHeight, topBannerHeightCssVar } from "@src/utils/constants";
 import { cn } from "@src/utils/styleUtils";
 import { LinearLoadingSkeleton } from "../shared/LinearLoadingSkeleton";
 import { Nav } from "./Nav";
+import { ProviderBuildDisabledBanner } from "./ProviderBuildDisabledBanner";
 import { Sidebar } from "./Sidebar";
 
 type Props = {
@@ -73,8 +74,9 @@ const LayoutApp: React.FC<Props> = ({ children, isLoading, disableContainer, con
   return (
     <>
       <div className="bg-card min-h-full">
-        <div className="h-full w-full" style={{ marginTop: `${accountBarHeight}px` }}>
+        <div className="h-full w-full" style={{ marginTop: `calc(${accountBarHeight}px + var(${topBannerHeightCssVar}, 0px))` }}>
           <div className="h-full">
+            <ProviderBuildDisabledBanner />
             <Nav />
             <div className="block h-full w-full flex-grow rounded-none md:flex">
               <Sidebar onOpenMenuClick={onOpenMenuClick} isNavOpen={isNavOpen} handleDrawerToggle={handleDrawerToggle} isMobileOpen={isMobileOpen} />

--- a/apps/provider-console/src/components/layout/Nav.tsx
+++ b/apps/provider-console/src/components/layout/Nav.tsx
@@ -10,7 +10,7 @@ export const Nav = () => {
   const theme = useCookieTheme();
 
   return (
-    <header className="border-border bg-popover dark:bg-background fixed top-0 z-50 w-full border-b">
+    <header className="border-border bg-popover dark:bg-background fixed top-[var(--top-banner-height,0px)] z-50 w-full border-b">
       <div className="flex h-14 items-center justify-between pl-4 pr-4">
         {!!theme && (
           <Link className="flex items-center" href="/">

--- a/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.spec.tsx
+++ b/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.spec.tsx
@@ -1,0 +1,47 @@
+import "@testing-library/jest-dom";
+
+import React from "react";
+
+import { topBannerHeightCssVar } from "@src/utils/constants";
+import { ProviderBuildDisabledBanner } from "./ProviderBuildDisabledBanner";
+
+import { render, screen } from "@testing-library/react";
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(globalThis, "ResizeObserver", { writable: true, value: ResizeObserverMock });
+
+describe(ProviderBuildDisabledBanner.name, () => {
+  it("tells users that provider builds are disabled and where to build instead", () => {
+    setup();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Provider builds are disabled in Provider Console. Use the Provider Playbook to build providers. Provider Console remains available for dashboards and management."
+    );
+  });
+
+  it("links to the Provider Playbook in a new tab", () => {
+    setup();
+
+    const link = screen.getByRole("link", { name: "Provider Playbook" });
+    expect(link).toHaveAttribute("href", "https://akash.network/docs/providers/setup-and-installation/provider-playbook/");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("publishes its height as a root CSS variable and clears it on unmount", () => {
+    const { unmount } = setup();
+
+    expect(document.documentElement.style.getPropertyValue(topBannerHeightCssVar)).toBe("0px");
+
+    unmount();
+
+    expect(document.documentElement.style.getPropertyValue(topBannerHeightCssVar)).toBe("");
+  });
+
+  function setup() {
+    return render(<ProviderBuildDisabledBanner />);
+  }
+});

--- a/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.spec.tsx
+++ b/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.spec.tsx
@@ -18,7 +18,7 @@ describe(ProviderBuildDisabledBanner.name, () => {
   it("tells users that provider builds are disabled and where to build instead", () => {
     setup();
 
-    expect(screen.getByRole("alert")).toHaveTextContent(
+    expect(screen.getByRole("note")).toHaveTextContent(
       "Provider builds are disabled in Provider Console. Use the Provider Playbook to build providers. Provider Console remains available for dashboards and management."
     );
   });

--- a/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.tsx
+++ b/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef } from "react";
+import { WarningTriangle } from "iconoir-react";
+import Link from "next/link";
+
+import { topBannerHeightCssVar } from "@src/utils/constants";
+
+const PROVIDER_PLAYBOOK_URL = "https://akash.network/docs/providers/setup-and-installation/provider-playbook/";
+
+export function ProviderBuildDisabledBanner() {
+  const bannerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(function publishBannerHeight() {
+    const banner = bannerRef.current;
+    if (!banner) return;
+
+    const updateBannerHeight = () => {
+      document.documentElement.style.setProperty(topBannerHeightCssVar, `${banner.offsetHeight}px`);
+    };
+    updateBannerHeight();
+
+    const resizeObserver = new ResizeObserver(updateBannerHeight);
+    resizeObserver.observe(banner);
+
+    return function stopPublishingBannerHeight() {
+      resizeObserver.disconnect();
+      document.documentElement.style.removeProperty(topBannerHeightCssVar);
+    };
+  }, []);
+
+  return (
+    <div ref={bannerRef} className="fixed top-0 z-[1100] w-full">
+      <div role="alert" className="bg-primary text-primary-foreground flex items-center justify-center gap-2 px-4 py-2 text-center text-xs">
+        <WarningTriangle className="h-4 w-4 flex-shrink-0" />
+        <span>
+          Provider builds are disabled in Provider Console. Use the{" "}
+          <Link href={PROVIDER_PLAYBOOK_URL} target="_blank" rel="noreferrer" className="text-primary-foreground font-semibold underline">
+            Provider Playbook
+          </Link>{" "}
+          to build providers. Provider Console remains available for dashboards and management.
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.tsx
+++ b/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.tsx
@@ -28,8 +28,8 @@ export function ProviderBuildDisabledBanner() {
   }, []);
 
   return (
-    <div ref={bannerRef} className="fixed top-0 z-[1100] w-full">
-      <div role="alert" className="bg-primary text-primary-foreground flex items-center justify-center gap-2 px-4 py-2 text-center text-xs">
+    <div ref={bannerRef} className="fixed top-0 z-[60] w-full">
+      <div role="note" className="bg-primary text-primary-foreground flex items-center justify-center gap-2 px-4 py-2 text-center text-xs">
         <WarningTriangle className="h-4 w-4 flex-shrink-0" />
         <span>
           Provider builds are disabled in Provider Console. Use the{" "}

--- a/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.tsx
+++ b/apps/provider-console/src/components/layout/ProviderBuildDisabledBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useLayoutEffect, useRef } from "react";
 import { WarningTriangle } from "iconoir-react";
 import Link from "next/link";
 
@@ -9,7 +9,7 @@ const PROVIDER_PLAYBOOK_URL = "https://akash.network/docs/providers/setup-and-in
 export function ProviderBuildDisabledBanner() {
   const bannerRef = useRef<HTMLDivElement>(null);
 
-  useEffect(function publishBannerHeight() {
+  useLayoutEffect(function publishBannerHeight() {
     const banner = bannerRef.current;
     if (!banner) return;
 

--- a/apps/provider-console/src/components/layout/Sidebar.tsx
+++ b/apps/provider-console/src/components/layout/Sidebar.tsx
@@ -26,7 +26,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import type { ISidebarGroupMenu } from "@src/types";
-import { closedDrawerWidth, drawerWidth } from "@src/utils/constants";
+import { closedDrawerWidth, drawerWidth, topBannerHeightCssVar } from "@src/utils/constants";
 import { cn } from "@src/utils/styleUtils";
 import { UrlService } from "@src/utils/urlUtils";
 import { ControlMachineStatus } from "./ControlMachineStatus";
@@ -277,7 +277,13 @@ export const Sidebar: React.FC<Props> = ({ isMobileOpen, handleDrawerToggle, isN
         }}
         sx={{
           display: { xs: "block", sm: "block", md: "none" },
-          "& .MuiDrawer-paper": { boxSizing: "border-box", width: drawerWidth, overflow: "hidden" }
+          "& .MuiDrawer-paper": {
+            boxSizing: "border-box",
+            width: drawerWidth,
+            overflow: "hidden",
+            top: `var(${topBannerHeightCssVar}, 0px)`,
+            height: `calc(100% - var(${topBannerHeightCssVar}, 0px))`
+          }
         }}
         PaperProps={{
           sx: {

--- a/apps/provider-console/src/components/layout/Sidebar.tsx
+++ b/apps/provider-console/src/components/layout/Sidebar.tsx
@@ -25,7 +25,6 @@ import getConfig from "next/config";
 import Image from "next/image";
 import Link from "next/link";
 
-import { useProvider } from "@src/context/ProviderContext";
 import type { ISidebarGroupMenu } from "@src/types";
 import { closedDrawerWidth, drawerWidth } from "@src/utils/constants";
 import { cn } from "@src/utils/styleUtils";
@@ -48,8 +47,6 @@ type Props = {
 
 export const Sidebar: React.FC<Props> = ({ isMobileOpen, handleDrawerToggle, isNavOpen, onOpenMenuClick }) => {
   const [isHovering, setIsHovering] = useState(false);
-
-  const { providerDetails, isLoadingProviderDetails, isOnline, isLoadingOnlineStatus } = useProvider();
 
   const _isNavOpen = isNavOpen || isHovering;
   const muiTheme = useMuiTheme();
@@ -182,17 +179,6 @@ export const Sidebar: React.FC<Props> = ({ isMobileOpen, handleDrawerToggle, isN
       className="border-muted-foreground/20 bg-popover dark:bg-background box-border flex h-full flex-shrink-0 flex-col items-center justify-between overflow-y-auto overflow-x-hidden border-r-[1px] transition-[width] duration-300 ease-in-out md:h-[calc(100%-57px)]"
     >
       <div className={cn("flex w-full flex-col items-center justify-between", { ["p-2"]: _isNavOpen, ["pb-2 pt-2"]: !_isNavOpen })}>
-        {(isLoadingProviderDetails || isLoadingOnlineStatus) && (!providerDetails || !isOnline) && (
-          <Link
-            className={cn(buttonVariants({ variant: "default", size: _isNavOpen ? "lg" : "icon" }), "h-[45px] w-full leading-4", {
-              ["h-[45px] w-[45px] min-w-0 pb-2 pt-2"]: !_isNavOpen
-            })}
-            href="/become-provider"
-          >
-            {_isNavOpen && "Create Provider "}
-          </Link>
-        )}
-
         {routeGroups.map((g, i) => (
           <SidebarGroupMenu key={i} group={g} hasDivider={g.hasDivider} isNavOpen={_isNavOpen} />
         ))}

--- a/apps/provider-console/src/components/layout/Sidebar.tsx
+++ b/apps/provider-console/src/components/layout/Sidebar.tsx
@@ -176,7 +176,7 @@ export const Sidebar: React.FC<Props> = ({ isMobileOpen, handleDrawerToggle, isN
   const drawer = (
     <div
       style={{ width: _isNavOpen ? drawerWidth : closedDrawerWidth }}
-      className="border-muted-foreground/20 bg-popover dark:bg-background box-border flex h-full flex-shrink-0 flex-col items-center justify-between overflow-y-auto overflow-x-hidden border-r-[1px] transition-[width] duration-300 ease-in-out md:h-[calc(100%-57px)]"
+      className="border-muted-foreground/20 bg-popover dark:bg-background box-border flex h-full flex-shrink-0 flex-col items-center justify-between overflow-y-auto overflow-x-hidden border-r-[1px] transition-[width] duration-300 ease-in-out md:h-[calc(100%_-_57px_-_var(--top-banner-height,0px))]"
     >
       <div className={cn("flex w-full flex-col items-center justify-between", { ["p-2"]: _isNavOpen, ["pb-2 pt-2"]: !_isNavOpen })}>
         {routeGroups.map((g, i) => (
@@ -294,10 +294,13 @@ export const Sidebar: React.FC<Props> = ({ isMobileOpen, handleDrawerToggle, isN
         onMouseEnter={onDrawerHover}
         onMouseLeave={() => setIsHovering(false)}
         PaperProps={{
-          className: cn("border-none ease z-[1000] bg-header/95 transition-[width] duration-300 box-border overflow-hidden mt-[57px]", {
-            ["md:w-[240px]"]: _isNavOpen,
-            ["md:w-[57px]"]: !_isNavOpen
-          })
+          className: cn(
+            "border-none ease z-[1000] bg-header/95 transition-[width] duration-300 box-border overflow-hidden mt-[calc(57px_+_var(--top-banner-height,0px))]",
+            {
+              ["md:w-[240px]"]: _isNavOpen,
+              ["md:w-[57px]"]: !_isNavOpen
+            }
+          )
         }}
         open
       >

--- a/apps/provider-console/src/pages/remedies/index.tsx
+++ b/apps/provider-console/src/pages/remedies/index.tsx
@@ -2,8 +2,7 @@
 
 import React, { useState } from "react";
 import { Button, Card, Separator, Tabs, TabsContent, TabsList, TabsTrigger } from "@akashnetwork/ui/components";
-import { ArrowRight, Globe, RefreshCircle, Server, ShieldAlert } from "iconoir-react";
-import { useAtom } from "jotai";
+import { Globe, RefreshCircle, Server, ShieldAlert } from "iconoir-react";
 import { useRouter } from "next/router";
 
 import { ProviderHealthCheck } from "@src/components/dashboard/ProviderHealthCheck";
@@ -14,13 +13,11 @@ import { useControlMachine } from "@src/context/ControlMachineProvider";
 import { useSelectedChain } from "@src/context/CustomChainProvider";
 import { useProvider } from "@src/context/ProviderContext";
 import { useProviderDetails } from "@src/queries/useProviderQuery";
-import providerProcessStore from "@src/store/providerProcessStore";
 
 const Remedies: React.FC = () => {
   const router = useRouter();
   const [activeTab, setActiveTab] = useState("general");
   const [isChecking, setIsChecking] = useState(false);
-  const [, resetProviderProcess] = useAtom(providerProcessStore.resetProviderProcess);
   const { address } = useSelectedChain();
   const { isOnline } = useProvider();
   const { activeControlMachine } = useControlMachine();
@@ -35,11 +32,6 @@ const Remedies: React.FC = () => {
     const hostMatch = providerDetails.hostUri.match(/provider\.([^:/]+)/);
     return hostMatch?.[1] || "";
   })();
-
-  const handleBecomeProvider = () => {
-    resetProviderProcess();
-    router.push("/become-provider");
-  };
 
   const checkProviderStatus = async () => {
     setIsChecking(true);
@@ -105,12 +97,6 @@ const Remedies: React.FC = () => {
                   <li>Provider services may take up to 1 hour to fully initialize</li>
                 </ul>
               </div>
-            </div>
-
-            <div className="mt-6">
-              <Button onClick={handleBecomeProvider} className="flex items-center gap-2">
-                Restart Provider Build <ArrowRight className="h-4 w-4" />
-              </Button>
             </div>
           </Card>
         </TabsContent>

--- a/apps/provider-console/src/styles/index.css
+++ b/apps/provider-console/src/styles/index.css
@@ -1,14 +1,14 @@
 
 
 html {
-  scroll-padding-top: 57px;
+  scroll-padding-top: calc(57px + var(--top-banner-height, 0px));
   -webkit-font-smoothing: auto;
   height: 100%;
   width: 100%;
 }
 
 body {
-  height: calc(100% - 57px) !important;
+  height: calc(100% - 57px - var(--top-banner-height, 0px)) !important;
   width: 100%;
   padding: 0 !important;
 }

--- a/apps/provider-console/src/utils/constants.ts
+++ b/apps/provider-console/src/utils/constants.ts
@@ -16,6 +16,7 @@ export const statusBarHeight = 30;
 export const drawerWidth = 240;
 export const closedDrawerWidth = 57;
 export const accountBarHeight = 57;
+export const topBannerHeightCssVar = "--top-banner-height";
 
 export const isProd = process.env.NODE_ENV === "production";
 export const isMaintenanceMode = process.env.MAINTENANCE_MODE === "true";


### PR DESCRIPTION
## Why

Provider creation and build through Provider Console needs to be paused temporarily. Users must not be able to start or resume a provider build from the UI, and should be pointed to the Provider Playbook instead.

Refs AKHN-441

## What

In `apps/provider-console`:

- Removed the `/become-provider` route. The wizard is preserved as `components/become-provider/BecomeProvider.tsx` so it can be re-mounted as a page later.
- Removed the "Create Provider" button from the sidebar and from the Get Started stepper.
- Removed the "Restart Provider Build" button from the remedies page.
- Added a fixed banner above the header on every page: "Provider builds are disabled in Provider Console. Use the Provider Playbook to build providers. Provider Console remains available for dashboards and management." The banner publishes its height as a `--top-banner-height` CSS variable, and the header, sidebar drawer, and body offsets add it to the existing 57px header offset.
- Added `docs/provider-builds-disabled.md` (linked from the app README) describing what was removed, what was kept, and how to re-enable builds.

No feature flag. Re-enabling means adding back `pages/become-provider/index.tsx` exporting `withAuth({ WrappedComponent: BecomeProvider, authLevel: "wallet" })`, restoring the three buttons, and removing the banner.

Out of scope: `provider-console-api` (separate repo). The `/build-provider` endpoint is not blocked server-side.

## Test plan

- [x] `/become-provider` returns 404
- [x] Sidebar shows no "Create Provider" button
- [x] Get Started final step shows only "Reset"
- [x] Remedies page General tab has no "Restart Provider Build" button
- [x] Banner shows above the header on every page, header/sidebar/content offset correctly, Playbook link opens in a new tab
- [x] `npm run test:unit`, `npm run lint -- --quiet` pass in `apps/provider-console`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent banner informing users that provider creation and builds are unavailable in Provider Console.
  * Added a link to the Provider Playbook for alternative provider-building guidance.
  * Updated page layout and navigation spacing to accommodate the banner.

* **Changes**
  * Removed provider creation links and the provider build restart flow from onboarding, navigation, and troubleshooting areas.

* **Documentation**
  * Added guidance explaining the disabled provider-building workflow and how to proceed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->