### PR TITLE
fix(billing): send the credits-low email at most once per wallet per cooldown

### DIFF
--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -51,6 +51,8 @@ export const envSchema = z.object({
   CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: z.number({ coerce: true }).min(0).default(30),
   /** How long credits must keep reading low before the email goes out, so a single misread cannot send one. */
   CREDITS_LOW_CONFIRM_WINDOW_MIN: z.number({ coerce: true }).min(0).default(30),
+  /** The notified latch holds at least this long before a recovery can clear it, so closing deployments and redeploying cannot re-arm the email within hours. */
+  CREDITS_LOW_RESEND_COOLDOWN_H: z.number({ coerce: true }).min(0).default(168),
   /** Safety net only: a cached refusal is dropped as soon as any funding path rewrites the wallet row, so this bounds nothing but the residual race. */
   DEPLOYMENT_CREATE_REFUSAL_CACHE_TTL_SECONDS: z.number({ coerce: true }).int().min(1).default(300),
   MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: z

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import subDays from "date-fns/subDays";
 import subMinutes from "date-fns/subMinutes";
 import { container } from "tsyringe";
 import { describe, expect, it } from "vitest";
@@ -7,6 +8,8 @@ import { UserRepository } from "@src/user/repositories";
 import { UserWalletRepository } from "./user-wallet.repository";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+
+const RECOVERY_WINDOWS = { confirmWindowMinutes: 30, resendCooldownHours: 168 };
 
 describe(UserWalletRepository.name, () => {
   describe("claimActivation", () => {
@@ -45,12 +48,12 @@ describe(UserWalletRepository.name, () => {
   describe("clearCreditsLowNotifiedIfRecoveryConfirmed", () => {
     it("clears the notified stamp once credits have read sufficient for the whole window", async () => {
       const { userWalletRepository, wallet } = await setup({
-        creditsLowNotifiedAt: subMinutes(new Date(), 90),
+        creditsLowNotifiedAt: subDays(new Date(), 8),
         creditsSufficientSince: subMinutes(new Date(), 31),
         creditsLowSince: subMinutes(new Date(), 120)
       });
 
-      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30);
+      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, RECOVERY_WINDOWS);
 
       const updated = await userWalletRepository.findById(wallet.id);
       expect(isCleared).toBe(true);
@@ -59,14 +62,28 @@ describe(UserWalletRepository.name, () => {
       expect(updated?.creditsLowSince).toBeNull();
     });
 
-    it("keeps the notified stamp while the window has not elapsed", async () => {
+    it("keeps the notified stamp while the email went out inside the resend cooldown", async () => {
       const creditsLowNotifiedAt = subMinutes(new Date(), 90);
+      const { userWalletRepository, wallet } = await setup({
+        creditsLowNotifiedAt,
+        creditsSufficientSince: subMinutes(new Date(), 31)
+      });
+
+      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, RECOVERY_WINDOWS);
+
+      const updated = await userWalletRepository.findById(wallet.id);
+      expect(isCleared).toBe(false);
+      expect(updated?.creditsLowNotifiedAt).toEqual(creditsLowNotifiedAt);
+    });
+
+    it("keeps the notified stamp while the window has not elapsed", async () => {
+      const creditsLowNotifiedAt = subDays(new Date(), 8);
       const { userWalletRepository, wallet } = await setup({
         creditsLowNotifiedAt,
         creditsSufficientSince: subMinutes(new Date(), 5)
       });
 
-      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30);
+      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, RECOVERY_WINDOWS);
 
       const updated = await userWalletRepository.findById(wallet.id);
       expect(isCleared).toBe(false);
@@ -76,7 +93,7 @@ describe(UserWalletRepository.name, () => {
     it("keeps the notified stamp when no recovery has been recorded", async () => {
       const { userWalletRepository, wallet } = await setup({ creditsLowNotifiedAt: subMinutes(new Date(), 90) });
 
-      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30);
+      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, RECOVERY_WINDOWS);
 
       expect(isCleared).toBe(false);
     });
@@ -84,18 +101,20 @@ describe(UserWalletRepository.name, () => {
     it("reports no clear when the wallet was never notified", async () => {
       const { userWalletRepository, wallet } = await setup({ creditsSufficientSince: subMinutes(new Date(), 90) });
 
-      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30);
+      const isCleared = await userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, RECOVERY_WINDOWS);
 
       expect(isCleared).toBe(false);
     });
 
     it("clears exactly once across concurrent attempts", async () => {
       const { userWalletRepository, wallet } = await setup({
-        creditsLowNotifiedAt: subMinutes(new Date(), 90),
+        creditsLowNotifiedAt: subDays(new Date(), 8),
         creditsSufficientSince: subMinutes(new Date(), 31)
       });
 
-      const results = await Promise.all(Array.from({ length: 5 }, () => userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, 30)));
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () => userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, RECOVERY_WINDOWS))
+      );
 
       expect(results.filter(Boolean)).toHaveLength(1);
     });

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -106,8 +106,11 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     return claimed ? this.toOutput(claimed) : undefined;
   }
 
-  /** Re-checks the window in SQL so a concurrent check that read the credits low still wins by clearing `creditsSufficientSince`. */
-  async clearCreditsLowNotifiedIfRecoveryConfirmed(id: UserWalletOutput["id"], confirmWindowMinutes: number): Promise<boolean> {
+  /** Re-checks both windows in SQL so a concurrent check that read the credits low still wins by clearing `creditsSufficientSince`. */
+  async clearCreditsLowNotifiedIfRecoveryConfirmed(
+    id: UserWalletOutput["id"],
+    { confirmWindowMinutes, resendCooldownHours }: { confirmWindowMinutes: number; resendCooldownHours: number }
+  ): Promise<boolean> {
     const [cleared] = await this.cursor
       .update(this.table)
       .set({ creditsLowNotifiedAt: null, creditsSufficientSince: null, creditsLowSince: null })
@@ -116,6 +119,7 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
           and(
             eq(this.table.id, id),
             isNotNull(this.table.creditsLowNotifiedAt),
+            lte(this.table.creditsLowNotifiedAt, sql`now() - ${resendCooldownHours}::double precision * interval '1 hour'`),
             isNotNull(this.table.creditsSufficientSince),
             lte(this.table.creditsSufficientSince, sql`now() - ${confirmWindowMinutes}::double precision * interval '1 minute'`)
           )

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.integration.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.integration.ts
@@ -1,6 +1,6 @@
 import "@src/app/providers/jobs.provider";
 
-import { subMinutes } from "date-fns";
+import { subHours, subMinutes } from "date-fns";
 import { eq } from "drizzle-orm";
 import nock from "nock";
 import { container } from "tsyringe";
@@ -23,6 +23,12 @@ const PAST_THE_CONFIRM_WINDOW_IN_MIN = 45;
 
 /** Longer than CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN, so a recovery stamped this long ago counts as held. */
 const PAST_THE_RECOVERY_WINDOW_IN_MIN = 24 * 60 * 3;
+
+/** Longer than CREDITS_LOW_RESEND_COOLDOWN_H, so an email sent this long ago no longer holds the latch. */
+const PAST_THE_RESEND_COOLDOWN_IN_H = 24 * 8;
+
+/** Shorter than CREDITS_LOW_RESEND_COOLDOWN_H, so an email sent this long ago still holds the latch. */
+const INSIDE_THE_RESEND_COOLDOWN_IN_H = 24;
 
 const jobWorkers = useJobWorkers(() => [container.resolve(WalletCreditsLowCheckHandler)]);
 
@@ -112,17 +118,32 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     expect(await findWallet()).toMatchObject({ creditsSufficientSince: expect.any(Date), creditsLowNotifiedAt: expect.any(Date) });
   });
 
-  it("clears the notice once the recovery has held past its window", async () => {
+  it("clears the notice once the recovery has held past its window and the resend cooldown has passed", async () => {
     const { checkCredits, findWallet } = await setup({
       balanceUsd: 50,
       weeklyCostUsd: 20,
-      creditsLowNotifiedAt: new Date(),
+      creditsLowNotifiedAt: subHours(new Date(), PAST_THE_RESEND_COOLDOWN_IN_H),
       creditsSufficientSince: subMinutes(new Date(), PAST_THE_RECOVERY_WINDOW_IN_MIN)
     });
 
     await checkCredits();
 
     expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt: null });
+  });
+
+  it("keeps the notice through the resend cooldown even after the recovery has held past its window", async () => {
+    const creditsLowNotifiedAt = subHours(new Date(), INSIDE_THE_RESEND_COOLDOWN_IN_H);
+    const { checkCredits, findWallet, sentNotifications } = await setup({
+      balanceUsd: 50,
+      weeklyCostUsd: 20,
+      creditsLowNotifiedAt,
+      creditsSufficientSince: subMinutes(new Date(), PAST_THE_RECOVERY_WINDOW_IN_MIN)
+    });
+
+    await checkCredits();
+
+    expect(await findWallet()).toMatchObject({ creditsLowNotifiedAt });
+    expect(sentNotifications()).toHaveLength(0);
   });
 
   it("emails nothing for a wallet still on trial", async () => {

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.spec.ts
@@ -292,7 +292,10 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
     await handler.handle(job);
 
-    expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).toHaveBeenCalledWith(wallet.id, 30);
+    expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).toHaveBeenCalledWith(wallet.id, {
+      confirmWindowMinutes: 30,
+      resendCooldownHours: 168
+    });
     expect(logger.info).toHaveBeenCalledWith({
       event: "CREDITS_LOW_NOTIFIED_CLEARED",
       userId: user.id,
@@ -312,7 +315,7 @@ describe(WalletCreditsLowCheckHandler.name, () => {
 
     await handler.handle(job);
 
-    expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).toHaveBeenCalledWith(wallet.id, expect.any(Number));
+    expect(userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed).toHaveBeenCalledWith(wallet.id, expect.any(Object));
     expect(userWalletRepository.updateById).not.toHaveBeenCalled();
     expect(logger.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "CREDITS_LOW_NOTIFIED_CLEARED" }));
   });
@@ -460,7 +463,8 @@ describe(WalletCreditsLowCheckHandler.name, () => {
     const billingConfig = mockConfigService<BillingConfigService>({
       CONSOLE_WEB_PAYMENT_LINK: paymentLink,
       CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN: input?.confirmWindowMinutes ?? 30,
-      CREDITS_LOW_CONFIRM_WINDOW_MIN: input?.confirmWindowMinutes ?? 30
+      CREDITS_LOW_CONFIRM_WINDOW_MIN: input?.confirmWindowMinutes ?? 30,
+      CREDITS_LOW_RESEND_COOLDOWN_H: 168
     });
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger = vi.fn<CreateLogger>(() => logger);

--- a/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-credits-low-check/wallet-credits-low-check.handler.ts
@@ -196,10 +196,10 @@ export class WalletCreditsLowCheckHandler implements JobHandler<WalletCreditsLow
       return;
     }
 
-    const isCleared = await this.userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(
-      wallet.id,
-      this.billingConfig.get("CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN")
-    );
+    const isCleared = await this.userWalletRepository.clearCreditsLowNotifiedIfRecoveryConfirmed(wallet.id, {
+      confirmWindowMinutes: this.billingConfig.get("CREDITS_LOW_RECOVERY_CONFIRM_WINDOW_MIN"),
+      resendCooldownHours: this.billingConfig.get("CREDITS_LOW_RESEND_COOLDOWN_H")
+    });
 
     if (isCleared) {
       this.logger.info({ event: "CREDITS_LOW_NOTIFIED_CLEARED", userId, reason, creditsSufficientSince: wallet.creditsSufficientSince });


### PR DESCRIPTION
## Why

One paid wallet received ten credits-low emails between Sep 2 and Sep 8. Its owner hovers around the threshold: they close deployments, which drops the weekly cost under the balance and unlatches the notice after the 30 minute recovery window, then redeploy, which puts the balance under the weekly cost again and sends a fresh email 30 minutes later. Every email was "correct" under the latch and confirm windows from CON-896, and the wallet still got one every 12 to 24 hours.

The latch and the two confirm windows protect against misreads, not against a wallet that genuinely crosses the threshold several times a day. This adds the missing bound: one credits-low email per wallet per cooldown, whatever the coverage does in between.

## What

- New `CREDITS_LOW_RESEND_COOLDOWN_H` (default 168). The confirmed-recovery clear of `credits_low_notified_at` now also requires the stamp to be older than the cooldown, checked in the same SQL update as the recovery window. While the latch holds, a wallet that drops low again is skipped as `already_notified` exactly as today, so no second email can go out inside the cooldown.
- No schema change. The immediate clear for a wallet with nothing left on auto top-up is unchanged, so a wallet that closes everything and comes back weeks later still gets its first warning.
- Latch, recovery and low confirm windows are otherwise unchanged.
