### PR TITLE
fix(deployment): stop funding deployments the chain has left unbilled past the arrears limit

### DIFF
--- a/apps/api/src/deployment/config/env.config.spec.ts
+++ b/apps/api/src/deployment/config/env.config.spec.ts
@@ -73,6 +73,18 @@ describe("deployment envSchema", () => {
     });
   });
 
+  describe("AUTO_TOP_UP_MAX_ARREARS_IN_H", () => {
+    it("defaults to three days", () => {
+      const result = envSchema.safeParse(setup());
+
+      expect(result.success && result.data.AUTO_TOP_UP_MAX_ARREARS_IN_H).toBe(72);
+    });
+
+    it("rejects a limit that would leave no room for a provider to bill", () => {
+      expect(envSchema.safeParse(setup({ AUTO_TOP_UP_MAX_ARREARS_IN_H: 0 })).success).toBe(false);
+    });
+  });
+
   describe("AUTO_TOP_UP_TARGET_RUNWAY_IN_H", () => {
     it("accepts the default target runway and look-ahead window", () => {
       const result = envSchema.safeParse(setup());

--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -53,6 +53,8 @@ export const envSchema = z
      * window is funded nothing and simply re-triggers, hence the schema check below.
      */
     AUTO_TOP_UP_TARGET_RUNWAY_IN_H: z.number({ coerce: true }).positive().finite().optional().default(48),
+    /** The chain settles an escrow only on a deposit, withdraw, or close, so a lease this long past its predicted close has gone unbilled by its provider and a deposit would only pay that back rent. */
+    AUTO_TOP_UP_MAX_ARREARS_IN_H: z.number({ coerce: true }).positive().finite().optional().default(72),
     AUTO_TOP_UP_DEDUP_COOLDOWN_IN_MIN: z.number({ coerce: true }).positive().optional().default(60),
     /**
      * Dollar floor auto-funding leaves in the available deployment allowance so a user with credits left can still

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -43,7 +43,7 @@ describe(DrainingDeploymentService.name, () => {
             owner: addresses[0],
             denom: "uakt",
             blockRate: faker.number.int({ min: 50, max: 100 }),
-            predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
+            predictedClosedHeight: faker.number.int({ min: currentHeight - averageBlockCountInAnHour * 24, max: currentHeight })
           }
         ],
         [
@@ -52,7 +52,7 @@ describe(DrainingDeploymentService.name, () => {
             owner: addresses[3],
             denom: "uakt",
             blockRate: faker.number.int({ min: 50, max: 100 }),
-            predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
+            predictedClosedHeight: faker.number.int({ min: currentHeight - averageBlockCountInAnHour * 24, max: currentHeight })
           }
         ]
       ];
@@ -144,6 +144,32 @@ describe(DrainingDeploymentService.name, () => {
         activeDeployments: [expect.objectContaining({ dseq: setting.dseq, predictedClosedHeight: farFromClosure.predictedClosedHeight })],
         drainingDeployments: []
       });
+    });
+
+    it("keeps a deployment overdue on chain among the owner's active deployments while leaving it out of the fundable subset", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const setting = createAutoTopUpDeployment();
+      const overdue = createDrainingDeployment({
+        dseq: Number(setting.dseq),
+        owner: setting.address,
+        predictedClosedHeight: currentHeight - averageBlockCountInAnHour * 24 * 15
+      });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          yield { address: setting.address, walletId: setting.walletId, deploymentSettings: [setting] };
+        })()
+      );
+      vi.spyOn(service, "findLeases").mockResolvedValue([overdue]);
+
+      const results: AutoTopUpOwnerDeployments[] = [];
+      for await (const result of service.findDrainingDeploymentsByOwner(currentHeight, mock<DeploymentTopUpInstrumentation>())) {
+        results.push(result);
+      }
+
+      expect(results).toHaveLength(1);
+      expect(results[0].activeDeployments).toEqual([expect.objectContaining({ dseq: setting.dseq, predictedClosedHeight: overdue.predictedClosedHeight })]);
+      expect(results[0].drainingDeployments).toEqual([]);
     });
 
     it("reports marked-closed deployments to the caller's instrumentation", async () => {
@@ -337,6 +363,48 @@ describe(DrainingDeploymentService.name, () => {
       expect(result).toEqual(
         expect.arrayContaining(settings.map(setting => expect.objectContaining({ dseq: setting.dseq, address, blockRate: 60, predictedClosedHeight: 1000500 })))
       );
+    });
+
+    it("leaves a deployment overdue on chain out of the fundable set and records it", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const sink = mock<DeploymentTopUpInstrumentation>();
+      const address = createAkashAddress();
+      const overdueSetting = createAutoTopUpDeployment({ address, dseq: "4001" });
+      const drainingSetting = createAutoTopUpDeployment({ address, dseq: "4002" });
+      const overdueHeight = currentHeight - averageBlockCountInAnHour * 72 - 1;
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue([overdueSetting, drainingSetting]);
+      vi.spyOn(service, "findLeases").mockResolvedValue([
+        createDrainingDeployment({ dseq: Number(overdueSetting.dseq), owner: address, predictedClosedHeight: overdueHeight }),
+        createDrainingDeployment({ dseq: Number(drainingSetting.dseq), owner: address, predictedClosedHeight: currentHeight + 500 })
+      ]);
+
+      const result = await service.findDrainingDeploymentsForOwner(address, sink, currentHeight);
+
+      expect(result.map(deployment => deployment.dseq)).toEqual([drainingSetting.dseq]);
+      expect(sink.recordDeploymentOverdueOnChain).toHaveBeenCalledWith({
+        dseq: overdueSetting.dseq,
+        address,
+        predictedClosedHeight: overdueHeight,
+        currentHeight
+      });
+    });
+
+    it("keeps funding a deployment whose escrow ran out inside the arrears limit", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const sink = mock<DeploymentTopUpInstrumentation>();
+      const address = createAkashAddress();
+      const setting = createAutoTopUpDeployment({ address, dseq: "4003" });
+
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue([setting]);
+      vi.spyOn(service, "findLeases").mockResolvedValue([
+        createDrainingDeployment({ dseq: Number(setting.dseq), owner: address, predictedClosedHeight: currentHeight - averageBlockCountInAnHour * 72 })
+      ]);
+
+      const result = await service.findDrainingDeploymentsForOwner(address, sink, currentHeight);
+
+      expect(result.map(deployment => deployment.dseq)).toEqual([setting.dseq]);
+      expect(sink.recordDeploymentOverdueOnChain).not.toHaveBeenCalled();
     });
 
     it("marks a deployment whose escrow account is no longer open even though its lease still reads open", async () => {
@@ -1560,7 +1628,8 @@ describe(DrainingDeploymentService.name, () => {
 
     const config = mockConfigService<DeploymentConfigService>({
       AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24,
-      AUTO_TOP_UP_TARGET_RUNWAY_IN_H: 48
+      AUTO_TOP_UP_TARGET_RUNWAY_IN_H: 48,
+      AUTO_TOP_UP_MAX_ARREARS_IN_H: 72
     });
 
     const service = new DrainingDeploymentService(

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -118,13 +118,37 @@ export class DrainingDeploymentService {
     const expectedClosureHeight = this.#getExpectedClosureHeight(currentHeight);
     const activeDeployments = await this.#resolveActiveDeployments(deploymentSettings, address, instrumentation, dryRun);
     const drainingDeployments = await this.#dropDeploymentsFundedToRuntimeLimit(
-      activeDeployments.filter(deployment => deployment.predictedClosedHeight <= expectedClosureHeight),
+      this.#dropDeploymentsOverdueOnChain(
+        activeDeployments.filter(deployment => deployment.predictedClosedHeight <= expectedClosureHeight),
+        currentHeight,
+        instrumentation
+      ),
       currentHeight,
       instrumentation,
       dryRun
     );
 
     return { activeDeployments, drainingDeployments };
+  }
+
+  /** The chain settles an escrow only on a deposit, withdraw, or close, so a lease this far past its predicted close has gone unbilled by its provider and a deposit would only pay that back rent. */
+  #dropDeploymentsOverdueOnChain(
+    deployments: DrainingDeployment[],
+    currentHeight: number,
+    instrumentation: DeploymentTopUpInstrumentation
+  ): DrainingDeployment[] {
+    const overdueHeight = currentHeight - averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_MAX_ARREARS_IN_H");
+
+    return deployments.filter(deployment => {
+      const predictedClosedHeight = Number(deployment.predictedClosedHeight);
+
+      if (predictedClosedHeight >= overdueHeight) {
+        return true;
+      }
+
+      instrumentation.recordDeploymentOverdueOnChain({ dseq: deployment.dseq, address: deployment.address, predictedClosedHeight, currentHeight });
+      return false;
+    });
   }
 
   async #resolveActiveDeployments(

--- a/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/deployment-top-up-instrumentation.ts
@@ -26,6 +26,7 @@ export interface DeploymentTopUpInstrumentation {
   recordDeploymentPreparation(ownerAddress: string, predictedClosedHeight: number): void;
   recordInvalidDepositAmount(details: { desiredAmount: number; dseq: string; address: string; blockRate: number }): void;
   recordRuntimeLimitReached(details: { dseq: string; address: string; runtimeEndsAt: Date }): void;
+  recordDeploymentOverdueOnChain(details: { dseq: string; address: string; predictedClosedHeight: number; currentHeight: number }): void;
   recordDepositBelowUsefulRunway(details: { deployment: DrainingDeployment; desiredAmount: number; affordableAmount: number; runwayMinutes: number }): void;
   recordHeadroomConceded(details: {
     dseq: string;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.spec.ts
@@ -288,6 +288,16 @@ describe(FundDrainingDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordDeploymentOverdueOnChain", () => {
+    it("counts the skip under its own reason", () => {
+      const { service, skips } = setup();
+
+      service.recordDeploymentOverdueOnChain({ dseq: "42", address: "akash1owner", predictedClosedHeight: 40, currentHeight: 100 });
+
+      expect(skips.add).toHaveBeenCalledWith(1, { reason: "overdue_on_chain" });
+    });
+  });
+
   describe("recordDeploymentClosedOnChain", () => {
     it("credits the marked-closed counter and warns rather than reporting a chain tx error", () => {
       const { service, deploymentsMarkedClosed, chainTxErrors } = setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/fund-draining-deployments-instrumentation.service.ts
@@ -13,7 +13,7 @@ import {
 
 export type FundDrainingFailureReason = "master_wallet_insufficient_funds" | "deposit_tx_failed" | "unknown";
 
-export type FundDrainingSkipReason = "nothing_to_fund" | "non_positive_amount" | "runtime_limit_reached" | "below_useful_runway";
+export type FundDrainingSkipReason = "nothing_to_fund" | "non_positive_amount" | "runtime_limit_reached" | "below_useful_runway" | "overdue_on_chain";
 
 export function classifyFailure(error: unknown): FundDrainingFailureReason {
   if (!(error instanceof Error)) {
@@ -163,6 +163,11 @@ export class FundDrainingDeploymentsInstrumentationService implements Deployment
   recordRuntimeLimitReached(details: { dseq: string; address: string; runtimeEndsAt: Date }): void {
     this.skips.add(1, { reason: "runtime_limit_reached" satisfies FundDrainingSkipReason });
     this.emitLog("info", { event: "FUND_DRAINING_RUNTIME_LIMIT_REACHED", ...details });
+  }
+
+  recordDeploymentOverdueOnChain(details: { dseq: string; address: string; predictedClosedHeight: number; currentHeight: number }): void {
+    this.skips.add(1, { reason: "overdue_on_chain" satisfies FundDrainingSkipReason });
+    this.emitLog("warn", { event: "FUND_DRAINING_DEPLOYMENT_OVERDUE_ON_CHAIN", ...details });
   }
 
   recordDepositBelowUsefulRunway({

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -122,6 +122,33 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     });
   });
 
+  describe("recordDeploymentOverdueOnChain", () => {
+    it("counts a deployment left unfunded for running too long past its predicted close", () => {
+      const { service, countersByName } = setup();
+      service.start(100, { dryRun: false });
+
+      service.recordDeploymentOverdueOnChain({ dseq: "42", address: "akash1owner", predictedClosedHeight: 40, currentHeight: 100 });
+
+      expect(countersByName["auto_top_up_deployments_overdue_on_chain_total"].add).toHaveBeenCalledWith(1);
+    });
+
+    it("warns with the heights that put the deployment past the arrears limit", () => {
+      const { service, logger } = setup();
+      service.start(100, { dryRun: true });
+
+      service.recordDeploymentOverdueOnChain({ dseq: "42", address: "akash1owner", predictedClosedHeight: 40, currentHeight: 100 });
+
+      expect(logger.warn).toHaveBeenCalledWith({
+        event: "TOP_UP_DEPLOYMENT_OVERDUE_ON_CHAIN",
+        dseq: "42",
+        address: "akash1owner",
+        predictedClosedHeight: 40,
+        currentHeight: 100,
+        dryRun: true
+      });
+    });
+  });
+
   describe("recordDeploymentCloseMarkFailed", () => {
     it("warns without claiming the deployment was marked closed", () => {
       const { service, logger, summarizer } = setup();

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -24,6 +24,7 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
   private readonly messagePreparationErrors: Counter;
   private readonly deploymentsMarkedClosed: Counter;
   private readonly settingsWithoutChainState: Counter;
+  private readonly deploymentsOverdueOnChain: Counter;
   private readonly deploymentsScanned: Counter;
   private readonly depositAmount: Histogram;
   private readonly predictedCloseBlocks: Histogram;
@@ -74,6 +75,10 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
 
     this.settingsWithoutChainState = this.metricsService.createCounter(this.meter, "auto_top_up_settings_without_chain_state_total", {
       description: "Deployment records the sweep could not resolve to any chain state, so it neither funded nor closed them"
+    });
+
+    this.deploymentsOverdueOnChain = this.metricsService.createCounter(this.meter, "auto_top_up_deployments_overdue_on_chain_total", {
+      description: "Deployments left unfunded because their escrow ran out longer ago than the arrears limit, so no provider has been billing them"
     });
 
     this.deploymentsScanned = this.metricsService.createCounter(this.meter, "auto_top_up_deployments_scanned_total", {
@@ -404,6 +409,14 @@ export class TopUpManagedDeploymentsInstrumentationService implements Deployment
       event: "TOP_UP_RUNTIME_LIMIT_REACHED",
       ...details
     });
+  }
+
+  recordDeploymentOverdueOnChain(details: { dseq: string; address: string; predictedClosedHeight: number; currentHeight: number }): void {
+    this.execWhenEnabled(() => {
+      this.deploymentsOverdueOnChain.add(1);
+    });
+
+    this.logger.warn({ event: "TOP_UP_DEPLOYMENT_OVERDUE_ON_CHAIN", ...details, dryRun: this.options?.dryRun });
   }
 
   recordMasterWalletInsufficientFundsError({


### PR DESCRIPTION
## Why

The hourly funding sweep has been reporting the same deployment as draining and short of balance every hour since Aug 30. On chain that deployment still holds its original 0.5 ACT escrow with nothing ever transferred to the provider. The escrow module's `EndBlocker` is a no-op, so an account only settles on a deposit, a withdraw or a close, and this lease's provider never withdrew. Its predicted close height is 15 days in the past and it will read `active` until something touches the account.

Had the owner added credits, either funding path would have deposited into it, and the next settlement would have taken two weeks of back rent for a lease no provider has been billing. The sweep should not pay that.

## What

- New `AUTO_TOP_UP_MAX_ARREARS_IN_H` (default 72). A draining deployment whose predicted close is further in the past than this is left out of the fundable set by both the cron and the event-driven path, and recorded as `TOP_UP_DEPLOYMENT_OVERDUE_ON_CHAIN` / `FUND_DRAINING_DEPLOYMENT_OVERDUE_ON_CHAIN`, with `auto_top_up_deployments_overdue_on_chain_total` and `fund_draining_deployments_skips_total{reason="overdue_on_chain"}` counting them.
- Deployments in arrears inside the limit are still funded as before, so a deployment whose escrow ran out between sweeps is still rescued.
- Overdue deployments stay in the owner's active set, so the weekly coverage behind the credits-low email is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable 72-hour limit for deployment arrears.
  * Deployments overdue beyond this limit are excluded from automatic funding while remaining active.
  * Added monitoring and warning logs for deployments skipped due to on-chain overdue status.

* **Bug Fixes**
  * Prevented automatic top-ups for deployments that have exceeded the configured arrears window.

* **Tests**
  * Added coverage for default settings, validation, overdue deployments, and monitoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->