### PR TITLE
feat(deployment): record runtime evidence in trial workload probes and re-probe after updates

### DIFF
--- a/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.integration.ts
@@ -192,6 +192,27 @@ describe(JobQueueService.name, () => {
     await waitForJobState(findJob, "completed");
   });
 
+  it("takes a replacement under a key a worker already holds, so a job enqueued to supersede the run in flight is not dropped", async () => {
+    const singletonKey = "row-1";
+    let release!: () => void;
+    const held = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const { jobQueue, handler, enqueue, findJob, findJobs } = await setup({ queueName: "stately-active", policy: "stately", handle: () => held });
+    await jobQueue.registerHandlers([handler]);
+    await enqueue({ singletonKey });
+    await jobQueue.startWorkers({ concurrency: 1, pollingIntervalSeconds: 0.5 });
+    await waitForJobState(findJob, "active");
+
+    const replacement = await enqueue({ singletonKey });
+    const secondReplacement = await enqueue({ singletonKey });
+
+    expect(replacement).toEqual(expect.any(String));
+    expect(secondReplacement).toBeNull();
+    release();
+    await vi.waitFor(async () => expect((await findJobs()).map(job => job.state)).toEqual(["completed", "completed"]), { timeout: 20_000, interval: 250 });
+  });
+
   it("reports a job under the key that is waiting on a retry", async () => {
     const singletonKey = "row-1";
     const { jobQueue, handler, enqueue, findJob } = await setup({ queueName: "waiting-retry", handle: vi.fn().mockRejectedValue(new Error("boom")) });
@@ -233,6 +254,15 @@ describe(JobQueueService.name, () => {
       constructor(public readonly data: Record<string, unknown> = {}) {}
     }
 
+    const findJobs = async () => {
+      const rows = await db.execute<JobRow>(
+        sql`select state, retry_limit, retry_backoff, retry_delay, retry_delay_max, start_after::text
+            from ${backgroundJobsSchema()}.job where name = ${queueName} order by created_on`
+      );
+
+      return rows as unknown as JobRow[];
+    };
+
     return {
       jobQueue,
       handler: {
@@ -252,14 +282,8 @@ describe(JobQueueService.name, () => {
 
         return (rows as unknown as QueueRow[])[0];
       },
-      findJob: async () => {
-        const rows = await db.execute<JobRow>(
-          sql`select state, retry_limit, retry_backoff, retry_delay, retry_delay_max, start_after::text
-              from ${backgroundJobsSchema()}.job where name = ${queueName}`
-        );
-
-        return (rows as unknown as JobRow[])[0];
-      }
+      findJob: async () => (await findJobs())[0],
+      findJobs
     };
   }
 });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -29,6 +29,7 @@ import type { SdlSecretsInheritanceService } from "@src/deployment/services/sdl-
 import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
 import { SECRET_UNREADABLE_ERROR_MESSAGE } from "@src/secret/config/secret-at-rest.config";
+import type { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
 import type { StaleManagedDeploymentsCleanerService } from "../stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
@@ -1232,6 +1233,33 @@ describe(DeploymentWriterService.name, () => {
       expect(jobQueueService.cancelCreatedBy).not.toHaveBeenCalled();
     });
 
+    it("starts the trial workload probes over once every provider holds the new manifest", async () => {
+      const { service, probeJobService, providerService } = setup({ isTrialing: true });
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl" });
+
+      expect(probeJobService.restartForUpdatedDeployment).toHaveBeenCalledWith({ walletId: wallet.id, dseq: "100", updatedAt: expect.any(Date) });
+      expect(providerService.sendManifest.mock.invocationCallOrder[0]).toBeLessThan(probeJobService.restartForUpdatedDeployment.mock.invocationCallOrder[0]);
+    });
+
+    it("leaves the probe schedule alone for an established wallet", async () => {
+      const { service, probeJobService } = setup();
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl" });
+
+      expect(probeJobService.restartForUpdatedDeployment).not.toHaveBeenCalled();
+    });
+
+    it("still answers the update when the probes cannot be restarted", async () => {
+      const { service, probeJobService, logger } = setup({ isTrialing: true });
+      probeJobService.restartForUpdatedDeployment.mockRejectedValue(new Error("queue down"));
+
+      const result = await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl" });
+
+      expect(result).toBe(deploymentData);
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBE_RESTART_FAILED", userId: "user-1", dseq: "100" }));
+    });
+
     it("skips update tx when manifest hash matches", async () => {
       const { service, signerService, rpcMessageService } = setup({ manifestVersion: new Uint8Array([1, 2, 3]) });
 
@@ -1956,6 +1984,23 @@ describe(DeploymentWriterService.name, () => {
     });
 
     describe("the trial limits a wallet is still under", () => {
+      it("starts a trialing wallet's workload probes over once the patched manifest is pushed", async () => {
+        const { service, ability, probeJobService, providerService } = setup({ isTrialing: true });
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { image: "nginx:1.27" } } }, ability);
+
+        expect(probeJobService.restartForUpdatedDeployment).toHaveBeenCalledWith({ walletId: 7, dseq: "1234", updatedAt: expect.any(Date) });
+        expect(providerService.sendManifest.mock.invocationCallOrder[0]).toBeLessThan(probeJobService.restartForUpdatedDeployment.mock.invocationCallOrder[0]);
+      });
+
+      it("leaves an established wallet's probe schedule alone", async () => {
+        const { service, ability, probeJobService } = setup({ isTrialing: false });
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { image: "nginx:1.27" } } }, ability);
+
+        expect(probeJobService.restartForUpdatedDeployment).not.toHaveBeenCalled();
+      });
+
       it("resolves a trialing wallet's patch under them", async () => {
         const { service, sdlService, ability } = setup({ isTrialing: true });
 
@@ -2039,6 +2084,7 @@ describe(DeploymentWriterService.name, () => {
       const createLogger: CreateLogger = () => logger;
 
       const sdlReferenceService = new SdlReferenceService();
+      const probeJobService = mock<TrialWorkloadProbeJobService>();
       const ability = mock<AnyAbility>();
       const service = new DeploymentWriterService(
         signerService,
@@ -2058,7 +2104,8 @@ describe(DeploymentWriterService.name, () => {
         new SdlSecretsDerivationService(new SdlReferenceService()),
         new SdlPatchService(),
         sdlReferenceService,
-        mock<SdlSecretsInheritanceService>()
+        mock<SdlSecretsInheritanceService>(),
+        probeJobService
       );
 
       function sealedFor() {
@@ -2076,6 +2123,7 @@ describe(DeploymentWriterService.name, () => {
         signerService,
         logger,
         sdlReferenceService,
+        probeJobService,
         sealedFor
       };
     }
@@ -2095,6 +2143,7 @@ describe(DeploymentWriterService.name, () => {
     storedSdl?: string;
     storedRuntimeLimitHours?: number | null;
     sourceSetting?: DeploymentSettingsOutput;
+    isTrialing?: boolean;
   }) {
     const signerService = mock<ManagedSignerService>();
     const rpcMessageService = mock<RpcMessageService>();
@@ -2152,7 +2201,8 @@ describe(DeploymentWriterService.name, () => {
     if (input?.inheritanceError) sdlSecretsInheritanceService.open.mockRejectedValue(input.inheritanceError);
     else sdlSecretsInheritanceService.open.mockResolvedValue(input?.inherited ?? {});
 
-    walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
+    walletReaderService.getWalletByUserId.mockResolvedValue(input?.isTrialing ? { ...wallet, isTrialing: true } : wallet);
+    const probeJobService = mock<TrialWorkloadProbeJobService>();
     sdlService.parse.mockReturnValue({ ok: true, value: parsedSdlValue } as any);
     sdlService.generateManifest.mockResolvedValue({ ok: true, value: manifestValue } as any);
     sdlService.generateManifestVersion.mockResolvedValue(new Uint8Array([4, 5, 6]));
@@ -2180,7 +2230,8 @@ describe(DeploymentWriterService.name, () => {
       sdlSecretsDerivationService,
       new SdlPatchService(),
       new SdlReferenceService(),
-      sdlSecretsInheritanceService
+      sdlSecretsInheritanceService,
+      probeJobService
     );
 
     function storedSecrets() {
@@ -2206,6 +2257,7 @@ describe(DeploymentWriterService.name, () => {
       sdlSecretsService,
       sdlSecretsInheritanceService,
       scopedSettingRepository,
+      probeJobService,
       ability: mock<AnyAbility>(),
       storedSecrets
     };

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -38,6 +38,7 @@ import type { StorableSdl, StoredSdlPosition, StoredSdlRefusal } from "@src/depl
 import { parseSdlForStorage, sdlForStorage } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { denomToUdenom } from "@src/utils/math";
+import { TrialWorkloadProbeJobService } from "@src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
 import { StaleManagedDeploymentsCleanerService } from "../stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
@@ -100,7 +101,8 @@ export class DeploymentWriterService {
     private readonly sdlSecretsDerivationService: SdlSecretsDerivationService,
     private readonly sdlPatchService: SdlPatchService,
     private readonly sdlReferenceService: SdlReferenceService,
-    private readonly sdlSecretsInheritanceService: SdlSecretsInheritanceService
+    private readonly sdlSecretsInheritanceService: SdlSecretsInheritanceService,
+    private readonly probeJobService: TrialWorkloadProbeJobService
   ) {
     this.logger = createLogger({ context: DeploymentWriterService.name });
   }
@@ -389,6 +391,7 @@ export class DeploymentWriterService {
     await this.ensureDeploymentIsUpToDate(wallet, dseq, manifestVersion, deployment);
     const auth = { walletId: wallet.id };
     await this.sendManifestToProviders({ auth, dseq, manifest: manifestToSortedJSON(manifest.groups), leases: deployment.leases });
+    await this.restartTrialWorkloadProbe(wallet, dseq);
 
     return await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
   }
@@ -460,8 +463,20 @@ export class DeploymentWriterService {
       manifest: manifestToSortedJSON(manifest.groups),
       leases: deployment.leases
     });
+    await this.restartTrialWorkloadProbe(wallet, dseq);
 
     return { ...(await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq)), manifestVersion: recordedVersion };
+  }
+
+  /** The probe is a backstopped extra, so failing to reschedule it must not fail an update the chain and the providers have already taken. */
+  private async restartTrialWorkloadProbe(wallet: UserWalletOutput, dseq: string): Promise<void> {
+    if (!wallet.isTrialing) return;
+
+    try {
+      await this.probeJobService.restartForUpdatedDeployment({ walletId: wallet.id, dseq, updatedAt: new Date() });
+    } catch (error) {
+      this.logger.error({ event: "TRIAL_WORKLOAD_PROBE_RESTART_FAILED", userId: wallet.userId, dseq, error });
+    }
   }
 
   /** Read through the caller's own ability as well as their id, so a definition is unreachable by anyone the ability excludes even before the write re-checks it. */

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { CompiledSignature } from "@src/workload-abuse/config/env.config";
-import { scanForSignals, toVerdict } from "./evidence-scanner";
+import { sanitizeEvidenceText, scanForSignals, toVerdict } from "./evidence-scanner";
 
 const SIGNATURES: CompiledSignature[] = [
   { bucket: "hard", category: "stratum-url", pattern: /stratum\+tcp:\/\//i },
@@ -32,12 +32,6 @@ describe("evidence scanner", () => {
       const [signal] = scanForSignals([{ kind: "shell", text: "cmd=miner \u001b[31m\u0007-o stratum+tcp://pool" }], SIGNATURES);
 
       expect(signal.snippet).toBe("cmd=miner  [31m -o stratum+tcp://pool");
-    });
-
-    it("keeps the tabs and newlines that hold the shell output's shape", () => {
-      const [signal] = scanForSignals([{ kind: "shell", text: "cmd=miner\t-o stratum+tcp://pool" }], SIGNATURES);
-
-      expect(signal.snippet).toBe("cmd=miner\t-o stratum+tcp://pool");
     });
 
     it("turns NUL bytes into spaces in the service name it stores, since the provider names its own services", () => {
@@ -94,6 +88,16 @@ describe("evidence scanner", () => {
     it("returns nothing for clean text or when there are no signatures", () => {
       expect(scanForSignals([{ kind: "logs", text: "nginx started\n\n" }], SIGNATURES)).toEqual([]);
       expect(scanForSignals([{ kind: "logs", text: "stratum+tcp://pool" }], [])).toEqual([]);
+    });
+  });
+
+  describe("sanitizeEvidenceText", () => {
+    it("keeps the tabs and newlines that hold the shell output's shape", () => {
+      expect(sanitizeEvidenceText("--tmp\ndrwx\t4096 /tmp\n")).toBe("--tmp\ndrwx\t4096 /tmp\n");
+    });
+
+    it("turns the control bytes around them into spaces", () => {
+      expect(sanitizeEvidenceText("--tmp\u0000\u001b[31m\u0007\ndrwx\t4096 /tmp")).toBe("--tmp  [31m \ndrwx\t4096 /tmp");
     });
   });
 

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.spec.ts
@@ -28,6 +28,18 @@ describe("evidence scanner", () => {
       expect(signal.snippet).toBe("cmd=sh -c tr ' ' ' ' -o stratum+tcp://pool");
     });
 
+    it("turns every other control byte into a space too, since a log line escapes each of them to six characters", () => {
+      const [signal] = scanForSignals([{ kind: "shell", text: "cmd=miner \u001b[31m\u0007-o stratum+tcp://pool" }], SIGNATURES);
+
+      expect(signal.snippet).toBe("cmd=miner  [31m -o stratum+tcp://pool");
+    });
+
+    it("keeps the tabs and newlines that hold the shell output's shape", () => {
+      const [signal] = scanForSignals([{ kind: "shell", text: "cmd=miner\t-o stratum+tcp://pool" }], SIGNATURES);
+
+      expect(signal.snippet).toBe("cmd=miner\t-o stratum+tcp://pool");
+    });
+
     it("turns NUL bytes into spaces in the service name it stores, since the provider names its own services", () => {
       const [signal] = scanForSignals([{ kind: "shell", service: "ssh\u0000box", text: "cmd=miner -o stratum+tcp://pool" }], SIGNATURES);
 

--- a/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.ts
+++ b/apps/api/src/workload-abuse/lib/evidence-scanner/evidence-scanner.ts
@@ -12,6 +12,7 @@ const MAX_SNIPPET_LENGTH = 180;
 const SNIPPET_LEAD_IN = 60;
 /** Any one soft category alone (a port number, the word nonce) shows up in honest workloads. */
 const MIN_SOFT_CATEGORIES_FOR_VERDICT = 3;
+const CONTROL_CHARACTERS_EXCEPT_TAB_AND_NEWLINE = /(?!\n|\t)\p{Cc}/gu;
 
 /** One signal per category per source, so a chatty miner log produces an auditable table rather than thousands of rows. */
 export function scanForSignals(sources: EvidenceSource[], signatures: CompiledSignature[]): DetectionSignal[] {
@@ -62,7 +63,7 @@ function toSnippet(line: string, matchIndex: number): string {
   return sanitizeEvidenceText(line.slice(start, start + MAX_SNIPPET_LENGTH)).trim();
 }
 
-/** Postgres rejects NUL in text and jsonb, and a container's output is raw bytes, so it becomes a space before it can reach a detection row. */
+/** Postgres rejects NUL in text and jsonb and a log line escapes every other control byte to six characters, so a container's raw output loses them all. */
 export function sanitizeEvidenceText(text: string): string {
-  return text.replaceAll("\u0000", " ");
+  return text.replace(CONTROL_CHARACTERS_EXCEPT_TAB_AND_NEWLINE, " ");
 }

--- a/apps/api/src/workload-abuse/lib/utf8-text/utf8-text.spec.ts
+++ b/apps/api/src/workload-abuse/lib/utf8-text/utf8-text.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { truncateToUtf8Bytes } from "./utf8-text";
+
+describe("truncateToUtf8Bytes", () => {
+  it("keeps text that already fits", () => {
+    expect(truncateToUtf8Bytes("miner", 16)).toBe("miner");
+  });
+
+  it("counts bytes rather than code units, so multibyte text stays inside the budget", () => {
+    const truncated = truncateToUtf8Bytes("日".repeat(10), 12);
+
+    expect(truncated).toBe("日".repeat(4));
+    expect(Buffer.byteLength(truncated, "utf8")).toBeLessThanOrEqual(12);
+  });
+
+  it("drops a character the budget cuts in half rather than emitting a replacement one", () => {
+    expect(truncateToUtf8Bytes("日", 2)).toBe("");
+  });
+
+  it("keeps a surrogate pair whole", () => {
+    expect(truncateToUtf8Bytes("🙂🙂", 7)).toBe("🙂");
+  });
+});

--- a/apps/api/src/workload-abuse/lib/utf8-text/utf8-text.ts
+++ b/apps/api/src/workload-abuse/lib/utf8-text/utf8-text.ts
@@ -1,0 +1,6 @@
+import { StringDecoder } from "node:string_decoder";
+
+/** `write` without `end` never emits a partial character, so the kept text stays within the byte budget. */
+export function truncateToUtf8Bytes(text: string, maxBytes: number): string {
+  return new StringDecoder("utf8").write(Buffer.from(text, "utf8").subarray(0, maxBytes));
+}

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
@@ -68,6 +68,15 @@ describe(ProbeTrialDeploymentHandler.name, () => {
     expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBED", verdict: "clean", evidence: "x".repeat(4_096) }));
   });
 
+  it("cuts the logged evidence by bytes, so multibyte output a workload controls cannot outgrow the line budget", async () => {
+    const multibyte = "\u65e5";
+    const { handler, logger } = setup({ report: createReport({ verdict: "clean", excerpt: multibyte.repeat(5_000) }) });
+
+    await handler.handle(PAYLOAD);
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBED", evidence: multibyte.repeat(1_365) }));
+  });
+
   it("records a suspicious workload for review and keeps probing it", async () => {
     const report = createReport({ verdict: "soft" });
     const { handler, wallet, probeJobService, detectionRepository, logger } = setup({ report });

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.spec.ts
@@ -60,6 +60,14 @@ describe(ProbeTrialDeploymentHandler.name, () => {
     expect(instrumentation.recordProbe).toHaveBeenCalledWith(expect.objectContaining({ verdict: "clean", probeStatus: "probed" }));
   });
 
+  it("logs what the shell saw for every verdict, cut so the line survives log shipping", async () => {
+    const { handler, logger } = setup({ report: createReport({ verdict: "clean", excerpt: "x".repeat(5_000) }) });
+
+    await handler.handle(PAYLOAD);
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "TRIAL_WORKLOAD_PROBED", verdict: "clean", evidence: "x".repeat(4_096) }));
+  });
+
   it("records a suspicious workload for review and keeps probing it", async () => {
     const report = createReport({ verdict: "soft" });
     const { handler, wallet, probeJobService, detectionRepository, logger } = setup({ report });

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
@@ -9,6 +9,9 @@ import { ProbeTrialDeployment, TrialWorkloadProbeJobService } from "@src/workloa
 import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
 import { WorkloadAbuseInstrumentationService } from "@src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service";
 
+/** Loki splits a line past 16 KiB into unparseable partials, and a clean verdict has nowhere else to keep what the shell saw. */
+const MAX_LOGGED_EXCERPT_LENGTH = 4_096;
+
 /** Re-reads the wallet and the chain on every run, so a probe that waited an hour decides on what is true when it runs, not when it was queued. */
 @singleton()
 export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeployment> {
@@ -94,6 +97,7 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
       userId: wallet.userId,
       verdict: report.verdict,
       probeStatus: report.probeStatus,
+      evidence: report.excerpt.slice(0, MAX_LOGGED_EXCERPT_LENGTH),
       leases: report.leases.map(lease => ({
         provider: lease.provider,
         services: lease.services,

--- a/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
+++ b/apps/api/src/workload-abuse/services/probe-trial-deployment/probe-trial-deployment.handler.ts
@@ -2,6 +2,7 @@ import { inject, singleton } from "tsyringe";
 
 import { isWalletInitialized, UserWalletRepository } from "@src/billing/repositories";
 import { type CreateLogger, JOB_NAME, type JobHandler, type JobPayload, type JobPermissions, JobQueueService, LOGGER_FACTORY } from "@src/core";
+import { truncateToUtf8Bytes } from "@src/workload-abuse/lib/utf8-text/utf8-text";
 import { WorkloadAbuseDetectionRepository } from "@src/workload-abuse/repositories/workload-abuse-detection/workload-abuse-detection.repository";
 import { EnforceTrialAbuse, enforceTrialAbuseKeyFor } from "@src/workload-abuse/services/enforce-trial-abuse/enforce-trial-abuse.handler";
 import { type ProbeReport, TrialWorkloadProbeService } from "@src/workload-abuse/services/trial-workload-probe/trial-workload-probe.service";
@@ -10,7 +11,7 @@ import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workloa
 import { WorkloadAbuseInstrumentationService } from "@src/workload-abuse/services/workload-abuse-instrumentation/workload-abuse-instrumentation.service";
 
 /** Loki splits a line past 16 KiB into unparseable partials, and a clean verdict has nowhere else to keep what the shell saw. */
-const MAX_LOGGED_EXCERPT_LENGTH = 4_096;
+const MAX_LOGGED_EXCERPT_BYTES = 4_096;
 
 /** Re-reads the wallet and the chain on every run, so a probe that waited an hour decides on what is true when it runs, not when it was queued. */
 @singleton()
@@ -97,7 +98,7 @@ export class ProbeTrialDeploymentHandler implements JobHandler<ProbeTrialDeploym
       userId: wallet.userId,
       verdict: report.verdict,
       probeStatus: report.probeStatus,
-      evidence: report.excerpt.slice(0, MAX_LOGGED_EXCERPT_LENGTH),
+      evidence: truncateToUtf8Bytes(report.excerpt, MAX_LOGGED_EXCERPT_BYTES),
       leases: report.leases.map(lease => ({
         provider: lease.provider,
         services: lease.services,

--- a/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
@@ -25,9 +25,31 @@ describe(ProviderShellProbeService.name, () => {
     });
 
     it("prints expanded lines with printf so a dash echo cannot turn the script's own cmdline into NUL bytes", () => {
-      expect(SHELL_PROBE_SCRIPT).toContain("printf '%s\\n' \"${p#/proc/} comm=");
+      expect(SHELL_PROBE_SCRIPT).toContain("printf '%s\\n' \"${p#/proc/} cpu_s=");
       expect(SHELL_PROBE_SCRIPT).toContain("printf '%s\\n' \"== $f\"");
       expect(SHELL_PROBE_SCRIPT).not.toMatch(/echo "/);
+    });
+
+    it("leaves its own shell and that shell's children out of the process listing by pid, not by what they run", () => {
+      expect(SHELL_PROBE_SCRIPT).toContain('[ "${p#/proc/}" = "$$" ] && continue');
+      expect(SHELL_PROBE_SCRIPT).toContain('[ "${2:-}" = "$$" ] && continue');
+    });
+
+    it("records cpu time and memory per process, decoded socket peers, and files written since the container started", () => {
+      expect(SHELL_PROBE_SCRIPT).toContain("cpu_s=$(( (${12:-0} + ${13:-0}) / 100 )) rss_mb=$(( ${22:-0} * 4 / 1024 ))");
+      expect(SHELL_PROBE_SCRIPT).toContain('printf \'st=%s remote=%d.%d.%d.%d:%d\\n\' "$st" "0x$d" "0x$c" "0x$b" "0x$a" "0x$po"');
+      expect(SHELL_PROBE_SCRIPT).toContain("printf 'listen=%d\\n' \"0x${la#*:}\"");
+      expect(SHELL_PROBE_SCRIPT).toContain(
+        "echo '--recent-exec'; find / \\( -path /proc -o -path /sys -o -path /dev \\) -prune -o -type f -perm -100 -newer /proc/1 -print"
+      );
+      expect(SHELL_PROBE_SCRIPT).toContain(
+        "echo '--recent-conf'; find / \\( -path /proc -o -path /sys -o -path /dev -o -path /etc -o -path /tmp -o -name node_modules \\) -prune"
+      );
+    });
+
+    it("only reads the container and never changes, fetches or runs anything in it", () => {
+      expect(SHELL_PROBE_SCRIPT).not.toMatch(/\b(curl|wget|chmod|chown|kill|rm|mv|cp|apt|apk|pip|npm)\b/);
+      expect(SHELL_PROBE_SCRIPT).not.toMatch(/[^2<]>\s*\/(?!dev\/null)/);
     });
   });
 

--- a/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
@@ -1,9 +1,13 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { ProviderStreamResult, ProviderStreamService } from "@src/workload-abuse/services/provider-stream/provider-stream.service";
 import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
-import { buildShellProbeUrl, ProviderShellProbeService, SHELL_PROBE_SCRIPT } from "./provider-shell-probe.service";
+import { buildShellProbeUrl, ProviderShellProbeService, SHELL_PROBE_COLLECTORS, SHELL_PROBE_SCRIPT } from "./provider-shell-probe.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
@@ -35,12 +39,11 @@ describe(ProviderShellProbeService.name, () => {
       expect(SHELL_PROBE_SCRIPT).toContain('[ "${2:-}" = "$$" ] && continue');
     });
 
-    it("records cpu time and memory per process, decoded socket peers, and files written since the container started", () => {
+    it("records cpu time and memory per process, listening ports, and files written since the container started", () => {
       expect(SHELL_PROBE_SCRIPT).toContain("cpu_s=$(( (${12:-0} + ${13:-0}) / 100 )) rss_mb=$(( ${22:-0} * 4 / 1024 ))");
-      expect(SHELL_PROBE_SCRIPT).toContain('printf \'st=%s remote=%d.%d.%d.%d:%d\\n\' "$st" "0x$d" "0x$c" "0x$b" "0x$a" "0x$po"');
       expect(SHELL_PROBE_SCRIPT).toContain("printf 'listen=%d\\n' \"0x${la#*:}\"");
       expect(SHELL_PROBE_SCRIPT).toContain(
-        "echo '--recent-exec'; find / \\( -path /proc -o -path /sys -o -path /dev \\) -prune -o -type f -perm -100 -newer /proc/1 -print"
+        "echo '--recent-exec'; find / \\( -path /proc -o -path /sys -o -path /dev -o -name node_modules \\) -prune -o -type f -perm -100 -newer /proc/1 -print"
       );
       expect(SHELL_PROBE_SCRIPT).toContain(
         "echo '--recent-conf'; find / \\( -path /proc -o -path /sys -o -path /dev -o -path /etc -o -path /tmp -o -name node_modules \\) -prune"
@@ -50,6 +53,49 @@ describe(ProviderShellProbeService.name, () => {
     it("only reads the container and never changes, fetches or runs anything in it", () => {
       expect(SHELL_PROBE_SCRIPT).not.toMatch(/\b(curl|wget|chmod|chown|kill|rm|mv|cp|apt|apk|pip|npm)\b/);
       expect(SHELL_PROBE_SCRIPT).not.toMatch(/[^2<]>\s*\/(?!dev\/null)/);
+    });
+  });
+
+  describe("the --net collector", () => {
+    it("decodes an IPv4 peer, a v4-mapped peer and a native IPv6 peer as the kernel encodes each of them", () => {
+      const reported = runNetCollector({
+        tcp: [
+          "   0: 00000000:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 1 1 0 0 0",
+          "   1: 0100007F:9C4E 140AB912:0D05 01 00000000:00000000 00:00000000 00000000     0        0 2 1 0 0 0"
+        ],
+        tcp6: [
+          "   0: 00000000000000000000000000000000:1F90 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 3 1 0 0 0",
+          "   1: 0000000000000000FFFF00000100007F:A0F0 0000000000000000FFFF000009030E34:0D05 01 00000000:00000000 00:00000000 00000000     0        0 4 1 0 0 0",
+          "   2: F804012A8F0B170C0000000002000000:A0F1 00470626000000470000000011110000:0D05 01 00000000:00000000 00:00000000 00000000     0        0 5 1 0 0 0"
+        ]
+      });
+
+      expect(reported).toEqual(
+        expect.arrayContaining([
+          "--net",
+          "2 listen=8080",
+          "1 st=01 remote=18.185.10.20:3333",
+          "1 st=01 remote=52.14.3.9:3333",
+          "1 st=01 remote=[2606:4700:4700:0000:0000:0000:0000:1111]:3333"
+        ])
+      );
+      expect(reported).toHaveLength(5);
+    });
+
+    it("keeps a loopback IPv6 peer out of the IPv4 range it would otherwise be printed in", () => {
+      const reported = runNetCollector({
+        tcp6: ["   0: F804012A8F0B170C0000000002000000:A0F2 00000000000000000000000001000000:1F91 02 00000000:00000000 00:00000000 00000000 0 0 6 1 0 0 0"]
+      });
+
+      expect(reported).toEqual(["--net", "1 st=02 remote=[0000:0000:0000:0000:0000:0000:0000:0001]:8081"]);
+    });
+
+    it("leaves out a socket that is neither established nor listening", () => {
+      const reported = runNetCollector({
+        tcp: ["   0: 0100007F:9C4E 140AB912:0D05 06 00000000:00000000 00:00000000 00000000     0        0 7 1 0 0 0"]
+      });
+
+      expect(reported).toEqual(["--net"]);
     });
   });
 
@@ -84,6 +130,23 @@ describe(ProviderShellProbeService.name, () => {
       expect((await service.run(TARGET)).status).toBe("token_expired");
     });
   });
+
+  function runNetCollector(procFiles: { tcp?: string[]; tcp6?: string[] }) {
+    const header = "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+    const directory = mkdtempSync(join(tmpdir(), "shell-probe-net-"));
+
+    for (const name of ["tcp", "tcp6"] as const) {
+      writeFileSync(join(directory, name), [header, ...(procFiles[name] ?? [])].join("\n") + "\n");
+    }
+
+    const collector = SHELL_PROBE_COLLECTORS.find(entry => entry.includes("--net")) ?? "";
+    const script = collector.replace("/proc/net/tcp /proc/net/tcp6", `${directory}/tcp ${directory}/tcp6`);
+
+    return execFileSync("sh", ["-c", script], { encoding: "utf8" })
+      .split("\n")
+      .filter(line => line.trim())
+      .map(line => line.trim());
+  }
 
   function setup(result: ProviderStreamResult) {
     const providerStreamService = mock<ProviderStreamService>();

--- a/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.ts
+++ b/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.ts
@@ -7,11 +7,13 @@ import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workloa
 const SHELL_PROBE_COLLECTORS = [
   "echo '--loadavg'; cat /proc/loadavg 2>/dev/null",
   "echo '--nproc'; nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null",
-  'echo \'--procs\'; for p in /proc/[0-9]*; do c=$(tr \'\\0\' \' \' < "$p/cmdline" 2>/dev/null); [ -n "$c" ] || continue; printf \'%s\\n\' "${p#/proc/} comm=$(cat "$p/comm" 2>/dev/null) exe=$(readlink "$p/exe" 2>/dev/null) cwd=$(readlink "$p/cwd" 2>/dev/null) cmd=$c"; done | head -150',
-  "echo '--net'; cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | head -80",
+  'echo \'--procs\'; for p in /proc/[0-9]*; do [ "${p#/proc/}" = "$$" ] && continue; c=$({ tr \'\\0\' \' \' < "$p/cmdline"; } 2>/dev/null); [ -n "$c" ] || continue; s=$(cat "$p/stat" 2>/dev/null); set -- ${s##*) }; [ "${2:-}" = "$$" ] && continue; printf \'%s\\n\' "${p#/proc/} cpu_s=$(( (${12:-0} + ${13:-0}) / 100 )) rss_mb=$(( ${22:-0} * 4 / 1024 )) comm=$(cat "$p/comm" 2>/dev/null) exe=$(readlink "$p/exe" 2>/dev/null) cwd=$(readlink "$p/cwd" 2>/dev/null) cmd=$c"; done | head -150',
+  'echo \'--net\'; for f in /proc/net/tcp /proc/net/tcp6; do [ -r "$f" ] || continue; while read -r sl la ra st rest; do case $st in 0A) printf \'listen=%d\\n\' "0x${la#*:}"; continue;; 01|02) ;; *) continue;; esac; h=${ra%:*}; po=${ra#*:}; h=${h#????????????????????????}; a=${h%??????}; b=${h%????}; b=${b#??}; c=${h%??}; c=${c#????}; d=${h#??????}; printf \'st=%s remote=%d.%d.%d.%d:%d\\n\' "$st" "0x$d" "0x$c" "0x$b" "0x$a" "0x$po"; done < "$f"; done 2>/dev/null | sort | uniq -c | head -80',
   "echo '--tmp'; ls -la /tmp /dev/shm 2>/dev/null | head -80",
   'echo \'--files\'; for f in /tmp/*.json /tmp/*.conf /tmp/*.txt /tmp/*/*.json /tmp/*/*.conf; do [ -f "$f" ] && [ "$(wc -c < "$f")" -lt 16384 ] && printf \'%s\\n\' "== $f" && cat "$f"; done 2>/dev/null | head -400',
-  "echo '--authorized-keys'; cat /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys 2>/dev/null | sort -u | head -10"
+  "echo '--authorized-keys'; cat /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys 2>/dev/null | sort -u | head -10",
+  "echo '--recent-exec'; find / \\( -path /proc -o -path /sys -o -path /dev \\) -prune -o -type f -perm -100 -newer /proc/1 -print 2>/dev/null | head -60 | while read -r f; do ls -la \"$f\" 2>/dev/null; done",
+  "echo '--recent-conf'; find / \\( -path /proc -o -path /sys -o -path /dev -o -path /etc -o -path /tmp -o -name node_modules \\) -prune -o -type f -newer /proc/1 \\( -name '*.json' -o -name '*.conf' -o -name '*.ini' -o -name '*.txt' \\) -size -16k -print 2>/dev/null | head -20 | while read -r f; do printf '%s\\n' \"== $f\"; cat \"$f\" 2>/dev/null; done | head -400"
 ];
 
 export const SHELL_PROBE_SCRIPT = SHELL_PROBE_COLLECTORS.join("; ");

--- a/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.ts
+++ b/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.ts
@@ -4,15 +4,15 @@ import { ProviderStreamService, type ProviderStreamStatus } from "@src/workload-
 import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
 
 /** Collect-only and printf-only: argv is visible to the workload through /proc, and dash's echo expands the `\0` in this script's own cmdline into a NUL byte. */
-const SHELL_PROBE_COLLECTORS = [
+export const SHELL_PROBE_COLLECTORS = [
   "echo '--loadavg'; cat /proc/loadavg 2>/dev/null",
   "echo '--nproc'; nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null",
   'echo \'--procs\'; for p in /proc/[0-9]*; do [ "${p#/proc/}" = "$$" ] && continue; c=$({ tr \'\\0\' \' \' < "$p/cmdline"; } 2>/dev/null); [ -n "$c" ] || continue; s=$(cat "$p/stat" 2>/dev/null); set -- ${s##*) }; [ "${2:-}" = "$$" ] && continue; printf \'%s\\n\' "${p#/proc/} cpu_s=$(( (${12:-0} + ${13:-0}) / 100 )) rss_mb=$(( ${22:-0} * 4 / 1024 )) comm=$(cat "$p/comm" 2>/dev/null) exe=$(readlink "$p/exe" 2>/dev/null) cwd=$(readlink "$p/cwd" 2>/dev/null) cmd=$c"; done | head -150',
-  'echo \'--net\'; for f in /proc/net/tcp /proc/net/tcp6; do [ -r "$f" ] || continue; while read -r sl la ra st rest; do case $st in 0A) printf \'listen=%d\\n\' "0x${la#*:}"; continue;; 01|02) ;; *) continue;; esac; h=${ra%:*}; po=${ra#*:}; h=${h#????????????????????????}; a=${h%??????}; b=${h%????}; b=${b#??}; c=${h%??}; c=${c#????}; d=${h#??????}; printf \'st=%s remote=%d.%d.%d.%d:%d\\n\' "$st" "0x$d" "0x$c" "0x$b" "0x$a" "0x$po"; done < "$f"; done 2>/dev/null | sort | uniq -c | head -80',
+  'echo \'--net\'; for f in /proc/net/tcp /proc/net/tcp6; do [ -r "$f" ] || continue; while read -r sl la ra st rest; do case $st in 0A) printf \'listen=%d\\n\' "0x${la#*:}"; continue;; 01|02) ;; *) continue;; esac; h=${ra%:*}; po=${ra#*:}; case $h in 0000000000000000[Ff][Ff][Ff][Ff]0000????????|????????) ;; ????????????????????????????????) w=${h%????????????????????????}; t=${h#????????}; x=${t%????????????????}; t=${h#????????????????}; y=${t%????????}; z=${h#????????????????????????}; o=; for q in $w $x $y $z; do u=${q%????}; v=${q%??}; o=$o${q#??????}${v#????}:${u#??}${q%??????}:; done; printf \'st=%s remote=[%s]:%d\\n\' "$st" "${o%:}" "0x$po"; continue;; esac; h=${h#????????????????????????}; a=${h%??????}; b=${h%????}; b=${b#??}; c=${h%??}; c=${c#????}; d=${h#??????}; printf \'st=%s remote=%d.%d.%d.%d:%d\\n\' "$st" "0x$d" "0x$c" "0x$b" "0x$a" "0x$po"; done < "$f"; done 2>/dev/null | sort | uniq -c | head -80',
   "echo '--tmp'; ls -la /tmp /dev/shm 2>/dev/null | head -80",
   'echo \'--files\'; for f in /tmp/*.json /tmp/*.conf /tmp/*.txt /tmp/*/*.json /tmp/*/*.conf; do [ -f "$f" ] && [ "$(wc -c < "$f")" -lt 16384 ] && printf \'%s\\n\' "== $f" && cat "$f"; done 2>/dev/null | head -400',
   "echo '--authorized-keys'; cat /root/.ssh/authorized_keys /home/*/.ssh/authorized_keys 2>/dev/null | sort -u | head -10",
-  "echo '--recent-exec'; find / \\( -path /proc -o -path /sys -o -path /dev \\) -prune -o -type f -perm -100 -newer /proc/1 -print 2>/dev/null | head -60 | while read -r f; do ls -la \"$f\" 2>/dev/null; done",
+  "echo '--recent-exec'; find / \\( -path /proc -o -path /sys -o -path /dev -o -name node_modules \\) -prune -o -type f -perm -100 -newer /proc/1 -print 2>/dev/null | head -60 | while read -r f; do ls -la \"$f\" 2>/dev/null; done",
   "echo '--recent-conf'; find / \\( -path /proc -o -path /sys -o -path /dev -o -path /etc -o -path /tmp -o -name node_modules \\) -prune -o -type f -newer /proc/1 \\( -name '*.json' -o -name '*.conf' -o -name '*.ini' -o -name '*.txt' \\) -size -16k -print 2>/dev/null | head -20 | while read -r f; do printf '%s\\n' \"== $f\"; cat \"$f\" 2>/dev/null; done | head -400"
 ];
 

--- a/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.ts
+++ b/apps/api/src/workload-abuse/services/provider-stream/provider-stream.service.ts
@@ -1,7 +1,7 @@
-import { StringDecoder } from "node:string_decoder";
 import { inject, singleton } from "tsyringe";
 
 import { decodeProviderFrame, parseShellExit, type ProviderFrame } from "@src/workload-abuse/lib/provider-frame/provider-frame";
+import { truncateToUtf8Bytes } from "@src/workload-abuse/lib/utf8-text/utf8-text";
 import {
   PROVIDER_PROXY_SOCKET_FACTORY,
   type ProviderProxySocketEvent,
@@ -127,11 +127,6 @@ export class ProviderStreamService {
       socket.addEventListener("error", () => finish("connection_error"));
     });
   }
-}
-
-/** `write` without `end` never emits a partial character, so the kept text stays within the byte budget. */
-function truncateToUtf8Bytes(text: string, maxBytes: number): string {
-  return new StringDecoder("utf8").write(Buffer.from(text, "utf8").subarray(0, maxBytes));
 }
 
 function toText(data: unknown): string | undefined {

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
@@ -54,6 +54,30 @@ describe(TrialWorkloadProbeJobService.name, () => {
     });
   });
 
+  describe("restartForUpdatedDeployment", () => {
+    it("drops the pending probe and starts the fixed early attempts over from the update", async () => {
+      const updatedAt = addMinutes(LEASE_CREATED_AT, 90);
+      const { service, jobQueueService } = setup({ now: updatedAt });
+
+      await service.restartForUpdatedDeployment({ ...TARGET, updatedAt });
+
+      expect(jobQueueService.cancelCreatedBy).toHaveBeenCalledWith({ name: "ProbeTrialDeployment", singletonKey: probeTrialDeploymentKeyFor(TARGET) });
+      expect(jobQueueService.enqueue).toHaveBeenCalledWith(new ProbeTrialDeployment({ ...TARGET, attempt: 1, leaseCreatedAt: updatedAt.toISOString() }), {
+        singletonKey: probeTrialDeploymentKeyFor(TARGET),
+        startAfter: addMinutes(updatedAt, 5).toISOString()
+      });
+      expect(jobQueueService.cancelCreatedBy.mock.invocationCallOrder[0]).toBeLessThan(jobQueueService.enqueue.mock.invocationCallOrder[0]);
+    });
+
+    it("touches the queue not at all while probing is disabled", async () => {
+      const { service, jobQueueService } = setup({ enabled: false });
+
+      expect(await service.restartForUpdatedDeployment({ ...TARGET, updatedAt: LEASE_CREATED_AT })).toBeNull();
+      expect(jobQueueService.cancelCreatedBy).not.toHaveBeenCalled();
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
   describe("startAfterFor", () => {
     it("places the first attempts at fixed offsets from the lease", () => {
       const { service } = setup({});

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.spec.ts
@@ -69,6 +69,20 @@ describe(TrialWorkloadProbeJobService.name, () => {
       expect(jobQueueService.cancelCreatedBy.mock.invocationCallOrder[0]).toBeLessThan(jobQueueService.enqueue.mock.invocationCallOrder[0]);
     });
 
+    it("leaves a probe that already comes due sooner alone, so updates on a timer cannot push every probe out of reach", async () => {
+      const updatedAt = addMinutes(LEASE_CREATED_AT, 90);
+      const { service, jobQueueService } = setup({ now: updatedAt, probeWaitingBeyondTheRestart: false });
+
+      expect(await service.restartForUpdatedDeployment({ ...TARGET, updatedAt })).toBeNull();
+      expect(jobQueueService.hasWaitingSingleton).toHaveBeenCalledWith({
+        name: "ProbeTrialDeployment",
+        singletonKey: probeTrialDeploymentKeyFor(TARGET),
+        notDueBefore: addMinutes(updatedAt, 5)
+      });
+      expect(jobQueueService.cancelCreatedBy).not.toHaveBeenCalled();
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
+    });
+
     it("touches the queue not at all while probing is disabled", async () => {
       const { service, jobQueueService } = setup({ enabled: false });
 
@@ -206,6 +220,7 @@ describe(TrialWorkloadProbeJobService.name, () => {
     now?: Date;
     intervalMin?: number;
     jitterMin?: number;
+    probeWaitingBeyondTheRestart?: boolean;
   }) {
     if (input.now) vi.useFakeTimers({ now: input.now, toFake: ["Date"] });
     else vi.useRealTimers();
@@ -213,6 +228,7 @@ describe(TrialWorkloadProbeJobService.name, () => {
     const jobQueueService = mock<JobQueueService>();
     jobQueueService.enqueue.mockResolvedValue("job-id");
     jobQueueService.findPendingSingletonKeys.mockResolvedValue(new Set(input.pendingKeys ?? []));
+    jobQueueService.hasWaitingSingleton.mockResolvedValue(input.probeWaitingBeyondTheRestart ?? true);
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.findLiveTrialDeployments.mockResolvedValue(input.live ?? []);
     const detectionRepository = mock<WorkloadAbuseDetectionRepository>();

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
@@ -59,6 +59,15 @@ export class TrialWorkloadProbeJobService {
     return this.#schedule({ ...previous, attempt: previous.attempt + 1 });
   }
 
+  /** A manifest update swaps the container, so the fixed early probes start over from the update instead of waiting for the next hourly one. */
+  async restartForUpdatedDeployment(target: ProbeTrialDeploymentTarget & { updatedAt: Date }): Promise<string | null> {
+    if (!this.config.get("WORKLOAD_ABUSE_PROBE_ENABLED")) return null;
+
+    await this.cancelForDeployment(target);
+
+    return this.#schedule({ walletId: target.walletId, dseq: target.dseq, attempt: 1, leaseCreatedAt: target.updatedAt.toISOString() });
+  }
+
   async cancelForDeployment(target: ProbeTrialDeploymentTarget): Promise<void> {
     await this.jobQueueService.cancelCreatedBy({ name: ProbeTrialDeployment[JOB_NAME], singletonKey: probeTrialDeploymentKeyFor(target) });
   }

--- a/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
+++ b/apps/api/src/workload-abuse/services/trial-workload-probe-job/trial-workload-probe-job.service.ts
@@ -59,13 +59,23 @@ export class TrialWorkloadProbeJobService {
     return this.#schedule({ ...previous, attempt: previous.attempt + 1 });
   }
 
-  /** A manifest update swaps the container, so the fixed early probes start over from the update instead of waiting for the next hourly one. */
+  /** A manifest update swaps the container, so the fixed early probes start over from it, but only where that brings the next probe forward: pushing it back would let a workload dodge every probe by patching itself on a timer. */
   async restartForUpdatedDeployment(target: ProbeTrialDeploymentTarget & { updatedAt: Date }): Promise<string | null> {
     if (!this.config.get("WORKLOAD_ABUSE_PROBE_ENABLED")) return null;
 
+    const data = { walletId: target.walletId, dseq: target.dseq, attempt: 1, leaseCreatedAt: target.updatedAt.toISOString() };
+    const startAfter = this.startAfterFor(data);
+    const waitsLongerThanTheRestart = await this.jobQueueService.hasWaitingSingleton({
+      name: ProbeTrialDeployment[JOB_NAME],
+      singletonKey: probeTrialDeploymentKeyFor(target),
+      notDueBefore: startAfter
+    });
+
+    if (!waitsLongerThanTheRestart) return null;
+
     await this.cancelForDeployment(target);
 
-    return this.#schedule({ walletId: target.walletId, dseq: target.dseq, attempt: 1, leaseCreatedAt: target.updatedAt.toISOString() });
+    return this.#schedule(data, startAfter);
   }
 
   async cancelForDeployment(target: ProbeTrialDeploymentTarget): Promise<void> {


### PR DESCRIPTION
## Why

Trial workload probes only kept evidence for non-clean verdicts, so a deployment that came back clean on every attempt left nothing to review. The collectors also missed common places a runtime payload lives (anything outside `/tmp`), reported sockets as raw hex nothing could match, and carried no notion of how busy a process was. A manifest update swapping the container waited for the next hourly probe.

## What

- `--procs` now carries `cpu_s` and `rss_mb` per process, read from `/proc/<pid>/stat`, and leaves the probe's own shell and its children out by pid rather than by command text.
- `--net` decodes `/proc/net/tcp` and `tcp6` into `remote=ip:port` for established and connecting sockets plus `listen=port`, so port and peer signatures can match.
- New `--recent-exec` and `--recent-conf` sections list executables and small json/conf/ini/txt files written since the container started, anywhere but `/proc`, `/sys`, `/dev`, `/etc`, `/tmp` and `node_modules`.
- The `TRIAL_WORKLOAD_PROBED` log line carries a 4 KiB excerpt of the collected output for every verdict.
- `updateByUserIdAndDseq` and `patchByUserIdAndDseq` restart the probe cadence for a trialing wallet once the providers hold the new manifest; a failure there is logged and never fails the update.

The script was run under dash (Debian bookworm) and busybox (Alpine 3.20) with a renamed binary, a CPU-bound process and a local socket to confirm every section prints and the self-filter holds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trial workload probes now restart automatically after deployment updates and patches.
  * Probe restarts apply only to trial wallets; established wallets are unaffected.
  * Deployment operations complete successfully even if probe restarting encounters an error.
  * Shell probe network results now support IPv4 and IPv6 endpoints, while recent file scans exclude dependency directories.
* **Bug Fixes**
  * Logged probe evidence is limited to 4,096 UTF-8 bytes without splitting characters, while complete detection data is preserved.
  * Control characters in stored evidence are sanitized without altering tabs or newlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->