### PR TITLE
fix(deployment): persist trial workload detections whose evidence carries NUL bytes

### DIFF
--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -337,7 +337,11 @@ describe(JobQueueService.name, () => {
         service.hasWaitingSingleton({ name: "test-job", singletonKey: "singleton-1", notDueBefore: new Date("2026-01-01T00:03:00.000Z") })
       ).resolves.toBe(true);
 
-      expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("state IN ('created', 'retry')"), ["test-job", "singleton-1", "2026-01-01T00:03:00.000Z"]);
+      expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("state IN ('created', 'retry')"), [
+        "test-job",
+        "singleton-1",
+        "2026-01-01T00:03:00.000Z"
+      ]);
       expect(executeSql).toHaveBeenCalledWith(expect.stringContaining("start_after > $3"), expect.anything());
     });
 
@@ -516,6 +520,39 @@ describe(JobQueueService.name, () => {
       });
       expect(handleFn).toHaveBeenCalledTimes(1);
       expect(handleFn).toHaveBeenCalledWith({ message: "Job 1", userId: "user-1" }, { id: job.id });
+    });
+
+    it("rethrows a NUL-free copy of a failing handler's error so pg-boss can store it", async () => {
+      const error = new Error("Failed query: insert params: cmd=tr '\u0000' ' '");
+      error.name = "DrizzleQueryError";
+      error.stack = "DrizzleQueryError: \u0000\n    at insert";
+      const { service, pgBoss, logger } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue(error))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      const thrown = (result as PromiseRejectedResult).reason as Error;
+      expect(thrown).not.toBe(error);
+      expect(thrown.name).toBe("DrizzleQueryError");
+      expect(thrown.message).toBe("Failed query: insert params: cmd=tr ' ' ' '");
+      expect(thrown.stack).toBe("DrizzleQueryError:  \n    at insert");
+      expect(logger.error).toHaveBeenCalledWith({ event: "JOB_FAILED", jobId: expect.any(String), error });
+    });
+
+    it("rewrites the error when only its stack carries a NUL byte", async () => {
+      const error = new Error("insert failed");
+      error.stack = "Error: insert failed\n    at params: \u0000";
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue(error))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      const thrown = (result as PromiseRejectedResult).reason as Error;
+      expect(thrown).not.toBe(error);
+      expect(thrown.message).toBe("insert failed");
+      expect(thrown.stack).toBe("Error: insert failed\n    at params:  ");
     });
 
     it("installs the permissions the handler declares for its execution", async () => {

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -594,6 +594,66 @@ describe(JobQueueService.name, () => {
       expect((result as PromiseRejectedResult).reason).toBe("boom");
     });
 
+    it("rewrites the error when a NUL byte sits only in a field of its own, as a failed insert's params do", async () => {
+      const error = Object.assign(new Error("insert failed"), { params: ["cmd=tr '\u0000' ' '"] });
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue(error))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      const thrown = (result as PromiseRejectedResult).reason as Error & { params?: string[] };
+      expect(thrown).not.toBe(error);
+      expect(thrown.message).toBe("insert failed");
+      expect(thrown.params).toBeUndefined();
+    });
+
+    it("rewrites the error when a NUL byte sits only in its cause", async () => {
+      const error = new Error("insert failed", { cause: new Error("params: \u0000") });
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue(error))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      const thrown = (result as PromiseRejectedResult).reason as Error;
+      expect(thrown).not.toBe(error);
+      expect(thrown.message).toBe("insert failed");
+      expect(thrown.cause).toBeUndefined();
+    });
+
+    it("strips the NUL bytes out of a rejected string", async () => {
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue("cmd=tr '\u0000' ' '"))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      expect((result as PromiseRejectedResult).reason).toBe("cmd=tr ' ' ' '");
+    });
+
+    it("describes a rejected object whose field carries a NUL byte", async () => {
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue({ evidence: "x\u0000y" }))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      expect((result as PromiseRejectedResult).reason).toBe('{"evidence":"x\\u0000y"}');
+    });
+
+    it("describes a rejected object Postgres could never store as one", async () => {
+      const cyclic: Record<string, unknown> = { evidence: "x\u0000y" };
+      cyclic.self = cyclic;
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue(cyclic))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      expect((result as PromiseRejectedResult).reason).toBe("unserializable rejection");
+    });
+
     it("installs the permissions the handler declares for its execution", async () => {
       const { service, pgBoss, executionContextService } = setup();
       deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -555,6 +555,45 @@ describe(JobQueueService.name, () => {
       expect(thrown.stack).toBe("Error: insert failed\n    at params:  ");
     });
 
+    it("rewrites the error when only its message carries a NUL byte", async () => {
+      const error = new Error("insert failed: \u0000");
+      error.stack = "Error: insert failed\n    at insert";
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue(error))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      const thrown = (result as PromiseRejectedResult).reason as Error;
+      expect(thrown).not.toBe(error);
+      expect(thrown.message).toBe("insert failed:  ");
+      expect(thrown.stack).toBe("Error: insert failed\n    at insert");
+    });
+
+    it("leaves the stack missing when the original error has none", async () => {
+      const error = new Error("insert failed: \u0000");
+      error.stack = undefined;
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue(error))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      const thrown = (result as PromiseRejectedResult).reason as Error;
+      expect(thrown.message).toBe("insert failed:  ");
+      expect(thrown.stack).toBeUndefined();
+    });
+
+    it("rethrows a non-Error rejection as it is", async () => {
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue("boom"))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      expect((result as PromiseRejectedResult).reason).toBe("boom");
+    });
+
     it("installs the permissions the handler declares for its execution", async () => {
       const { service, pgBoss, executionContextService } = setup();
       deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -584,6 +584,17 @@ describe(JobQueueService.name, () => {
       expect(thrown.stack).toBeUndefined();
     });
 
+    it("rethrows an error whose cause is null as it is", async () => {
+      const error = new Error("insert failed", { cause: null });
+      const { service, pgBoss } = setup();
+      deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
+
+      await service.registerHandlers([new TestHandler(vi.fn().mockRejectedValue(error))]);
+      const [result] = await Promise.allSettled([service.startWorkers({ concurrency: 1 })]);
+
+      expect((result as PromiseRejectedResult).reason).toBe(error);
+    });
+
     it("rethrows a non-Error rejection as it is", async () => {
       const { service, pgBoss } = setup();
       deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
@@ -643,8 +654,9 @@ describe(JobQueueService.name, () => {
     });
 
     it("describes a rejected object Postgres could never store as one", async () => {
-      const cyclic: Record<string, unknown> = { evidence: "x\u0000y" };
+      const cyclic: Record<string, unknown> = {};
       cyclic.self = cyclic;
+      cyclic.evidence = "x\u0000y";
       const { service, pgBoss } = setup();
       deliverOneJob(pgBoss, { message: "Job 1", userId: "user-1" });
 

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -36,17 +36,39 @@ function retryOptionsOf(queue: QueueRetryOptions) {
   return RETRY_OPTION_KEYS.map(key => [key, queue[key]] as const);
 }
 
-/** pg-boss writes the thrown error into the job's jsonb output, which Postgres rejects when it carries NUL, and a rejected write leaves the job active for good. */
+const NUL_BYTE = "\u0000";
+
+function withoutNulBytes(text: string): string {
+  return text.replaceAll(NUL_BYTE, " ");
+}
+
+function carriesNulByte(value: unknown, seen: WeakSet<object>): boolean {
+  if (typeof value === "string") return value.includes(NUL_BYTE);
+  if (value === null || typeof value !== "object" || seen.has(value)) return false;
+
+  seen.add(value);
+  const serializedFields = value instanceof Error ? [value.message, value.stack, value.cause, ...Object.values(value)] : Object.values(value);
+
+  return serializedFields.some(field => carriesNulByte(field, seen));
+}
+
+function describeRejection(value: unknown): string {
+  try {
+    return typeof value === "string" ? value : JSON.stringify(value);
+  } catch {
+    return "unserializable rejection";
+  }
+}
+
+/** pg-boss serializes the whole thrown value into the job's jsonb output, and Postgres rejects that write over a NUL anywhere in it, which leaves the job active for good. */
 function toStorableError(error: unknown): unknown {
-  if (!(error instanceof Error)) return error;
+  if (!carriesNulByte(error, new WeakSet())) return error;
+  if (!(error instanceof Error)) return withoutNulBytes(describeRejection(error));
 
-  const message = error.message.replaceAll("\u0000", " ");
-  const stack = error.stack?.replaceAll("\u0000", " ");
-  if (message === error.message && stack === error.stack) return error;
-
-  const storable = new Error(message);
+  const storable = new Error(withoutNulBytes(error.message));
   storable.name = error.name;
-  storable.stack = stack;
+  storable.stack = error.stack === undefined ? undefined : withoutNulBytes(error.stack);
+
   return storable;
 }
 

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -36,6 +36,20 @@ function retryOptionsOf(queue: QueueRetryOptions) {
   return RETRY_OPTION_KEYS.map(key => [key, queue[key]] as const);
 }
 
+/** pg-boss writes the thrown error into the job's jsonb output, which Postgres rejects when it carries NUL, and a rejected write leaves the job active for good. */
+function toStorableError(error: unknown): unknown {
+  if (!(error instanceof Error)) return error;
+
+  const message = error.message.replaceAll("\u0000", " ");
+  const stack = error.stack?.replaceAll("\u0000", " ");
+  if (message === error.message && stack === error.stack) return error;
+
+  const storable = new Error(message);
+  storable.name = error.name;
+  storable.stack = stack;
+  return storable;
+}
+
 @singleton()
 export class JobQueueService implements Disposable {
   private readonly pgBoss: PgBoss;
@@ -370,7 +384,7 @@ export class JobQueueService implements Disposable {
                   jobId: job.id,
                   error
                 });
-                throw error;
+                throw toStorableError(error);
               }
             });
           });

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
@@ -28,6 +28,12 @@ describe("evidence scanner", () => {
       expect(signal.snippet).toBe("cmd=sh -c tr ' ' ' ' -o stratum+tcp://pool");
     });
 
+    it("turns NUL bytes into spaces in the service name it stores, since the provider names its own services", () => {
+      const [signal] = scanForSignals([{ kind: "shell", service: "ssh\u0000box", text: "cmd=miner -o stratum+tcp://pool" }], SIGNATURES);
+
+      expect(signal.service).toBe("ssh box");
+    });
+
     it("reports one signal per category per source however many lines match", () => {
       const signals = scanForSignals([{ kind: "logs", text: "speed 10 H/s\nspeed 12 H/s\nspeed 15 H/s" }], SIGNATURES);
 

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
@@ -22,6 +22,12 @@ describe("evidence scanner", () => {
       ]);
     });
 
+    it("turns NUL bytes into spaces in the snippet it stores", () => {
+      const [signal] = scanForSignals([{ kind: "shell", text: "cmd=sh -c tr '\u0000' ' ' -o stratum+tcp://pool" }], SIGNATURES);
+
+      expect(signal.snippet).toBe("cmd=sh -c tr ' ' ' ' -o stratum+tcp://pool");
+    });
+
     it("reports one signal per category per source however many lines match", () => {
       const signals = scanForSignals([{ kind: "logs", text: "speed 10 H/s\nspeed 12 H/s\nspeed 15 H/s" }], SIGNATURES);
 

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.ts
@@ -19,6 +19,8 @@ export function scanForSignals(sources: EvidenceSource[], signatures: CompiledSi
   const seen = new Set<string>();
 
   for (const source of sources) {
+    const service = source.service === undefined ? undefined : sanitizeEvidenceText(source.service);
+
     for (const line of source.text.split("\n")) {
       if (!line.trim()) continue;
 
@@ -26,7 +28,7 @@ export function scanForSignals(sources: EvidenceSource[], signatures: CompiledSi
         const match = signature.pattern.exec(line);
         if (!match) continue;
 
-        const key = `${signature.bucket}|${signature.category}|${source.kind}|${source.service ?? ""}`;
+        const key = `${signature.bucket}|${signature.category}|${source.kind}|${service ?? ""}`;
         if (seen.has(key)) continue;
 
         seen.add(key);
@@ -34,7 +36,7 @@ export function scanForSignals(sources: EvidenceSource[], signatures: CompiledSi
           bucket: signature.bucket,
           category: signature.category,
           source: source.kind,
-          service: source.service,
+          service,
           snippet: toSnippet(line, match.index)
         });
       }

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.ts
@@ -57,5 +57,10 @@ export function toVerdict(signals: DetectionSignal[]): WorkloadVerdict {
 
 function toSnippet(line: string, matchIndex: number): string {
   const start = Math.max(0, matchIndex - SNIPPET_LEAD_IN);
-  return line.slice(start, start + MAX_SNIPPET_LENGTH).trim();
+  return sanitizeEvidenceText(line.slice(start, start + MAX_SNIPPET_LENGTH)).trim();
+}
+
+/** Postgres rejects NUL in text and jsonb, and a container's output is raw bytes, so it becomes a space before it can reach a detection row. */
+export function sanitizeEvidenceText(text: string): string {
+  return text.replaceAll("\u0000", " ");
 }

--- a/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
@@ -23,6 +23,12 @@ describe(ProviderShellProbeService.name, () => {
       expect(url.searchParams.get("cmd2")).toBe(SHELL_PROBE_SCRIPT);
       expect(url.searchParams.get("service")).toBe("ssh box");
     });
+
+    it("prints expanded lines with printf so a dash echo cannot turn the script's own cmdline into NUL bytes", () => {
+      expect(SHELL_PROBE_SCRIPT).toContain("printf '%s\\n' \"${p#/proc/} comm=");
+      expect(SHELL_PROBE_SCRIPT).toContain("printf '%s\\n' \"== $f\"");
+      expect(SHELL_PROBE_SCRIPT).not.toMatch(/echo "/);
+    });
   });
 
   describe("run", () => {

--- a/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.ts
+++ b/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.ts
@@ -3,14 +3,14 @@ import { singleton } from "tsyringe";
 import { ProviderStreamService, type ProviderStreamStatus } from "@src/workload-abuse/services/provider-stream/provider-stream.service";
 import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
 
-/** Collect-only: nothing here names what the scanner looks for, because argv is visible to the workload through /proc. */
+/** Collect-only and printf-only: argv is visible to the workload through /proc, and dash's echo expands the `\0` in this script's own cmdline into a NUL byte. */
 const SHELL_PROBE_COLLECTORS = [
   "echo '--loadavg'; cat /proc/loadavg 2>/dev/null",
   "echo '--nproc'; nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null",
-  'echo \'--procs\'; for p in /proc/[0-9]*; do c=$(tr \'\\0\' \' \' < "$p/cmdline" 2>/dev/null); [ -n "$c" ] || continue; echo "${p#/proc/} comm=$(cat "$p/comm" 2>/dev/null) exe=$(readlink "$p/exe" 2>/dev/null) cwd=$(readlink "$p/cwd" 2>/dev/null) cmd=$c"; done | head -150',
+  'echo \'--procs\'; for p in /proc/[0-9]*; do c=$(tr \'\\0\' \' \' < "$p/cmdline" 2>/dev/null); [ -n "$c" ] || continue; printf \'%s\\n\' "${p#/proc/} comm=$(cat "$p/comm" 2>/dev/null) exe=$(readlink "$p/exe" 2>/dev/null) cwd=$(readlink "$p/cwd" 2>/dev/null) cmd=$c"; done | head -150',
   "echo '--net'; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | head -80",
   "echo '--tmp'; ls -la /tmp /dev/shm 2>/dev/null | head -80",
-  'echo \'--files\'; for f in /tmp/*.json /tmp/*.conf /tmp/*.txt /tmp/*/*.json /tmp/*/*.conf; do [ -f "$f" ] && [ "$(wc -c < "$f")" -lt 16384 ] && echo "== $f" && cat "$f"; done 2>/dev/null | head -400',
+  'echo \'--files\'; for f in /tmp/*.json /tmp/*.conf /tmp/*.txt /tmp/*/*.json /tmp/*/*.conf; do [ -f "$f" ] && [ "$(wc -c < "$f")" -lt 16384 ] && printf \'%s\\n\' "== $f" && cat "$f"; done 2>/dev/null | head -400',
   "echo '--authorized-keys'; cat /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys 2>/dev/null | sort -u | head -10"
 ];
 

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
@@ -138,7 +138,19 @@ describe(TrialWorkloadProbeService.name, () => {
 
     expect(report.verdict).toBe("hard");
     expect(report.excerpt).not.toContain("\u0000");
-    expect(report.excerpt).toContain("--- shell ssh\n--procs\n3917 comm=sh cmd=sh -c tr ' ' ' ' -o stratum+tcp://pool:3333");
+    expect(report.excerpt).toContain("\n--- shell ssh\n--procs\n3917 comm=sh cmd=sh -c tr ' ' ' ' -o stratum+tcp://pool:3333");
+  });
+
+  it("caps the excerpt it reports at 8192 characters", async () => {
+    const { service, wallet } = setup({
+      leases: [createRpcLease()],
+      services: { ssh: 1 },
+      shell: { status: "completed", output: `stratum+tcp://pool:3333\n${"x".repeat(9_000)}` }
+    });
+
+    const report = await service.probe({ wallet, dseq: DSEQ });
+
+    expect(report.excerpt).toHaveLength(8_192);
   });
 
   it("still scans what it has when the container has no shell", async () => {

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.spec.ts
@@ -127,6 +127,20 @@ describe(TrialWorkloadProbeService.name, () => {
     expect(report.excerpt).toContain("--- shell ssh");
   });
 
+  it("keeps NUL bytes out of the excerpt it reports", async () => {
+    const { service, wallet } = setup({
+      leases: [createRpcLease()],
+      services: { ssh: 1 },
+      shell: { status: "completed", output: "--procs\n3917 comm=sh cmd=sh -c tr '\u0000' ' ' -o stratum+tcp://pool:3333" }
+    });
+
+    const report = await service.probe({ wallet, dseq: DSEQ });
+
+    expect(report.verdict).toBe("hard");
+    expect(report.excerpt).not.toContain("\u0000");
+    expect(report.excerpt).toContain("--- shell ssh\n--procs\n3917 comm=sh cmd=sh -c tr ' ' ' ' -o stratum+tcp://pool:3333");
+  });
+
   it("still scans what it has when the container has no shell", async () => {
     const { service, wallet } = setup({
       leases: [createRpcLease()],

--- a/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service.ts
@@ -10,6 +10,7 @@ import type { ProviderAuth } from "@src/provider/services/provider/provider-prox
 import {
   type DetectionSignal,
   type EvidenceSource,
+  sanitizeEvidenceText,
   scanForSignals,
   toVerdict,
   type WorkloadVerdict
@@ -182,5 +183,5 @@ function buildExcerpt(sources: EvidenceSource[], signals: DetectionSignal[]): st
   );
   const shellOutput = sources.filter(source => source.kind === "shell").map(source => `--- shell ${source.service ?? ""}\n${source.text}`);
 
-  return [...signalLines, ...shellOutput].join("\n").slice(0, MAX_EXCERPT_LENGTH);
+  return sanitizeEvidenceText([...signalLines, ...shellOutput].join("\n")).slice(0, MAX_EXCERPT_LENGTH);
 }


### PR DESCRIPTION
## Why

Trial workload probes in production were finding violations but never storing them. Provider output is raw bytes and can contain NUL, which Postgres rejects in both `text` and `jsonb`. The detection insert failed on it, and pg-boss then failed to record that error for the same reason, leaving every such job `active` until the supervisor reaped it fifteen minutes later, only to repeat. The detections table stayed empty while the job log filled with `JOB_FAILED` / `JOB_QUEUE_ERROR` pairs.

Related to CON-950

## What

- Sanitize evidence text (signal snippets and the excerpt) before it can reach a detection row.
- Print with `printf` instead of `echo` in the shell probe script, so a shell that expands backslash escapes cannot introduce the byte itself.
- Rethrow a storable copy of a failing handler's error from the job wrapper, so a bad payload becomes a `failed` job with a retry rather than an orphaned `active` row. The original error is still logged in full.

No migration, no config change. Already-orphaned jobs will run again on their next retry and persist normally once this is deployed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Sanitized unexpected NUL characters in job failure details, evidence snippets, and workload probe output for reliable storage and display.
  - Preserved error names, messages, and stack traces while preventing invalid characters from disrupting processing.
  - Improved shell probe output formatting for consistent process and file evidence collection.
  - Preserved meaningful context in evidence excerpts after sanitization and truncation, including a maximum excerpt length of 8,192 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->