### PR TITLE
fix(deployment): give the record-setting queue the exclusive policy its comment promised

### DIFF
--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.integration.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.integration.ts
@@ -40,6 +40,16 @@ describe(RecordDeploymentSettingHandler.name, () => {
     expect(settings[0]).toMatchObject({ autoTopUpEnabled: false, runtimeLimitHours: 12 });
   });
 
+  it("refuses a second record for the same deployment while the first is still queued", async () => {
+    const { enqueueRecord } = await setup();
+
+    const first = await enqueueRecord();
+    const second = await enqueueRecord();
+
+    expect(first).toEqual(expect.any(String));
+    expect(second).toBeNull();
+  });
+
   async function setup() {
     const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
     const deploymentSettingsTable = resolveTable("DeploymentSettings");

--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.spec.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.spec.ts
@@ -49,6 +49,12 @@ describe(RecordDeploymentSettingHandler.name, () => {
     expect(createLogger).toHaveBeenCalledWith({ context: RecordDeploymentSettingHandler.name });
   });
 
+  it("declares the exclusive policy, so a retried broadcast of the same create enqueues one job across queued, retrying and running", () => {
+    const { handler } = setup({});
+
+    expect(handler.policy).toBe("exclusive");
+  });
+
   it("declares no permissions for its execution", () => {
     const { handler } = setup({});
 

--- a/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
+++ b/apps/api/src/deployment/services/record-deployment-setting/record-deployment-setting.handler.ts
@@ -26,8 +26,8 @@ export function recordDeploymentSettingKeyFor({ userId, dseq }: { userId: string
 export class RecordDeploymentSettingHandler implements JobHandler<RecordDeploymentSetting> {
   public readonly accepts = RecordDeploymentSetting;
 
-  /** Gives the command's per-deployment singletonKey its meaning: without it the key is inert and a retried broadcast queues a second job. */
-  public readonly policy = "singleton";
+  /** One record per deployment across queued, retrying and running, so a retried broadcast of the same create enqueues nothing new; pg-boss's `singleton` only caps the running ones. */
+  public readonly policy = "exclusive";
 
   private readonly logger: ReturnType<CreateLogger>;
 


### PR DESCRIPTION
## Why

Related to CON-923.

`RecordDeploymentSettingHandler` declared pg-boss's `singleton` policy while its comment promised that a retried broadcast of the same create enqueues one job, not two. `singleton` only caps running jobs, so two such broadcasts inside the same window both queued. The handler is idempotent, so the duplicate cost a job and a query rather than a wrong row, which is why #3838 left it alone.

## What

The handler now declares `exclusive`, one job per key across queued, retrying and running. The boot-time policy convergence from #3838 rewrites the live queue from `singleton` to `exclusive` on the first pod start; jobs already queued under the old policy keep their own `policy` column and finish normally.

An integration case enqueues the same deployment twice against real pg-boss and expects the second enqueue to be refused.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Updates**
  - Prevented duplicate deployment-setting jobs for the same deployment while an existing job is queued, retrying, or running.

- **Tests**
  - Added coverage confirming duplicate jobs are rejected and that the initial job is accepted.
  - Added verification for the updated job execution policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->