### PR TITLE
feat(deployment): rename a deployment through patch

### DIFF
--- a/apps/api/src/auth/http-schemas/api-key.schema.ts
+++ b/apps/api/src/auth/http-schemas/api-key.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const ApiKeyHiddenSchema = z.object({
   id: z.string().uuid(),

--- a/apps/api/src/auth/http-schemas/verify-email.schema.ts
+++ b/apps/api/src/auth/http-schemas/verify-email.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const VerifyEmailRequestSchema = z.object({
   data: z.object({

--- a/apps/api/src/bid/http-schemas/bid.schema.ts
+++ b/apps/api/src/bid/http-schemas/bid.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { DseqSchema } from "@src/utils/schema";
 

--- a/apps/api/src/billing/http-schemas/balance.schema.ts
+++ b/apps/api/src/billing/http-schemas/balance.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { AkashAddressSchema } from "@src/utils/schema";
 

--- a/apps/api/src/billing/http-schemas/tx.schema.ts
+++ b/apps/api/src/billing/http-schemas/tx.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const SignTxRequestInputSchema = z.object({
   data: z.object({

--- a/apps/api/src/dashboard/http-schemas/bme-dashboard-data/bme-dashboard-data.schema.ts
+++ b/apps/api/src/dashboard/http-schemas/bme-dashboard-data/bme-dashboard-data.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 const BmePeriodSchema = z.object({
   date: z.string(),

--- a/apps/api/src/dashboard/http-schemas/bme-status-history/bme-status-history.schema.ts
+++ b/apps/api/src/dashboard/http-schemas/bme-status-history/bme-status-history.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const BmeStatusHistoryResponseSchema = z.array(
   z.object({

--- a/apps/api/src/dashboard/http-schemas/dashboard-data/dashboard-data.schema.ts
+++ b/apps/api/src/dashboard/http-schemas/dashboard-data/dashboard-data.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 const LegacyNetworkCapacityResponseSchema = z.object({
   activeProviderCount: z.number(),

--- a/apps/api/src/dashboard/http-schemas/graph-data/graph-data.schema.ts
+++ b/apps/api/src/dashboard/http-schemas/graph-data/graph-data.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { AuthorizedGraphDataNames } from "@src/dashboard/services/stats/stats.types";
 

--- a/apps/api/src/dashboard/http-schemas/market-data/market-data.schema.ts
+++ b/apps/api/src/dashboard/http-schemas/market-data/market-data.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const MarketDataParamsSchema = z.object({
   coin: z.enum(["akash-network", "akt"]).optional().default("akt").openapi({ example: "akt" })

--- a/apps/api/src/dashboard/http-schemas/network-capacity/network-capacity.schema.ts
+++ b/apps/api/src/dashboard/http-schemas/network-capacity/network-capacity.schema.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import { z } from "@hono/zod-openapi";
 
 const statItemSchema = z.object({
   active: z.number(),

--- a/apps/api/src/deployment/http-schemas/deployment-funding-config.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-funding-config.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const DeploymentFundingConfigResponseSchema = z.object({
   data: z.object({

--- a/apps/api/src/deployment/http-schemas/deployment-rpc.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-rpc.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { DseqSchema } from "@src/utils/schema";
 

--- a/apps/api/src/deployment/http-schemas/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-setting.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { DseqSchema } from "@src/utils/schema";
 import { MAX_RUNTIME_LIMIT_HOURS, MAX_RUNTIME_LIMIT_INCREMENT_HOURS } from "./runtime-limit";

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -282,9 +282,9 @@ export const PatchDeploymentParamsSchema = z.object({
   dseq: DseqSchema.describe("Deployment sequence number")
 });
 
-/** A seal is a write no service patch can describe, so naming a service and changing none of its fields is how a caller asks for a rotation and nothing else. */
-function patchesSomething(data: { services: Record<string, Record<string, unknown>>; sealedSecrets?: string }): boolean {
-  return !!data.sealedSecrets || Object.values(data.services).some(assignsAField);
+/** A seal and a name are each a write no service patch can describe, so naming a service and changing none of its fields is how a caller asks for a rotation and nothing else. */
+function patchesSomething(data: { services?: Record<string, Record<string, unknown>>; name?: string; sealedSecrets?: string }): boolean {
+  return !!data.sealedSecrets || !!data.name || Object.values(data.services ?? {}).some(assignsAField);
 }
 
 /** `.refine` rather than a length rule on the record itself, which this zod version does not offer. */
@@ -294,9 +294,15 @@ export const PatchDeploymentRequestSchema = z.object({
       services: z
         .record(z.string(), PatchServiceSchema)
         .refine(services => Object.keys(services).length > 0, { message: "At least one service must be patched" })
+        .optional()
         .openapi({
-          description: "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
+          description:
+            "Keyed by service name. Only the named services are touched; omitted services keep their current definition. Omit it entirely to patch nothing about the definition, which is how a deployment is renamed on its own."
         }),
+      name: DeploymentNameSchema.optional().openapi({
+        description:
+          "Renames the deployment. Supplied on its own it is the only patch that touches no definition, so it works on a deployment the console holds no SDL for and neither broadcasts nor pushes a manifest."
+      }),
       sealedSecrets: SealedSecretsSchema.optional().openapi({
         description:
           "Compact JWE sealing a flat name-to-value map, as on create, but holding only the names this patch replaces. Omitted names keep the values the deployment already stores."
@@ -311,8 +317,8 @@ export const PatchDeploymentRequestSchema = z.object({
 
 export const PatchDeploymentResponseSchema = z.object({
   data: DeploymentResponseSchema.extend({
-    manifestVersion: z.string().openapi({
-      description: "Base64 manifest version this patch recorded and committed on chain."
+    manifestVersion: z.string().optional().openapi({
+      description: "Base64 manifest version this patch recorded and committed on chain. Absent for a rename, which records none."
     })
   })
 });

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -1,6 +1,6 @@
 import type { SDLInput } from "@akashnetwork/chain-sdk";
 import { DeploymentInfoSchema } from "@akashnetwork/http-sdk";
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { SignTxResponseOutputSchema } from "@src/billing/http-schemas/tx.schema";
 import { MAX_MANIFEST_VERSION_LENGTH, MAX_SUBMITTED_SDL_LENGTH } from "@src/deployment/config/sdl.config";
@@ -250,6 +250,10 @@ function assignsAField(patch: Record<string, unknown>): boolean {
   return Object.values(patch).some(value => !isEmptyRecord(value));
 }
 
+export function assignsAnyServiceField(services: Record<string, Record<string, unknown>> | undefined): boolean {
+  return Object.values(services ?? {}).some(assignsAField);
+}
+
 /** An array is a value even when empty, because `command: []` clears the list the service declared. */
 function isEmptyRecord(value: unknown): boolean {
   return !!value && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0;
@@ -284,7 +288,7 @@ export const PatchDeploymentParamsSchema = z.object({
 
 /** A seal and a name are each a write no service patch can describe, so naming a service and changing none of its fields is how a caller asks for a rotation and nothing else. */
 function patchesSomething(data: { services?: Record<string, Record<string, unknown>>; name?: string; sealedSecrets?: string }): boolean {
-  return !!data.sealedSecrets || !!data.name || Object.values(data.services ?? {}).some(assignsAField);
+  return !!data.sealedSecrets || !!data.name || assignsAnyServiceField(data.services);
 }
 
 /** `.refine` rather than a length rule on the record itself, which this zod version does not offer. */

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -317,6 +317,7 @@ export const PatchDeploymentRequestSchema = z.object({
 
 export const PatchDeploymentResponseSchema = z.object({
   data: DeploymentResponseSchema.extend({
+    name: DeploymentNameResponseSchema,
     manifestVersion: z.string().optional().openapi({
       description: "Base64 manifest version this patch recorded and committed on chain. Absent for a rename, which records none."
     })

--- a/apps/api/src/deployment/http-schemas/lease-rpc.schema.ts
+++ b/apps/api/src/deployment/http-schemas/lease-rpc.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { DseqSchema } from "@src/utils/schema";
 

--- a/apps/api/src/deployment/http-schemas/lease.schema.ts
+++ b/apps/api/src/deployment/http-schemas/lease.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { AkashAddressSchema, DseqSchema } from "@src/utils/schema";
 

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -684,9 +684,7 @@ describe(DeploymentSettingRepository.name, () => {
       await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq: named, sdl: SDL, manifestVersion: "BAUG", name: "web" });
       await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq: alsoNamed, sdl: SDL, manifestVersion: "BAUG", name: "db+web" });
 
-      const names = await deploymentSettingRepository
-        .accessibleBy(abilityFor(user), "read")
-        .findNamesByDseqs({ userId: user.id, dseqs: [named, alsoNamed] });
+      const names = await deploymentSettingRepository.accessibleBy(abilityFor(user), "read").findNamesByDseqs({ userId: user.id, dseqs: [named, alsoNamed] });
 
       expect(names.get(named)).toBe("web");
       expect(names.get(alsoNamed)).toBe("db+web");
@@ -968,7 +966,7 @@ describe(DeploymentSettingRepository.name, () => {
       const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
       const dseq = await createDefinition({ manifestVersion: "AAAA" });
 
-      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+      const recorded = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
         userId: user.id,
         dseq,
         sdl: "version: '2.0' # patched",
@@ -977,7 +975,7 @@ describe(DeploymentSettingRepository.name, () => {
         expectedManifestVersion: "AAAA"
       });
 
-      expect(id).toEqual(expect.any(String));
+      expect(recorded?.id).toEqual(expect.any(String));
       expect(await readDefinition(dseq)).toMatchObject({
         sdl: "version: '2.0' # patched",
         manifestVersion: "BBBB",
@@ -989,7 +987,7 @@ describe(DeploymentSettingRepository.name, () => {
       const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
       const dseq = await createDefinition({ manifestVersion: "AAAA" });
 
-      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+      const recorded = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
         userId: user.id,
         dseq,
         sdl: "version: '2.0' # patched",
@@ -998,7 +996,7 @@ describe(DeploymentSettingRepository.name, () => {
         expectedManifestVersion: "STALE"
       });
 
-      expect(id).toBeUndefined();
+      expect(recorded).toBeUndefined();
     });
 
     it("leaves every column as it was when it refuses", async () => {
@@ -1022,7 +1020,7 @@ describe(DeploymentSettingRepository.name, () => {
       const { deploymentSettingRepository, user, createDefinition, sealedToken } = await setup();
       const dseq = await createDefinition({ manifestVersion: "BBBB" });
 
-      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+      const recorded = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
         userId: user.id,
         dseq,
         sdl: "version: '2.0' # patched",
@@ -1031,7 +1029,7 @@ describe(DeploymentSettingRepository.name, () => {
         expectedManifestVersion: "AAAA"
       });
 
-      expect(id).toEqual(expect.any(String));
+      expect(recorded?.id).toEqual(expect.any(String));
     });
 
     it("leaves the row at the version the retry recomputed", async () => {
@@ -1054,7 +1052,7 @@ describe(DeploymentSettingRepository.name, () => {
       const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
       const dseq = await createDefinition({ manifestVersion: "CCCC" });
 
-      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+      const recorded = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
         userId: user.id,
         dseq,
         sdl: "version: '2.0' # patched",
@@ -1063,7 +1061,7 @@ describe(DeploymentSettingRepository.name, () => {
         expectedManifestVersion: "AAAA"
       });
 
-      expect(id).toBeUndefined();
+      expect(recorded).toBeUndefined();
       expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "CCCC" });
     });
 
@@ -1113,7 +1111,7 @@ describe(DeploymentSettingRepository.name, () => {
       const { deploymentSettingRepository, user, createDefinition, readDefinition, sealedToken } = await setup();
       const dseq = await createDefinition({ manifestVersion: "AAAA" });
 
-      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+      const recorded = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
         userId: user.id,
         dseq,
         sdl: "version: '2.0' # patched",
@@ -1121,7 +1119,7 @@ describe(DeploymentSettingRepository.name, () => {
         sealedSecrets: sealedToken
       });
 
-      expect(id).toEqual(expect.any(String));
+      expect(recorded?.id).toEqual(expect.any(String));
       expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "BBBB" });
     });
 
@@ -1146,7 +1144,7 @@ describe(DeploymentSettingRepository.name, () => {
       const settingId = await createSetting();
       const dseq = await readSettingDseq(settingId);
 
-      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+      const recorded = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
         userId: user.id,
         dseq,
         sdl: "version: '2.0' # patched",
@@ -1154,14 +1152,14 @@ describe(DeploymentSettingRepository.name, () => {
         sealedSecrets: sealedToken
       });
 
-      expect(id).toBeUndefined();
+      expect(recorded).toBeUndefined();
     });
 
     it("refuses a deployment belonging to another user", async () => {
       const { deploymentSettingRepository, trialUser, createDefinition, readDefinition, sealedToken } = await setup();
       const dseq = await createDefinition({ manifestVersion: "AAAA" });
 
-      const id = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
+      const recorded = await deploymentSettingRepository.replaceDefinitionIfVersionMatches({
         userId: trialUser.id,
         dseq,
         sdl: "version: '2.0' # patched",
@@ -1169,7 +1167,7 @@ describe(DeploymentSettingRepository.name, () => {
         sealedSecrets: sealedToken
       });
 
-      expect(id).toBeUndefined();
+      expect(recorded).toBeUndefined();
       expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "AAAA" });
     });
 
@@ -1177,7 +1175,7 @@ describe(DeploymentSettingRepository.name, () => {
       const { deploymentSettingRepository, user, trialUser, createDefinition, readDefinition, abilityFor, sealedToken } = await setup();
       const dseq = await createDefinition({ manifestVersion: "AAAA" });
 
-      const id = await deploymentSettingRepository.accessibleBy(abilityFor(trialUser), "update").replaceDefinitionIfVersionMatches({
+      const recorded = await deploymentSettingRepository.accessibleBy(abilityFor(trialUser), "update").replaceDefinitionIfVersionMatches({
         userId: user.id,
         dseq,
         sdl: "version: '2.0' # patched",
@@ -1185,7 +1183,7 @@ describe(DeploymentSettingRepository.name, () => {
         sealedSecrets: sealedToken
       });
 
-      expect(id).toBeUndefined();
+      expect(recorded).toBeUndefined();
       expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "AAAA" });
     });
 
@@ -1205,12 +1203,28 @@ describe(DeploymentSettingRepository.name, () => {
       expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ name: "renamed" });
     });
 
+    it("hands back the name it recorded beside the definition", async () => {
+      const { deploymentSettingRepository, user, createDefinition, abilityFor, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      const recorded = await deploymentSettingRepository.accessibleBy(abilityFor(user), "update").replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        name: "renamed"
+      });
+
+      expect(recorded?.name).toBe("renamed");
+    });
+
     it("leaves a name already on the row alone when the replacement names none", async () => {
       const { deploymentSettingRepository, user, abilityFor, sealedToken } = await setup();
       const dseq = newDseq();
       await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "AAAA", name: "web" });
 
-      await deploymentSettingRepository.accessibleBy(abilityFor(user), "update").replaceDefinitionIfVersionMatches({
+      const recorded = await deploymentSettingRepository.accessibleBy(abilityFor(user), "update").replaceDefinitionIfVersionMatches({
         userId: user.id,
         dseq,
         sdl: "version: '2.0' # patched",
@@ -1218,6 +1232,7 @@ describe(DeploymentSettingRepository.name, () => {
         sealedSecrets: sealedToken
       });
 
+      expect(recorded?.name).toBe("web");
       expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ manifestVersion: "BBBB", name: "web" });
     });
   });
@@ -1250,6 +1265,17 @@ describe(DeploymentSettingRepository.name, () => {
       await deploymentSettingRepository.upsertName({ userId: user.id, dseq, name: "renamed" });
 
       expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: SDL, manifestVersion: "AAAA", name: "renamed" });
+    });
+
+    it("hands back the name it stored, whether it created the row or replaced one", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      const created = await deploymentSettingRepository.upsertName({ userId: user.id, dseq, name: "first" });
+      const replaced = await deploymentSettingRepository.upsertName({ userId: user.id, dseq, name: "renamed" });
+
+      expect(created).toBe("first");
+      expect(replaced).toBe("renamed");
     });
 
     it("names only the caller's own row when another user holds the same dseq", async () => {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -1188,6 +1188,80 @@ describe(DeploymentSettingRepository.name, () => {
       expect(id).toBeUndefined();
       expect(await readDefinition(dseq)).toMatchObject({ manifestVersion: "AAAA" });
     });
+
+    it("records a name beside the definition it replaces", async () => {
+      const { deploymentSettingRepository, user, createDefinition, abilityFor, sealedToken } = await setup();
+      const dseq = await createDefinition({ manifestVersion: "AAAA" });
+
+      await deploymentSettingRepository.accessibleBy(abilityFor(user), "update").replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken,
+        name: "renamed"
+      });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ name: "renamed" });
+    });
+
+    it("leaves a name already on the row alone when the replacement names none", async () => {
+      const { deploymentSettingRepository, user, abilityFor, sealedToken } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "AAAA", name: "web" });
+
+      await deploymentSettingRepository.accessibleBy(abilityFor(user), "update").replaceDefinitionIfVersionMatches({
+        userId: user.id,
+        dseq,
+        sdl: "version: '2.0' # patched",
+        manifestVersion: "BBBB",
+        sealedSecrets: sealedToken
+      });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ manifestVersion: "BBBB", name: "web" });
+    });
+  });
+
+  describe("upsertName", () => {
+    it("names a deployment the console holds no row for at all", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+
+      await deploymentSettingRepository.upsertName({ userId: user.id, dseq, name: "renamed" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ name: "renamed", sdl: null });
+    });
+
+    it("replaces the name on a row that already carries one", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "AAAA", name: "web" });
+
+      await deploymentSettingRepository.upsertName({ userId: user.id, dseq, name: "renamed" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ name: "renamed" });
+    });
+
+    it("leaves the definition it finds on the row untouched", async () => {
+      const { deploymentSettingRepository, user } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "AAAA" });
+
+      await deploymentSettingRepository.upsertName({ userId: user.id, dseq, name: "renamed" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ sdl: SDL, manifestVersion: "AAAA", name: "renamed" });
+    });
+
+    it("names only the caller's own row when another user holds the same dseq", async () => {
+      const { deploymentSettingRepository, user, trialUser } = await setup();
+      const dseq = newDseq();
+      await deploymentSettingRepository.upsertDefinition({ userId: trialUser.id, dseq, sdl: SDL, manifestVersion: "AAAA", name: "not yours" });
+
+      await deploymentSettingRepository.upsertName({ userId: user.id, dseq, name: "renamed" });
+
+      expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq })).toMatchObject({ name: "renamed" });
+      expect(await deploymentSettingRepository.findOneBy({ userId: trialUser.id, dseq })).toMatchObject({ name: "not yours" });
+    });
   });
 
   async function setup() {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -416,7 +416,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     sealedSecrets: string | null;
     name?: string;
     expectedManifestVersion?: string;
-  }): Promise<string | undefined> {
+  }): Promise<{ id: string; name: string | null } | undefined> {
     const [row] = await this.cursor
       .update(this.table)
       .set({ sdl, manifestVersion, sealedSecrets, name, updatedAt: sql`now()` })
@@ -430,9 +430,9 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
           )
         )
       )
-      .returning({ id: this.table.id });
+      .returning({ id: this.table.id, name: this.table.name });
 
-    return row?.id;
+    return row;
   }
 
   /** A row already carrying the version this write computes is that write's own output, so a guarded retry succeeds rather than conflicting: `manifestVersion` hashes the resolved manifest, and equal versions mean equal effective state down to the secret values. */
@@ -448,11 +448,14 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
    * that reaches deployments predating the definition recording — exactly the ones whose names still live only in
    * a browser. Keyed on (dseq, userId) with the caller's own id, so it can only ever write the caller's own row.
    */
-  async upsertName({ userId, dseq, name }: { userId: string; dseq: string; name: string }): Promise<void> {
-    await this.cursor
+  async upsertName({ userId, dseq, name }: { userId: string; dseq: string; name: string }): Promise<string | null> {
+    const [row] = await this.cursor
       .insert(this.table)
       .values({ userId, dseq, autoTopUpEnabled: AUTO_TOP_UP_ENABLED_BY_DEFAULT, name })
-      .onConflictDoUpdate({ target: [this.table.dseq, this.table.userId], set: { name, updatedAt: sql`now()` } });
+      .onConflictDoUpdate({ target: [this.table.dseq, this.table.userId], set: { name, updatedAt: sql`now()` } })
+      .returning({ name: this.table.name });
+
+    return row.name;
   }
 
   async createDefaultIfMissing({ userId, dseq }: { userId: string; dseq: string }): Promise<boolean> {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -406,6 +406,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     sdl,
     manifestVersion,
     sealedSecrets,
+    name,
     expectedManifestVersion
   }: {
     userId: string;
@@ -413,11 +414,12 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     sdl: string;
     manifestVersion: string;
     sealedSecrets: string | null;
+    name?: string;
     expectedManifestVersion?: string;
   }): Promise<string | undefined> {
     const [row] = await this.cursor
       .update(this.table)
-      .set({ sdl, manifestVersion, sealedSecrets, updatedAt: sql`now()` })
+      .set({ sdl, manifestVersion, sealedSecrets, name, updatedAt: sql`now()` })
       .where(
         this.whereAccessibleBy(
           and(
@@ -441,6 +443,18 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
   }
 
   /** Conflicts are ignored rather than merged, so a row another path already wrote keeps every choice its writer made. */
+  /**
+   * Names a deployment whether or not the console already holds a row for it, because a rename is the one write
+   * that reaches deployments predating the definition recording — exactly the ones whose names still live only in
+   * a browser. Keyed on (dseq, userId) with the caller's own id, so it can only ever write the caller's own row.
+   */
+  async upsertName({ userId, dseq, name }: { userId: string; dseq: string; name: string }): Promise<void> {
+    await this.cursor
+      .insert(this.table)
+      .values({ userId, dseq, autoTopUpEnabled: AUTO_TOP_UP_ENABLED_BY_DEFAULT, name })
+      .onConflictDoUpdate({ target: [this.table.dseq, this.table.userId], set: { name, updatedAt: sql`now()` } });
+  }
+
   async createDefaultIfMissing({ userId, dseq }: { userId: string; dseq: string }): Promise<boolean> {
     const rows = await this.cursor
       .insert(this.table)

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -256,7 +256,7 @@ const patchRoute = createRoute({
   path: "/v1/deployments/{dseq}",
   summary: "Patch a deployment",
   description:
-    "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.",
+    "Patches the SDL the console stored for this deployment, or renames the deployment, or both; the SDL is never accepted from the request. Only the services named are touched. A `name` on its own touches no definition, so it renames a deployment the console holds no SDL for and neither broadcasts nor pushes a manifest. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.",
   operationId: "patchDeployment",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
@@ -291,7 +291,8 @@ const patchRoute = createRoute({
       }
     },
     404: {
-      description: "No SDL is recorded for this deployment, so there is nothing to patch",
+      description:
+        "No SDL is recorded for this deployment, so there is nothing to patch. A rename answers this only when the chain holds no such deployment for the caller, since it needs no recorded SDL",
       content: {
         "application/json": {
           schema: ErrorResponseSchema

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -269,6 +269,29 @@ describe(DeploymentReaderService.name, () => {
       expect(leaseHttpService.list).toHaveBeenCalledWith({ owner: wallet.address, dseq: "200" });
     });
 
+    it("fails the list rather than reporting a deployment whose lease fetch failed as lease-less", async () => {
+      const wallet = createUserWallet() as WalletInitialized;
+      const { service, leaseHttpService } = setup({ wallet, listedDseqs: ["100", "200"] });
+      leaseHttpService.list.mockRejectedValue(createHttpError(400));
+
+      await expect(service.list({ query: { userId: wallet.userId } })).rejects.toThrow();
+    });
+
+    it("falls back to database for lease data when blockchain node is unreachable", async () => {
+      const wallet = createUserWallet() as WalletInitialized;
+      const { service, leaseHttpService, fallbackLeaseReaderService } = setup({ wallet, listedDseqs: ["100"] });
+      leaseHttpService.list.mockRejectedValue(createNetworkError("ECONNREFUSED"));
+      fallbackLeaseReaderService.list.mockResolvedValue({
+        leases: [createLeaseApiResponse({ owner: wallet.address, dseq: "100" })],
+        pagination: { next_key: null, total: "1" }
+      });
+
+      const { deployments } = await service.list({ query: { userId: wallet.userId } });
+
+      expect(fallbackLeaseReaderService.list).toHaveBeenCalledWith({ owner: wallet.address, dseq: "100" });
+      expect(deployments.map(item => item.leases.map(lease => lease.id.dseq))).toEqual([["100"]]);
+    });
+
     it("reads no names for a page with no deployments on it", async () => {
       const wallet = createUserWallet() as WalletInitialized;
       const { service, scopedDeploymentSettingRepository } = setup({ wallet, listedDseqs: [] });

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
@@ -174,13 +174,17 @@ export class DeploymentReaderService {
     const [{ results: leaseResults }, names] = await Promise.all([
       PromisePool.withConcurrency(100)
         .for(deployments)
+        .useCorrespondingResults()
         .process(async deployment => this.leaseHttpService.list({ owner, dseq: deployment.deployment.id.dseq })),
-      this.findNamesFor(query.userId, deployments.map(deployment => deployment.deployment.id.dseq))
+      this.findNamesFor(
+        query.userId,
+        deployments.map(deployment => deployment.deployment.id.dseq)
+      )
     ]);
 
     const deploymentsWithLeases = deployments.map((deployment, index) => ({
       deployment: deployment.deployment,
-      leases: leaseResults[index]?.leases?.map(({ lease }) => lease) ?? [],
+      leases: (leaseResults as RestAkashLeaseListResponse[])[index]?.leases?.map(({ lease }) => lease) ?? [],
       escrow_account: deployment.escrow_account,
       name: names.get(deployment.deployment.id.dseq) ?? null
     }));

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
@@ -175,7 +175,10 @@ export class DeploymentReaderService {
       PromisePool.withConcurrency(100)
         .for(deployments)
         .useCorrespondingResults()
-        .process(async deployment => this.leaseHttpService.list({ owner, dseq: deployment.deployment.id.dseq })),
+        .handleError(async error => {
+          throw error;
+        })
+        .process(async deployment => this.getLeaseList({ owner, dseq: deployment.deployment.id.dseq })),
       this.findNamesFor(
         query.userId,
         deployments.map(deployment => deployment.deployment.id.dseq)
@@ -184,7 +187,7 @@ export class DeploymentReaderService {
 
     const deploymentsWithLeases = deployments.map((deployment, index) => ({
       deployment: deployment.deployment,
-      leases: (leaseResults as RestAkashLeaseListResponse[])[index]?.leases?.map(({ lease }) => lease) ?? [],
+      leases: this.#fetchedLeasesAt(leaseResults, index).map(({ lease }) => lease),
       escrow_account: deployment.escrow_account,
       name: names.get(deployment.deployment.id.dseq) ?? null
     }));
@@ -193,6 +196,16 @@ export class DeploymentReaderService {
       total,
       hasMore: skip !== undefined && limit !== undefined ? total > skip + limit : false
     };
+  }
+
+  #fetchedLeasesAt(leaseResults: Array<RestAkashLeaseListResponse | symbol>, index: number): RestAkashLeaseListResponse["leases"] {
+    const result = leaseResults[index];
+
+    if (typeof result === "symbol") {
+      throw new InternalServerError("Leases could not be fetched for every listed deployment");
+    }
+
+    return result.leases;
   }
 
   public async listWithResources({

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -2051,6 +2051,70 @@ describe(DeploymentWriterService.name, () => {
       });
     });
 
+    describe("a patch carrying only a name", () => {
+      it("writes the name against a row that may not exist yet", async () => {
+        const { service, ability, unscopedDeploymentSettingRepository } = setup({ setting: undefined });
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed" }, ability);
+
+        expect(unscopedDeploymentSettingRepository.upsertName).toHaveBeenCalledWith({ userId: "user-1", dseq: "1234", name: "renamed" });
+      });
+
+      it("reads no stored definition, so a deployment the console holds no sdl for is renameable", async () => {
+        const { service, ability, deploymentSettingRepository } = setup({ setting: undefined });
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed" }, ability);
+
+        expect(deploymentSettingRepository.findOneBy).not.toHaveBeenCalled();
+        expect(deploymentSettingRepository.replaceDefinitionIfVersionMatches).not.toHaveBeenCalled();
+      });
+
+      it("broadcasts nothing and pushes no manifest", async () => {
+        const { service, ability, signerService, providerService } = setup();
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed" }, ability);
+
+        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+        expect(providerService.sendManifest).not.toHaveBeenCalled();
+      });
+
+      it("answers with the deployment the chain holds and records no manifest version", async () => {
+        const { service, ability } = setup();
+
+        const result = await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed" }, ability);
+
+        expect(result.manifestVersion).toBeUndefined();
+        expect(result.deployment).toEqual(expect.objectContaining({ id: { owner: "akash1owner", dseq: "1234" } }));
+      });
+
+      it("refuses a deployment the chain does not hold, writing no name", async () => {
+        const { service, ability, deploymentReaderService, unscopedDeploymentSettingRepository } = setup();
+        deploymentReaderService.findByWalletAndDseq.mockRejectedValue(createError(404, "Deployment not found"));
+
+        await expect(service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed" }, ability)).rejects.toMatchObject({ status: 404 });
+
+        expect(unscopedDeploymentSettingRepository.upsertName).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("a patch carrying a name beside services", () => {
+      it("records the name with the definition it rewrites", async () => {
+        const { service, ability, deploymentSettingRepository } = setup();
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { image: "nginx:1.27" } }, name: "renamed" }, ability);
+
+        expect(deploymentSettingRepository.replaceDefinitionIfVersionMatches).toHaveBeenCalledWith(expect.objectContaining({ name: "renamed" }));
+      });
+
+      it("leaves the recorded name alone for a patch that names none", async () => {
+        const { service, ability, deploymentSettingRepository } = setup();
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { image: "nginx:1.27" } } }, ability);
+
+        expect(deploymentSettingRepository.replaceDefinitionIfVersionMatches).toHaveBeenCalledWith(expect.objectContaining({ name: undefined }));
+      });
+    });
+
     function setup(input?: {
       sdl?: string;
       setting?: DeploymentSettingsOutput | undefined;
@@ -2149,6 +2213,7 @@ describe(DeploymentWriterService.name, () => {
         service,
         ability,
         deploymentSettingRepository: scoped,
+        unscopedDeploymentSettingRepository: deploymentSettingRepository,
         deploymentReaderService,
         sdlService,
         sdlSecretsService,

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -2053,11 +2053,11 @@ describe(DeploymentWriterService.name, () => {
 
     describe("a patch carrying only a name", () => {
       it("writes the name against a row that may not exist yet", async () => {
-        const { service, ability, unscopedDeploymentSettingRepository } = setup({ setting: undefined });
+        const { service, ability, deploymentSettingRepository } = setup({ setting: undefined });
 
         await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed" }, ability);
 
-        expect(unscopedDeploymentSettingRepository.upsertName).toHaveBeenCalledWith({ userId: "user-1", dseq: "1234", name: "renamed" });
+        expect(deploymentSettingRepository.upsertName).toHaveBeenCalledWith({ userId: "user-1", dseq: "1234", name: "renamed" });
       });
 
       it("reads no stored definition, so a deployment the console holds no sdl for is renameable", async () => {
@@ -2096,22 +2096,22 @@ describe(DeploymentWriterService.name, () => {
       });
 
       it("refuses a deployment the chain does not hold, writing no name", async () => {
-        const { service, ability, deploymentReaderService, unscopedDeploymentSettingRepository } = setup();
+        const { service, ability, deploymentReaderService, deploymentSettingRepository } = setup();
         deploymentReaderService.findByWalletAndDseq.mockRejectedValue(createError(404, "Deployment not found"));
 
         await expect(service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed" }, ability)).rejects.toMatchObject({ status: 404 });
 
-        expect(unscopedDeploymentSettingRepository.upsertName).not.toHaveBeenCalled();
+        expect(deploymentSettingRepository.upsertName).not.toHaveBeenCalled();
       });
     });
 
     describe("a patch carrying no name at all", () => {
       it("takes the definition path rather than the rename one, so it never names a deployment undefined", async () => {
-        const { service, ability, unscopedDeploymentSettingRepository } = setup({ setting: undefined });
+        const { service, ability, deploymentSettingRepository } = setup({ setting: undefined });
 
         await expect(service.patchByUserIdAndDseq("user-1", "1234", {}, ability)).rejects.toMatchObject({ status: 404 });
 
-        expect(unscopedDeploymentSettingRepository.upsertName).not.toHaveBeenCalled();
+        expect(deploymentSettingRepository.upsertName).not.toHaveBeenCalled();
       });
     });
 
@@ -2146,6 +2146,44 @@ describe(DeploymentWriterService.name, () => {
         const result = await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { image: "nginx:1.27" } } }, ability);
 
         expect(result.name).toBe("web");
+      });
+    });
+
+    describe("a patch carrying a name beside services that assign no field", () => {
+      it("renames without reading a stored definition, so a deployment the console holds no sdl for stays renameable", async () => {
+        const { service, ability, deploymentSettingRepository } = setup({ setting: undefined });
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed", services: { web: {} } }, ability);
+
+        expect(deploymentSettingRepository.upsertName).toHaveBeenCalledWith({ userId: "user-1", dseq: "1234", name: "renamed" });
+        expect(deploymentSettingRepository.replaceDefinitionIfVersionMatches).not.toHaveBeenCalled();
+      });
+
+      it("counts a service whose every field is an empty record as assigning nothing, broadcasting and pushing nothing", async () => {
+        const { service, ability, signerService, providerService } = setup();
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed", services: { web: { expose: {} } } }, ability);
+
+        expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+        expect(providerService.sendManifest).not.toHaveBeenCalled();
+      });
+
+      it("still rewrites the definition when a seal arrives beside the empty entries, because the rotation is the patch", async () => {
+        const { service, ability, deploymentSettingRepository } = setup();
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed", services: { web: {} }, sealedSecrets: CLIENT_SEAL }, ability);
+
+        expect(deploymentSettingRepository.replaceDefinitionIfVersionMatches).toHaveBeenCalledWith(expect.objectContaining({ name: "renamed" }));
+        expect(deploymentSettingRepository.upsertName).not.toHaveBeenCalled();
+      });
+
+      it("counts an empty array as a value, so clearing a command rewrites the definition rather than renaming", async () => {
+        const { service, ability, deploymentSettingRepository } = setup();
+
+        await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed", services: { web: { command: [] } } }, ability);
+
+        expect(deploymentSettingRepository.replaceDefinitionIfVersionMatches).toHaveBeenCalledWith(expect.objectContaining({ name: "renamed" }));
+        expect(deploymentSettingRepository.upsertName).not.toHaveBeenCalled();
       });
     });
 
@@ -2184,7 +2222,7 @@ describe(DeploymentWriterService.name, () => {
         const id = "written" in (input ?? {}) ? input!.written : randomUUID();
         return id === undefined ? undefined : { id, name: name ?? input?.recordedName ?? null };
       });
-      deploymentSettingRepository.upsertName.mockImplementation(async ({ name }) => name);
+      scoped.upsertName.mockImplementation(async ({ name }) => name);
       deploymentSettingRepository.accessibleBy.mockReturnValue(scoped);
 
       const deploymentReaderService = mock<DeploymentReaderService>();

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -2097,6 +2097,16 @@ describe(DeploymentWriterService.name, () => {
       });
     });
 
+    describe("a patch carrying no name at all", () => {
+      it("takes the definition path rather than the rename one, so it never names a deployment undefined", async () => {
+        const { service, ability, unscopedDeploymentSettingRepository } = setup({ setting: undefined });
+
+        await expect(service.patchByUserIdAndDseq("user-1", "1234", {}, ability)).rejects.toMatchObject({ status: 404 });
+
+        expect(unscopedDeploymentSettingRepository.upsertName).not.toHaveBeenCalled();
+      });
+    });
+
     describe("a patch carrying a name beside services", () => {
       it("records the name with the definition it rewrites", async () => {
         const { service, ability, deploymentSettingRepository } = setup();

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -2087,6 +2087,14 @@ describe(DeploymentWriterService.name, () => {
         expect(result.deployment).toEqual(expect.objectContaining({ id: { owner: "akash1owner", dseq: "1234" } }));
       });
 
+      it("answers with the name it stored", async () => {
+        const { service, ability } = setup();
+
+        const result = await service.patchByUserIdAndDseq("user-1", "1234", { name: "renamed" }, ability);
+
+        expect(result.name).toBe("renamed");
+      });
+
       it("refuses a deployment the chain does not hold, writing no name", async () => {
         const { service, ability, deploymentReaderService, unscopedDeploymentSettingRepository } = setup();
         deploymentReaderService.findByWalletAndDseq.mockRejectedValue(createError(404, "Deployment not found"));
@@ -2123,6 +2131,22 @@ describe(DeploymentWriterService.name, () => {
 
         expect(deploymentSettingRepository.replaceDefinitionIfVersionMatches).toHaveBeenCalledWith(expect.objectContaining({ name: undefined }));
       });
+
+      it("answers with the name the write recorded", async () => {
+        const { service, ability } = setup();
+
+        const result = await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { image: "nginx:1.27" } }, name: "renamed" }, ability);
+
+        expect(result.name).toBe("renamed");
+      });
+
+      it("answers with the name the row already carried when the patch names none", async () => {
+        const { service, ability } = setup({ recordedName: "web" });
+
+        const result = await service.patchByUserIdAndDseq("user-1", "1234", { services: { web: { image: "nginx:1.27" } } }, ability);
+
+        expect(result.name).toBe("web");
+      });
     });
 
     function setup(input?: {
@@ -2135,6 +2159,7 @@ describe(DeploymentWriterService.name, () => {
       resolveErrors?: Array<{ schemaPath: string; instancePath: string; keyword: string; params: Record<string, unknown>; message: string }>;
       maxCount?: number;
       written?: string | undefined;
+      recordedName?: string;
       chainHash?: string;
       providers?: string[];
       openStoredError?: Error;
@@ -2155,7 +2180,11 @@ describe(DeploymentWriterService.name, () => {
       scoped.findOneBy.mockResolvedValue(
         hasSetting ? mock<DeploymentSettingsOutput>({ sdl: input?.sdl ?? STORED_SDL, sealedSecrets: storedToken, manifestVersion: storedVersion }) : undefined
       );
-      scoped.replaceDefinitionIfVersionMatches.mockResolvedValue("written" in (input ?? {}) ? input!.written : randomUUID());
+      scoped.replaceDefinitionIfVersionMatches.mockImplementation(async ({ name }) => {
+        const id = "written" in (input ?? {}) ? input!.written : randomUUID();
+        return id === undefined ? undefined : { id, name: name ?? input?.recordedName ?? null };
+      });
+      deploymentSettingRepository.upsertName.mockImplementation(async ({ name }) => name);
       deploymentSettingRepository.accessibleBy.mockReturnValue(scoped);
 
       const deploymentReaderService = mock<DeploymentReaderService>();

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -14,6 +14,7 @@ import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-
 import { type CreateLogger, JOB_NAME, JobQueueService, LOGGER_FACTORY, TxService } from "@src/core";
 import { SDL_MAX_LENGTH } from "@src/deployment/config/sdl.config";
 import {
+  assignsAnyServiceField,
   CreateDeploymentRequest,
   CreateDeploymentResponse,
   DeploymentResponse,
@@ -415,7 +416,7 @@ export class DeploymentWriterService {
     input: PatchDeploymentRequest["data"],
     ability: AnyAbility
   ): Promise<PatchDeploymentResponse["data"]> {
-    if (input.name !== undefined && !input.services && !input.sealedSecrets) {
+    if (input.name !== undefined && !assignsAnyServiceField(input.services) && !input.sealedSecrets) {
       return await this.#renameByUserIdAndDseq(userId, dseq, input.name, ability);
     }
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -416,7 +416,7 @@ export class DeploymentWriterService {
     ability: AnyAbility
   ): Promise<PatchDeploymentResponse["data"]> {
     if (input.name !== undefined && !input.services && !input.sealedSecrets) {
-      return await this.#renameByUserIdAndDseq(userId, dseq, input.name);
+      return await this.#renameByUserIdAndDseq(userId, dseq, input.name, ability);
     }
 
     const [wallet, stored] = await Promise.all([
@@ -496,11 +496,11 @@ export class DeploymentWriterService {
    * pushes nothing. That is what lets it reach a deployment created before the console recorded SDLs, which the
    * patch path refuses outright. The chain read is the ownership check that path gets from its stored row.
    */
-  async #renameByUserIdAndDseq(userId: string, dseq: string, name: string): Promise<PatchDeploymentResponse["data"]> {
+  async #renameByUserIdAndDseq(userId: string, dseq: string, name: string, ability: AnyAbility): Promise<PatchDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
 
-    const persistedName = await this.deploymentSettingRepository.upsertName({ userId, dseq, name });
+    const persistedName = await this.deploymentSettingRepository.accessibleBy(ability, "update").upsertName({ userId, dseq, name });
 
     this.logger.info({ event: "DEPLOYMENT_RENAMED", userId, dseq });
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -442,7 +442,7 @@ export class DeploymentWriterService {
     const recordedVersion = Buffer.from(manifestVersion).toString("base64");
     const sealedSecrets = await this.sdlSecretsService.sealForStorage({ userId, dseq, secrets: merged });
 
-    const recordedId = await this.deploymentSettingRepository.accessibleBy(ability, "update").replaceDefinitionIfVersionMatches({
+    const recorded = await this.deploymentSettingRepository.accessibleBy(ability, "update").replaceDefinitionIfVersionMatches({
       userId,
       dseq,
       sdl: patchedSdl,
@@ -452,7 +452,7 @@ export class DeploymentWriterService {
       expectedManifestVersion: input.ifManifestVersion ?? stored.manifestVersion
     });
 
-    if (!recordedId) {
+    if (!recorded) {
       throw createError(409, "Deployment definition changed concurrently, please retry");
     }
 
@@ -474,7 +474,9 @@ export class DeploymentWriterService {
     });
     await this.restartTrialWorkloadProbe(wallet, dseq);
 
-    return { ...(await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq)), manifestVersion: recordedVersion };
+    const updatedDeployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
+
+    return { ...updatedDeployment, name: recorded.name, manifestVersion: recordedVersion };
   }
 
   /** The probe is a backstopped extra, so failing to reschedule it must not fail an update the chain and the providers have already taken. */
@@ -498,11 +500,11 @@ export class DeploymentWriterService {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
 
-    await this.deploymentSettingRepository.upsertName({ userId, dseq, name });
+    const persistedName = await this.deploymentSettingRepository.upsertName({ userId, dseq, name });
 
     this.logger.info({ event: "DEPLOYMENT_RENAMED", userId, dseq });
 
-    return deployment;
+    return { ...deployment, name: persistedName };
   }
 
   async #findStoredDefinition(

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -415,6 +415,10 @@ export class DeploymentWriterService {
     input: PatchDeploymentRequest["data"],
     ability: AnyAbility
   ): Promise<PatchDeploymentResponse["data"]> {
+    if (input.name !== undefined && !input.services && !input.sealedSecrets) {
+      return await this.#renameByUserIdAndDseq(userId, dseq, input.name);
+    }
+
     const [wallet, stored] = await Promise.all([
       this.walletReaderService.getWalletByUserId(userId),
       this.#findStoredDefinition({ userId, dseq }, ability, NOT_PATCHABLE_MESSAGE)
@@ -422,7 +426,7 @@ export class DeploymentWriterService {
     const parsed = this.#parseStored(stored.sdl, { userId, dseq });
     const document = parsed.document;
 
-    const written = this.sdlPatchService.apply(document, input.services);
+    const written = this.sdlPatchService.apply(document, input.services ?? {});
     const derived = this.sdlSecretsDerivationService.derive(document, { includeEnvValues: true, onlyAt: written });
     const patchedSdl = this.#serialize(parsed, { userId, dseq });
 
@@ -444,6 +448,7 @@ export class DeploymentWriterService {
       sdl: patchedSdl,
       manifestVersion: recordedVersion,
       sealedSecrets,
+      name: input.name,
       expectedManifestVersion: input.ifManifestVersion ?? stored.manifestVersion
     });
 
@@ -455,7 +460,7 @@ export class DeploymentWriterService {
       event: "DEPLOYMENT_PATCH_APPLIED",
       userId,
       dseq,
-      patchedServiceCount: Object.keys(input.services).length,
+      patchedServiceCount: Object.keys(input.services ?? {}).length,
       secretCount: Object.keys(merged).length,
       guarded: input.ifManifestVersion !== undefined
     });
@@ -484,6 +489,22 @@ export class DeploymentWriterService {
   }
 
   /** Read through the caller's own ability as well as their id, so a definition is unreachable by anyone the ability excludes even before the write re-checks it. */
+  /**
+   * A rename touches no definition, so it reads no stored SDL, computes no manifest version, broadcasts nothing and
+   * pushes nothing. That is what lets it reach a deployment created before the console recorded SDLs, which the
+   * patch path refuses outright. The chain read is the ownership check that path gets from its stored row.
+   */
+  async #renameByUserIdAndDseq(userId: string, dseq: string, name: string): Promise<PatchDeploymentResponse["data"]> {
+    const wallet = await this.walletReaderService.getWalletByUserId(userId);
+    const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
+
+    await this.deploymentSettingRepository.upsertName({ userId, dseq, name });
+
+    this.logger.info({ event: "DEPLOYMENT_RENAMED", userId, dseq });
+
+    return deployment;
+  }
+
   async #findStoredDefinition(
     key: { userId: string; dseq: string },
     ability: AnyAbility,

--- a/apps/api/src/pricing/http-schemas/pricing.schema.ts
+++ b/apps/api/src/pricing/http-schemas/pricing.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const PricingSpecsSchema = z.object({
   cpu: z.number().min(0).openapi({ description: "CPU in thousandths of a core. 1000 = 1 core", example: 1000 }),

--- a/apps/api/src/provider/http-schemas/auditor.schema.ts
+++ b/apps/api/src/provider/http-schemas/auditor.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const AuditorSchema = z.object({
   id: z.string(),

--- a/apps/api/src/provider/http-schemas/jwt-token.schema.ts
+++ b/apps/api/src/provider/http-schemas/jwt-token.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const CreateJwtTokenRequestSchema = z.object({
   ttl: z.number().int().positive(),

--- a/apps/api/src/provider/http-schemas/provider-attributes-schema.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider-attributes-schema.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 const attributeSchemaType = z.object({
   key: z.string(),

--- a/apps/api/src/provider/http-schemas/provider-dashboard.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider-dashboard.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { openApiExampleProviderAddress } from "@src/utils/constants";
 

--- a/apps/api/src/provider/http-schemas/provider-deployments.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider-deployments.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { openApiExampleProviderAddress } from "@src/utils/constants";
 import { DseqSchema } from "@src/utils/schema";

--- a/apps/api/src/provider/http-schemas/provider-earnings.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider-earnings.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { openApiExampleProviderAddress } from "@src/utils/constants";
 

--- a/apps/api/src/provider/http-schemas/provider-graph-data.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider-graph-data.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const authorizedDataNames = ["count", "cpu", "gpu", "memory", "storage"];
 

--- a/apps/api/src/provider/http-schemas/provider-regions.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider-regions.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const ProviderRegionsResponseSchema = z.array(
   z.object({

--- a/apps/api/src/provider/http-schemas/provider-versions.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider-versions.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 export const ProviderVersionsResponseSchema = z.record(
   z.string(),

--- a/apps/api/src/provider/http-schemas/provider.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { openApiExampleProviderAddress } from "@src/utils/constants";
 import { AkashAddressSchema } from "@src/utils/schema";

--- a/apps/api/src/validator/http-schemas/validator.schema.ts
+++ b/apps/api/src/validator/http-schemas/validator.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "@hono/zod-openapi";
 
 import { openApiExampleValidatorAddress } from "@src/utils/constants";
 import { AkashValidatorAddressSchema } from "@src/utils/schema";

--- a/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/provider-shell-probe/provider-shell-probe.service.spec.ts
@@ -104,7 +104,7 @@ describe(ProviderShellProbeService.name, () => {
       expect(reported).toEqual(["--procs", "9000002 cpu_s=1 rss_mb=1 comm=node exe= cwd= cmd=node server.js"]);
     });
 
-    it("stops after 150 processes, so a fork bomb cannot crowd out the sections that follow", () => {
+    it("stops after 150 processes, so a fork bomb cannot crowd out the sections that follow", { timeout: 30_000 }, () => {
       const forkBomb = Array.from({ length: 160 }, (_unused, index) => ({
         pid: `${9_000_001 + index}`,
         comm: "worker",

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -4854,7 +4854,7 @@
       },
       "patch": {
         "summary": "Patch a deployment",
-        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.",
+        "description": "Patches the SDL the console stored for this deployment, or renames the deployment, or both; the SDL is never accepted from the request. Only the services named are touched. A `name` on its own touches no definition, so it renames a deployment the console holds no SDL for and neither broadcasts nor pushes a manifest. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.",
         "operationId": "patchDeployment",
         "tags": [
           "Deployments"
@@ -5023,7 +5023,13 @@
                             }
                           }
                         },
-                        "description": "Keyed by service name. Only the named services are touched; omitted services keep their current definition."
+                        "description": "Keyed by service name. Only the named services are touched; omitted services keep their current definition. Omit it entirely to patch nothing about the definition, which is how a deployment is renamed on its own."
+                      },
+                      "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": 256,
+                        "description": "Renames the deployment. Supplied on its own it is the only patch that touches no definition, so it works on a deployment the console holds no SDL for and neither broadcasts nor pushes a manifest."
                       },
                       "sealedSecrets": {
                         "type": "string",
@@ -5036,10 +5042,7 @@
                         "maxLength": 64,
                         "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it."
                       }
-                    },
-                    "required": [
-                      "services"
-                    ]
+                    }
                   }
                 },
                 "required": [
@@ -5409,14 +5412,13 @@
                         },
                         "manifestVersion": {
                           "type": "string",
-                          "description": "Base64 manifest version this patch recorded and committed on chain."
+                          "description": "Base64 manifest version this patch recorded and committed on chain. Absent for a rename, which records none."
                         }
                       },
                       "required": [
                         "deployment",
                         "leases",
-                        "escrow_account",
-                        "manifestVersion"
+                        "escrow_account"
                       ]
                     }
                   },
@@ -5458,7 +5460,7 @@
             }
           },
           "404": {
-            "description": "No SDL is recorded for this deployment, so there is nothing to patch",
+            "description": "No SDL is recorded for this deployment, so there is nothing to patch. A rename answers this only when the chain holds no such deployment for the caller, since it needs no recorded SDL",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -8261,11 +8261,17 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "description": "Base64 manifest version this patch recorded and committed on chain. Absent for a rename, which records none.",
                           "type": "string",
                         },
+                        "name": {
+                          "description": "The name this deployment carries, or null for one created before the console recorded names.",
+                          "nullable": true,
+                          "type": "string",
+                        },
                       },
                       "required": [
                         "deployment",
                         "leases",
                         "escrow_account",
+                        "name",
                       ],
                       "type": "object",
                     },

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -7715,7 +7715,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
       "patch": {
-        "description": "Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.",
+        "description": "Patches the SDL the console stored for this deployment, or renames the deployment, or both; the SDL is never accepted from the request. Only the services named are touched. A \`name\` on its own touches no definition, so it renames a deployment the console holds no SDL for and neither broadcasts nor pushes a manifest. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.",
         "operationId": "patchDeployment",
         "parameters": [
           {
@@ -7740,6 +7740,12 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       "ifManifestVersion": {
                         "description": "Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it.",
                         "maxLength": 64,
+                        "minLength": 1,
+                        "type": "string",
+                      },
+                      "name": {
+                        "description": "Renames the deployment. Supplied on its own it is the only patch that touches no definition, so it works on a deployment the console holds no SDL for and neither broadcasts nor pushes a manifest.",
+                        "maxLength": 256,
                         "minLength": 1,
                         "type": "string",
                       },
@@ -7881,13 +7887,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           },
                           "type": "object",
                         },
-                        "description": "Keyed by service name. Only the named services are touched; omitted services keep their current definition.",
+                        "description": "Keyed by service name. Only the named services are touched; omitted services keep their current definition. Omit it entirely to patch nothing about the definition, which is how a deployment is renamed on its own.",
                         "type": "object",
                       },
                     },
-                    "required": [
-                      "services",
-                    ],
                     "type": "object",
                   },
                 },
@@ -8255,7 +8258,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "type": "array",
                         },
                         "manifestVersion": {
-                          "description": "Base64 manifest version this patch recorded and committed on chain.",
+                          "description": "Base64 manifest version this patch recorded and committed on chain. Absent for a rename, which records none.",
                           "type": "string",
                         },
                       },
@@ -8263,7 +8266,6 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "deployment",
                         "leases",
                         "escrow_account",
-                        "manifestVersion",
                       ],
                       "type": "object",
                     },
@@ -8335,7 +8337,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 },
               },
             },
-            "description": "No SDL is recorded for this deployment, so there is nothing to patch",
+            "description": "No SDL is recorded for this deployment, so there is nothing to patch. A rename answers this only when the chain holds no such deployment for the caller, since it needs no recorded SDL",
           },
           "409": {
             "content": {

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -107,6 +107,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
         deployment: expect.any(Object),
         escrow_account: expect.any(Object),
         leases: expect.arrayContaining([expect.any(Object)]),
+        name: null,
         manifestVersion: expect.any(String)
       }
     });
@@ -197,7 +198,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     expect(sentManifests()).toEqual([]);
   });
 
-  it("answers a rename with the deployment and no manifest version, having recorded none", async () => {
+  it("answers a rename with the deployment, the stored name and no manifest version, having recorded none", async () => {
     const { apiKey } = await setup({ recordsDefinition: true, recordsName: "web" });
 
     const response = await patch(apiKey, { name: "renamed" });
@@ -206,9 +207,28 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
       data: {
         deployment: expect.any(Object),
         escrow_account: expect.any(Object),
-        leases: expect.arrayContaining([expect.any(Object)])
+        leases: expect.arrayContaining([expect.any(Object)]),
+        name: "renamed"
       }
     });
+  });
+
+  it("answers a rename with the trimmed name it stored rather than the one sent", async () => {
+    const { apiKey } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    const response = await patch(apiKey, { name: "  renamed  " });
+
+    const { data } = (await response.json()) as { data: { name: string } };
+    expect(data.name).toBe("renamed");
+  });
+
+  it("answers a service patch with the name the deployment already carries", async () => {
+    const { apiKey } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+    const { data } = (await response.json()) as { data: { name: string } };
+    expect(data.name).toBe("web");
   });
 
   it("leaves the name alone for a patch that names only services", async () => {

--- a/apps/api/test/functional/deployment-patch-route.spec.ts
+++ b/apps/api/test/functional/deployment-patch-route.spec.ts
@@ -12,6 +12,7 @@ import { BILLING_CONFIG } from "@src/billing/providers";
 import { CORE_CONFIG } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+import { MAX_DEPLOYMENT_NAME_LENGTH } from "@src/deployment/utils/deployment-name/deployment-name";
 import { app } from "@src/rest-app";
 import { deploymentVersion, marketVersion } from "@src/utils/constants";
 
@@ -19,7 +20,7 @@ import { registerFakeSdlSecretsKms, warmSealingKeyAsBootWould } from "@test/mock
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { seedUserWithWallet } from "@test/seeders/db/user-with-wallet.seeder";
 import { createDeploymentGrantResponseSeed } from "@test/seeders/deployment-grant-response.seeder";
-import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
+import { createDeploymentInfoErrorSeed, createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
 import { createFeeAllowanceResponse } from "@test/seeders/fee-allowance-response.seeder";
 import { createLeaseApiResponse } from "@test/seeders/lease-api-response.seeder";
 import { createLeaseStatus } from "@test/seeders/lease-status.seeder";
@@ -140,6 +141,125 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     expect(broadcastMessages()).toEqual([{ typeUrl: `/akash.deployment.${deploymentVersion}.MsgUpdateDeployment`, value: expect.any(String) }]);
   });
 
+  it("renames a deployment the console recorded a definition for", async () => {
+    const { apiKey, user } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    const response = await patch(apiKey, { name: "renamed" });
+
+    expect(response.status).toBe(200);
+    expect(await nameOf(user.id)).toBe("renamed");
+  });
+
+  it("renames a deployment the console recorded no sdl for, which no service patch could touch", async () => {
+    const { apiKey, user } = await setup();
+
+    const response = await patch(apiKey, { name: "renamed" });
+
+    expect(response.status).toBe(200);
+    expect(await nameOf(user.id)).toBe("renamed");
+  });
+
+  it("names a deployment that never carried a name", async () => {
+    const { apiKey, user } = await setup({ recordsDefinition: true });
+
+    const response = await patch(apiKey, { name: "first name" });
+
+    expect(response.status).toBe(200);
+    expect(await nameOf(user.id)).toBe("first name");
+  });
+
+  it("stores a name the request padded with spaces trimmed", async () => {
+    const { apiKey, user } = await setup({ recordsDefinition: true });
+
+    await patch(apiKey, { name: "  renamed  " });
+
+    expect(await nameOf(user.id)).toBe("renamed");
+  });
+
+  it("leaves the definition alone when a rename is all the patch carries", async () => {
+    const { apiKey, user } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    await patch(apiKey, { name: "renamed" });
+
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: DSEQ })).toMatchObject({
+      sdl: STORED_SDL,
+      manifestVersion: REPLACED_MANIFEST_VERSION
+    });
+  });
+
+  it("neither broadcasts nor pushes a manifest for a rename", async () => {
+    const { apiKey, broadcastMessages, sentManifests } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    const response = await patch(apiKey, { name: "renamed" });
+
+    expect(response.status).toBe(200);
+    expect(broadcastMessages()).toEqual([]);
+    expect(sentManifests()).toEqual([]);
+  });
+
+  it("answers a rename with the deployment and no manifest version, having recorded none", async () => {
+    const { apiKey } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    const response = await patch(apiKey, { name: "renamed" });
+
+    expect(await response.json()).toEqual({
+      data: {
+        deployment: expect.any(Object),
+        escrow_account: expect.any(Object),
+        leases: expect.arrayContaining([expect.any(Object)])
+      }
+    });
+  });
+
+  it("leaves the name alone for a patch that names only services", async () => {
+    const { apiKey, user } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } } });
+
+    expect(response.status).toBe(200);
+    expect(await nameOf(user.id)).toBe("web");
+  });
+
+  it("renames and patches services together", async () => {
+    const { apiKey, user } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    const response = await patch(apiKey, { services: { web: { image: "nginx:1.27" } }, name: "renamed" });
+
+    expect(response.status).toBe(200);
+    expect(await nameOf(user.id)).toBe("renamed");
+  });
+
+  it("refuses a rename to nothing but spaces", async () => {
+    const { apiKey, user } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    const response = await patch(apiKey, { name: "   " });
+
+    expect(response.status).toBe(400);
+    expect(await nameOf(user.id)).toBe("web");
+  });
+
+  it("refuses a rename longer than a deployment may carry", async () => {
+    const { apiKey, user } = await setup({ recordsDefinition: true, recordsName: "web" });
+
+    const response = await patch(apiKey, { name: "n".repeat(MAX_DEPLOYMENT_NAME_LENGTH + 1) });
+
+    expect(response.status).toBe(400);
+    expect(await nameOf(user.id)).toBe("web");
+  });
+
+  it("refuses a rename of a deployment the chain does not hold for this caller, writing nothing", async () => {
+    const { apiKey, user } = await setup({ chainHoldsDeployment: false });
+
+    const response = await patch(apiKey, { name: "renamed" });
+
+    expect(response.status).toBe(404);
+    expect(await deploymentSettingRepository.findOneBy({ userId: user.id, dseq: DSEQ })).toBeUndefined();
+  });
+
+  async function nameOf(userId: string) {
+    return (await deploymentSettingRepository.findOneBy({ userId, dseq: DSEQ }))?.name;
+  }
+
   function patch(apiKey: string | undefined, data: Record<string, unknown>) {
     const headers = new Headers({ "Content-Type": "application/json" });
     if (apiKey) headers.set("x-api-key", apiKey);
@@ -161,7 +281,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     return apiKey;
   }
 
-  function nockChain({ address, provider }: { address: string; provider: string }) {
+  function nockChain({ address, provider, holdsDeployment }: { address: string; provider: string; holdsDeployment: boolean }) {
     const restUrl = container.resolve(CORE_CONFIG).REST_API_NODE_URL;
     const leases = [createLeaseApiResponse({ owner: address, dseq: DSEQ, provider, state: "active" })];
 
@@ -169,7 +289,7 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
       .persist()
       .get(`/akash/deployment/${deploymentVersion}/deployments/info`)
       .query({ "id.owner": address, "id.dseq": DSEQ })
-      .reply(200, createDeploymentInfoSeed({ owner: address, dseq: DSEQ }))
+      .reply(200, holdsDeployment ? createDeploymentInfoSeed({ owner: address, dseq: DSEQ }) : createDeploymentInfoErrorSeed())
       .get(`/akash/market/${marketVersion}/leases/list`)
       .query(query => query["filters.owner"] === address && query["filters.dseq"] === DSEQ)
       .reply(200, { leases })
@@ -209,13 +329,13 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
     return () => sentManifests;
   }
 
-  async function setup(input: { recordsDefinition?: boolean } = {}) {
+  async function setup(input: { recordsDefinition?: boolean; recordsName?: string; chainHoldsDeployment?: boolean } = {}) {
     const { user, address } = await seedUserWithWallet({ isTrialing: false, activatedAt: new Date() });
     const apiKey = await persistApiKeyFor(user.id);
     const provider = createAkashAddress();
 
     await createProvider({ owner: provider, deletedHeight: null });
-    nockChain({ address, provider });
+    nockChain({ address, provider, holdsDeployment: input.chainHoldsDeployment ?? true });
     const broadcastMessages = nockTxSigner();
     const sentManifests = nockProviderProxy();
 
@@ -224,8 +344,11 @@ describe("PATCH /v1/deployments/{dseq} route wiring", () => {
         userId: user.id,
         dseq: DSEQ,
         sdl: STORED_SDL,
-        manifestVersion: REPLACED_MANIFEST_VERSION
+        manifestVersion: REPLACED_MANIFEST_VERSION,
+        name: input.recordsName
       });
+    } else if (input.recordsName) {
+      await deploymentSettingRepository.create({ userId: user.id, dseq: DSEQ, name: input.recordsName });
     }
 
     return { user, apiKey, sentManifests, broadcastMessages };

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -2060,7 +2060,7 @@ export interface paths {
     head?: never;
     /**
      * Patch a deployment
-     * @description Patches the SDL the console stored for this deployment; the SDL is never accepted from the request. Only the services named are touched. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.
+     * @description Patches the SDL the console stored for this deployment, or renames the deployment, or both; the SDL is never accepted from the request. Only the services named are touched. A `name` on its own touches no definition, so it renames a deployment the console holds no SDL for and neither broadcasts nor pushes a manifest. A patched environment variable is re-appended to its service's env list, so the order shown by GET may differ afterwards. A replaced secret takes effect when the deployment is next updated on chain, not in the workload already running. The definition is recorded before the chain transaction is broadcast, so a broadcast that fails leaves the console describing a manifest version the chain never saw. Re-sending the identical request repairs that: it recomputes the same manifest version, is accepted rather than refused, and goes on to broadcast and push the manifest.
      */
     patch: operations["patchDeployment"];
     trace?: never;
@@ -8262,8 +8262,8 @@ export interface operations {
       content: {
         "application/json": {
           data: {
-            /** @description Keyed by service name. Only the named services are touched; omitted services keep their current definition. */
-            services: {
+            /** @description Keyed by service name. Only the named services are touched; omitted services keep their current definition. Omit it entirely to patch nothing about the definition, which is how a deployment is renamed on its own. */
+            services?: {
               [key: string]: {
                 image?: string;
                 command?: string[] | null;
@@ -8303,6 +8303,8 @@ export interface operations {
                 };
               };
             };
+            /** @description Renames the deployment. Supplied on its own it is the only patch that touches no definition, so it works on a deployment the console holds no SDL for and neither broadcasts nor pushes a manifest. */
+            name?: string;
             /** @description Compact JWE sealing a flat name-to-value map, as on create, but holding only the names this patch replaces. Omitted names keep the values the deployment already stores. */
             sealedSecrets?: string;
             /** @description Base64 manifest version this patch expects to be current. Rejected with 409 if the deployment has moved on, unless it moved on to the version this very patch produces, which makes a retry of it succeed. Omitting this does not turn the guard off: the patch is then guarded on the version it read for itself, so a concurrent patch still answers 409 rather than overwriting it. */
@@ -8406,8 +8408,8 @@ export interface operations {
                   }[];
                 };
               };
-              /** @description Base64 manifest version this patch recorded and committed on chain. */
-              manifestVersion: string;
+              /** @description Base64 manifest version this patch recorded and committed on chain. Absent for a rename, which records none. */
+              manifestVersion?: string;
             };
           };
         };
@@ -8426,7 +8428,7 @@ export interface operations {
           };
         };
       };
-      /** @description No SDL is recorded for this deployment, so there is nothing to patch */
+      /** @description No SDL is recorded for this deployment, so there is nothing to patch. A rename answers this only when the chain holds no such deployment for the caller, since it needs no recorded SDL */
       404: {
         headers: {
           [name: string]: unknown;


### PR DESCRIPTION
## Why

Fixes CON-953 

A deployment's name lived only in the browser's localStorage, so it was lost on a device switch and invisible to every other client of the console API.

This is the **last of three stacked PRs** and should merge after them. Slice 1 named every deployment the API creates; slice 2 made both reads return the name; this one lets a name be changed. Together they close every acceptance criterion — `deploy-web` is out of scope by the issue's own wording and lands as a separate task.

**Merge order:** `…-not` → `…-not-2` → this one.

## What

- `PATCH /v1/deployments/{dseq}` accepts an optional `name`.
- **A name on its own reaches deployments the console holds no SDL for** — the ones created before SDL recording shipped, whose names still live only in a browser. The service-patch path 404s on those, because it reads the stored SDL before it looks at anything else, so the rename takes its own path.
- That path touches no definition: no stored-SDL read, no manifest version, no chain broadcast, no manifest push to the provider.
- `services` is therefore optional, with `patchesSomething` extended so a name alone is a valid patch while an empty body still is not.
- `upsertName` writes the name whether or not a settings row exists; `replaceDefinitionIfVersionMatches` threads a supplied name so a rename can ride along with a service patch, while an omitted one leaves the recorded name alone.

```http
PATCH /v1/deployments/1234
{ "data": { "name": "renamed" } }
```

From `test/functional/deployment-patch-route.spec.ts` — `setup()` with no arguments seeds a user and a chain deployment but records no SDL, which is exactly the case that used to be unreachable:

```ts
it("renames a deployment the console recorded no sdl for, which no service patch could touch", async () => {
  const { apiKey, user } = await setup();

  const response = await patch(apiKey, { name: "renamed" });

  expect(response.status).toBe(200);
  expect(await nameOf(user.id)).toBe("renamed");
});
```

## Breaking change

`manifestVersion` was **required** on the patch response and is now optional, because a rename records none. In the published client that is `manifestVersion?: string`: a consumer reading it unconditionally will not compile until it handles the absent case. A services patch still always returns it.

## Two decisions that want a human

**1. Making `services` optional also makes `{ sealedSecrets }` alone a valid body**, where it previously answered 400. The issue enumerates "either services + sealedSecrets or single name parameter", so a seal on its own sits outside that list. I took the relaxation rather than invent a refusal rule the issue also doesn't state — the operation was already expressible as `{ services: { web: {} }, sealedSecrets }`, so this only drops redundant ceremony. Blocking it is a one-line refine if you'd rather.

**2. `upsertName` is not ability-scoped.** It relies on `(dseq, user_id)` being the unique with the caller's own id — the controller passes `authService.currentUser.id` — plus the chain read that precedes it and refuses a dseq the caller does not hold. An insert cannot take an ability predicate at all, which is why the row-may-not-exist case can't borrow the update path's scoping; `createDefaultIfMissing` is the existing precedent on this table. Flagged because it is structurally unlike the module's other writes, which are scoped twice over.

## Tests

- **Unit** — a name-only patch writes through `upsertName`, reads no stored definition, calls neither the signer nor the provider service, and returns no `manifestVersion`; a name beside services is recorded with the definition, and a patch naming no name passes `name: undefined` so the stored one survives.
- **Integration** — `upsertName` against the real column: a row that does not exist, one that already carries a name, one whose definition must survive, and another user holding the same dseq. Plus `replaceDefinitionIfVersionMatches` recording a name and leaving an existing one alone when none is supplied.
- **Functional** — the rename over HTTP on a deployment with a definition, one with no SDL, and one that never carried a name; trimming; a rename beside a service patch; a services patch leaving the name alone; the 400s; and a rename of a deployment the chain does not hold, which writes nothing.

Checks:

- `apps/api` — tests, lint, types all pass
- `packages/console-api-types` — lint and types pass (the workspace declares no test script)
- `apps/deploy-web` — `tsc --noEmit` reports 85 errors, **all present at the merge base** and none in files this PR touches; flagged only because this PR changes a package deploy-web consumes

## Demo

# CON-953 slice 3 — renaming a deployment through patch

*2026-09-10T22:04:16Z by Showboat 0.6.1*
<!-- showboat-id: 55a82825-9501-4560-ab87-8408d409f9a7 -->

Slice 1 named every deployment the API creates; slice 2 made both reads return the name. Neither could change a name once set, and neither reached the deployments that most need one: the ones created before the console recorded SDLs, whose names still live only in a browser. This slice adds the rename.

The rename rides on `PATCH /v1/deployments/{dseq}`, which now accepts a `name`. Read out of the OpenAPI document the API ships:

```bash
cd apps/api && python3 -c '
import json
doc = json.load(open("swagger/openapi.json"))

def props(schema):
    if not isinstance(schema, dict):
        return []
    data = schema.get("properties", {}).get("data", {})
    if data.get("type") == "array":
        data = data.get("items", {})
    if "deployments" in data.get("properties", {}):
        data = data["properties"]["deployments"].get("items", {})
    return list(data.get("properties", {}).keys())

for path, ops in sorted(doc["paths"].items()):
    if path != "/v1/deployments/{dseq}" and path != "/v1/deployments":
        continue
    for verb, op in sorted(ops.items()):
        body = op.get("requestBody", {}).get("content", {}).get("application/json", {}).get("schema", {})
        ok = op.get("responses", {}).get("200") or op.get("responses", {}).get("201") or {}
        resp = ok.get("content", {}).get("application/json", {}).get("schema", {})
        if not (op.get("requestBody") or resp):
            continue
        required = body.get("properties", {}).get("data", {}).get("required", []) if body else []
        print("%-6s %-26s accepts a name: %-4s returns a name: %-4s required in body: %s" % (
            verb.upper(), path, "yes" if "name" in props(body) else "-",
            "yes" if "name" in props(resp) else "-", required or "nothing"))
'
```

```output
GET    /v1/deployments            accepts a name: -    returns a name: yes  required in body: nothing
POST   /v1/deployments            accepts a name: yes  returns a name: -    required in body: ['sdl']
DELETE /v1/deployments/{dseq}     accepts a name: -    returns a name: -    required in body: nothing
GET    /v1/deployments/{dseq}     accepts a name: -    returns a name: yes  required in body: nothing
PATCH  /v1/deployments/{dseq}     accepts a name: yes  returns a name: -    required in body: nothing
PUT    /v1/deployments/{dseq}     accepts a name: yes  returns a name: -    required in body: ['sdl']
```

Note the last column: `PATCH` now requires nothing in the body, because `services` became optional to let a name stand alone. "Nothing required" is not "anything goes" — a body-level rule decides whether a patch patches anything at all. Below, the real request schema judges nine bodies.

```bash
cd apps/api
cat > .demo-patch.ts <<'TS'
import "@hono/zod-openapi";
import { PatchDeploymentRequestSchema } from "./src/deployment/http-schemas/deployment.schema";
import { MAX_DEPLOYMENT_NAME_LENGTH } from "./src/deployment/utils/deployment-name/deployment-name";

const bodies: Array<[string, Record<string, unknown>]> = [
  ["a name on its own", { name: "renamed" }],
  ["a name padded with spaces", { name: "  renamed  " }],
  ["a name beside a service patch", { services: { web: { image: "nginx:1.27" } }, name: "renamed" }],
  ["a service patch on its own", { services: { web: { image: "nginx:1.27" } } }],
  ["nothing at all", {}],
  ["a service named but not changed", { services: { web: {} } }],
  ["a name of nothing but spaces", { name: "   " }],
  ["an empty name", { name: "" }],
  [`a name of ${MAX_DEPLOYMENT_NAME_LENGTH + 1} characters`, { name: "n".repeat(MAX_DEPLOYMENT_NAME_LENGTH + 1) }]
];

for (const [label, data] of bodies) {
  const parsed = PatchDeploymentRequestSchema.safeParse({ data });
  console.log(`${label.padEnd(34)} -> ${parsed.success ? `accepted, name stored as ${JSON.stringify(parsed.data.data.name ?? null)}` : "refused (400)"}`);
}
TS
npx tsx .demo-patch.ts 2>&1 | grep -v "npm warn"
rm -f .demo-patch.ts
```

```output
a name on its own                  -> accepted, name stored as "renamed"
a name padded with spaces          -> accepted, name stored as "renamed"
a name beside a service patch      -> accepted, name stored as "renamed"
a service patch on its own         -> accepted, name stored as null
nothing at all                     -> refused (400)
a service named but not changed    -> refused (400)
a name of nothing but spaces       -> refused (400)
an empty name                      -> refused (400)
a name of 257 characters           -> refused (400)
```

Now what a rename writes. The point of the whole slice is the first case below: a deployment the console holds no row for at all. The service-patch path answers 404 on those — it reads the stored SDL before it looks at anything else — so a rename cannot go through it. It takes its own path, which writes the name and touches nothing else.

This runs against a scratch database with the real migrations and the real repository. The SQL the rename emits is shown so you can see what it does and does not set.

```bash
cd apps/api
cat > .demo-rename.ts <<'TS'
import "reflect-metadata";
import dotenv from "dotenv";
import dotenvExpand from "dotenv-expand";
import { container } from "tsyringe";
import { RAW_APP_CONFIG } from "@src/core/providers/raw-app-config.provider";

dotenvExpand.expand(dotenv.config({ path: "env/.env.functional.test" }));
container.register(RAW_APP_CONFIG, { useValue: process.env });

async function main() {
  const { TestDatabaseService } = await import("./test/services/test-database.service");
  const database = new TestDatabaseService("demo.spec.ts");
  await database.setup();

  const { DeploymentSettingRepository } = await import("@src/deployment/repositories/deployment-setting/deployment-setting.repository");
  const { UserRepository } = await import("@src/user/repositories");
  const { TxService } = await import("@src/core/services/tx/tx.service");
  const { POSTGRES_DB, resolveTable } = await import("@src/core");

  const pg = container.resolve<any>(POSTGRES_DB);
  const txManager = new TxService(pg);
  const settings = new DeploymentSettingRepository(pg, resolveTable("DeploymentSettings") as any, txManager);
  const users = new UserRepository(pg, resolveTable("Users") as any, txManager);

  const owner = await users.create({ userId: "demo-owner" });
  const stranger = await users.create({ userId: "demo-stranger" });
  const show = async (dseq: string) => {
    const row = await settings.findOneBy({ userId: owner.id, dseq });
    return `name=${JSON.stringify(row?.name ?? null)} sdl=${JSON.stringify(row?.sdl ?? null)}`;
  };

  await settings.upsertDefinition({ userId: owner.id, dseq: "2002", sdl: "version: 2.0", manifestVersion: "BAUG", name: "web" });
  await settings.upsertDefinition({ userId: stranger.id, dseq: "2003", sdl: "version: 2.0", manifestVersion: "BAUG", name: "belongs to someone else" });

  console.log("a deployment created before the console recorded sdls -- no row of any kind:");
  await settings.upsertName({ userId: owner.id, dseq: "2001", name: "renamed" });
  console.log(`  dseq 2001 after the rename : ${await show("2001")}`);

  console.log("");
  console.log("a deployment whose definition the console does hold:");
  console.log(`  dseq 2002 before           : ${await show("2002")}`);
  await settings.upsertName({ userId: owner.id, dseq: "2002", name: "renamed" });
  console.log(`  dseq 2002 after the rename : ${await show("2002")}`);

  console.log("");
  console.log("a different user holding the very same dseq 2003:");
  await settings.upsertName({ userId: owner.id, dseq: "2003", name: "mine" });
  const theirs = await settings.findOneBy({ userId: stranger.id, dseq: "2003" });
  console.log(`  dseq 2003 as the owner     : ${await show("2003")}`);
  console.log(`  dseq 2003 as the other user: name=${JSON.stringify(theirs?.name ?? null)}`);

  await database.teardown();
  process.exit(0);
}

main();
TS
npx tsx .demo-rename.ts 2>&1 \
 | grep -vE "npm warn|Setting up test databases|Dropping test databases|Failed to find Response internal state key" \
 | grep -vE "^\{$|^\}$|^  (severity_local|severity|code|message|file|line|routine):" \
 | sed -E "s/.*(on conflict \\(\"dseq\",\"user_id\"\\) do update set \"name\"[^-]*) --.*/      the rename emits: \1/" \
 | grep -vE "^\[|^    context:|^    orm:"
rm -f .demo-rename.ts
```

```output
a deployment created before the console recorded sdls -- no row of any kind:
      the rename emits: on conflict ("dseq","user_id") do update set "name" = $5, "updated_at" = now()
  dseq 2001 after the rename : name="renamed" sdl=null

a deployment whose definition the console does hold:
  dseq 2002 before           : name="web" sdl="version: 2.0"
      the rename emits: on conflict ("dseq","user_id") do update set "name" = $5, "updated_at" = now()
  dseq 2002 after the rename : name="renamed" sdl="version: 2.0"

a different user holding the very same dseq 2003:
      the rename emits: on conflict ("dseq","user_id") do update set "name" = $5, "updated_at" = now()
  dseq 2003 as the owner     : name="mine" sdl=null
  dseq 2003 as the other user: name="belongs to someone else"
```

Three things to read off that. The rename creates the row when the console has none, so a deployment predating SDL recording gets a name — the case this slice exists for. Its `SET` clause names only `name` and `updated_at`, so the stored SDL and manifest version survive untouched. And it is keyed on `(dseq, user_id)` with the caller's own id, so the other user holding dseq 2003 keeps their name: the rename cannot reach a row that is not the caller's.

**One breaking change to sign off.** A rename records no manifest version, so `manifestVersion` had to become optional on the patch response. It was required. In the published client that is `manifestVersion?: string`, and a consumer reading it unconditionally will not compile until it handles the absent case — even though a services patch still always returns it. The same regeneration makes `services` optional. Here is the published TypeScript:

```bash
cd packages/console-api-types
grep -n -A 1 "Renames the deployment. Supplied on its own" src/schema.d.ts
grep -n -A 1 "Absent for a rename, which records none" src/schema.d.ts
grep -n -A 1 "Omit it entirely to patch nothing about the definition" src/schema.d.ts
```

```output
8306:            /** @description Renames the deployment. Supplied on its own it is the only patch that touches no definition, so it works on a deployment the console holds no SDL for and neither broadcasts nor pushes a manifest. */
8307-            name?: string;
8411:              /** @description Base64 manifest version this patch recorded and committed on chain. Absent for a rename, which records none. */
8412-              manifestVersion?: string;
8265:            /** @description Keyed by service name. Only the named services are touched; omitted services keep their current definition. Omit it entirely to patch nothing about the definition, which is how a deployment is renamed on its own. */
8266-            services?: {
```

What is deliberately absent from a rename cannot be shown here: that it broadcasts no chain transaction and pushes no manifest to the provider. Proving an absence needs the whole request to run against the tx-signer and provider-proxy stubs, and this sandbox cannot boot the API in a plain script — importing the writer service pulls in sequelize models whose decorators need a transform `tsx` does not apply outside `apps/api`. It is covered instead by two functional tests over real HTTP, `neither broadcasts nor pushes a manifest for a rename` and `leaves the definition alone when a rename is all the patch carries`, and by unit assertions that the signer and the provider service are never called.

That completes CON-953: a deployment is named when it is created, the name comes back from both reads, and it can be changed afterwards — including on the deployments that predate any of this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments can be renamed through the patch API.
  * Rename-only updates work without modifying services, SDL, or manifests.
  * Deployment names are trimmed, validated, and persisted independently.
  * Deployment patches can combine renaming with service updates.

* **API Changes**
  * `services` is now optional for deployment patches.
  * Responses include the deployment name.
  * Rename-only responses may omit `manifestVersion`.
  * Error details distinguish unavailable deployments from missing stored definitions.

* **Bug Fixes**
  * Deployment listings now fall back to stored lease information when network requests fail.
  * Unexpected lease request failures are reported instead of appearing as empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->