### PR TITLE
fix(billing): revoke the deposit grant when a refund drains the deployment allowance

### DIFF
--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
@@ -1,4 +1,4 @@
-import type { AuthzHttpService } from "@akashnetwork/http-sdk";
+import type { AuthzHttpService, ExactDepositDeploymentGrant } from "@akashnetwork/http-sdk";
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import { faker } from "@faker-js/faker";
 import addDays from "date-fns/addDays";
@@ -154,6 +154,59 @@ describe(ManagedUserWalletService.name, () => {
     });
   });
 
+  describe("deployment spending authorization", () => {
+    it("grants the deposit authorization at the requested limit", async () => {
+      const { service, signer, config, rpcMessageService, authzHttpService } = setup();
+      const address = createAkashAddress();
+      const grantMsg = { typeUrl: "/deposit-grant", value: {} } as unknown as EncodeObject;
+      rpcMessageService.getDepositDeploymentGrantMsg.mockReturnValue(grantMsg);
+
+      await service.authorizeSpending(signer, { address, limits: { deployment: 110_000_000, fees: config.FEE_ALLOWANCE_REFILL_AMOUNT } });
+
+      expect(rpcMessageService.getDepositDeploymentGrantMsg).toHaveBeenCalledWith(
+        expect.objectContaining({ grantee: address, denom: config.DEPLOYMENT_GRANT_DENOM, limit: 110_000_000 })
+      );
+      expect(signer.executeFundingTx).toHaveBeenCalledWith([grantMsg]);
+      expect(authzHttpService.getValidDepositDeploymentGrantsForGranterAndGrantee).not.toHaveBeenCalled();
+    });
+
+    it("revokes the deposit authorization instead of granting a zero limit", async () => {
+      const { service, signer, config, rpcMessageService, authzHttpService, txManagerService } = setup();
+      const address = createAkashAddress();
+      const granter = await txManagerService.getFundingWalletAddress();
+      const revokeMsg = { typeUrl: "/deposit-revoke", value: {} } as unknown as EncodeObject;
+      rpcMessageService.getRevokeDepositDeploymentGrantMsg.mockReturnValue(revokeMsg);
+      authzHttpService.getValidDepositDeploymentGrantsForGranterAndGrantee.mockResolvedValue(mock<ExactDepositDeploymentGrant>());
+
+      await service.authorizeSpending(signer, { address, limits: { deployment: 0, fees: config.FEE_ALLOWANCE_REFILL_AMOUNT } });
+
+      expect(rpcMessageService.getDepositDeploymentGrantMsg).not.toHaveBeenCalled();
+      expect(rpcMessageService.getRevokeDepositDeploymentGrantMsg).toHaveBeenCalledWith(expect.objectContaining({ granter, grantee: address }));
+      expect(signer.executeFundingTx).toHaveBeenCalledWith([revokeMsg]);
+    });
+
+    it("broadcasts nothing for a zero limit when the wallet holds no deposit authorization", async () => {
+      const { service, signer, config, rpcMessageService, authzHttpService, logger } = setup();
+      authzHttpService.getValidDepositDeploymentGrantsForGranterAndGrantee.mockResolvedValue(undefined);
+
+      await service.authorizeSpending(signer, { address: createAkashAddress(), limits: { deployment: 0, fees: config.FEE_ALLOWANCE_REFILL_AMOUNT } });
+
+      expect(rpcMessageService.getRevokeDepositDeploymentGrantMsg).not.toHaveBeenCalled();
+      expect(signer.executeFundingTx).toHaveBeenCalledTimes(1);
+      expect(signer.executeFundingTx).not.toHaveBeenCalledWith([expect.objectContaining({ typeUrl: "/deposit-revoke" })]);
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DEPOSIT_GRANT_ALREADY_ABSENT" }));
+    });
+
+    it("keeps refilling the fee allowance when the deployment limit drops to zero", async () => {
+      const { service, signer, config, rpcMessageService, authzHttpService } = setup();
+      authzHttpService.getValidDepositDeploymentGrantsForGranterAndGrantee.mockResolvedValue(mock<ExactDepositDeploymentGrant>());
+
+      await service.authorizeSpending(signer, { address: createAkashAddress(), limits: { deployment: 0, fees: config.FEE_ALLOWANCE_REFILL_AMOUNT } });
+
+      expect(rpcMessageService.getFeesAllowanceGrantMsg).toHaveBeenCalledWith(expect.objectContaining({ limit: config.FEE_ALLOWANCE_REFILL_AMOUNT }));
+    });
+  });
+
   it("creates the logger with the service context", () => {
     const { createLogger } = setup();
 
@@ -180,6 +233,8 @@ describe(ManagedUserWalletService.name, () => {
     authzHttpService.hasFeeAllowance.mockResolvedValue(false);
     rpcMessageService.getFeesAllowanceGrantMsg.mockReturnValue({ typeUrl: "/fee-grant", value: {} } as unknown as EncodeObject);
     rpcMessageService.getRevokeAllowanceMsg.mockReturnValue({ typeUrl: "/fee-revoke", value: {} } as unknown as EncodeObject);
+    rpcMessageService.getDepositDeploymentGrantMsg.mockReturnValue({ typeUrl: "/deposit-grant", value: {} } as unknown as EncodeObject);
+    rpcMessageService.getRevokeDepositDeploymentGrantMsg.mockReturnValue({ typeUrl: "/deposit-revoke", value: {} } as unknown as EncodeObject);
     signer.executeFundingTx.mockResolvedValue({ code: 0, hash: "hash", rawLog: "[]" } as never);
 
     const service = new ManagedUserWalletService(config, txManagerService, rpcMessageService, authzHttpService, createLogger);

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -175,8 +175,27 @@ export class ManagedUserWalletService {
 
   private async authorizeDeploymentSpending(signer: ManagedSignerService, options: SpendingAuthorizationMsgOptions) {
     return withSpan("ManagedUserWalletService.authorizeDeploymentSpending", async () => {
+      if (options.limit <= 0) {
+        return await this.revokeDeploymentSpending(signer, options);
+      }
+
       const deploymentAllowanceMsg = this.rpcMessageService.getDepositDeploymentGrantMsg(options);
       return await signer.executeFundingTx([deploymentAllowanceMsg]);
     });
+  }
+
+  /** The chain rejects a zero spend limit as an invalid coin, so a drained deployment allowance is expressed by removing the grant. */
+  private async revokeDeploymentSpending(signer: ManagedSignerService, options: SpendingAuthorizationMsgOptions) {
+    const grant = await this.authzHttpService.getValidDepositDeploymentGrantsForGranterAndGrantee(options.granter, options.grantee);
+
+    if (!grant) {
+      this.logger.info({ event: "DEPOSIT_GRANT_ALREADY_ABSENT", grantee: options.grantee });
+      return;
+    }
+
+    const result = await signer.executeFundingTx([this.rpcMessageService.getRevokeDepositDeploymentGrantMsg(options)]);
+    this.logger.info({ event: "DEPOSIT_GRANT_REVOKED_AT_ZERO_LIMIT", grantee: options.grantee });
+
+    return result;
   }
 }


### PR DESCRIPTION
## Why

A full Stripe refund of a purchase the user never spent fails, and the failure is silent from the user's side. The webhook throws, the whole refund transaction rolls back, and the user keeps credits we already paid back to them.

It showed up on a $100 purchase plus the $10 first-purchase bonus, refunded before any of it was spent. The wallet's remaining deployment limit was exactly the amount being clawed back, so the new limit came out at 0. `reduceWalletBalance` re-granted the deposit authorization at that limit and the chain rejected it:

```
spend limits are not valid: invalid coins [pkg.akt.dev/go@v0.2.14/node/escrow/v1/authz.go:162]
```

The one account this hit was cleared by hand. Partial refunds, and full refunds on accounts that had already burned some credit, leave a positive remainder and keep working. Zero is the only broken case, and a full refund of an unspent purchase always lands there.

## What

`authorizeDeploymentSpending` revokes the deposit grant when the limit is 0 instead of granting a zero spend limit, which the escrow authz module reads as an invalid coin. When the wallet holds no grant to revoke, nothing is broadcast and it logs `DEPOSIT_GRANT_ALREADY_ABSENT`. The fee leg of the authorization is unchanged.

The guard sits at the message-sending seam rather than in the refund path, so any caller that lands on a zero deployment limit gets the same behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment spending authorization now revokes existing permissions when the requested limit is zero or negative.
  * Avoids submitting zero-limit authorization requests when no active permission exists.
  * Fee refills continue to process correctly after deployment authorization reaches zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->