### PR TITLE
feat(user): show the fair use policy as a step during onboarding

### DIFF
--- a/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyContent/FairUsePolicyContent.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyContent/FairUsePolicyContent.tsx
@@ -1,0 +1,42 @@
+"use client";
+import type { ComponentType } from "react";
+import { Ban, Coins, Copyright, CreditCard, Mail, ShieldAlert } from "lucide-react";
+import Link from "next/link";
+
+import { UrlService } from "@src/utils/urlUtils";
+
+export const FAIR_USE_POLICY_TITLE = "Review and accept our Fair Use Policy before you deploy on Akash Console";
+export const FAIR_USE_POLICY_ACCEPT_LABEL = "I agree to the Fair Use Policy";
+
+const PROHIBITED_WORKLOADS: { label: string; Icon: ComponentType<{ className?: string }> }[] = [
+  { label: "Crypto miners", Icon: Coins },
+  { label: "Phishing", Icon: ShieldAlert },
+  { label: "Card fraud & testing", Icon: CreditCard },
+  { label: "Spam", Icon: Mail },
+  { label: "Pirated content", Icon: Copyright },
+  { label: "Anything illegal", Icon: Ban }
+];
+
+export function FairUsePolicyContent() {
+  return (
+    <div className="space-y-4">
+      <p className="text-sm font-medium text-destructive">Hosting or distributing any of the following will permanently close your account.</p>
+      <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {PROHIBITED_WORKLOADS.map(({ label, Icon }) => (
+          <li key={label} className="flex items-center gap-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm">
+            <Icon className="h-4 w-4 shrink-0 text-destructive" />
+            <span>{label}</span>
+          </li>
+        ))}
+      </ul>
+      <p className="text-sm text-muted-foreground">
+        Akash Console is for building and deploying software. We do not allow the kind of resource abuse that degrades the network for everyone else. The full
+        list of prohibited uses is in section 7 of the{" "}
+        <Link href={UrlService.prohibitedUse()} target="_blank" className="underline">
+          Terms of Service
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}

--- a/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal.tsx
@@ -1,24 +1,16 @@
 "use client";
-import type { ComponentType } from "react";
 import { Popup } from "@akashnetwork/ui/components";
-import { Ban, Coins, Copyright, CreditCard, Mail, ShieldAlert } from "lucide-react";
-import Link from "next/link";
 
-import { UrlService } from "@src/utils/urlUtils";
+import {
+  FAIR_USE_POLICY_ACCEPT_LABEL,
+  FAIR_USE_POLICY_TITLE,
+  FairUsePolicyContent
+} from "@src/components/fair-use-policy/FairUsePolicyContent/FairUsePolicyContent";
 
 type Props = {
   onAccept: () => void;
   isAccepting: boolean;
 };
-
-const PROHIBITED_WORKLOADS: { label: string; Icon: ComponentType<{ className?: string }> }[] = [
-  { label: "Crypto miners", Icon: Coins },
-  { label: "Phishing", Icon: ShieldAlert },
-  { label: "Card fraud & testing", Icon: CreditCard },
-  { label: "Spam", Icon: Mail },
-  { label: "Pirated content", Icon: Copyright },
-  { label: "Anything illegal", Icon: Ban }
-];
 
 export function FairUsePolicyModal({ onAccept, isAccepting }: Props) {
   return (
@@ -28,11 +20,11 @@ export function FairUsePolicyModal({ onAccept, isAccepting }: Props) {
       hideCloseButton
       maxWidth="sm"
       variant="custom"
-      title="Review and accept our Fair Use Policy before you deploy on Akash Console"
+      title={FAIR_USE_POLICY_TITLE}
       testId="fair-use-policy-modal"
       actions={[
         {
-          label: "I agree to the Fair Use Policy",
+          label: FAIR_USE_POLICY_ACCEPT_LABEL,
           side: "right",
           color: "primary",
           className: "w-full",
@@ -43,25 +35,7 @@ export function FairUsePolicyModal({ onAccept, isAccepting }: Props) {
         }
       ]}
     >
-      <div className="space-y-4">
-        <p className="text-sm font-medium text-destructive">Hosting or distributing any of the following will permanently close your account.</p>
-        <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-          {PROHIBITED_WORKLOADS.map(({ label, Icon }) => (
-            <li key={label} className="flex items-center gap-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm">
-              <Icon className="h-4 w-4 shrink-0 text-destructive" />
-              <span>{label}</span>
-            </li>
-          ))}
-        </ul>
-        <p className="text-sm text-muted-foreground">
-          Akash Console is for building and deploying software. We do not allow the kind of resource abuse that degrades the network for everyone else. The full
-          list of prohibited uses is in section 7 of the{" "}
-          <Link href={UrlService.prohibitedUse()} target="_blank" className="underline">
-            Terms of Service
-          </Link>
-          .
-        </p>
-      </div>
+      <FairUsePolicyContent />
     </Popup>
   );
 }

--- a/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyStep/FairUsePolicyStep.spec.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyStep/FairUsePolicyStep.spec.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./FairUsePolicyStep";
+import { FairUsePolicyStep } from "./FairUsePolicyStep";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+describe(FairUsePolicyStep.name, () => {
+  it("lists the prohibited workloads and accepts on the single action", () => {
+    const { onAccept } = setup({ isAccepting: false });
+
+    fireEvent.click(screen.getByTestId("fair-use-policy-accept-button"));
+
+    expect(screen.getByText("Crypto miners")).toBeInTheDocument();
+    expect(screen.getByText("Anything illegal")).toBeInTheDocument();
+    expect(onAccept).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the action while the acceptance is in flight", () => {
+    setup({ isAccepting: true });
+
+    expect(screen.getByTestId("fair-use-policy-accept-button")).toBeDisabled();
+  });
+
+  it("keeps the onboarding chrome above the prompt", () => {
+    setup({ isAccepting: false });
+
+    expect(screen.getByTestId("onboarding-header")).toBeInTheDocument();
+  });
+
+  it("exposes the prompt as a named region rather than a dialog", () => {
+    setup({ isAccepting: false });
+
+    expect(screen.getByRole("region", { name: /fair use policy/i })).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { isAccepting: boolean }) {
+    const onAccept = vi.fn();
+    const dependencies: typeof DEPENDENCIES = {
+      OnboardingHeader: () => <header data-testid="onboarding-header" />
+    };
+
+    render(<FairUsePolicyStep onAccept={onAccept} isAccepting={input.isAccepting} dependencies={dependencies} />);
+
+    return { onAccept };
+  }
+});

--- a/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyStep/FairUsePolicyStep.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/FairUsePolicyStep/FairUsePolicyStep.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { Card, CardContent, LoadingButton } from "@akashnetwork/ui/components";
+
+import {
+  FAIR_USE_POLICY_ACCEPT_LABEL,
+  FAIR_USE_POLICY_TITLE,
+  FairUsePolicyContent
+} from "@src/components/fair-use-policy/FairUsePolicyContent/FairUsePolicyContent";
+import { OnboardingHeader } from "@src/components/layout/OnboardingHeader/OnboardingHeader";
+
+export const DEPENDENCIES = { OnboardingHeader };
+
+type Props = {
+  onAccept: () => void;
+  isAccepting: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+const TITLE_ID = "fair-use-policy-title";
+
+/** The onboarding-flow presentation of the policy prompt: a page of its own rather than a modal over an empty page. */
+export function FairUsePolicyStep({ onAccept, isAccepting, dependencies: d = DEPENDENCIES }: Props) {
+  return (
+    <div className="flex min-h-screen flex-col bg-background">
+      <d.OnboardingHeader />
+
+      <div className="flex flex-1 items-center justify-center px-4 py-8">
+        <section aria-labelledby={TITLE_ID} className="w-full max-w-xl">
+          <Card>
+            <CardContent className="space-y-4 p-6">
+              <h1 id={TITLE_ID} className="text-lg font-semibold leading-snug tracking-tight">
+                {FAIR_USE_POLICY_TITLE}
+              </h1>
+
+              <FairUsePolicyContent />
+
+              <LoadingButton className="w-full" loading={isAccepting} onClick={onAccept} data-testid="fair-use-policy-accept-button">
+                {FAIR_USE_POLICY_ACCEPT_LABEL}
+              </LoadingButton>
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.spec.tsx
@@ -17,6 +17,30 @@ describe(RequireFairUsePolicy.name, () => {
     expect(screen.getByTestId("layout")).toContainElement(screen.getByTestId("fair-use-policy-modal"));
   });
 
+  it("shows the onboarding step instead of the modal while the user is still on the onboarding route", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: null, pathname: "/onboarding" });
+
+    expect(screen.queryByText("child")).not.toBeInTheDocument();
+    expect(screen.getByTestId("fair-use-policy-step")).toBeInTheDocument();
+    expect(screen.queryByTestId("fair-use-policy-modal")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("layout")).not.toBeInTheDocument();
+  });
+
+  it("accepts the policy when the onboarding step action is used", () => {
+    const { accept } = setup({ userId: "u1", fairUsePolicyAcceptedAt: null, pathname: "/onboarding" });
+
+    fireEvent.click(screen.getByTestId("fair-use-policy-accept-button"));
+
+    expect(accept).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders only the page on the onboarding route once the user has accepted", () => {
+    setup({ userId: "u1", fairUsePolicyAcceptedAt: ACCEPTED_AT, pathname: "/onboarding" });
+
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.queryByTestId("fair-use-policy-step")).not.toBeInTheDocument();
+  });
+
   it("demands acceptance before the trial wallet exists", () => {
     setup({ userId: "u1", fairUsePolicyAcceptedAt: null, isTrialing: false, hasWallet: false });
 
@@ -80,6 +104,7 @@ describe(RequireFairUsePolicy.name, () => {
   function setup(input: {
     userId?: string;
     fairUsePolicyAcceptedAt?: string | null;
+    pathname?: string;
     isPublic?: boolean;
     loggedOut?: boolean;
     isTrialing?: boolean;
@@ -105,7 +130,15 @@ describe(RequireFairUsePolicy.name, () => {
         }),
       useFlag: flag => flag === "fair_use_policy_gate" && (input.isGateEnabled ?? true),
       useAcceptFairUsePolicy: () => ({ accept, isAccepting: false, hasAccepted: input.hasAccepted ?? false }),
+      usePathname: () => input.pathname ?? "/deployments",
       Layout: ({ children }) => <div data-testid="layout">{children}</div>,
+      FairUsePolicyStep: ({ onAccept }) => (
+        <div data-testid="fair-use-policy-step">
+          <button data-testid="fair-use-policy-accept-button" onClick={onAccept}>
+            agree
+          </button>
+        </div>
+      ),
       FairUsePolicyModal: ({ onAccept }) => (
         <div data-testid="fair-use-policy-modal">
           <button data-testid="fair-use-policy-accept-button" onClick={onAccept}>

--- a/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
+++ b/apps/deploy-web/src/components/fair-use-policy/RequireFairUsePolicy/RequireFairUsePolicy.tsx
@@ -1,20 +1,25 @@
 "use client";
 import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
 
 import { FairUsePolicyModal } from "@src/components/fair-use-policy/FairUsePolicyModal/FairUsePolicyModal";
+import { FairUsePolicyStep } from "@src/components/fair-use-policy/FairUsePolicyStep/FairUsePolicyStep";
 import Layout from "@src/components/layout/Layout";
 import { useWallet } from "@src/context/WalletProvider";
 import { useAcceptFairUsePolicy } from "@src/hooks/useAcceptFairUsePolicy";
 import { useFlag } from "@src/hooks/useFlag";
 import { useUser } from "@src/hooks/useUser";
+import { UrlService } from "@src/utils/urlUtils";
 
 export const DEPENDENCIES = {
   useUser,
   useWallet,
   useFlag,
   useAcceptFairUsePolicy,
+  usePathname,
   Layout,
-  FairUsePolicyModal
+  FairUsePolicyModal,
+  FairUsePolicyStep
 };
 
 type Props = {
@@ -24,16 +29,22 @@ type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-/** Holds the page back until acceptance, so an auto-started deployment cannot fire behind the modal, and renders the shell the withheld page would have. */
+/** Holds the page back until acceptance, so an auto-started deployment cannot fire behind the prompt. */
 export function RequireFairUsePolicy({ children, isPublic, dependencies: d = DEPENDENCIES }: Props) {
   const { user } = d.useUser();
   const { isTrialing, hasWallet, isWalletLookupFailed } = d.useWallet();
   const isGateEnabled = d.useFlag("fair_use_policy_gate");
   const { accept, isAccepting, hasAccepted } = d.useAcceptFairUsePolicy();
+  /** Only a user who has never deployed can reach the onboarding route, so there the prompt belongs in the page flow rather than over it. */
+  const isOnboardingRoute = d.usePathname() === UrlService.onboardingPicker();
   const isAwaitingTrialWallet = !hasWallet && !isWalletLookupFailed;
   const mustAccept = !isPublic && isGateEnabled && (isTrialing || isAwaitingTrialWallet) && !!user?.userId && !user.fairUsePolicyAcceptedAt && !hasAccepted;
 
   if (mustAccept) {
+    if (isOnboardingRoute) {
+      return <d.FairUsePolicyStep onAccept={accept} isAccepting={isAccepting} />;
+    }
+
     return (
       <d.Layout>
         <d.FairUsePolicyModal onAccept={accept} isAccepting={isAccepting} />

--- a/apps/deploy-web/src/components/layout/OnboardingHeader/OnboardingHeader.spec.tsx
+++ b/apps/deploy-web/src/components/layout/OnboardingHeader/OnboardingHeader.spec.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./OnboardingHeader";
+import { OnboardingHeader } from "./OnboardingHeader";
+
+import { render, screen } from "@testing-library/react";
+
+describe(OnboardingHeader.name, () => {
+  it("reduces the account menu to its minimal variant", () => {
+    const { AccountMenu } = setup({});
+
+    expect(AccountMenu.mock.calls.at(-1)![0]?.minimal).toBe(true);
+  });
+
+  it("renders the actions it is given", () => {
+    setup({ children: <button>Hackathon? click here</button> });
+
+    expect(screen.getByText("Hackathon? click here")).toBeInTheDocument();
+  });
+
+  function setup(input: { children?: ReactNode }) {
+    const AccountMenu = vi.fn<typeof DEPENDENCIES.AccountMenu>(() => <div data-testid="account-menu" />);
+
+    render(<OnboardingHeader dependencies={{ AccountMenu }}>{input.children}</OnboardingHeader>);
+
+    return { AccountMenu };
+  }
+});

--- a/apps/deploy-web/src/components/layout/OnboardingHeader/OnboardingHeader.tsx
+++ b/apps/deploy-web/src/components/layout/OnboardingHeader/OnboardingHeader.tsx
@@ -1,0 +1,27 @@
+"use client";
+import type { ReactNode } from "react";
+
+import { AkashConsoleLogo } from "@src/components/icons/AkashConsoleLogo";
+import { AccountMenu } from "@src/components/layout/AccountMenu";
+
+export const DEPENDENCIES = { AccountMenu };
+
+type Props = {
+  children?: ReactNode;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/** Shared by the onboarding picker and the fair use policy step, so accepting the policy does not shift the chrome. */
+export function OnboardingHeader({ children, dependencies: d = DEPENDENCIES }: Props) {
+  return (
+    <header className="relative flex items-center justify-between border-b border-border">
+      <div className="flex h-14 w-full items-center justify-between pl-4 pr-4">
+        <AkashConsoleLogo />
+        <div className="flex items-center gap-2">
+          {children}
+          <d.AccountMenu minimal />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -28,14 +28,6 @@ describe(OnboardingPickerPage.name, () => {
     expect(titles).toEqual(["Hello world", "Space Agent", "LLM Chatbot"]);
   });
 
-  it("renders the account menu in its minimal variant", () => {
-    // AccountMenu's optional-props signature isn't assignable from the generic ComponentMock, so cast the override only.
-    const AccountMenu = vi.fn(ComponentMock);
-    setup({ dependencies: { AccountMenu: AccountMenu as unknown as typeof DEPENDENCIES.AccountMenu } });
-
-    expect((AccountMenu.mock.calls.at(-1)![0] as { minimal?: boolean }).minimal).toBe(true);
-  });
-
   it("renders the trial credit amount from public config", () => {
     setup({ trialCreditsAmount: 1 });
 

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -11,8 +11,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
 import { BONUS_PERCENT, MAX_BONUS } from "@src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert";
 import { DeploymentTemplatePickerCard } from "@src/components/deployments/DeploymentTemplatePickerCard/DeploymentTemplatePickerCard";
-import { AkashConsoleLogo } from "@src/components/icons/AkashConsoleLogo";
-import { AccountMenu } from "@src/components/layout/AccountMenu";
+import { OnboardingHeader } from "@src/components/layout/OnboardingHeader/OnboardingHeader";
 import { SkipOnboardingButton } from "@src/components/onboarding-picker/SkipOnboardingButton/SkipOnboardingButton";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
@@ -40,7 +39,7 @@ export const DEPENDENCIES = {
   useFlag,
   DeploymentTemplatePickerCard,
   AddCreditsSheet,
-  AccountMenu,
+  OnboardingHeader,
   SkipOnboardingButton,
   Button
 };
@@ -108,20 +107,14 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
         <meta name="description" content="Deploy your first app on Akash Network with our onboarding flow. Get a live URL in about 30 seconds." />
       </Head>
       <div className="flex min-h-screen flex-col bg-background">
-        <header className="relative flex items-center justify-between border-b border-border">
-          <div className="flex h-14 w-full items-center justify-between pl-4 pr-4">
-            <AkashConsoleLogo />
-            <div className="flex items-center gap-2">
-              {showHackathonEntry && (
-                <d.Button onClick={() => setAddCreditsSheetReason("hackathon-coupon")} variant="ghost" size="sm">
-                  Hackathon? click here
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </d.Button>
-              )}
-              <d.AccountMenu minimal />
-            </div>
-          </div>
-        </header>
+        <d.OnboardingHeader>
+          {showHackathonEntry && (
+            <d.Button onClick={() => setAddCreditsSheetReason("hackathon-coupon")} variant="ghost" size="sm">
+              Hackathon? click here
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </d.Button>
+          )}
+        </d.OnboardingHeader>
 
         <div className="mx-auto w-full max-w-5xl px-6 pt-8 [@media(max-height:520px)]:pb-12">
           <div className="flex w-full flex-col gap-10">

--- a/apps/deploy-web/tests/ui/actions/fair-use-policy.ts
+++ b/apps/deploy-web/tests/ui/actions/fair-use-policy.ts
@@ -2,9 +2,14 @@ import type { Locator, Page } from "@playwright/test";
 
 const PROMPT_TIMEOUT_MS = 30_000;
 
+/** Matches both presentations: an onboarding user gets the prompt as a page section, everyone else gets it as a modal. */
+function locatePrompt(page: Page): Locator {
+  return page.getByRole("region", { name: /fair use policy/i }).or(page.getByRole("dialog", { name: /fair use policy/i }));
+}
+
 /** Races the prompt against the onboarding heading, because the heading is what a new user sees instead when the gate is off. */
 export async function acceptFairUsePolicyIfPrompted(page: Page): Promise<void> {
-  const prompt = page.getByRole("dialog", { name: /fair use policy/i });
+  const prompt = locatePrompt(page);
   const onboardingHeading = page.getByRole("heading", { name: /deploy your first app/i });
 
   await Promise.race([waitForVisible(prompt), waitForVisible(onboardingHeading)]);


### PR DESCRIPTION
## Why

A user who has just registered met the Fair Use Policy as a modal. A modal reads as an interruption to the page underneath, and a brand-new user has no page underneath yet, since they have not reached the picker.

#3888, which put the app header behind the modal, has merged, so this now targets `main` directly.

## What

The onboarding route is reachable only by someone who has never deployed, because the onboarding gate sends anyone already onboarded, or who skipped it, somewhere else. That makes it a safe place to split the presentation:

- On `/onboarding` the prompt is now a page of its own, a card under the same logo-and-menu header the picker renders. Accepting it reveals the picker with no visible change to the header.
- Everywhere else it stays a modal over the current page. That includes an existing trial user who meets the prompt once the flag is turned on.

The prompt body, its heading and its button label now live in one module that both presentations use, so the two cannot drift apart. The picker's header moved into a shared component, which the picker and the new step both render.

The page is still withheld until acceptance in both cases, so an auto-started deploy cannot fire behind the prompt. That guarantee never came from the modal backdrop.

The Playwright helper now matches either role, a named region or a dialog. The signup journeys it runs on are exactly the ones that stop being a dialog.
