### PR TITLE
feat(deployment): name every deployment the api creates

### DIFF
--- a/apps/api/drizzle/0053_deployment_name.sql
+++ b/apps/api/drizzle/0053_deployment_name.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "deployment_settings" ADD COLUMN "name" text;

--- a/apps/api/drizzle/meta/0053_snapshot.json
+++ b/apps/api/drizzle/meta/0053_snapshot.json
@@ -1,0 +1,1756 @@
+{
+  "id": "ac23eb43-aae2-4886-bc9e-754d7776ba29",
+  "prevId": "5bd1a611-9b71-43ba-9ac6-260581ff5218",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_sufficient_since": {
+          "name": "credits_sufficient_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_since": {
+          "name": "credits_low_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abuse_locked_at": {
+          "name": "abuse_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abuse_locked_reason": {
+          "name": "abuse_locked_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reload_failure_count": {
+          "name": "auto_reload_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_reload_paused_at": {
+          "name": "auto_reload_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fair_use_policy_accepted_at": {
+          "name": "fair_use_policy_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_secrets": {
+          "name": "sealed_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workload_abuse_detections": {
+      "name": "workload_abuse_detections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "workload_abuse_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probe_status": {
+          "name": "probe_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signals": {
+          "name": "signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_excerpt": {
+          "name": "evidence_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "workload_abuse_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "enforcement_error": {
+          "name": "enforcement_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workload_abuse_detections_user_id_idx": {
+          "name": "workload_abuse_detections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workload_abuse_detections_dseq_idx": {
+          "name": "workload_abuse_detections_dseq_idx",
+          "columns": [
+            {
+              "expression": "dseq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workload_abuse_detections_user_id_userSetting_id_fk": {
+          "name": "workload_abuse_detections_user_id_userSetting_id_fk",
+          "tableFrom": "workload_abuse_detections",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    },
+    "public.workload_abuse_action": {
+      "name": "workload_abuse_action",
+      "schema": "public",
+      "values": [
+        "detected",
+        "enforcing",
+        "enforced",
+        "enforcement_failed"
+      ]
+    },
+    "public.workload_abuse_verdict": {
+      "name": "workload_abuse_verdict",
+      "schema": "public",
+      "values": [
+        "hard",
+        "soft",
+        "proxy"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1788721409589,
       "tag": "0052_user_wallet_abuse_lock",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1789051951342,
+      "tag": "0053_deployment_name",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
@@ -115,7 +115,6 @@ describe(DeploymentSettingController.name, () => {
       autoTopUpEnabled: faker.datatype.boolean(),
       closed: false,
       sdl: "sdl",
-      name: null,
       estimatedTopUpAmount: faker.number.float({ min: 0, max: 100 }),
       topUpFrequencyMs: faker.number.int({ min: 1000, max: 100000 }),
       runtimeLimitHours: null,

--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
@@ -115,6 +115,7 @@ describe(DeploymentSettingController.name, () => {
       autoTopUpEnabled: faker.datatype.boolean(),
       closed: false,
       sdl: "sdl",
+      name: null,
       estimatedTopUpAmount: faker.number.float({ min: 0, max: 100 }),
       topUpFrequencyMs: faker.number.int({ min: 1000, max: 100000 }),
       runtimeLimitHours: null,

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { SignTxResponseOutputSchema } from "@src/billing/http-schemas/tx.schema";
 import { MAX_MANIFEST_VERSION_LENGTH, MAX_SUBMITTED_SDL_LENGTH } from "@src/deployment/config/sdl.config";
+import { MAX_DEPLOYMENT_NAME_LENGTH } from "@src/deployment/utils/deployment-name/deployment-name";
 import { openApiExampleAddress } from "@src/utils/constants";
 import { AkashAddressSchema, DseqSchema } from "@src/utils/schema";
 import { LeaseStatusResponseSchema } from "./lease.schema";
@@ -109,9 +110,16 @@ export const GetDeploymentParamsSchema = z.object({
 /** Every reader treats an empty seal as no seal, so accepting one would take a request the caller meant as a secret write and silently do nothing. */
 const SealedSecretsSchema = z.string().min(1);
 
+/** Trimmed before it is measured, so a name of nothing but spaces is refused rather than stored as a blank one. */
+const DeploymentNameSchema = z.string().trim().min(1).max(MAX_DEPLOYMENT_NAME_LENGTH);
+
 export const CreateDeploymentRequestSchema = z.object({
   data: z.object({
     sdl: z.string().max(MAX_SUBMITTED_SDL_LENGTH),
+    name: DeploymentNameSchema.optional().openapi({
+      description:
+        "Name for this deployment, shown wherever it is listed. Omit it and the console names the deployment after the services the SDL declares, joined with `+`."
+    }),
     sealedSecrets: SealedSecretsSchema.optional().openapi({
       description:
         "Compact JWE sealing a flat name-to-value map of the secrets this SDL references, encrypted to the console's public sealing key. Fetch that key and the claims to sign from GET /v1/sdl-secrets-context. Values are never returned by any endpoint once sealed."
@@ -167,7 +175,11 @@ export const DepositDeploymentResponseSchema = z.object({
 
 export const UpdateDeploymentRequestSchema = z.object({
   data: z.object({
-    sdl: z.string()
+    sdl: z.string(),
+    name: DeploymentNameSchema.optional().openapi({
+      description:
+        "Renames the deployment. Omitting it keeps the name the deployment already carries, unlike the rest of the definition this endpoint replaces wholesale."
+    })
   })
 });
 

--- a/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/model-schemas/deployment-setting/deployment-setting.schema.ts
@@ -19,6 +19,8 @@ export const DeploymentSettings = pgTable(
     lastFundedAt: timestamp("last_funded_at"),
     runtimeLimitHours: integer("runtime_limit_hours"),
     sdl: text("sdl"),
+    /** Unsized on purpose: the length a caller may supply is bounded by the request schema, while a name the console derives from an SDL is bounded by nothing the caller controls. */
+    name: text("name"),
     /** A JWE compact serialization, so `text` rather than a sized column: the plaintext it carries is bounded, its ciphertext is not sized by anything this schema knows. */
     sealedSecrets: text("sealed_secrets"),
     manifestVersion: varchar("manifest_version", { length: 64 }),

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -512,6 +512,54 @@ describe(DeploymentSettingRepository.name, () => {
       expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ runtimeLimitHours: 6 });
     });
 
+    it("records the name a create was given", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG", name: "web+db" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ name: "web+db" });
+    });
+
+    it("records no name for a definition written without one", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ name: null });
+    });
+
+    it("leaves a name already on the row alone when none is given", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG", name: "web" });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.1'", manifestVersion: "BQYH" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: "version: '2.1'", name: "web" });
+    });
+
+    it("replaces a name an earlier write recorded", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG", name: "web" });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG", name: "renamed" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ name: "renamed" });
+    });
+
+    it("names a row a settings read created first", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.create({ userId: user.id, dseq, autoTopUpEnabled: false });
+
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: "version: '2.0'", manifestVersion: "BAUG", name: "web" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ name: "web" });
+    });
+
     it("replaces a definition an earlier write recorded", async () => {
       const { deploymentSettingRepository, user } = await setup();
       const dseq = newDseq();

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -340,9 +340,9 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
    * Upserts on the (dseq, userId) unique because a settings read creates a row lazily, because the
    * caller retries a create that failed to broadcast, and because an update of a deployment that
    * predates any record has to produce the row a create would have. The conflict branch leaves every
-   * field it does not name as the earlier writer set them, and an absent runtime limit counts as
-   * unnamed: drizzle drops undefined out of the set clause, so neither creating nor updating without a
-   * limit can clear one already there.
+   * field it does not name as the earlier writer set them, and an absent runtime limit or name counts
+   * as unnamed: drizzle drops undefined out of the set clause, so neither creating nor updating
+   * without one can clear what is already there.
    *
    * `sealedSecrets` reads that same rule in both directions, which is why it is typed to allow null.
    * A create always states a value — the token, or null when the request carried no secrets — so a
@@ -355,7 +355,8 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     sdl,
     manifestVersion,
     runtimeLimitHours,
-    sealedSecrets
+    sealedSecrets,
+    name
   }: {
     userId: string;
     dseq: string;
@@ -363,13 +364,14 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     manifestVersion: string;
     runtimeLimitHours?: number;
     sealedSecrets?: string | null;
+    name?: string;
   }): Promise<string> {
     const [row] = await this.cursor
       .insert(this.table)
-      .values({ userId, dseq, autoTopUpEnabled: AUTO_TOP_UP_ENABLED_BY_DEFAULT, sdl, manifestVersion, runtimeLimitHours, sealedSecrets })
+      .values({ userId, dseq, autoTopUpEnabled: AUTO_TOP_UP_ENABLED_BY_DEFAULT, sdl, manifestVersion, runtimeLimitHours, sealedSecrets, name })
       .onConflictDoUpdate({
         target: [this.table.dseq, this.table.userId],
-        set: { sdl, manifestVersion, runtimeLimitHours, sealedSecrets, updatedAt: sql`now()` }
+        set: { sdl, manifestVersion, runtimeLimitHours, sealedSecrets, name, updatedAt: sql`now()` }
       })
       .returning({ id: this.table.id });
 

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -528,6 +528,7 @@ describe(DeploymentSettingService.name, () => {
       lastFundedAt: null,
       runtimeLimitHours: null,
       sdl: null,
+      name: null,
       sealedSecrets: null,
       manifestVersion: null,
       runtimeEndsAt: null,

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -33,6 +33,20 @@ describe(DeploymentSettingService.name, () => {
       expect(result).toEqual(expect.objectContaining({ userId: params.userId, dseq: params.dseq }));
     });
 
+    it("publishes none of the stored fields this response does not document, the deployment's name among them", async () => {
+      const { service, deploymentSettingRepository } = setup();
+      const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
+
+      deploymentSettingRepository.accessibleBy.mockReturnValue(deploymentSettingRepository);
+      deploymentSettingRepository.findOneBy.mockResolvedValue(createDeploymentSettingsOutput({ ...params, name: "web", sealedSecrets: "seal" }));
+
+      const result = await service.findByUserIdAndDseq(params);
+
+      expect(result).not.toHaveProperty("name");
+      expect(result).not.toHaveProperty("sealedSecrets");
+      expect(result).not.toHaveProperty("manifestVersion");
+    });
+
     it("returns undefined and writes no row when nothing is stored for the deployment", async () => {
       const { service, deploymentSettingRepository } = setup();
       const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -26,7 +26,7 @@ type DeploymentSettingChange = Pick<DeploymentSettingsInput, "runtimeLimitHours"
 
 type DeploymentSettingWithEstimatedTopUpAmount = Omit<
   DeploymentSettingsOutput,
-  "lastFundedAt" | "runtimeEndingNotifiedFor" | "providerUnreachableNotifiedFor" | "sealedSecrets" | "manifestVersion" | "runtimeEndsAt"
+  "lastFundedAt" | "runtimeEndingNotifiedFor" | "providerUnreachableNotifiedFor" | "sealedSecrets" | "manifestVersion" | "name" | "runtimeEndsAt"
 > & {
   estimatedTopUpAmount: number;
   topUpFrequencyMs: number;
@@ -324,7 +324,8 @@ export class DeploymentSettingService {
       return undefined;
     }
 
-    const { lastFundedAt, runtimeEndingNotifiedFor, providerUnreachableNotifiedFor, sdl, sealedSecrets, manifestVersion, runtimeEndsAt, ...rest } = params;
+    const { lastFundedAt, runtimeEndingNotifiedFor, providerUnreachableNotifiedFor, sdl, sealedSecrets, manifestVersion, name, runtimeEndsAt, ...rest } =
+      params;
     const setting = { ...rest, runtimeEndsAt: runtimeEndsAt?.toISOString() ?? null };
 
     if (!setting.autoTopUpEnabled) {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -173,12 +173,12 @@ describe(DeploymentWriterService.name, () => {
   } as WalletInitialized;
 
   const manifestValue = {
-    groups: [{ name: "test-group" }],
+    groups: [{ name: "test-group", services: [{ name: "web" }] }],
     groupSpecs: [{ name: "test-group", resources: [] }]
   };
 
   const resolvedManifestValue = {
-    groups: [{ name: "resolved-group" }],
+    groups: [{ name: "resolved-group", services: [{ name: "web" }] }],
     groupSpecs: [{ name: "resolved-group", resources: [] }]
   };
 
@@ -368,8 +368,25 @@ describe(DeploymentWriterService.name, () => {
         sdl: expect.stringContaining("API_TOKEN="),
         manifestVersion: "BAUG",
         sealedSecrets: null,
-        runtimeLimitHours: undefined
+        runtimeLimitHours: undefined,
+        name: "web"
       });
+    });
+
+    it("names the deployment after the services the manifest declares, joined", async () => {
+      const { service, deploymentSettingRepository } = setup({ serviceNames: ["db", "web"] });
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5 });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ name: "db+web" }));
+    });
+
+    it("keeps the name the request supplied rather than deriving one", async () => {
+      const { service, deploymentSettingRepository } = setup({ serviceNames: ["db", "web"] });
+
+      await service.create({ userId: "user-1", sdl: SDL_WITH_SECRETS, deposit: 5, name: "checkout stack" });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ name: "checkout stack" }));
     });
 
     it("passes the seal and the sdl exactly as they arrived to the intake", async () => {
@@ -1222,6 +1239,22 @@ describe(DeploymentWriterService.name, () => {
       expect(rpcMessageService.getUpdateDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ owner: wallet.address, dseq: "100" }));
       expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledWith("user-1", [updateMsg]);
       expect(result).toBe(deploymentData);
+    });
+
+    it("records the name the update supplies", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl", name: "renamed" });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ name: "renamed" }));
+    });
+
+    it("names no name for an update that supplies none, leaving the one already recorded", async () => {
+      const { service, deploymentSettingRepository } = setup();
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl" });
+
+      expect(deploymentSettingRepository.upsertDefinition).toHaveBeenCalledWith(expect.objectContaining({ name: undefined }));
     });
 
     it("enqueues no compensation for an update, whose deployment the chain has already answered for", async () => {
@@ -2144,6 +2177,7 @@ describe(DeploymentWriterService.name, () => {
     storedRuntimeLimitHours?: number | null;
     sourceSetting?: DeploymentSettingsOutput;
     isTrialing?: boolean;
+    serviceNames?: string[];
   }) {
     const signerService = mock<ManagedSignerService>();
     const rpcMessageService = mock<RpcMessageService>();
@@ -2206,9 +2240,12 @@ describe(DeploymentWriterService.name, () => {
     sdlService.parse.mockReturnValue({ ok: true, value: parsedSdlValue } as any);
     sdlService.generateManifest.mockResolvedValue({ ok: true, value: manifestValue } as any);
     sdlService.generateManifestVersion.mockResolvedValue(new Uint8Array([4, 5, 6]));
+    const resolvedManifest = input?.serviceNames
+      ? { ...resolvedManifestValue, groups: [{ name: "resolved-group", services: input.serviceNames.map(name => ({ name })) }] }
+      : resolvedManifestValue;
     sdlService.generateResolvedManifest.mockResolvedValue({
       ok: true,
-      value: { manifest: resolvedManifestValue, manifestVersion: input?.manifestVersion ?? new Uint8Array([4, 5, 6]) }
+      value: { manifest: resolvedManifest, manifestVersion: input?.manifestVersion ?? new Uint8Array([4, 5, 6]) }
     } as any);
     deploymentReaderService.findByWalletAndDseq.mockResolvedValue(deploymentData);
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -34,6 +34,7 @@ import { SdlSecretsService, unreferencedNameError } from "@src/deployment/servic
 import { SdlSecretsDerivationService } from "@src/deployment/services/sdl-secrets-derivation/sdl-secrets-derivation.service";
 import { SdlSecretsInheritanceService } from "@src/deployment/services/sdl-secrets-inheritance/sdl-secrets-inheritance.service";
 import type { SdlSecrets } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import { deriveDeploymentName } from "@src/deployment/utils/deployment-name/deployment-name";
 import type { StorableSdl, StoredSdlPosition, StoredSdlRefusal } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
 import { parseSdlForStorage, sdlForStorage } from "@src/deployment/utils/sdl-for-storage/sdl-for-storage";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
@@ -146,7 +147,8 @@ export class DeploymentWriterService {
       sdl,
       manifestVersion,
       sealedSecrets,
-      runtimeLimitHours: input.runtimeLimitHours
+      runtimeLimitHours: input.runtimeLimitHours,
+      name: input.name ?? deriveDeploymentName(manifest.groups)
     });
 
     const result = await this.signerService.executeDerivedDecodedTxByUserId(wallet.userId, [message]);
@@ -169,6 +171,7 @@ export class DeploymentWriterService {
     manifestVersion: Uint8Array;
     sealedSecrets: string | null;
     runtimeLimitHours?: number;
+    name?: string;
   }): Promise<void> {
     const { owner, ...definition } = input;
 
@@ -222,6 +225,7 @@ export class DeploymentWriterService {
     /** Stated rather than optional, so a definition write cannot leave the previous create's token beside an SDL that no longer references the names in it. */
     sealedSecrets: string | null;
     runtimeLimitHours?: number;
+    name?: string;
   }): Promise<string> {
     const { manifestVersion, ...rest } = input;
 
@@ -386,7 +390,7 @@ export class DeploymentWriterService {
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
     const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId: wallet.userId, dseq, secrets: derived });
 
-    await this.recordDefinition({ userId: wallet.userId, dseq, sdl, manifestVersion, sealedSecrets });
+    await this.recordDefinition({ userId: wallet.userId, dseq, sdl, manifestVersion, sealedSecrets, name: input.name });
 
     await this.ensureDeploymentIsUpToDate(wallet, dseq, manifestVersion, deployment);
     const auth = { walletId: wallet.id };

--- a/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
+++ b/apps/api/src/deployment/services/initial-deployment-funding/initial-deployment-funding.service.spec.ts
@@ -640,6 +640,7 @@ describe(InitialDeploymentFundingService.name, () => {
       lastFundedAt: null,
       runtimeLimitHours: null,
       sdl: null,
+      name: null,
       sealedSecrets: null,
       manifestVersion: null,
       runtimeEndsAt: null,

--- a/apps/api/src/deployment/utils/deployment-name/deployment-name.spec.ts
+++ b/apps/api/src/deployment/utils/deployment-name/deployment-name.spec.ts
@@ -1,0 +1,50 @@
+import type { Manifest } from "@akashnetwork/chain-sdk";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { deriveDeploymentName, MAX_DEPLOYMENT_NAME_LENGTH } from "./deployment-name";
+
+type ManifestGroup = Manifest[number];
+type ManifestService = ManifestGroup["services"][number];
+
+describe("deriveDeploymentName", () => {
+  it("names a single-service deployment after that service", () => {
+    expect(deriveDeploymentName(manifestOf({ dcloud: ["web"] }))).toBe("web");
+  });
+
+  it("joins the service names a group declares in the order the manifest holds them", () => {
+    expect(deriveDeploymentName(manifestOf({ dcloud: ["db", "web"] }))).toBe("db+web");
+  });
+
+  it("joins the service names across groups", () => {
+    expect(deriveDeploymentName(manifestOf({ akash: ["api"], dcloud: ["worker"] }))).toBe("api+worker");
+  });
+
+  it("names a service placed under two placements once", () => {
+    expect(deriveDeploymentName(manifestOf({ akash: ["web"], dcloud: ["web"] }))).toBe("web");
+  });
+
+  it("shortens a name longer than a deployment may carry", () => {
+    const serviceNames = Array.from({ length: 40 }, (_, index) => `service-${index}`.padEnd(20, "x"));
+
+    const name = deriveDeploymentName(manifestOf({ dcloud: serviceNames }));
+
+    expect(name).toHaveLength(MAX_DEPLOYMENT_NAME_LENGTH);
+    expect(name).toBe(serviceNames.join("+").slice(0, MAX_DEPLOYMENT_NAME_LENGTH));
+  });
+
+  it("leaves out a service the manifest names with blank space", () => {
+    expect(deriveDeploymentName(manifestOf({ dcloud: ["   ", "web"] }))).toBe("web");
+  });
+
+  it("derives nothing from a manifest declaring no service at all", () => {
+    expect(deriveDeploymentName(manifestOf({ dcloud: [] }))).toBeUndefined();
+    expect(deriveDeploymentName([])).toBeUndefined();
+  });
+
+  function manifestOf(groups: Record<string, string[]>): Manifest {
+    return Object.entries(groups).map(([name, serviceNames]) =>
+      mock<ManifestGroup>({ name, services: serviceNames.map(serviceName => mock<ManifestService>({ name: serviceName })) })
+    );
+  }
+});

--- a/apps/api/src/deployment/utils/deployment-name/deployment-name.ts
+++ b/apps/api/src/deployment/utils/deployment-name/deployment-name.ts
@@ -1,0 +1,21 @@
+import type { Manifest } from "@akashnetwork/chain-sdk";
+
+/** Bounds the name in the request schema alone, the column being unsized, so a name the console derives for a caller who supplied none is shortened rather than refusing a create that would succeed today. */
+export const MAX_DEPLOYMENT_NAME_LENGTH = 256;
+
+const SERVICE_NAME_SEPARATOR = "+";
+
+export function deriveDeploymentName(groups: Manifest): string | undefined {
+  const serviceNames = new Set(
+    groups
+      .flatMap(group => group.services)
+      .map(service => service.name.trim())
+      .filter(serviceName => serviceName.length > 0)
+  );
+
+  if (serviceNames.size === 0) {
+    return undefined;
+  }
+
+  return [...serviceNames].join(SERVICE_NAME_SEPARATOR).slice(0, MAX_DEPLOYMENT_NAME_LENGTH);
+}

--- a/apps/api/src/deployment/utils/deployment-name/deployment-name.ts
+++ b/apps/api/src/deployment/utils/deployment-name/deployment-name.ts
@@ -7,7 +7,7 @@ const SERVICE_NAME_SEPARATOR = "+";
 
 export function deriveDeploymentName(groups: Manifest): string | undefined {
   const serviceNames = new Set(
-    groups
+    Iterator.from(groups)
       .flatMap(group => group.services)
       .map(service => service.name.trim())
       .filter(serviceName => serviceName.length > 0)

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4451,6 +4451,12 @@
                     "properties": {
                       "sdl": {
                         "type": "string"
+                      },
+                      "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256,
+                        "description": "Renames the deployment. Omitting it keeps the name the deployment already carries, unlike the rest of the definition this endpoint replaces wholesale."
                       }
                     },
                     "required": [
@@ -5595,6 +5601,12 @@
                       "sdl": {
                         "type": "string",
                         "maxLength": 524288
+                      },
+                      "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256,
+                        "description": "Name for this deployment, shown wherever it is listed. Omit it and the console names the deployment after the services the SDL declares, joined with `+`."
                       },
                       "sealedSecrets": {
                         "type": "string",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -6970,6 +6970,12 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "pattern": "^0*[1-9]\\d*$",
                         "type": "string",
                       },
+                      "name": {
+                        "description": "Name for this deployment, shown wherever it is listed. Omit it and the console names the deployment after the services the SDL declares, joined with \`+\`.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string",
+                      },
                       "runtimeLimitHours": {
                         "description": "Optional runtime limit in hours (1 to 48), counted from lease start. Automatic funding keeps the deployment running until the limit, then the deployment is closed automatically and unused funds are returned. Extend a limit with PATCH /v2/deployment-settings/{dseq}. Omit for always-on funding.",
                         "maximum": 48,
@@ -8447,6 +8453,12 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 "properties": {
                   "data": {
                     "properties": {
+                      "name": {
+                        "description": "Renames the deployment. Omitting it keeps the name the deployment already carries, unlike the rest of the definition this endpoint replaces wholesale.",
+                        "maxLength": 256,
+                        "minLength": 1,
+                        "type": "string",
+                      },
                       "sdl": {
                         "type": "string",
                       },

--- a/apps/api/test/functional/deployment-sealed-secrets.spec.ts
+++ b/apps/api/test/functional/deployment-sealed-secrets.spec.ts
@@ -545,7 +545,7 @@ describe("Deployment sealed secrets", () => {
     expect(response.status).toBe(200);
     const createBody = (JSON.parse(document) as OpenApiPaths).paths["/v1/deployments"].post.requestBody.content["application/json"].schema.properties.data
       .properties;
-    expect(Object.keys(createBody)).toEqual(["sdl", "sealedSecrets", "inheritSecretsFrom", "deposit", "runtimeLimitHours"]);
+    expect(Object.keys(createBody)).toEqual(["sdl", "name", "sealedSecrets", "inheritSecretsFrom", "deposit", "runtimeLimitHours"]);
   });
 
   it("describes the seal on both routes that accept one, so neither reads as create-only", async () => {

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -24,6 +24,7 @@ import { DeploymentReaderService } from "@src/deployment/services/deployment-rea
 import { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import { SdlReferenceService } from "@src/deployment/services/sdl-reference/sdl-reference.service";
 import { SdlSecretsService } from "@src/deployment/services/sdl-secrets/sdl-secrets.service";
+import { MAX_DEPLOYMENT_NAME_LENGTH } from "@src/deployment/utils/deployment-name/deployment-name";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { app } from "@src/rest-app";
 import type { RestAkashDeploymentInfoResponse } from "@src/types/rest";
@@ -942,6 +943,66 @@ describe("Deployments API", () => {
       });
     }
 
+    it("names a deployment after the single service its sdl declares", async () => {
+      expect(await createDeploymentNamed()).toMatchObject({ name: "web" });
+    });
+
+    it("names a deployment after every service its sdl declares, joined", async () => {
+      expect(await createDeploymentNamed({ sdl: "two-service-sdl.yml" })).toMatchObject({ name: "db+web" });
+    });
+
+    it("records the name the request supplied, trimmed, rather than deriving one", async () => {
+      expect(await createDeploymentNamed({ sdl: "two-service-sdl.yml", name: "  checkout stack  " })).toMatchObject({ name: "checkout stack" });
+    });
+
+    it("records a name of the greatest length a deployment may carry", async () => {
+      const name = "n".repeat(MAX_DEPLOYMENT_NAME_LENGTH);
+
+      expect(await createDeploymentNamed({ name })).toMatchObject({ name });
+    });
+
+    it("returns 400 for a name of nothing but spaces", async () => {
+      const { userApiKeySecret } = await mockUser();
+
+      const response = await postDeployment(userApiKeySecret, { name: "   " });
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 for a name longer than a deployment may carry", async () => {
+      const { userApiKeySecret } = await mockUser();
+
+      const response = await postDeployment(userApiKeySecret, { name: "n".repeat(MAX_DEPLOYMENT_NAME_LENGTH + 1) });
+
+      expect(response.status).toBe(400);
+    });
+
+    function postDeployment(userApiKeySecret: string, data: { name?: string }) {
+      const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
+
+      return app.request("/v1/deployments", {
+        method: "POST",
+        body: JSON.stringify({ data: { sdl: yml, ...data } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+    }
+
+    async function createDeploymentNamed(input: { sdl?: string; name?: string } = {}) {
+      const { userApiKeySecret, user } = await mockPersistedUser();
+      const yml = fs.readFileSync(path.resolve(__dirname, `../mocks/${input.sdl ?? "hello-world-sdl.yml"}`), "utf8");
+
+      const response = await app.request("/v1/deployments", {
+        method: "POST",
+        body: JSON.stringify({ data: { sdl: yml, name: input.name } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(201);
+      const result = (await response.json()) as { data: { dseq: string } };
+
+      return await container.resolve(DeploymentSettingRepository).findOneBy({ userId: user.id, dseq: result.data.dseq });
+    }
+
     async function createDeploymentWithSecrets() {
       const { userApiKeySecret, user } = await mockPersistedUser();
       const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl-with-secrets.yml"), "utf8");
@@ -1207,6 +1268,57 @@ describe("Deployments API", () => {
         leases: expect.arrayContaining([expect.any(Object)])
       });
     });
+
+    it("renames the deployment", async () => {
+      const { user, setting } = await update({ recordedName: "web", name: "renamed" });
+
+      expect(setting).toMatchObject({ userId: user.id, name: "renamed" });
+    });
+
+    it("names a deployment the console recorded no name for", async () => {
+      const { setting } = await update({ name: "renamed" });
+
+      expect(setting).toMatchObject({ name: "renamed" });
+    });
+
+    it("leaves the name alone for an update that supplies none", async () => {
+      const { setting } = await update({ recordedName: "web" });
+
+      expect(setting).toMatchObject({ name: "web" });
+    });
+
+    it("returns 400 for a name of nothing but spaces", async () => {
+      const { userApiKeySecret, wallets } = await mockPersistedUser();
+      await setupDeploymentInfoMock(wallets, "1234");
+      const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
+
+      const response = await app.request("/v1/deployments/1234", {
+        method: "PUT",
+        body: JSON.stringify({ data: { sdl: yml, name: "   " } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    async function update(input: { recordedName?: string; name?: string }) {
+      const { userApiKeySecret, user, wallets } = await mockPersistedUser();
+      const dseq = "1234";
+      await setupDeploymentInfoMock(wallets, dseq);
+      const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
+      const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: yml, manifestVersion: "BAUG", name: input.recordedName });
+
+      const response = await app.request(`/v1/deployments/${dseq}`, {
+        method: "PUT",
+        body: JSON.stringify({ data: { sdl: yml, name: input.name } }),
+        headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
+      });
+
+      expect(response.status).toBe(200);
+
+      return { user, setting: await deploymentSettingRepository.findOneBy({ userId: user.id, dseq }) };
+    }
 
     it("should return 404 if deployment does not exist", async () => {
       const { userApiKeySecret } = await mockUser();

--- a/apps/api/test/mocks/two-service-sdl.yml
+++ b/apps/api/test/mocks/two-service-sdl.yml
@@ -1,0 +1,52 @@
+---
+version: "2.0"
+services:
+  web:
+    image: ghcr.io/akash-network/hello-akash-world:2.1.0
+    expose:
+      - port: 3000
+        as: 80
+        to:
+          - global: true
+  db:
+    image: postgres:16-alpine
+    expose:
+      - port: 5432
+        to:
+          - service: web
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 512Mi
+    db:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 1Gi
+        storage:
+          - size: 1Gi
+  placement:
+    dcloud:
+      pricing:
+        web:
+          denom: uact
+          amount: 1000
+        db:
+          denom: uact
+          amount: 1000
+deployment:
+  web:
+    dcloud:
+      profile: web
+      count: 1
+  db:
+    dcloud:
+      profile: db
+      count: 1


### PR DESCRIPTION
## Why

Part of CON-953 — https://linear.app/ovrclk/issue/CON-953/store-a-deployments-name-on-the-deployment-not-in-the-browser

A deployment's name lives only in the browser's localStorage today, so it is lost on a device switch or a storage clear, invisible to every other client of the console API, and unavailable to anything the server renders.

This is **slice 1 of 3**: it puts the name in the database and makes sure every deployment the API creates ends up with one. Returning it from the read endpoints is slice 2; renaming through `PATCH` is slice 3.

## What

- `POST /v1/deployments` and `PUT /v1/deployments/{dseq}` accept an optional `name`.
- Created with no name, a deployment is named after the services its SDL declares — de-duplicated across placements, joined with `+`, so a one-service SDL is named `web`.
- Omitting `name` on `PUT` leaves the stored name alone. That is a deliberate exception to this endpoint's wholesale-replacement convention, and the same rule `runtimeLimitHours` already relies on: `undefined` drops the column out of drizzle's `SET` clause.
- `name` is trimmed before it is measured and bounded at 256 characters, so `"  api  "` is stored as `"api"` while `""`, `"   "` and 257 characters each answer 400.
- Migration `0053_deployment_name` adds `name text` to `deployment_settings`, nullable, with no backfill — deployments created before this ship keep no name rather than having one invented for them.

The column is `text` rather than `varchar(256)` on purpose. The 256 bound applies to what a *caller* may supply and lives in the request schema; a name the console *derives* is bounded by nothing the caller controls, so it is clamped in code rather than rejected by Postgres mid-create.

### Example

Creating a deployment without a name, adapted from `test/functional/deployments.spec.ts` with its fixture helpers inlined:

```ts
const response = await app.request("/v1/deployments", {
  method: "POST",
  body: JSON.stringify({ data: { sdl: twoServiceSdl } }),
  headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
});

expect(response.status).toBe(201);
const { data } = (await response.json()) as { data: { dseq: string } };

expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: data.dseq })).toMatchObject({ name: "db+web" });
```

Supplying `{ data: { sdl, name: "  checkout stack  " } }` instead stores `"checkout stack"` and derives nothing.

## Two decisions that want a human

**1. A multi-service name comes out alphabetical, not in document order.** `two-service-sdl.yml` declares `web` before `db`, and the deployment is named `db+web`. The issue asks for the service names "joined with `+`" and prints `web+db` as its example, but it also states the order is the order of services inside `manifest.groups` — and the chain SDK sorts services with `compareStrings` before emitting the manifest, so that pair can never come out `web+db`. The explicit rule was followed over the example. This is now pinned by a functional test, so flipping it is a one-line change plus a decision about rows already created.

**2. The name is stripped from every deployment-settings response.** It is exposed only by `GET /v1/deployments` and `GET /v1/deployments/{dseq}` (slice 2), and deliberately not by `/v1/deployment-settings` or `/v2/deployment-settings`.

`DeploymentSettingService.withEstimatedTopUpAmount` assembles that response *opt-out*: it destructures the columns that must not be published out of the row and spreads the rest, and its return type is an `Omit<…>` built the same way. Adding any column to `deployment_settings` therefore publishes it on four shipped routes by default. Without the exclusion this PR adds, `name` joined those routes as a field `DeploymentSettingResponseSchema` does not declare — present in the JSON, absent from `openapi.json` and the published docs. It is stripped to keep a documented response documented, and the issue names only the two deployment reads as returning the name.

The trade-off to weigh: a client rendering console state from a settings endpoint gets every stored field except the name, and must also call `GET /v1/deployments/{dseq}` once slice 2 lands. If those endpoints should carry it, the change is additive — declare `name` on `DeploymentSettingResponseSchema` and regenerate the docs — and does not alter what this PR stores.

## Not in this slice

- Reading the name back from `GET /v1/deployments` and `GET /v1/deployments/{dseq}` — slice 2.
- Renaming through `PATCH /v1/deployments/{dseq}`, including a name-only patch of a deployment with no recorded SDL — slice 3.
- `deploy-web` changes, which CON-953 puts out of scope.

## Tests

- **Unit** — `deployment-name.spec.ts` covers the derivation: one service, several, a service under two placements, an over-long join and a manifest with no services. `deployment-writer.service.spec.ts` covers `input.name ?? derived` precedence. `deployment-setting.service.spec.ts` pins the settings-response exclusion, so the next column added to that table cannot leak silently.
- **Integration** — `deployment-setting.repository.integration.ts` covers the omit-keeps-it rule against the real column, because that guarantee lives in whether drizzle emits the column in the `SET` clause and a mocked cursor cannot get it wrong on the code's behalf.
- **Functional** — `deployments.spec.ts` covers create and PUT end to end over HTTP: the derived name, a supplied name, trimming, the 256 boundary and the 400s.

Checks on this branch:

- `npm test` — passed (exit 0)
- `npm run lint -- --quiet` — passed (exit 0)
- `npx tsc --noEmit` — passed (exit 0)

Known non-blocking review follow-ups, left for a later slice rather than widening this diff: no assertion yet that a services-only `PATCH` cannot erase a stored name (the guarantee currently rests on `name` being absent from `replaceDefinitionIfVersionMatches`'s `SET` clause); `MAX_DEPLOYMENT_NAME_LENGTH` sits in the derivation util rather than in `config/sdl.config.ts` with the module's other request bounds; and two pairs of tests duplicate a setup that could be folded together.

## Demo

# CON-953 slice 1 — naming a deployment at the moment it is created

*2026-09-10T19:40:26Z by Showboat 0.6.1*
<!-- showboat-id: 326b3c21-5396-406e-b0b1-c810bb613b28 -->

A deployment's name has lived in the browser's localStorage until now, so it was lost on a device switch and invisible to every other client of the console API. This slice puts the name in the database and makes sure every deployment the API creates ends up with one. Reading the name back from the deployment endpoints is slice 2; renaming through PATCH is slice 3.

Start with the column. The migration adds it nullable and backfills nothing, which is what leaves deployments created before this change without a name rather than inventing one for them.

```bash
cat apps/api/drizzle/0053_deployment_name.sql
echo
echo "UPDATE / SET statements in the migration: $(grep -ciE "update|set " apps/api/drizzle/0053_deployment_name.sql || true)"
```

```output
ALTER TABLE "deployment_settings" ADD COLUMN "name" text;
UPDATE / SET statements in the migration: 0
```

Next, what a deployment gets called when the caller supplies no name. The API derives it from the manifest it already builds for the chain: the service names, de-duplicated, joined with `+`. Below, two real SDL files go through the real manifest generator and the real derivation the create path calls.

```bash
cd apps/api
cat > .demo-derive.ts <<'TS'
import { readFileSync } from "node:fs";
import { generateManifest, yaml } from "@akashnetwork/chain-sdk";
import type { SDLInput } from "@akashnetwork/chain-sdk";
import { deriveDeploymentName } from "./src/deployment/utils/deployment-name/deployment-name";

for (const file of ["hello-world-sdl.yml", "two-service-sdl.yml"]) {
  const parsed = yaml.raw<SDLInput>(readFileSync(`test/mocks/${file}`, "utf8"));
  const manifest = generateManifest(parsed);
  if (!manifest.ok) throw new Error("sdl did not generate a manifest");
  const services = manifest.value.groups.flatMap(g => g.services.map(s => s.name));
  console.log(file);
  console.log(`  services in manifest.groups : ${JSON.stringify(services)}`);
  console.log(`  deployment is named         : ${deriveDeploymentName(manifest.value.groups)}`);
}
TS
npx tsx .demo-derive.ts 2>&1 | grep -v "npm warn"
rm -f .demo-derive.ts
```

```output
hello-world-sdl.yml
  services in manifest.groups : ["web"]
  deployment is named         : web
two-service-sdl.yml
  services in manifest.groups : ["db","web"]
  deployment is named         : db+web
```

Worth pausing on `db+web`. The issue asks for the service names "joined with `+`" and prints `web+db` as its example, but it also states the order is the order of services inside `manifest.groups` — and the chain SDK sorts services alphabetically while building the manifest, so that pair can only ever come out `db+web`. The explicit rule was followed rather than the example; a reviewer should confirm that is the intended reading.

Now what a caller may supply. The name is optional, trimmed before it is measured, and bounded at 256 characters — a bound that lives in the request schema, not in the database. Below, the real create and update request schemas judge a series of names.

```bash
cd apps/api
cat > .demo-schema.ts <<'TS'
import "@hono/zod-openapi";
import { CreateDeploymentRequestSchema, UpdateDeploymentRequestSchema } from "./src/deployment/http-schemas/deployment.schema";

const attempts: Array<[string, string]> = [
  ["a plain name", "staging api"],
  ["padded with spaces", "   checkout stack   "],
  ["nothing but spaces", "   "],
  ["empty", ""],
  ["256 characters", "n".repeat(256)],
  ["257 characters", "n".repeat(257)]
];

for (const [label, name] of attempts) {
  const create = CreateDeploymentRequestSchema.safeParse({ data: { sdl: "version: 2.0", name } });
  const update = UpdateDeploymentRequestSchema.safeParse({ data: { sdl: "version: 2.0", name } });
  const stored = create.success
    ? (create.data.data.name!.length > 40 ? `stored, ${create.data.data.name!.length} characters` : `stored as ${JSON.stringify(create.data.data.name)}`)
    : "refused (400)";
  console.log(`POST ${label.padEnd(19)} -> ${stored.padEnd(28)} | PUT -> ${update.success ? "accepted" : "refused (400)"}`);
}

const omitted = CreateDeploymentRequestSchema.safeParse({ data: { sdl: "version: 2.0" } });
console.log(`POST ${"no name at all".padEnd(19)} -> ${omitted.success ? "accepted, the api derives one" : "refused (400)"}`);
TS
npx tsx .demo-schema.ts 2>&1 | grep -v "npm warn"
rm -f .demo-schema.ts
```

```output
POST a plain name        -> stored as "staging api"      | PUT -> accepted
POST padded with spaces  -> stored as "checkout stack"   | PUT -> accepted
POST nothing but spaces  -> refused (400)                | PUT -> refused (400)
POST empty               -> refused (400)                | PUT -> refused (400)
POST 256 characters      -> stored, 256 characters       | PUT -> accepted
POST 257 characters      -> refused (400)                | PUT -> refused (400)
POST no name at all      -> accepted, the api derives one
```

Then the database itself. This creates a scratch database, runs the real migrations against it, and drives the real repository — no mocks. It matters because the guarantee that "updating a deployment without naming it leaves the name alone" is not a branch in the code: it is whether drizzle puts the column in the `SET` clause at all. The emitted SQL is shown alongside each result.

```bash
cd apps/api
cat > .demo-db.ts <<'TS'
import "reflect-metadata";
import dotenv from "dotenv";
import dotenvExpand from "dotenv-expand";
import { container } from "tsyringe";
import { RAW_APP_CONFIG } from "@src/core/providers/raw-app-config.provider";

dotenvExpand.expand(dotenv.config({ path: "env/.env.functional.test" }));
container.register(RAW_APP_CONFIG, { useValue: process.env });

async function main() {
  const { TestDatabaseService } = await import("./test/services/test-database.service");
  const database = new TestDatabaseService("demo.spec.ts");
  await database.setup();

  const { DeploymentSettingRepository } = await import("@src/deployment/repositories/deployment-setting/deployment-setting.repository");
  const { UserRepository } = await import("@src/user/repositories");
  const { TxService } = await import("@src/core/services/tx/tx.service");
  const { POSTGRES_DB, resolveTable } = await import("@src/core");

  const pg = container.resolve<any>(POSTGRES_DB);
  const txManager = new TxService(pg);
  const settings = new DeploymentSettingRepository(pg, resolveTable("DeploymentSettings") as any, txManager);
  const users = new UserRepository(pg, resolveTable("Users") as any, txManager);
  const user = await users.create({ userId: "demo-user" });

  const [column] = await pg.execute(
    `select data_type, is_nullable, character_maximum_length from information_schema.columns
     where table_name = 'deployment_settings' and column_name = 'name'`
  );
  console.log(`the column: name ${column.data_type}, nullable=${column.is_nullable}, length limit in the database=${column.character_maximum_length ?? "none"}`);

  console.log("");
  console.log("a deployment created with a name, then updated with a new sdl and no name:");
  await settings.upsertDefinition({ userId: user.id, dseq: "1001", sdl: "version: 2.0", manifestVersion: "BAUG", name: "web" });
  const created = await settings.findOneBy({ userId: user.id, dseq: "1001" });
  console.log(`  after create : sdl=${JSON.stringify(created?.sdl)} name=${JSON.stringify(created?.name)}`);

  await settings.upsertDefinition({ userId: user.id, dseq: "1001", sdl: "version: 2.1", manifestVersion: "BQYH" });
  const updated = await settings.findOneBy({ userId: user.id, dseq: "1001" });
  console.log(`  after update : sdl=${JSON.stringify(updated?.sdl)} name=${JSON.stringify(updated?.name)}  <- the rename-free update left the name alone`);

  console.log("");
  console.log("a deployment recorded the way every deployment before this change was recorded, with no name:");
  await settings.upsertDefinition({ userId: user.id, dseq: "1002", sdl: "version: 2.0", manifestVersion: "BAUG" });
  const legacy = await settings.findOneBy({ userId: user.id, dseq: "1002" });
  console.log(`  reads back   : name=${JSON.stringify(legacy?.name)}`);

  await database.teardown();
  process.exit(0);
}

main();
TS
npx tsx .demo-db.ts 2>&1 \
 | grep -vE "npm warn|Setting up test databases|Dropping test databases|Failed to find Response internal state key" \
 | grep -vE "^\{$|^\}$|^  (severity_local|severity|code|message|file|line|routine):" \
 | sed -E "s/.*(on conflict[^-]*) --.*/      emitted SQL: \1/" \
 | grep -vE "^\[|^    context:|^    orm:"
rm -f .demo-db.ts
```

```output
the column: name text, nullable=YES, length limit in the database=none

a deployment created with a name, then updated with a new sdl and no name:
      emitted SQL: on conflict ("dseq","user_id") do update set "sdl" = $7, "name" = $8, "manifest_version" = $9, "updated_at" = now() returning "id"
  after create : sdl="version: 2.0" name="web"
      emitted SQL: on conflict ("dseq","user_id") do update set "sdl" = $6, "manifest_version" = $7, "updated_at" = now() returning "id"
  after update : sdl="version: 2.1" name="web"  <- the rename-free update left the name alone

a deployment recorded the way every deployment before this change was recorded, with no name:
      emitted SQL: on conflict ("dseq","user_id") do update set "sdl" = $6, "manifest_version" = $7, "updated_at" = now() returning "id"
  reads back   : name=null
```

Finally, which endpoints carry the name. This reads the generated OpenAPI document that ships with the API, so it is the contract a client actually sees rather than a claim about it.

```bash
cd apps/api && python3 -c '
import json
doc = json.load(open("swagger/openapi.json"))

def props(schema):
    if not isinstance(schema, dict):
        return []
    data = schema.get("properties", {}).get("data", {})
    if data.get("type") == "array":
        data = data.get("items", {})
    return list(data.get("properties", {}).keys())

rows = []
for path, ops in sorted(doc["paths"].items()):
    if "deployment" not in path:
        continue
    for verb, op in sorted(ops.items()):
        body = op.get("requestBody", {}).get("content", {}).get("application/json", {}).get("schema", {})
        ok = op.get("responses", {}).get("200") or op.get("responses", {}).get("201") or {}
        resp = ok.get("content", {}).get("application/json", {}).get("schema", {})
        if op.get("requestBody") or resp:
            rows.append(("%-6s %s" % (verb.upper(), path), "name" in props(body), "name" in props(resp)))

print("%-58s %14s %14s" % ("endpoint", "accepts a name", "returns a name"))
for label, accepts, returns in rows:
    print("%-58s %14s %14s" % (label, "yes" if accepts else "-", "yes" if returns else "-"))
'
```

```output
endpoint                                                   accepts a name returns a name
GET    /akash/deployment/{version}/deployments/info                     -              -
GET    /akash/deployment/{version}/deployments/list                     -              -
GET    /v1/addresses/{address}/deployments/{skip}/{limit}               -              -
GET    /v1/deployment-alerts/{dseq}                                     -              -
POST   /v1/deployment-alerts/{dseq}                                     -              -
GET    /v1/deployment-funding-config                                    -              -
POST   /v1/deployment-settings                                          -              -
GET    /v1/deployment-settings/{userId}/{dseq}                          -              -
PATCH  /v1/deployment-settings/{userId}/{dseq}                          -              -
GET    /v1/deployment/{owner}/{dseq}                                    -              -
GET    /v1/deployments                                                  -              -
POST   /v1/deployments                                                yes              -
DELETE /v1/deployments/{dseq}                                           -              -
GET    /v1/deployments/{dseq}                                           -              -
PATCH  /v1/deployments/{dseq}                                           -              -
PUT    /v1/deployments/{dseq}                                         yes              -
POST   /v1/deposit-deployment                                           -              -
GET    /v1/providers/{provider}/deployments/{skip}/{limit}              -              -
POST   /v2/deployment-settings                                          -              -
GET    /v2/deployment-settings/{dseq}                                   -              -
PATCH  /v2/deployment-settings/{dseq}                                   -              -
```

Two things to read off that table. The `yes` column is this slice: `POST /v1/deployments` and `PUT /v1/deployments/{dseq}` take a name. Nothing returns one yet — the two GET reads gain it in slice 2, which is why the create results above were read from the database rather than from a response body.

The rest of the table is a decision that wants a human. The `/v1/deployment-settings` and `/v2/deployment-settings` endpoints are named after a deployment's settings and the name is stored on that very row, yet they neither accept nor return it. That is deliberate: the settings response is assembled by dropping the fields it must not publish and spreading the rest, so the new column joined four shipped routes as a field the response schema never declared — present in the JSON, absent from the docs above. It is stripped to keep a documented response documented, and the issue names only the two deployment reads as returning the name. If those endpoints should carry it, the change is to declare it on `DeploymentSettingResponseSchema` and regenerate the docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment names can now be provided when creating or updating deployments.
  * Names are trimmed, must be non-empty, and may contain up to 256 characters.
  * Deployments without an explicit name automatically receive one based on their services.
  * Existing names are preserved when updates omit the name.
  * Deployments can be renamed or assigned a name after creation.
* **Documentation**
  * Deployment API specifications now document the optional name field and its validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->