### PR TITLE
fix(deployment): refuse a create before recording the settings row its refusal would strand

### DIFF
--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -1010,7 +1010,7 @@ describe(ManagedSignerService.name, () => {
     it("throws 404 when the wallet is missing", async () => {
       const { service } = setup({ findOneByUserId: vi.fn().mockResolvedValue(null) });
 
-      await expect(service.assertCanBroadcast("user-123", [])).rejects.toThrow("UserWallet Not Found");
+      await expect(service.assertCanBroadcast("user-123", [])).rejects.toMatchObject({ status: 404, message: "UserWallet Not Found" });
     });
   });
 

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -962,6 +962,58 @@ describe(ManagedSignerService.name, () => {
     });
   });
 
+  describe("assertCanBroadcast", () => {
+    it("refuses a create the deployment allowance cannot cover, without broadcasting", async () => {
+      const { service, txManagerService, logger } = setupForCreate({ deploymentLimit: 400000 });
+
+      await expect(service.assertCanBroadcast("user-123", [createDeploymentMessage(500000)])).rejects.toMatchObject({ status: 402 });
+
+      expect(txManagerService.signAndBroadcastWithDerivedWallet).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPLOYMENT_CREATE_REFUSED_INSUFFICIENT_ALLOWANCE", requiredDeposit: 500000 }));
+    });
+
+    it("remembers the refusal, so the broadcast that would have followed is refused from the cache", async () => {
+      const { service, balancesService } = setupForCreate({ deploymentLimit: 400000 });
+      await expect(service.assertCanBroadcast("user-123", [createDeploymentMessage(500000)])).rejects.toMatchObject({ status: 402 });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [createDeploymentMessage(500000)])).rejects.toMatchObject({ status: 402 });
+
+      expect(balancesService.retrieveDeploymentLimit).toHaveBeenCalledTimes(1);
+    });
+
+    it("refuses a spend the wallet is not yet activated for", async () => {
+      const { service, trialActivationJobService, txManagerService } = setupForCreate({ deploymentLimit: 500000 });
+      trialActivationJobService.assertActivated.mockRejectedValue(createError(409, "provisioning", { errorCode: "wallet_provisioning" }));
+
+      await expect(service.assertCanBroadcast("user-123", [createDeploymentMessage(500000)])).rejects.toMatchObject({ status: 409 });
+
+      expect(txManagerService.signAndBroadcastWithDerivedWallet).not.toHaveBeenCalled();
+    });
+
+    it("lets a create the allowance covers through and broadcasts nothing", async () => {
+      const { service, txManagerService, balancesService } = setupForCreate({ deploymentLimit: 500000 });
+
+      await service.assertCanBroadcast("user-123", [createDeploymentMessage(500000)]);
+
+      expect(txManagerService.signAndBroadcastWithDerivedWallet).not.toHaveBeenCalled();
+      expect(balancesService.refreshUserWalletLimits).not.toHaveBeenCalled();
+    });
+
+    it("reads the wallet with the sign ability, as the broadcast does", async () => {
+      const { service, userWalletRepository, authService } = setupForCreate({ deploymentLimit: 500000 });
+
+      await service.assertCanBroadcast("user-123", [createDeploymentMessage(500000)]);
+
+      expect(userWalletRepository.accessibleBy).toHaveBeenCalledWith(authService.ability, "sign");
+    });
+
+    it("throws 404 when the wallet is missing", async () => {
+      const { service } = setup({ findOneByUserId: vi.fn().mockResolvedValue(null) });
+
+      await expect(service.assertCanBroadcast("user-123", [])).rejects.toThrow("UserWallet Not Found");
+    });
+  });
+
   describe("executeDerivedEncodedTxByUserId", () => {
     it("executes transaction and calls scheduleImmediate when transaction contains MsgCreateDeployment", async () => {
       const wallet = createUserWallet({

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -103,12 +103,22 @@ export class ManagedSignerService {
     transactionHash: string;
     rawLog: string;
   }> {
+    return this.executeDecodedTxByUserWallet(await this.#findSigningWallet(userId), messages);
+  }
+
+  /** Every refusal the broadcast would raise before signing, for a caller that must not record anything a refusal would strand. */
+  @Trace()
+  async assertCanBroadcast(userId: UserWalletOutput["userId"], messages: EncodeObject[]): Promise<void> {
+    await this.#assertBroadcastable(await this.#findSigningWallet(userId), messages);
+  }
+
+  async #findSigningWallet(userId: UserWalletOutput["userId"]): Promise<UserWalletOutput> {
     assert(userId, 404, "User Not Found");
 
     const userWallet = await this.userWalletRepository.accessibleBy(this.authService.ability, "sign").findOneByUserId(userId);
     assert(userWallet, 404, "UserWallet Not Found");
 
-    return this.executeDecodedTxByUserWallet(userWallet, messages);
+    return userWallet;
   }
 
   @Trace()
@@ -121,16 +131,7 @@ export class ManagedSignerService {
     transactionHash: string;
     rawLog: string;
   }> {
-    await this.#assertActivatedForSpending(userWallet, messages);
-    await this.#validateBalances(userWallet, messages);
-    await Promise.all([
-      this.anonymousValidateService.validateLeaseProvidersAuditors(messages, userWallet),
-      this.anonymousValidateService.validateDeploymentGpuModels(messages, userWallet),
-      this.anonymousValidateService.validateDeploymentGpuInterconnect(messages, userWallet),
-      this.anonymousValidateService.validateDeploymentResources(messages, userWallet),
-      this.anonymousValidateService.validateLeaseGpuModels(messages, userWallet),
-      this.anonymousValidateService.validateFairUsePolicyAccepted(messages, userWallet)
-    ]);
+    await this.#assertBroadcastable(userWallet, messages);
 
     const createLeaseMessage: { typeUrl: string; value: MsgCreateLease } | undefined = messages.find(message => message.typeUrl.endsWith(".MsgCreateLease"));
     const hasCreateTrialLeaseMessage = userWallet.isTrialing && !!createLeaseMessage;
@@ -251,6 +252,19 @@ export class ManagedSignerService {
 
   #hasSpendingTx(messages: EncodeObject[]): boolean {
     return messages.some(message => SPENDING_TXS.some(msg => message.typeUrl.endsWith(msg.$type)));
+  }
+
+  async #assertBroadcastable(userWallet: UserWalletOutput, messages: EncodeObject[]): Promise<void> {
+    await this.#assertActivatedForSpending(userWallet, messages);
+    await this.#validateBalances(userWallet, messages);
+    await Promise.all([
+      this.anonymousValidateService.validateLeaseProvidersAuditors(messages, userWallet),
+      this.anonymousValidateService.validateDeploymentGpuModels(messages, userWallet),
+      this.anonymousValidateService.validateDeploymentGpuInterconnect(messages, userWallet),
+      this.anonymousValidateService.validateDeploymentResources(messages, userWallet),
+      this.anonymousValidateService.validateLeaseGpuModels(messages, userWallet),
+      this.anonymousValidateService.validateFairUsePolicyAccepted(messages, userWallet)
+    ]);
   }
 
   /**

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.integration.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.integration.ts
@@ -199,6 +199,7 @@ describe(DeploymentWriterService.name, () => {
     const broadcast = vi
       .spyOn(container.resolve(ManagedSignerService), "executeDerivedDecodedTxByUserId")
       .mockResolvedValue({ code: 0, transactionHash: "tx-hash", hash: "tx-hash", rawLog: "" });
+    vi.spyOn(container.resolve(ManagedSignerService), "assertCanBroadcast").mockResolvedValue(undefined);
 
     const { user } = await seedUserWithWallet();
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -253,7 +253,9 @@ describe(DeploymentWriterService.name, () => {
 
       expect(signerService.assertCanBroadcast).toHaveBeenCalledWith("user-1", [createMsg]);
       expect(signerService.assertCanBroadcast.mock.invocationCallOrder[0]).toBeLessThan(sdlSecretsService.sealForStorage.mock.invocationCallOrder[0]);
-      expect(signerService.assertCanBroadcast.mock.invocationCallOrder[0]).toBeLessThan(deploymentSettingRepository.upsertDefinition.mock.invocationCallOrder[0]);
+      expect(signerService.assertCanBroadcast.mock.invocationCallOrder[0]).toBeLessThan(
+        deploymentSettingRepository.upsertDefinition.mock.invocationCallOrder[0]
+      );
     });
 
     it("records nothing and seals nothing when the signer refuses the create", async () => {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -244,6 +244,30 @@ describe(DeploymentWriterService.name, () => {
       expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledWith("user-1", [createMsg]);
     });
 
+    it("asks the signer whether the create can be broadcast before sealing or recording anything", async () => {
+      const { service, signerService, rpcMessageService, sdlSecretsService, deploymentSettingRepository } = setup();
+      const createMsg = { typeUrl: "/create", value: MsgCreateDeployment.fromPartial({}) };
+      rpcMessageService.getCreateDeploymentMsg.mockReturnValue(createMsg);
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(signerService.assertCanBroadcast).toHaveBeenCalledWith("user-1", [createMsg]);
+      expect(signerService.assertCanBroadcast.mock.invocationCallOrder[0]).toBeLessThan(sdlSecretsService.sealForStorage.mock.invocationCallOrder[0]);
+      expect(signerService.assertCanBroadcast.mock.invocationCallOrder[0]).toBeLessThan(deploymentSettingRepository.upsertDefinition.mock.invocationCallOrder[0]);
+    });
+
+    it("records nothing and seals nothing when the signer refuses the create", async () => {
+      const { service, signerService, sdlSecretsService, deploymentSettingRepository, jobQueueService } = setup();
+      signerService.assertCanBroadcast.mockRejectedValue(createError(402, "Not enough balance to cover the deployment deposit."));
+
+      await expect(service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 })).rejects.toMatchObject({ status: 402 });
+
+      expect(sdlSecretsService.sealForStorage).not.toHaveBeenCalled();
+      expect(deploymentSettingRepository.upsertDefinition).not.toHaveBeenCalled();
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+    });
+
     it("throws 400 when SDL is invalid", async () => {
       const { service, sdlService } = setup();
       sdlService.generateResolvedManifest.mockReturnValue({

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -894,6 +894,15 @@ describe(DeploymentWriterService.name, () => {
       expect(loggedTextOf(logger)).not.toContain("API_TOKEN");
     });
 
+    it("reclaims a trial wallet's orphans before asking whether the create can be broadcast, so the freed allowance counts", async () => {
+      const { service, staleDeploymentsCleaner, signerService, walletReaderService } = setup();
+      walletReaderService.getWalletByUserId.mockResolvedValue({ ...wallet, isTrialing: true });
+
+      await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
+
+      expect(staleDeploymentsCleaner.cleanUpForWallet.mock.invocationCallOrder[0]).toBeLessThan(signerService.assertCanBroadcast.mock.invocationCallOrder[0]);
+    });
+
     it("reclaims trial orphans with age 0 before signing the create when the wallet is trialing", async () => {
       const { service, staleDeploymentsCleaner, signerService, walletReaderService } = setup();
       walletReaderService.getWalletByUserId.mockResolvedValue({ ...wallet, isTrialing: true });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -129,13 +129,13 @@ export class DeploymentWriterService {
       reclamation: manifest.reclamation
     });
 
-    await this.signerService.assertCanBroadcast(wallet.userId, [message]);
-
-    const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: stored });
-
     if (wallet.isTrialing) {
       await this.reclaimTrialOrphanedDeployments(wallet);
     }
+
+    await this.signerService.assertCanBroadcast(wallet.userId, [message]);
+
+    const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: stored });
 
     await this.recordDefinitionWithCompensation({
       userId: wallet.userId,
@@ -308,11 +308,11 @@ export class DeploymentWriterService {
   /**
    * Reclaims escrow from a trial wallet's orphaned (open, lease-less) deployments before a new create, so a stranded
    * trial user whose earlier close failed can deploy again without waiting for the periodic cleanup job. It runs
-   * before the create tx so the freed deployment allowance is available when the create's balance check runs.
+   * before the signer's pre-flight so the freed deployment allowance is available when the balance check runs.
    * Best-effort: a cleanup failure never blocks the create, which then proceeds and may 402 exactly as it would today.
    * Age 0 also closes an actively-quoting lease-less deployment of the same trial user, acceptable since a trial
-   * balance cannot fund two deployments at once — but only because every way this request can still be refused has
-   * already been tried. Nothing that can reject the caller may be added below this line.
+   * balance cannot fund two deployments at once — but only because every way the submitted document can be refused
+   * has already been tried. Nothing that can reject the document may be added below this line.
    */
   private async reclaimTrialOrphanedDeployments(wallet: WalletInitialized): Promise<void> {
     try {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -119,6 +119,18 @@ export class DeploymentWriterService {
     const dseq = Date.now().toString();
     const { manifestVersion, manifest } = await this.#resolveSdl(input.sdl, { secrets: { ...inherited, ...supplied }, isTrialing: !!wallet.isTrialing });
     const unresolvedManifest = await this.#unresolvedManifestOf(input.sdl);
+    const message = this.rpcMessageService.getCreateDeploymentMsg({
+      owner: wallet.address,
+      dseq,
+      groups: manifest.groupSpecs,
+      denom: this.billingConfig.get("DEPLOYMENT_GRANT_DENOM"),
+      amount: denomToUdenom(depositInDollars),
+      hash: manifestVersion,
+      reclamation: manifest.reclamation
+    });
+
+    await this.signerService.assertCanBroadcast(wallet.userId, [message]);
+
     const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: stored });
 
     if (wallet.isTrialing) {
@@ -133,16 +145,6 @@ export class DeploymentWriterService {
       manifestVersion,
       sealedSecrets,
       runtimeLimitHours: input.runtimeLimitHours
-    });
-
-    const message = this.rpcMessageService.getCreateDeploymentMsg({
-      owner: wallet.address,
-      dseq,
-      groups: manifest.groupSpecs,
-      denom: this.billingConfig.get("DEPLOYMENT_GRANT_DENOM"),
-      amount: denomToUdenom(depositInDollars),
-      hash: manifestVersion,
-      reclamation: manifest.reclamation
     });
 
     const result = await this.signerService.executeDerivedDecodedTxByUserId(wallet.userId, [message]);

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -114,6 +114,7 @@ describe("Deployment sealed secrets", () => {
       hash: "fake-transaction-hash",
       rawLog: "fake-raw-log"
     });
+    vi.spyOn(signerService, "assertCanBroadcast").mockResolvedValue(undefined);
     kmsClient.asymmetricDecrypt.mockClear();
   });
 

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -1,6 +1,6 @@
 import { manifestToSortedJSON } from "@akashnetwork/chain-sdk";
 import { faker } from "@faker-js/faker";
-import { NotFound } from "http-errors";
+import createError, { NotFound } from "http-errors";
 import nock from "nock";
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
@@ -116,6 +116,8 @@ describe("Deployments API", () => {
       hash: "fake-transaction-hash",
       rawLog: "fake-raw-log"
     });
+
+    vi.spyOn(signerService, "assertCanBroadcast").mockResolvedValue(undefined);
 
     vi.spyOn(providerService, "sendManifest").mockResolvedValue(true);
     vi.spyOn(providerService, "getLeaseStatus").mockResolvedValue(createLeaseStatus());
@@ -622,6 +624,24 @@ describe("Deployments API", () => {
           rawLog: expect.any(String)
         }
       });
+    });
+
+    it("records nothing for a create the signer refuses", async () => {
+      const { user, userApiKeySecret } = await mockPersistedUser();
+      const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
+      vi.mocked(signerService.assertCanBroadcast).mockRejectedValue(
+        createError(402, "Not enough balance to cover the deployment deposit.", { headers: { "Retry-After": "300" } })
+      );
+
+      const response = await app.request("/v1/deployments", {
+        method: "POST",
+        body: JSON.stringify({ data: { sdl: yml, deposit: 5.5 } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(402);
+      expect(await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id })).toBeUndefined();
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
     });
 
     it("returns 401 for an unauthenticated request", async () => {


### PR DESCRIPTION
## Why

Related to CON-923.

A create records its settings row, seals its secrets through KMS and enqueues its compensation before the signer runs the checks that can refuse the broadcast. On prod about 270 creates per half hour are refused with a 402 for insufficient deposit balance (the zero-balance retry loop), and each one still went through all three steps, leaving a row the compensation deletes an hour later. That is about 13k row writes and deletes a day for deployments that never had a chance, and since #3838 it is most of what `closed_deployments_reconcile_rows_without_chain_state_total` measures.

## What

`ManagedSignerService.assertCanBroadcast` runs every refusal the broadcast raises before signing: wallet activation (409), fee and deposit allowance (402, through the same refusal cache and with the same `Retry-After`), and the trial validations. The broadcast path is unchanged and still runs them itself.

`DeploymentWriterService.create` calls it as soon as the create message can be built, before sealing, before the trial reclaim and before recording. A refused create now writes nothing. A successful create pays two extra light chain reads (fee grant and deployment allowance are read once by the pre-flight and once by the broadcast).

The functional and integration suites that create deployments stub the pre-flight next to the broadcast stub they already had, and a new functional case drives a refused create end to end and checks that no row is left behind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment requests now undergo broadcast eligibility checks before secrets are sealed or deployment details are saved.
  * Successful checks continue through the normal deployment and transaction process.

* **Bug Fixes**
  * Prevented deployments from creating partial records or processing secrets when wallet balance or activation validation fails.
  * Deployment requests rejected during eligibility checks now return an appropriate payment-required response without recording a transaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->