### PR TITLE
fix(deployment): keep an enforcement failure recordable and its log intact

### DIFF
--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.spec.ts
@@ -111,6 +111,35 @@ describe(TrialAbuseEnforcementService.name, () => {
     expect(instrumentation.recordEnforcement).toHaveBeenCalledWith("failed");
   });
 
+  it("strips the NUL bytes out of the failure it records, since Postgres rejects them in text", async () => {
+    const { service, wallet, signerService, detectionRepository } = setup({ liveDseqs: [] });
+    signerService.executeFundingTx.mockRejectedValueOnce(new Error("broadcast failed: raw_log=\u0000miner"));
+
+    await expect(service.enforce({ wallet, detectionId: DETECTION_ID })).rejects.toThrow("broadcast failed");
+
+    expect(detectionRepository.updateById).toHaveBeenLastCalledWith(DETECTION_ID, {
+      action: "enforcement_failed",
+      enforcementError: "broadcast failed: raw_log= miner",
+      updatedAt: expect.any(Date)
+    });
+  });
+
+  it("logs the enforcement failure and rethrows it when the failure itself cannot be recorded", async () => {
+    const { service, wallet, signerService, detectionRepository, logger, instrumentation } = setup({ liveDseqs: [] });
+    const wipeError = new Error("account sequence mismatch");
+    const recordError = new Error("invalid byte sequence for encoding UTF8");
+    signerService.executeFundingTx.mockRejectedValueOnce(wipeError);
+    detectionRepository.updateById.mockImplementation(async (_detectionId, payload) => {
+      if (payload.action === "enforcement_failed") throw recordError;
+    });
+
+    await expect(service.enforce({ wallet, detectionId: DETECTION_ID })).rejects.toBe(wipeError);
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_FAILED", error: wipeError }));
+    expect(logger.error).toHaveBeenCalledWith({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECORD_FAILED", detectionId: DETECTION_ID, error: recordError });
+    expect(instrumentation.recordEnforcement).toHaveBeenCalledWith("failed");
+  });
+
   it("leaves the wallet untouched and keeps its probes scheduled when a revoke fails for another reason", async () => {
     const { service, wallet, signerService, userWalletRepository, deploymentWriterService, probeJobService } = setup({ liveDseqs: ["11"] });
     signerService.executeFundingTx.mockRejectedValueOnce(new Error("account sequence mismatch"));

--- a/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-abuse-enforcement/trial-abuse-enforcement.service.ts
@@ -9,6 +9,7 @@ import { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc
 import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
 import { type CreateLogger, LOGGER_FACTORY, TxService } from "@src/core";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import { sanitizeEvidenceText } from "@src/workload-abuse/lib/evidence-scanner/evidence-scanner";
 import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
 import { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
 import { WorkloadAbuseInstrumentationService } from "@src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service";
@@ -60,7 +61,6 @@ export class TrialAbuseEnforcementService {
     try {
       outcome = await this.txService.transaction(() => this.#wipeUnlessPaid(wallet));
     } catch (error) {
-      await this.detectionRepository.updateById(detectionId, { action: "enforcement_failed", enforcementError: toErrorMessage(error), updatedAt: new Date() });
       this.instrumentation.recordEnforcement("failed");
       this.logger.error({
         event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_FAILED",
@@ -70,6 +70,7 @@ export class TrialAbuseEnforcementService {
         owner: wallet.address,
         error
       });
+      await this.#recordEnforcementFailure(detectionId, error);
       throw error;
     }
 
@@ -92,6 +93,19 @@ export class TrialAbuseEnforcementService {
     this.logger.warn({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCED", detectionId, walletId: wallet.id, userId: wallet.userId, owner: wallet.address, ...outcome });
 
     return outcome;
+  }
+
+  /** findStalledEnforcements re-queues a detection left in enforcing, so a record that cannot be written is worth a log rather than the failure it was recording. */
+  async #recordEnforcementFailure(detectionId: string, error: unknown): Promise<void> {
+    try {
+      await this.detectionRepository.updateById(detectionId, {
+        action: "enforcement_failed",
+        enforcementError: toStorableErrorMessage(error),
+        updatedAt: new Date()
+      });
+    } catch (recordError) {
+      this.logger.error({ event: "TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECORD_FAILED", detectionId, error: recordError });
+    }
   }
 
   /** Holds the wallet row for the whole wipe, so a payment settling at the same time waits for it and then clears the lock instead of re-granting between the revokes. */
@@ -180,6 +194,7 @@ function isGrantMissingError(error: unknown): boolean {
   return messages.some(message => message && GRANT_MISSING_PATTERN.test(message));
 }
 
-function toErrorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+/** Postgres rejects NUL in text, so an error quoting bytes it read back would fail the very update that records the failure. */
+function toStorableErrorMessage(error: unknown): string {
+  return sanitizeEvidenceText(error instanceof Error ? error.message : String(error));
 }


### PR DESCRIPTION
## Why

Follow-up to #3898. That PR stopped a NUL byte in provider output from failing the detection insert. The same table has one more write that takes free text: `enforcementError`, set from the thrown error when a wipe fails.

The order in that catch block made a rejected write expensive. The record went in before the log line, so a rejected update replaced the original error with the write error. No `TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_FAILED` line, no `failed` metric, and the row left in `enforcing` for `findStalledEnforcements` to re-queue with nothing recorded about why it failed. A NUL in the message was one way to get there, since Postgres refuses it in `text`, but any rejected write did it.

I have not seen this in production, and reachability is lower than the evidence path the parent PR fixed: these messages come from chain and RPC errors rather than raw provider bytes.

## What

- log and count the failure before recording it, so a failed write cannot erase the diagnostic
- sanitize the message the record carries
- a record that still cannot be written reports itself under `TRIAL_WORKLOAD_ABUSE_ENFORCEMENT_RECORD_FAILED` and rethrows the original failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of trial-enforcement failures by sanitizing recorded error details.
  * Preserved the original enforcement error when failure recording encounters an additional problem.
  * Added logging and failed-instrumentation handling for recording failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->