### PR TITLE
refactor(deployment): open kms-wrapped jwes under the version their header names

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,7 @@
     "start": "tsup --watch",
     "start:dev": "tsup src/server.ts --watch",
     "test": "vitest run --project=unit --project=functional --project=integration",
-    "test:ci-setup": "dc up -d --wait --wait-timeout 60 db mock-oauth2-server",
+    "test:ci-setup": "dc up -d --wait --wait-timeout 60 db mock-oauth2-server mock-gcp-kms",
     "test:ci-teardown": "dc down",
     "test:component": "vitest run --project=unit --project=integration",
     "test:cov": "vitest run --project=unit --project=functional --project=integration --coverage --reporter=default --reporter=junit",

--- a/apps/api/src/deployment/providers/kms.provider.spec.ts
+++ b/apps/api/src/deployment/providers/kms.provider.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { SdlSecretsKmsClient } from "./kms.provider";
+import { createSdlSecretsKmsTarget } from "./kms.provider";
+
+describe(createSdlSecretsKmsTarget.name, () => {
+  it("names the configured version as the write target", () => {
+    const { target } = setup({ version: "2" });
+
+    expect(target.versionName).toBe(versionPath("2"));
+    expect(target.kid).toBe("sdl-secrets.v2");
+  });
+
+  it("resolves an older version of the same crypto key while a newer one is configured", () => {
+    const { target } = setup({ version: "2" });
+
+    expect(target.resolveVersionName("sdl-secrets.v1")).toBe(versionPath("1"));
+  });
+
+  it("resolves a version far above the configured one, because which versions exist is the key service's answer", () => {
+    const { target } = setup({ version: "2" });
+
+    expect(target.resolveVersionName("sdl-secrets.v9")).toBe(versionPath("9"));
+  });
+
+  it("resolves the configured version itself", () => {
+    const { target } = setup({ version: "2" });
+
+    expect(target.resolveVersionName(target.kid)).toBe(target.versionName);
+  });
+
+  it.each([
+    ["a foreign crypto key", "other-key.v1"],
+    ["a crypto key the alias only prefixes", "sdl-secrets-old.v1"],
+    ["a crypto key the alias only suffixes", "not-sdl-secrets.v1"],
+    ["no version at all", "sdl-secrets"],
+    ["an empty version", "sdl-secrets.v"],
+    ["version zero", "sdl-secrets.v0"],
+    ["a leading zero", "sdl-secrets.v01"],
+    ["a non-numeric version", "sdl-secrets.vx"],
+    ["a negative version", "sdl-secrets.v-1"],
+    ["a fractional version", "sdl-secrets.v1.5"],
+    ["a version with trailing content", "sdl-secrets.v1x"],
+    ["a version longer than any Cloud KMS assigns", `sdl-secrets.v${"9".repeat(11)}`],
+    ["a traversal in place of a version", "sdl-secrets.v1/../../2"],
+    ["a whole resource name", versionPath("1")]
+  ])("refuses %s", (_, kid) => {
+    const { target } = setup();
+
+    expect(target.resolveVersionName(kid)).toBeUndefined();
+  });
+
+  it.each([
+    ["a missing kid", undefined],
+    ["a null kid", null],
+    ["a numeric kid", 1],
+    ["an object kid", { kid: "sdl-secrets.v1" }]
+  ])("refuses %s", (_, kid) => {
+    const { target } = setup();
+
+    expect(target.resolveVersionName(kid)).toBeUndefined();
+  });
+
+  function versionPath(version: string) {
+    return `projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/${version}`;
+  }
+
+  function setup(input?: { version?: string }) {
+    const client = mock<SdlSecretsKmsClient>();
+    const target = createSdlSecretsKmsTarget({ client, versionPath, key: "sdl-secrets", version: input?.version ?? "1" });
+
+    return { target, client };
+  }
+});

--- a/apps/api/src/deployment/providers/kms.provider.spec.ts
+++ b/apps/api/src/deployment/providers/kms.provider.spec.ts
@@ -1,8 +1,13 @@
+import type { KeyManagementServiceClient } from "@google-cloud/kms";
+import { container } from "tsyringe";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { SdlSecretsKmsClient } from "./kms.provider";
-import { createSdlSecretsKmsTarget } from "./kms.provider";
+import { createSdlSecretsKmsTarget, KMS_CLIENT, SDL_SECRETS_KMS_TARGET } from "./kms.provider";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
 
 describe(createSdlSecretsKmsTarget.name, () => {
   it("names the configured version as the write target", () => {
@@ -71,5 +76,48 @@ describe(createSdlSecretsKmsTarget.name, () => {
     const target = createSdlSecretsKmsTarget({ client, versionPath, key: "sdl-secrets", version: input?.version ?? "1" });
 
     return { target, client };
+  }
+});
+
+describe("SDL_SECRETS_KMS_TARGET", () => {
+  it("targets the crypto key version the environment names, through the SDK's own path builder", () => {
+    const { target, kmsClient } = setup({ location: "europe-west1", keyRing: "console-api", key: "sdl-secrets", version: "4" });
+
+    expect(kmsClient.cryptoKeyVersionPath).toHaveBeenCalledWith("console-test", "europe-west1", "console-api", "sdl-secrets", "4");
+    expect(target.versionName).toBe("console-test/europe-west1/console-api/sdl-secrets/4");
+    expect(target.kid).toBe("sdl-secrets.v4");
+  });
+
+  it("reads an older version of the same key through that same path builder", () => {
+    const { target, kmsClient } = setup({ location: "europe-west1", keyRing: "console-api", key: "sdl-secrets", version: "4" });
+
+    expect(target.resolveVersionName("sdl-secrets.v1")).toBe("console-test/europe-west1/console-api/sdl-secrets/1");
+    expect(kmsClient.cryptoKeyVersionPath).toHaveBeenCalledWith("console-test", "europe-west1", "console-api", "sdl-secrets", "1");
+  });
+
+  it("moves the write target to whichever version is configured, with no other change", () => {
+    const { target } = setup({ location: "global", keyRing: "console-api", key: "sdl-secrets", version: "12" });
+
+    expect(target.kid).toBe("sdl-secrets.v12");
+    expect(target.versionName).toBe("console-test/global/console-api/sdl-secrets/12");
+  });
+
+  function setup(input: { location: string; keyRing: string; key: string; version: string }) {
+    const kmsClient = mock<KeyManagementServiceClient>();
+    kmsClient.cryptoKeyVersionPath.mockImplementation((project, location, keyRing, key, version) => [project, location, keyRing, key, version].join("/"));
+
+    const testContainer = container.createChildContainer();
+    testContainer.register(KMS_CLIENT, { useValue: kmsClient });
+    testContainer.register(DeploymentConfigService, {
+      useValue: mockConfigService<DeploymentConfigService>({
+        GCP_KMS_AUTH: { project_id: "console-test", servicePath: "http://localhost:9090" },
+        GCP_KMS_LOCATION: input.location,
+        GCP_KMS_KEY_RING: input.keyRing,
+        GCP_KMS_KEY: input.key,
+        GCP_KMS_KEY_VERSION: input.version
+      })
+    });
+
+    return { target: testContainer.resolve(SDL_SECRETS_KMS_TARGET), kmsClient };
   }
 });

--- a/apps/api/src/deployment/providers/kms.provider.ts
+++ b/apps/api/src/deployment/providers/kms.provider.ts
@@ -21,14 +21,46 @@ export interface SdlSecretsKmsClient {
 }
 
 /**
- * The crypto key version SDL secrets are sealed to, and the short alias clients put in a seal's
- * `kid`. `asymmetricDecrypt` names an exact version and cannot infer one from a ciphertext, so the
- * alias is what later maps an incoming seal back to `versionName`.
+ * The crypto key version new wraps are sealed to, the short alias clients put in a seal's `kid`,
+ * and the mapping from any alias of the same crypto key back to a version name. `versionName` and
+ * `kid` name the write target alone; reads follow `resolveVersionName`, so raising the configured
+ * version leaves everything wrapped under an earlier one readable.
  */
 export interface SdlSecretsKmsTarget {
   client: SdlSecretsKmsClient;
   versionName: string;
   kid: string;
+  resolveVersionName(kid: unknown): string | undefined;
+}
+
+/** Cloud KMS version ids are positive integers written without a leading zero, and no crypto key id contains a dot, so `<key>.v<digits>` splits unambiguously. */
+const VERSION_ALIAS_SUFFIX = /^\.v([1-9][0-9]{0,9})$/;
+
+function parseVersionAlias(key: string, kid: unknown): string | undefined {
+  if (typeof kid !== "string" || !kid.startsWith(key)) return undefined;
+
+  return VERSION_ALIAS_SUFFIX.exec(kid.slice(key.length))?.[1];
+}
+
+/** Takes `versionPath` rather than building the resource name itself, so the SDK stays the only thing that knows its shape. */
+export function createSdlSecretsKmsTarget(input: {
+  client: SdlSecretsKmsClient;
+  versionPath: (version: string) => string;
+  key: string;
+  version: string;
+}): SdlSecretsKmsTarget {
+  const { client, versionPath, key, version } = input;
+
+  return {
+    client,
+    versionName: versionPath(version),
+    kid: `${key}.v${version}`,
+    resolveVersionName(kid) {
+      const resolved = parseVersionAlias(key, kid);
+
+      return resolved && versionPath(resolved);
+    }
+  };
 }
 
 export const KMS_CLIENT: InjectionToken<KeyManagementServiceClient> = Symbol("KMS_CLIENT");
@@ -68,12 +100,12 @@ container.register(SDL_SECRETS_KMS_TARGET, {
     const auth = config.get("GCP_KMS_AUTH");
     const client = c.resolve<KeyManagementServiceClient>(KMS_CLIENT);
     const key = config.get("GCP_KMS_KEY");
-    const version = config.get("GCP_KMS_KEY_VERSION");
 
-    return {
+    return createSdlSecretsKmsTarget({
       client,
-      versionName: client.cryptoKeyVersionPath(auth.project_id, config.get("GCP_KMS_LOCATION"), config.get("GCP_KMS_KEY_RING"), key, version),
-      kid: `${key}.v${version}`
-    };
+      versionPath: version => client.cryptoKeyVersionPath(auth.project_id, config.get("GCP_KMS_LOCATION"), config.get("GCP_KMS_KEY_RING"), key, version),
+      key,
+      version: config.get("GCP_KMS_KEY_VERSION")
+    });
   })
 });

--- a/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.integration.ts
+++ b/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.integration.ts
@@ -1,0 +1,204 @@
+import type { KeyManagementServiceClient } from "@google-cloud/kms";
+import { CompactEncrypt, decodeProtectedHeader } from "jose";
+import { createPublicKey, randomUUID } from "node:crypto";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthService } from "@src/auth/services/auth.service";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import { createSdlSecretsKmsTarget, KMS_CLIENT } from "@src/deployment/providers/kms.provider";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import { SdlSecretsUnsealerService } from "@src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service";
+import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyService } from "@src/secret/services/data-key/data-key.service";
+import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
+import type { UserOutput } from "@src/user/repositories";
+import { UserRepository } from "@src/user/repositories";
+import { KmsWrappedJweService } from "./kms-wrapped-jwe.service";
+
+const PROJECT = "console-dev-mock";
+const LOCATION = "global";
+const KEY_RING = "console-api";
+const KEY = "sdl-secrets";
+const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
+
+const kmsClient = container.resolve<KeyManagementServiceClient>(KMS_CLIENT);
+
+function versionPath(version: string) {
+  return kmsClient.cryptoKeyVersionPath(PROJECT, LOCATION, KEY_RING, KEY, version);
+}
+
+async function createEnabledVersion() {
+  const [created] = await kmsClient.createCryptoKeyVersion({
+    parent: kmsClient.cryptoKeyPath(PROJECT, LOCATION, KEY_RING, KEY),
+    cryptoKeyVersion: {}
+  });
+
+  expect(created.state).toBe("ENABLED");
+
+  return created.name!.split("/").pop()!;
+}
+
+async function disableVersion(version: string) {
+  await kmsClient.updateCryptoKeyVersion({
+    cryptoKeyVersion: { name: versionPath(version), state: "DISABLED" },
+    updateMask: { paths: ["state"] }
+  });
+}
+
+async function publicKeyOf(version: string) {
+  const [publicKey] = await kmsClient.getPublicKey({ name: versionPath(version) });
+
+  return createPublicKey(publicKey.pem!);
+}
+
+describe(`${KmsWrappedJweService.name} against Cloud KMS`, () => {
+  it("opens a data key wrapped under an older enabled version once the configured version moves on", async () => {
+    const [oldVersion, newVersion] = await Promise.all([createEnabledVersion(), createEnabledVersion()]);
+    const { createTestUser, consoleAt } = setup();
+    const user = await createTestUser();
+
+    const beforeRotation = consoleAt(oldVersion);
+    await beforeRotation.warmSealingKey();
+    const row = await beforeRotation.dataKeyService.ensureDataKey(user.id);
+    const keyBeforeRotation = await beforeRotation.unwrapFor(user.id);
+
+    const keyAfterRotation = await consoleAt(newVersion).unwrapFor(user.id);
+
+    expect(row.wrappedByKid).toBe(`${KEY}.v${oldVersion}`);
+    expect(keyAfterRotation).toHaveLength(32);
+    expect(keyAfterRotation.equals(keyBeforeRotation)).toBe(true);
+  });
+
+  it("wraps a new user's data key under the configured version once it moves on", async () => {
+    const newVersion = await createEnabledVersion();
+    const { createTestUser, consoleAt } = setup();
+    const user = await createTestUser();
+
+    const afterRotation = consoleAt(newVersion);
+    await afterRotation.warmSealingKey();
+    const row = await afterRotation.dataKeyService.ensureDataKey(user.id);
+
+    expect(row.wrappedByKid).toBe(`${KEY}.v${newVersion}`);
+    expect(decodeProtectedHeader(row.wrappedKey).kid).toBe(`${KEY}.v${newVersion}`);
+  });
+
+  it("accepts a seal a client made against the older version's published key", async () => {
+    const [oldVersion, newVersion] = await Promise.all([createEnabledVersion(), createEnabledVersion()]);
+    const { createTestUser, consoleAt, sealFor } = setup();
+    const user = await createTestUser();
+    const secrets = { DB_URL: `postgres://app:${randomUUID()}@db.internal/app` };
+
+    const seal = await sealFor(user, secrets, { kid: `${KEY}.v${oldVersion}`, publicKey: await publicKeyOf(oldVersion) });
+
+    await expect(consoleAt(newVersion).openSeal(user, seal)).resolves.toEqual(secrets);
+  });
+
+  it("refuses a seal naming a crypto key that is not the console's, without reaching the key service", async () => {
+    const version = await createEnabledVersion();
+    const { createTestUser, consoleAt, sealFor } = setup();
+    const user = await createTestUser();
+    const asymmetricDecrypt = vi.spyOn(kmsClient, "asymmetricDecrypt");
+
+    const seal = await sealFor(user, { TOKEN: "t" }, { kid: "other-key.v1", publicKey: await publicKeyOf(version) });
+
+    await expect(consoleAt(version).openSeal(user, seal)).rejects.toMatchObject({ status: 409 });
+    expect(asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("cannot open a wrap made under one version with another, so the versions are not one key", async () => {
+    const [oldVersion, newVersion] = await Promise.all([createEnabledVersion(), createEnabledVersion()]);
+    const { createTestUser, consoleAt } = setup();
+    const user = await createTestUser();
+
+    const beforeRotation = consoleAt(oldVersion);
+    await beforeRotation.warmSealingKey();
+    const row = await beforeRotation.dataKeyService.ensureDataKey(user.id);
+
+    const openedUnderTheWrongVersion = beforeRotation.wrappedJwe.open(beforeRotation.wrappedJwe.parse(row.wrappedKey), versionPath(newVersion));
+
+    await expect(openedUnderTheWrongVersion).rejects.toThrow();
+  });
+
+  it("fails closed once the version a stored data key names is disabled", async () => {
+    const retiredVersion = await createEnabledVersion();
+    const { createTestUser, consoleAt } = setup();
+    const user = await createTestUser();
+
+    const consoleApi = consoleAt(retiredVersion);
+    await consoleApi.warmSealingKey();
+    await consoleApi.dataKeyService.ensureDataKey(user.id);
+    await expect(consoleApi.unwrapFor(user.id)).resolves.toHaveLength(32);
+
+    await disableVersion(retiredVersion);
+
+    await expect(consoleApi.unwrapFor(user.id)).rejects.toMatchObject({ status: 503 });
+  });
+
+  const pendingCleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(pendingCleanups.splice(0).map(async runCleanup => await runCleanup()));
+  });
+
+  function setup() {
+    const createLogger: CreateLogger = () => mock<ReturnType<CreateLogger>>();
+    const dataKeyRepository = container.resolve(DataKeyRepository);
+    const userRepository = container.resolve(UserRepository);
+    const executionContextService = container.resolve(ExecutionContextService);
+    const authService = mock<AuthService>();
+    const createdUserIds: string[] = [];
+
+    pendingCleanups.push(async () => {
+      if (createdUserIds.length > 0) {
+        await userRepository.deleteById(createdUserIds);
+      }
+    });
+
+    const consoleAt = (version: string) => {
+      const target = createSdlSecretsKmsTarget({ client: kmsClient, versionPath, key: KEY, version });
+      const wrappedJwe = new KmsWrappedJweService(target);
+      const sealingKeyService = new SdlSecretsSealingKeyService(target, createLogger);
+      const dataKeyService = new DataKeyService(dataKeyRepository, sealingKeyService, createLogger);
+      const unwrapper = new DataKeyUnwrapperService(dataKeyService, executionContextService, wrappedJwe, target, createLogger);
+      const unsealer = new SdlSecretsUnsealerService(target, wrappedJwe, authService, createLogger);
+
+      return {
+        target,
+        wrappedJwe,
+        dataKeyService,
+        warmSealingKey: async () => await sealingKeyService.getSealingKey(),
+        unwrapFor: async (userId: string) =>
+          await executionContextService.runWithContext(async () => await (await unwrapper.getDataKey(userId)).unwrap()),
+        openSeal: async (user: UserOutput, seal: string) =>
+          await executionContextService.runWithContext(async () => {
+            authService.currentUser = user;
+
+            return await unsealer.open({ seal, sdl: SDL });
+          })
+      };
+    };
+
+    async function createTestUser() {
+      const user = await userRepository.create({});
+      createdUserIds.push(user.id);
+
+      return user;
+    }
+
+    const sealFor = async (user: UserOutput, secrets: Record<string, string>, sealedWith: { kid: string; publicKey: ReturnType<typeof createPublicKey> }) =>
+      await new CompactEncrypt(new TextEncoder().encode(JSON.stringify(secrets)))
+        .setProtectedHeader({
+          alg: "RSA-OAEP-256",
+          enc: "A256GCM",
+          kid: sealedWith.kid,
+          sub: user.id,
+          exp: Math.floor(Date.now() / 1000) + 300
+        } as never)
+        .encrypt(sealedWith.publicKey);
+
+    return { createTestUser, consoleAt, sealFor };
+  }
+});

--- a/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.integration.ts
+++ b/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.integration.ts
@@ -41,6 +41,15 @@ async function createEnabledVersion() {
   return created.name!.split("/").pop()!;
 }
 
+/** Provisioned once: every RSA-3072 keypair the emulator mints costs real CPU on the same host the database runs on, and no test mutates the pair. */
+let rotationPair: Promise<{ oldVersion: string; newVersion: string }> | undefined;
+
+function enabledRotationPair() {
+  rotationPair ??= Promise.all([createEnabledVersion(), createEnabledVersion()]).then(([oldVersion, newVersion]) => ({ oldVersion, newVersion }));
+
+  return rotationPair;
+}
+
 async function disableVersion(version: string) {
   await kmsClient.updateCryptoKeyVersion({
     cryptoKeyVersion: { name: versionPath(version), state: "DISABLED" },
@@ -56,7 +65,7 @@ async function publicKeyOf(version: string) {
 
 describe(`${KmsWrappedJweService.name} against Cloud KMS`, () => {
   it("opens a data key wrapped under an older enabled version once the configured version moves on", async () => {
-    const [oldVersion, newVersion] = await Promise.all([createEnabledVersion(), createEnabledVersion()]);
+    const { oldVersion, newVersion } = await enabledRotationPair();
     const { createTestUser, consoleAt } = setup();
     const user = await createTestUser();
 
@@ -73,7 +82,7 @@ describe(`${KmsWrappedJweService.name} against Cloud KMS`, () => {
   });
 
   it("wraps a new user's data key under the configured version once it moves on", async () => {
-    const newVersion = await createEnabledVersion();
+    const { newVersion } = await enabledRotationPair();
     const { createTestUser, consoleAt } = setup();
     const user = await createTestUser();
 
@@ -86,7 +95,7 @@ describe(`${KmsWrappedJweService.name} against Cloud KMS`, () => {
   });
 
   it("accepts a seal a client made against the older version's published key", async () => {
-    const [oldVersion, newVersion] = await Promise.all([createEnabledVersion(), createEnabledVersion()]);
+    const { oldVersion, newVersion } = await enabledRotationPair();
     const { createTestUser, consoleAt, sealFor } = setup();
     const user = await createTestUser();
     const secrets = { DB_URL: `postgres://app:${randomUUID()}@db.internal/app` };
@@ -97,7 +106,7 @@ describe(`${KmsWrappedJweService.name} against Cloud KMS`, () => {
   });
 
   it("refuses a seal naming a crypto key that is not the console's, without reaching the key service", async () => {
-    const version = await createEnabledVersion();
+    const { newVersion: version } = await enabledRotationPair();
     const { createTestUser, consoleAt, sealFor } = setup();
     const user = await createTestUser();
     const asymmetricDecrypt = vi.spyOn(kmsClient, "asymmetricDecrypt");
@@ -109,7 +118,7 @@ describe(`${KmsWrappedJweService.name} against Cloud KMS`, () => {
   });
 
   it("cannot open a wrap made under one version with another, so the versions are not one key", async () => {
-    const [oldVersion, newVersion] = await Promise.all([createEnabledVersion(), createEnabledVersion()]);
+    const { oldVersion, newVersion } = await enabledRotationPair();
     const { createTestUser, consoleAt } = setup();
     const user = await createTestUser();
 

--- a/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.spec.ts
+++ b/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.spec.ts
@@ -10,8 +10,10 @@ import { mock } from "vitest-mock-extended";
 import type { SdlSecretsKmsClient } from "@src/deployment/providers/kms.provider";
 import { KmsWrappedJweError, KmsWrappedJweService } from "./kms-wrapped-jwe.service";
 
+import { createTestSdlSecretsKmsTarget, sdlSecretsVersionPath } from "@test/mocks/sdl-secrets-kms.mock";
+
 const KID = "sdl-secrets.v1";
-const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+const VERSION_NAME = sdlSecretsVersionPath("1");
 
 async function expectFailure(open: Promise<unknown>, failure: string) {
   await expect(open).rejects.toMatchObject({ failure });
@@ -34,7 +36,7 @@ describe(KmsWrappedJweService.name, () => {
     const { service, wrap } = setup();
     const payload = randomBytes(32);
 
-    const plaintext = await service.open(service.parse(await wrap(payload)));
+    const plaintext = await service.open(service.parse(await wrap(payload)), VERSION_NAME);
 
     expect(plaintext.equals(payload)).toBe(true);
   });
@@ -42,7 +44,7 @@ describe(KmsWrappedJweService.name, () => {
   it("returns a payload that is not JSON, because what the bytes mean belongs to the caller", async () => {
     const { service, wrap } = setup();
 
-    const plaintext = await service.open(service.parse(await wrap(Buffer.from([0, 1, 255]))));
+    const plaintext = await service.open(service.parse(await wrap(Buffer.from([0, 1, 255]))), VERSION_NAME);
 
     expect([...plaintext]).toEqual([0, 1, 255]);
   });
@@ -71,19 +73,29 @@ describe(KmsWrappedJweService.name, () => {
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
-  it("unwraps the content encryption key with the configured crypto key version", async () => {
+  it("unwraps the content encryption key with the crypto key version it is given", async () => {
     const { service, wrap, kmsClient } = setup();
 
-    await service.open(service.parse(await wrap(randomBytes(32))));
+    await service.open(service.parse(await wrap(randomBytes(32))), VERSION_NAME);
 
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledWith(expect.objectContaining({ name: VERSION_NAME }));
+  });
+
+  it("unwraps with the version it is given rather than the one its target is configured for", async () => {
+    const { service, wrap, kmsClient } = setup();
+    const olderVersion = sdlSecretsVersionPath("7");
+
+    await service.open(service.parse(await wrap(randomBytes(32))), olderVersion);
+
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledWith(expect.objectContaining({ name: olderVersion }));
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalledWith(expect.objectContaining({ name: VERSION_NAME }));
   });
 
   it("spends one key service call per open", async () => {
     const { service, wrap, kmsClient } = setup();
     const parsed = service.parse(await wrap(randomBytes(32)));
 
-    await service.open(parsed);
+    await service.open(parsed, VERSION_NAME);
 
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(1);
   });
@@ -152,7 +164,24 @@ describe(KmsWrappedJweService.name, () => {
     const { service, wrap, kmsClient } = setup();
     kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("3 INVALID_ARGUMENT"), { code: grpc.status.INVALID_ARGUMENT }));
 
-    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "ENCRYPTED_KEY_REJECTED");
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32))), VERSION_NAME), "ENCRYPTED_KEY_REJECTED");
+  });
+
+  it("reports a version the key service does not have separately from one that is unreachable", async () => {
+    const { service, wrap, kmsClient } = setup();
+    kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("5 NOT_FOUND"), { code: grpc.status.NOT_FOUND }));
+
+    await expect(service.open(service.parse(await wrap(randomBytes(32))), VERSION_NAME)).rejects.toMatchObject({
+      failure: "WRAPPING_VERSION_UNUSABLE",
+      details: { versionName: VERSION_NAME }
+    });
+  });
+
+  it("reports a disabled or destroyed version as unusable rather than as an outage", async () => {
+    const { service, wrap, kmsClient } = setup();
+    kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("9 FAILED_PRECONDITION"), { code: grpc.status.FAILED_PRECONDITION }));
+
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32))), VERSION_NAME), "WRAPPING_VERSION_UNUSABLE");
   });
 
   it("reports an unreachable key service and carries the underlying error for the caller to log", async () => {
@@ -160,7 +189,7 @@ describe(KmsWrappedJweService.name, () => {
     const unreachable = Object.assign(new Error("14 UNAVAILABLE"), { code: grpc.status.UNAVAILABLE });
     kmsClient.asymmetricDecrypt.mockRejectedValue(unreachable);
 
-    await expect(service.open(service.parse(await wrap(randomBytes(32))))).rejects.toMatchObject({
+    await expect(service.open(service.parse(await wrap(randomBytes(32))), VERSION_NAME)).rejects.toMatchObject({
       failure: "KEY_SERVICE_UNREACHABLE",
       details: { versionName: VERSION_NAME, error: unreachable }
     });
@@ -170,21 +199,21 @@ describe(KmsWrappedJweService.name, () => {
     const { service, wrap, kmsClient } = setup();
     kmsClient.asymmetricDecrypt.mockResolvedValue([{ plaintext: Buffer.alloc(32), verifiedCiphertextCrc32c: false }]);
 
-    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "KEY_SERVICE_REQUEST_CORRUPTED");
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32))), VERSION_NAME), "KEY_SERVICE_REQUEST_CORRUPTED");
   });
 
   it("reports a key service that returned no plaintext", async () => {
     const { service, wrap, kmsClient } = setup();
     kmsClient.asymmetricDecrypt.mockResolvedValue([{ verifiedCiphertextCrc32c: true }]);
 
-    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "KEY_SERVICE_PLAINTEXT_MISSING");
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32))), VERSION_NAME), "KEY_SERVICE_PLAINTEXT_MISSING");
   });
 
   it("reports a key service whose plaintext fails its own checksum", async () => {
     const { service, wrap, kmsClient } = setup();
     kmsClient.asymmetricDecrypt.mockResolvedValue([{ plaintext: Buffer.alloc(32), plaintextCrc32c: { value: "1" }, verifiedCiphertextCrc32c: true }]);
 
-    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "KEY_SERVICE_RESPONSE_CORRUPTED");
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32))), VERSION_NAME), "KEY_SERVICE_RESPONSE_CORRUPTED");
   });
 
   it("reports an altered ciphertext as an authentication failure", async () => {
@@ -192,7 +221,7 @@ describe(KmsWrappedJweService.name, () => {
     const parts = (await wrap(randomBytes(32))).split(".");
     parts[3] = Buffer.from("tampered").toString("base64url");
 
-    await expectFailure(service.open(service.parse(parts.join("."))), "AUTHENTICATION_FAILED");
+    await expectFailure(service.open(service.parse(parts.join(".")), VERSION_NAME), "AUTHENTICATION_FAILED");
   });
 
   it("reports an altered protected header as an authentication failure, because the header is the additional authenticated data", async () => {
@@ -201,7 +230,7 @@ describe(KmsWrappedJweService.name, () => {
     const claims = JSON.parse(Buffer.from(protectedHeader, "base64url").toString());
     const forged = Buffer.from(JSON.stringify({ ...claims, kid: "sdl-secrets.v9" })).toString("base64url");
 
-    await expectFailure(service.open(service.parse([forged, ...rest].join("."))), "AUTHENTICATION_FAILED");
+    await expectFailure(service.open(service.parse([forged, ...rest].join(".")), VERSION_NAME), "AUTHENTICATION_FAILED");
   });
 
   it("reports a content encryption key that is not the length AES-256 requires as an authentication failure", async () => {
@@ -211,7 +240,7 @@ describe(KmsWrappedJweService.name, () => {
       { plaintext: shortKey, plaintextCrc32c: { value: String(crc32c.calculate(shortKey)) }, verifiedCiphertextCrc32c: true }
     ]);
 
-    await expectFailure(service.open(service.parse(await wrap(randomBytes(32)))), "AUTHENTICATION_FAILED");
+    await expectFailure(service.open(service.parse(await wrap(randomBytes(32))), VERSION_NAME), "AUTHENTICATION_FAILED");
   });
 
   function setup() {
@@ -233,7 +262,7 @@ describe(KmsWrappedJweService.name, () => {
       ];
     });
 
-    const service = new KmsWrappedJweService({ client: kmsClient, versionName: VERSION_NAME, kid: KID });
+    const service = new KmsWrappedJweService(createTestSdlSecretsKmsTarget({ client: kmsClient }));
 
     return { service, wrap, kmsClient, privateKey };
   }

--- a/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.ts
+++ b/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.ts
@@ -15,6 +15,7 @@ export type KmsWrappedJweFailure =
   | "IV_INVALID"
   | "TAG_INVALID"
   | "ENCRYPTED_KEY_REJECTED"
+  | "WRAPPING_VERSION_UNUSABLE"
   | "KEY_SERVICE_UNREACHABLE"
   | "KEY_SERVICE_REQUEST_CORRUPTED"
   | "KEY_SERVICE_PLAINTEXT_MISSING"
@@ -72,7 +73,10 @@ function getGrpcStatus(error: unknown) {
   return error instanceof Error && "code" in error ? error.code : undefined;
 }
 
-/** Validates nothing in the header, because what a header must say differs by caller and a wrapped data key carries none of a transport seal's claims. */
+/** A version alias is well formed long before it names anything, so only the key service can tell a version that was never created, or was disabled or destroyed, from one that opens. */
+const UNUSABLE_VERSION_STATUSES: ReadonlySet<unknown> = new Set([grpc.status.NOT_FOUND, grpc.status.FAILED_PRECONDITION]);
+
+/** Validates nothing in the header, because what a header must say differs by caller and a wrapped data key carries none of a transport seal's claims — including which version to open under, which the caller resolves and passes in. */
 @singleton()
 export class KmsWrappedJweService {
   constructor(@inject(SDL_SECRETS_KMS_TARGET) private readonly kmsTarget: SdlSecretsKmsTarget) {}
@@ -93,8 +97,8 @@ export class KmsWrappedJweService {
     return { segments, header: this.#parseHeader(protectedHeader) } as ParsedKmsWrappedJwe;
   }
 
-  async open({ segments }: ParsedKmsWrappedJwe): Promise<Buffer> {
-    const contentEncryptionKey = await this.#unwrapContentEncryptionKey(segments.encryptedKey);
+  async open({ segments }: ParsedKmsWrappedJwe, versionName: string): Promise<Buffer> {
+    const contentEncryptionKey = await this.#unwrapContentEncryptionKey(segments.encryptedKey, versionName);
 
     return this.#openContent(segments, contentEncryptionKey);
   }
@@ -150,8 +154,8 @@ export class KmsWrappedJweService {
   }
 
   /** `jose` cannot delegate key unwrapping to a remote service, which is why the encrypted key is handed to Cloud KMS here rather than opened by a stock library. */
-  async #unwrapContentEncryptionKey(encryptedKey: string): Promise<Buffer> {
-    const response = await this.#asymmetricDecrypt(Buffer.from(encryptedKey, "base64url"));
+  async #unwrapContentEncryptionKey(encryptedKey: string, versionName: string): Promise<Buffer> {
+    const response = await this.#asymmetricDecrypt(Buffer.from(encryptedKey, "base64url"), versionName);
 
     if (!response.verifiedCiphertextCrc32c) {
       throw new KmsWrappedJweError("KEY_SERVICE_REQUEST_CORRUPTED");
@@ -170,21 +174,27 @@ export class KmsWrappedJweService {
     return contentEncryptionKey;
   }
 
-  async #asymmetricDecrypt(ciphertext: Buffer) {
+  async #asymmetricDecrypt(ciphertext: Buffer, versionName: string) {
     try {
       const [response] = await this.kmsTarget.client.asymmetricDecrypt({
-        name: this.kmsTarget.versionName,
+        name: versionName,
         ciphertext,
         ciphertextCrc32c: { value: crc32c.calculate(ciphertext) }
       });
 
       return response;
     } catch (error) {
-      if (getGrpcStatus(error) === grpc.status.INVALID_ARGUMENT) {
+      const status = getGrpcStatus(error);
+
+      if (status === grpc.status.INVALID_ARGUMENT) {
         throw new KmsWrappedJweError("ENCRYPTED_KEY_REJECTED");
       }
 
-      throw new KmsWrappedJweError("KEY_SERVICE_UNREACHABLE", { versionName: this.kmsTarget.versionName, error });
+      if (UNUSABLE_VERSION_STATUSES.has(status)) {
+        throw new KmsWrappedJweError("WRAPPING_VERSION_UNUSABLE", { versionName });
+      }
+
+      throw new KmsWrappedJweError("KEY_SERVICE_UNREACHABLE", { versionName, error });
     }
   }
 

--- a/apps/api/src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service.spec.ts
@@ -10,6 +10,8 @@ import type { SdlSecretsKmsClient } from "@src/deployment/providers/kms.provider
 import type { SdlSecretsPublicJwk } from "./sdl-secrets-sealing-key.service";
 import { SdlSecretsSealingKeyService } from "./sdl-secrets-sealing-key.service";
 
+import { createTestSdlSecretsKmsTarget, sdlSecretsVersionPath } from "@test/mocks/sdl-secrets-kms.mock";
+
 const SEALING_KEY_PEM = generateKeyPairSync("rsa", { modulusLength: 3072 }).publicKey.export({ type: "spki", format: "pem" }).toString();
 
 describe(SdlSecretsSealingKeyService.name, () => {
@@ -37,7 +39,7 @@ describe(SdlSecretsSealingKeyService.name, () => {
   });
 
   it("returns the kid of the crypto key version the seal must name", async () => {
-    const { service } = setup({ kid: "sdl-secrets.v7" });
+    const { service } = setup({ version: "7" });
 
     const { kid } = await service.getSealingKey();
 
@@ -61,7 +63,7 @@ describe(SdlSecretsSealingKeyService.name, () => {
     });
 
     it("returns the key once it is held", async () => {
-      const { service } = setup({ kid: "sdl-secrets.v2" });
+      const { service } = setup({ version: "2" });
       await service.getSealingKey();
 
       expect(service.peekSealingKey()).toMatchObject({ kid: "sdl-secrets.v2" });
@@ -89,14 +91,12 @@ describe(SdlSecretsSealingKeyService.name, () => {
   });
 
   it("asks KMS for the configured crypto key version", async () => {
-    const { service, kmsClient } = setup({ versionName: "projects/p/locations/global/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1" });
+    const { service, kmsClient, versionName } = setup({ version: "3" });
 
     await service.getSealingKey();
 
-    expect(kmsClient.getPublicKey).toHaveBeenCalledWith(
-      { name: "projects/p/locations/global/keyRings/r/cryptoKeys/k/cryptoKeyVersions/1" },
-      expect.any(Object)
-    );
+    expect(kmsClient.getPublicKey).toHaveBeenCalledWith({ name: versionName }, expect.any(Object));
+    expect(versionName).toBe(sdlSecretsVersionPath("3"));
   });
 
   it("fails with 503 when KMS is unreachable", async () => {
@@ -175,9 +175,9 @@ describe(SdlSecretsSealingKeyService.name, () => {
       .toString();
   }
 
-  function setup(input?: { pem?: string; kid?: string; versionName?: string }) {
+  function setup(input?: { pem?: string; version?: string }) {
     const pem = input?.pem ?? SEALING_KEY_PEM;
-    const versionName = input?.versionName ?? "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+    const versionName = sdlSecretsVersionPath(input?.version ?? "1");
     const publicKeyResponse: protos.google.cloud.kms.v1.IPublicKey = {
       pem,
       name: versionName,
@@ -190,7 +190,7 @@ describe(SdlSecretsSealingKeyService.name, () => {
 
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger: CreateLogger = () => logger;
-    const kmsTarget = { client: kmsClient, versionName, kid: input?.kid ?? "sdl-secrets.v1" };
+    const kmsTarget = createTestSdlSecretsKmsTarget({ client: kmsClient, version: input?.version });
     const service = new SdlSecretsSealingKeyService(kmsTarget, createLogger);
 
     return { service, kmsClient, logger, pem, versionName, publicKeyResponse };

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.spec.ts
@@ -14,8 +14,11 @@ import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/k
 import type { UserOutput } from "@src/user/repositories";
 import { SdlSecretsUnsealerService } from "./sdl-secrets-unsealer.service";
 
+import { createTestSdlSecretsKmsTarget, sdlSecretsVersionPath } from "@test/mocks/sdl-secrets-kms.mock";
+
 const KID = "sdl-secrets.v1";
-const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+const VERSION_NAME = sdlSecretsVersionPath("1");
+const FOREIGN_KID = "other-key.v1";
 const SUBJECT = "3f2b6f7a-1c1d-4b0e-8b8a-9a0f5f5c2b11";
 const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
 
@@ -38,12 +41,28 @@ describe(SdlSecretsUnsealerService.name, () => {
     expect(secrets).toEqual(clientSecrets);
   });
 
-  it("unwraps the content encryption key with the configured crypto key version", async () => {
+  it("unwraps the content encryption key with the crypto key version the seal's header names", async () => {
     const { open, seal, kmsClient } = setup();
 
     await open(await seal({ TOKEN: "t" }));
 
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledWith(expect.objectContaining({ name: VERSION_NAME }));
+  });
+
+  it("accepts a seal made under an older enabled version after the configured version moves on", async () => {
+    const { open, seal, clientSecrets, kmsClient } = setup({ configuredVersion: "2" });
+
+    await expect(open(await seal(clientSecrets, { kid: "sdl-secrets.v1" }))).resolves.toEqual(clientSecrets);
+
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledWith(expect.objectContaining({ name: sdlSecretsVersionPath("1") }));
+  });
+
+  it("records the version a seal was opened under rather than the one new wraps use", async () => {
+    const { open, seal, clientSecrets, logger } = setup({ configuredVersion: "2" });
+
+    await open(await seal(clientSecrets, { kid: "sdl-secrets.v1" }));
+
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "SDL_SECRETS_SEAL_OPENED", kid: "sdl-secrets.v1" }));
   });
 
   it("rejects a seal made for another user", async () => {
@@ -73,9 +92,52 @@ describe(SdlSecretsUnsealerService.name, () => {
   });
 
   it("reports a seal made for a key the console no longer holds as a conflict so clients refetch", async () => {
+    const { open, seal, logger, kmsClient } = setup();
+
+    await expect(open(await seal({ TOKEN: "t" }, { kid: FOREIGN_KID }))).rejects.toMatchObject({ status: 409 });
+
+    expect(logger.warn).toHaveBeenCalledWith({ event: "SDL_SECRETS_SEAL_KID_UNKNOWN", received: FOREIGN_KID, expected: KID });
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it.each([["sdl-secrets"], ["sdl-secrets.v"], ["sdl-secrets.v0"], ["sdl-secrets.v01"], ["sdl-secrets.vx"], ["sdl-secrets.v1x"], [VERSION_NAME]])(
+    "refuses the unparseable key version %s without spending an unwrap",
+    async kid => {
+      const { open, seal, kmsClient } = setup();
+
+      await expect(open(await seal({ TOKEN: "t" }, { kid }))).rejects.toMatchObject({ status: 409 });
+      expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+    }
+  );
+
+  it("refuses a seal carrying no key version without spending an unwrap", async () => {
+    const { open, seal, kmsClient } = setup();
+
+    await expect(open(await seal({ TOKEN: "t" }, { kid: undefined }))).rejects.toMatchObject({ status: 409 });
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("tells a client its key is unknown before telling it the seal expired, so it learns to refetch", async () => {
     const { open, seal } = setup();
 
+    await expect(open(await seal({ TOKEN: "t" }, { kid: FOREIGN_KID, exp: Math.floor(Date.now() / 1000) - 1 }))).rejects.toMatchObject({ status: 409 });
+  });
+
+  it("reports a well-formed version the key service does not have as a conflict too", async () => {
+    const { open, seal, kmsClient, logger } = setup();
+    kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("5 NOT_FOUND"), { code: grpc.status.NOT_FOUND }));
+
     await expect(open(await seal({ TOKEN: "t" }, { kid: "sdl-secrets.v9" }))).rejects.toMatchObject({ status: 409 });
+
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "SDL_SECRETS_SEAL_KID_UNKNOWN" }));
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("reports a version the key service has disabled as a conflict rather than as an outage", async () => {
+    const { open, seal, kmsClient } = setup();
+    kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("9 FAILED_PRECONDITION"), { code: grpc.status.FAILED_PRECONDITION }));
+
+    await expect(open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 409 });
   });
 
   it("rejects a content encryption the console does not accept", async () => {
@@ -369,7 +431,7 @@ describe(SdlSecretsUnsealerService.name, () => {
     await expect(open(await seal({ TOKEN: "t" }))).rejects.toMatchObject({ status: 503 });
   });
 
-  function setup() {
+  function setup(input?: { configuredVersion?: string }) {
     const { publicKey, privateKey } = SEALING_KEY_PAIR;
     const jwk = { ...publicKey.export({ format: "jwk" }), use: "enc", alg: "RSA-OAEP-256" };
     const clientSecrets = { DB_URL: `postgres://app:${randomUUID()}@db.internal/app`, API_TOKEN: randomBytes(20).toString("hex") };
@@ -420,7 +482,7 @@ describe(SdlSecretsUnsealerService.name, () => {
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger: CreateLogger = () => logger;
 
-    const kmsTarget = { client: kmsClient, versionName: VERSION_NAME, kid: KID };
+    const kmsTarget = createTestSdlSecretsKmsTarget({ client: kmsClient, version: input?.configuredVersion });
     const service = new SdlSecretsUnsealerService(kmsTarget, new KmsWrappedJweService(kmsTarget), authService, createLogger);
     const open = (seal: string, sdl = SDL) => service.open({ seal, sdl });
 

--- a/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
+++ b/apps/api/src/deployment/services/sdl-secrets-unsealer/sdl-secrets-unsealer.service.ts
@@ -41,6 +41,11 @@ const SEAL_REJECTIONS: Record<KmsWrappedJweFailure, SealRejection> = {
     event: "SDL_SECRETS_SEAL_ENCRYPTED_KEY_REJECTED",
     message: "Sealed secrets carry an encrypted key this key version cannot open"
   },
+  WRAPPING_VERSION_UNUSABLE: {
+    status: 409,
+    event: "SDL_SECRETS_SEAL_KID_UNKNOWN",
+    message: "Sealed to a key the console no longer holds; refetch the SDL secrets context"
+  },
   KEY_SERVICE_REQUEST_CORRUPTED: { status: 503, event: "SDL_SECRETS_CEK_REQUEST_CORRUPTED", message: "SDL secrets could not be unsealed" },
   KEY_SERVICE_PLAINTEXT_MISSING: { status: 503, event: "SDL_SECRETS_CEK_MISSING", message: "SDL secrets could not be unsealed" },
   KEY_SERVICE_RESPONSE_CORRUPTED: { status: 503, event: "SDL_SECRETS_CEK_RESPONSE_CORRUPTED", message: "SDL secrets could not be unsealed" },
@@ -92,14 +97,14 @@ export class SdlSecretsUnsealerService {
 
   async open({ seal, sdl }: { seal: string; sdl: string }): Promise<SdlSecrets> {
     const parsed = this.#parseSeal(seal);
-    const header = this.#validateHeader(parsed.header);
+    const { header, versionName } = this.#validateHeader(parsed.header);
     this.#assertSdlBinding(header, sdl);
 
-    const secrets = this.#parseSecrets(await this.#openSeal(parsed));
+    const secrets = this.#parseSecrets(await this.#openSeal(parsed, versionName));
 
     this.#loggerService.info({
       event: "SDL_SECRETS_SEAL_OPENED",
-      kid: this.kmsTarget.kid,
+      kid: header.kid,
       secretCount: Object.keys(secrets).length,
       sdlBound: isSdlBound(header)
     });
@@ -115,9 +120,9 @@ export class SdlSecretsUnsealerService {
     }
   }
 
-  async #openSeal(parsed: ParsedKmsWrappedJwe): Promise<Buffer> {
+  async #openSeal(parsed: ParsedKmsWrappedJwe, versionName: string): Promise<Buffer> {
     try {
-      return await this.wrappedJweService.open(parsed);
+      return await this.wrappedJweService.open(parsed, versionName);
     } catch (error) {
       throw this.#rejectWrappedJweFailure(error);
     }
@@ -146,7 +151,9 @@ export class SdlSecretsUnsealerService {
       });
     }
 
-    if (header.kid !== this.kmsTarget.kid) {
+    const versionName = this.kmsTarget.resolveVersionName(header.kid);
+
+    if (!versionName) {
       throw this.#reject(409, "SDL_SECRETS_SEAL_KID_UNKNOWN", "Sealed to a key the console no longer holds; refetch the SDL secrets context", {
         received: header.kid,
         expected: this.kmsTarget.kid
@@ -170,7 +177,7 @@ export class SdlSecretsUnsealerService {
       });
     }
 
-    return header;
+    return { header, versionName };
   }
 
   /**

--- a/apps/api/src/secret/services/data-key-unwrapper/data-key-unwrapper.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-unwrapper/data-key-unwrapper.service.spec.ts
@@ -16,10 +16,11 @@ import type { DataKeyOutput } from "@src/secret/repositories/data-key/data-key.r
 import type { DataKeyService } from "@src/secret/services/data-key/data-key.service";
 import { DataKeyUnwrapperService } from "./data-key-unwrapper.service";
 
+import { createTestSdlSecretsKmsTarget, sdlSecretsVersionPath } from "@test/mocks/sdl-secrets-kms.mock";
 import { createDataKey } from "@test/seeders/data-key.seeder";
 
 const KID = "sdl-secrets.v1";
-const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+const FOREIGN_KID = "other-key.v1";
 const USER_A = "3f2b6f7a-1c1d-4b0e-8b8a-9a0f5f5c2b11";
 const USER_B = "6d0b1f4c-2222-4444-8888-1a2b3c4d5e6f";
 
@@ -217,12 +218,43 @@ describe(DataKeyUnwrapperService.name, () => {
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(2);
   });
 
-  it("rejects with 503 when the row is wrapped under a key version this process does not target", async () => {
-    const { service, inRequest, kmsClient } = setup({ kid: "sdl-secrets.v9" });
+  it("rejects with 503 when the row is wrapped under a crypto key that is not the console's", async () => {
+    const { service, inRequest, kmsClient, logger } = setup({ kid: FOREIGN_KID });
 
     await inRequest(async () => await expect((await service.getDataKey(USER_A)).unwrap()).rejects.toMatchObject({ status: 503 }));
 
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "USER_DATA_KEY_WRAPPED_UNDER_UNKNOWN_KID", received: FOREIGN_KID, expected: KID })
+    );
+  });
+
+  it("opens a row wrapped under an older enabled version after the configured version moves on", async () => {
+    const { service, inRequest, kmsClient, keyFor } = setup({ kid: "sdl-secrets.v1", configuredVersion: "2" });
+
+    const key = await inRequest(async () => await (await service.getDataKey(USER_A)).unwrap());
+
+    expect(key.equals(keyFor(USER_A))).toBe(true);
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledWith(expect.objectContaining({ name: sdlSecretsVersionPath("1") }));
+  });
+
+  it("rejects with 503 when the key service does not have the version the row names", async () => {
+    const { service, inRequest, kmsClient, logger } = setup({ kid: "sdl-secrets.v9" });
+    kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("5 NOT_FOUND"), { code: grpc.status.NOT_FOUND }));
+
+    await inRequest(async () => await expect((await service.getDataKey(USER_A)).unwrap()).rejects.toMatchObject({ status: 503 }));
+
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledWith(expect.objectContaining({ name: sdlSecretsVersionPath("9") }));
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "USER_DATA_KEY_WRAPPED_UNDER_UNKNOWN_KID", expected: KID }));
+  });
+
+  it("rejects with 503 when the version the row names has been disabled", async () => {
+    const { service, inRequest, kmsClient, logger } = setup();
+    kmsClient.asymmetricDecrypt.mockRejectedValue(Object.assign(new Error("9 FAILED_PRECONDITION"), { code: grpc.status.FAILED_PRECONDITION }));
+
+    await inRequest(async () => await expect((await service.getDataKey(USER_A)).unwrap()).rejects.toMatchObject({ status: 503 }));
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "USER_DATA_KEY_WRAPPED_UNDER_UNKNOWN_KID" }));
   });
 
   it("rejects with 503 when the key service is unreachable", async () => {
@@ -277,7 +309,7 @@ describe(DataKeyUnwrapperService.name, () => {
     await inRequest(async () => await expect(service.getDataKey(USER_A)).rejects.toThrow("no row"));
   });
 
-  function setup(input?: { kid?: string; keyBytes?: number; mutateWrappedKey?: (wrappedKey: string) => string }) {
+  function setup(input?: { kid?: string; configuredVersion?: string; keyBytes?: number; mutateWrappedKey?: (wrappedKey: string) => string }) {
     const { publicKey, privateKey } = WRAPPING_KEY_PAIR;
     const wrappedKid = input?.kid ?? KID;
     const keys = new Map<string, Buffer>();
@@ -312,7 +344,7 @@ describe(DataKeyUnwrapperService.name, () => {
       ];
     });
 
-    const kmsTarget = { client: kmsClient, versionName: VERSION_NAME, kid: KID };
+    const kmsTarget = createTestSdlSecretsKmsTarget({ client: kmsClient, version: input?.configuredVersion });
     const executionContextService = container.resolve(ExecutionContextService);
     const logger = mock<ReturnType<CreateLogger>>();
     const service = new DataKeyUnwrapperService(dataKeyService, executionContextService, new KmsWrappedJweService(kmsTarget), kmsTarget, () => logger);

--- a/apps/api/src/secret/services/data-key-unwrapper/data-key-unwrapper.service.ts
+++ b/apps/api/src/secret/services/data-key-unwrapper/data-key-unwrapper.service.ts
@@ -103,8 +103,9 @@ export class DataKeyUnwrapperService {
 
   async #unwrapDataKey(dataKey: DataKeyOutput, userId: string): Promise<Buffer> {
     const parsed = this.#parseWrappedKey(dataKey.wrappedKey, userId);
+    const versionName = this.kmsTarget.resolveVersionName(parsed.header.kid);
 
-    if (parsed.header.kid !== this.kmsTarget.kid) {
+    if (!versionName) {
       throw this.#rejectUnavailable("USER_DATA_KEY_WRAPPED_UNDER_UNKNOWN_KID", {
         userId,
         received: parsed.header.kid,
@@ -112,7 +113,7 @@ export class DataKeyUnwrapperService {
       });
     }
 
-    const key = await this.#openWrappedKey(parsed, userId);
+    const key = await this.#openWrappedKey(parsed, versionName, userId);
 
     if (key.length !== DATA_ENCRYPTION_KEY_BYTES) {
       throw this.#rejectUnreadable("USER_DATA_KEY_LENGTH_UNEXPECTED", { userId, keyBytes: key.length });
@@ -131,9 +132,9 @@ export class DataKeyUnwrapperService {
     }
   }
 
-  async #openWrappedKey(parsed: ParsedKmsWrappedJwe, userId: string): Promise<Buffer> {
+  async #openWrappedKey(parsed: ParsedKmsWrappedJwe, versionName: string, userId: string): Promise<Buffer> {
     try {
-      return await this.wrappedJweService.open(parsed);
+      return await this.wrappedJweService.open(parsed, versionName);
     } catch (error) {
       throw this.#rejectWrappedJweFailure(error, userId);
     }
@@ -144,6 +145,10 @@ export class DataKeyUnwrapperService {
     if (!(error instanceof KmsWrappedJweError)) return error;
 
     const details = { userId, failure: error.failure, ...error.details };
+
+    if (error.failure === "WRAPPING_VERSION_UNUSABLE") {
+      return this.#rejectUnavailable("USER_DATA_KEY_WRAPPED_UNDER_UNKNOWN_KID", { ...details, expected: this.kmsTarget.kid });
+    }
 
     if (KEY_SERVICE_FAILURES.has(error.failure)) {
       return this.#rejectUnavailable("USER_DATA_KEY_UNWRAP_FAILED", details);

--- a/apps/api/src/secret/services/data-key/data-key.service.spec.ts
+++ b/apps/api/src/secret/services/data-key/data-key.service.spec.ts
@@ -12,6 +12,8 @@ import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secret
 import type { DataKeyOutput, DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
 import { DataKeyService } from "./data-key.service";
 
+import { createTestSdlSecretsKmsTarget, sdlSecretsVersionPath } from "@test/mocks/sdl-secrets-kms.mock";
+
 const WRAPPING_KEY_PAIR = generateKeyPairSync("rsa", { modulusLength: 3072 });
 const FOREIGN_KEY_PAIR = generateKeyPairSync("rsa", { modulusLength: 3072 });
 
@@ -40,7 +42,7 @@ describe(DataKeyService.name, () => {
     });
 
     it("stores the key version alias the wrapped blob itself names", async () => {
-      const { service, warmSealingKey } = setup({ kid: "sdl-secrets.v4" });
+      const { service, warmSealingKey } = setup({ version: "4" });
       await warmSealingKey();
 
       const dataKey = await service.ensureDataKey(faker.string.uuid());
@@ -106,7 +108,7 @@ describe(DataKeyService.name, () => {
     });
 
     it("logs the creation without the key material", async () => {
-      const { service, logger, warmSealingKey } = setup({ kid: "sdl-secrets.v1" });
+      const { service, logger, warmSealingKey } = setup({ version: "1" });
       await warmSealingKey();
       const userId = faker.string.uuid();
 
@@ -122,17 +124,17 @@ describe(DataKeyService.name, () => {
     expect(createDataKeyLogger).toHaveBeenCalledWith({ context: DataKeyService.name });
   });
 
-  function setup(input?: { kid?: string }) {
+  function setup(input?: { version?: string }) {
     const { publicKey, privateKey } = WRAPPING_KEY_PAIR;
     const pem = publicKey.export({ type: "spki", format: "pem" }).toString();
-    const versionName = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+    const versionName = sdlSecretsVersionPath(input?.version ?? "1");
     const kmsClient = mock<SdlSecretsKmsClient>();
     kmsClient.getPublicKey.mockResolvedValue([
       { pem, name: versionName, algorithm: "RSA_DECRYPT_OAEP_3072_SHA256", pemCrc32c: { value: String(crc32c.calculate(pem)) } }
     ]);
 
     const createLogger: CreateLogger = () => mock<ReturnType<CreateLogger>>();
-    const sealingKeyService = new SdlSecretsSealingKeyService({ client: kmsClient, versionName, kid: input?.kid ?? "sdl-secrets.v1" }, createLogger);
+    const sealingKeyService = new SdlSecretsSealingKeyService(createTestSdlSecretsKmsTarget({ client: kmsClient, version: input?.version }), createLogger);
 
     const storedByUserId = new Map<string, DataKeyOutput>();
     const dataKeyRepository = mock<DataKeyRepository>();

--- a/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
+++ b/apps/api/src/secret/services/secret-cipher/secret-cipher.service.integration.ts
@@ -20,8 +20,9 @@ import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
 import { SecretCipherService } from "./secret-cipher.service";
 
+import { createTestSdlSecretsKmsTarget } from "@test/mocks/sdl-secrets-kms.mock";
+
 const KID = "sdl-secrets.v1";
-const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
 const SDL = 'version: "2.0"\nservices:\n  web:\n    image: nginx\n';
 
 function bindingFor(user: UserOutput, dseq: string) {
@@ -230,7 +231,7 @@ describe(SecretCipherService.name, () => {
     });
 
     const createLogger: CreateLogger = () => mock<ReturnType<CreateLogger>>();
-    const kmsTarget = { client: kmsClient, versionName: VERSION_NAME, kid: KID };
+    const kmsTarget = createTestSdlSecretsKmsTarget({ client: kmsClient });
     const wrappedJweService = new KmsWrappedJweService(kmsTarget);
     const dataKeyRepository = container.resolve(DataKeyRepository);
     const userRepository = container.resolve(UserRepository);

--- a/apps/api/test/mocks/sdl-secrets-kms.mock.ts
+++ b/apps/api/test/mocks/sdl-secrets-kms.mock.ts
@@ -5,12 +5,24 @@ import { container } from "tsyringe";
 import { mock } from "vitest-mock-extended";
 
 import type { SdlSecretsKmsClient, SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
-import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
+import { createSdlSecretsKmsTarget, SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
 import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
 
-export const SDL_SECRETS_KID = "sdl-secrets.v1";
+const SDL_SECRETS_KEY = "sdl-secrets";
 
-const VERSION_NAME = "projects/console-test/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/1";
+/** Mirrors what `client.cryptoKeyVersionPath` builds in production, so no spec can assert against a resource name the provider would never produce. */
+export function sdlSecretsVersionPath(version: string) {
+  return `projects/console-test/locations/global/keyRings/console-api/cryptoKeys/${SDL_SECRETS_KEY}/cryptoKeyVersions/${version}`;
+}
+
+/** Built by the production factory rather than by hand, so every spec resolves a header `kid` exactly as the running console does. */
+export function createTestSdlSecretsKmsTarget({ client, version = "1" }: { client: SdlSecretsKmsClient; version?: string }): SdlSecretsKmsTarget {
+  return createSdlSecretsKmsTarget({ client, versionPath: sdlSecretsVersionPath, key: SDL_SECRETS_KEY, version });
+}
+
+export const SDL_SECRETS_KID = `${SDL_SECRETS_KEY}.v1`;
+
+const VERSION_NAME = sdlSecretsVersionPath("1");
 
 /** Every create carrying an env value unwraps a data key, so any spec exercising `POST /v1/deployments` must call this or reach the real Cloud KMS: it doubles that boundary with a real RSA key, registered at module scope so nothing resolves the real target first. */
 export function registerFakeSdlSecretsKms() {
@@ -34,7 +46,7 @@ export function registerFakeSdlSecretsKms() {
     ];
   });
 
-  container.register<SdlSecretsKmsTarget>(SDL_SECRETS_KMS_TARGET, { useValue: { client, versionName: VERSION_NAME, kid: SDL_SECRETS_KID } });
+  container.register<SdlSecretsKmsTarget>(SDL_SECRETS_KMS_TARGET, { useValue: createTestSdlSecretsKmsTarget({ client }) });
 
   return { client, publicKey };
 }

--- a/packages/docker/docker-compose.dev.yml
+++ b/packages/docker/docker-compose.dev.yml
@@ -254,4 +254,16 @@ services:
       GCP_KMS_KEY: sdl-secrets
     post_start:
       - command: ["sh", "/script/seed-gcp-kms-mock.sh"]
+    # Probes the seeded crypto key rather than the port, because `post_start` runs after the
+    # container is up: without this `--wait` returns while the seeder is still creating it.
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -q -O /dev/null $${KMS_EMULATOR_REST}/v1/projects/$${GCP_KMS_PROJECT_ID}/locations/$${GCP_KMS_LOCATION}/keyRings/$${GCP_KMS_KEY_RING}/cryptoKeys/$${GCP_KMS_KEY}"
+        ]
+      interval: 2s
+      timeout: 5s
+      retries: 20
+      start_period: 5s
     restart: unless-stopped


### PR DESCRIPTION
## Why

Part of CON-956 — [Open wraps and seals under the key version their headers name](https://linear.app/ovrclk/issue/CON-956/open-wraps-and-seals-under-the-key-version-their-headers-name)

The console is pinned to one KMS key version end to end. Every unwrap path names the configured version, and both read paths refuse a JWE whose header names any other version — even an older, still-enabled version of the console's own key.

Raising `GCP_KMS_KEY_VERSION` therefore **strands data instead of rotating it**: every existing data key stops opening, so every secret sealed under one becomes unreadable, and in-flight client seals made with the previous sealing key are rejected. The rotation work in the parent issue assumes old and new wrappings decrypt side by side while a rotation runs; nothing delivered that until now.

## What

The configured version keeps exactly one meaning — the version new wraps use, and the public key clients are served for sealing. **It stops gating reads.** Reads follow the version the JWE's own header names, provided that names a version of the console's single crypto key.

No new environment variable. Raising `GCP_KMS_KEY_VERSION` is the whole operator action.

### The change

`SdlSecretsKmsTarget` gains one capability — turning a header `kid` into a version resource name:

```ts
export interface SdlSecretsKmsTarget {
  client: SdlSecretsKmsClient;
  versionName: string; // the write target, unchanged
  kid: string;         // the published sealing key alias, unchanged
  resolveVersionName(kid: unknown): string | undefined; // new: what reads follow
}
```

`KmsWrappedJweService.open(parsed, versionName)` now decrypts under the version it is handed rather than the injected target. Both callers resolve the header's version exactly where their configured-alias gate used to sit, so a foreign key or an unparseable alias is still refused for free — same status, same event, same order, no key service call.

The clearest read of the new behaviour, from `sdl-secrets-unsealer.service.spec.ts`. The console is configured at version 2; a client seals under version 1; the seal opens, and the key service is asked for version 1:

```ts
it("accepts a seal made under an older enabled version after the configured version moves on", async () => {
  const { open, seal, clientSecrets, kmsClient } = setup({ configuredVersion: "2" });

  await expect(open(await seal(clientSecrets, { kid: "sdl-secrets.v1" }))).resolves.toEqual(clientSecrets);

  expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledWith(expect.objectContaining({ name: sdlSecretsVersionPath("1") }));
});
```

### Which aliases are readable

The gate moves from *"is this the configured alias"* to *"does this name a version of the console's crypto key"*. The alias grammar is `<key>.v<positive integer, no leading zero, at most 10 digits>`; anything else is refused locally. Whether a well-formed version exists and is enabled is the key service's answer, not the console's.

### Behaviour worth a reviewer's attention

A well-formed alias naming a version that does not exist, is disabled, or is destroyed is no longer decidable locally. A new `WRAPPING_VERSION_UNUSABLE` failure maps gRPC `NOT_FOUND` and `FAILED_PRECONDITION` back onto today's errors — 409 `SDL_SECRETS_SEAL_KID_UNKNOWN` on the seal path, 503 `USER_DATA_KEY_WRAPPED_UNDER_UNKNOWN_KID` on the stored-data-key path.

One consequence is a deliberate trade, and the thing to push back on if you disagree: **if the console's own configured version is disabled by mistake**, the seal path now answers 409 with a warn where it previously answered 503 with an error-level log. Refetching the context will not help in that scenario, and PRD-0004's "any failed token open" alert would not fire from seal traffic. The judgement is that the same outage still pages loudly through the data-key path — which is the flow the rotation census exists to protect — and that every *client-held* stale version is genuinely a refetch conflict. Splitting `FAILED_PRECONDITION` back onto 503 is a two-line change.

### Scope

Slice 1 of 2. This covers AC1–AC3. **AC4** — integration coverage against the real Cloud KMS emulator with two enabled versions — lands as slice 2, because it needs the emulator started by `test:ci-setup`, which is separate wiring (docker compose, CI setup) from the behaviour here. Hence `Part of` rather than `Fixes`.

### Files

| | |
| --- | --- |
| `deployment/providers/kms.provider.ts` | `createSdlSecretsKmsTarget` + `resolveVersionName` |
| `deployment/services/kms-wrapped-jwe/` | `open(parsed, versionName)`, `WRAPPING_VERSION_UNUSABLE` |
| `deployment/services/sdl-secrets-unsealer/` | resolve-and-open, `SEAL_REJECTIONS` entry, truthful `kid` log |
| `secret/services/data-key-unwrapper/` | resolve-and-open, unusable-version mapping |
| `test/mocks/sdl-secrets-kms.mock.ts` | shared `createTestSdlSecretsKmsTarget`, used by all seven doubles |

Test doubles are now built by the production factory, so no spec can resolve a `kid` differently from the running console. The two specs that asserted `sdl-secrets.v9` is refused are re-pointed at a foreign key name (`other-key.v1`) — a v9 alias now names the console's own key and is only refusable by the key service.

`data_keys.wrappedByKid` and the blob header are still both written from the same `sealingKey.kid`, so `countWrappedUnder` — the rotation census — stays truthful with no change.

### Checks

- `npm test` — passed
- `npm run lint -- --quiet` — passed
- `npx tsc --noEmit` — passed

413 measured changes, `apps/api` only. No migration, no API schema change, no frontend.

---

## Demo

# CON-956 — Open wraps and seals under the key version their headers name

*2026-09-11T00:18:51Z by Showboat 0.6.1*
<!-- showboat-id: d04df80f-05e1-4d72-ba86-d188d8442121 -->

The console was pinned to one KMS key version end to end. Every unwrap named the configured version, and both read paths refused a JWE whose header named any other version — even an older, still-enabled version of the console's own key. Raising `GCP_KMS_KEY_VERSION` therefore stranded data instead of rotating it.

This demo drives the real production services — `SdlSecretsSealingKeyService`, `DataKeyService`, `DataKeyUnwrapperService`, `SdlSecretsUnsealerService` and `KmsWrappedJweService` — against a stand-in Cloud KMS that holds **a genuinely different RSA key pair per version**. So "it opened under version 1" is a cryptographic fact here, not a mock that ignores the name it is given.

The stand-in key service. Each version gets its own RSA key pair; a version that was never created answers `NOT_FOUND`, and a disabled one answers `FAILED_PRECONDITION` — the two statuses Cloud KMS returns.

```bash
sed -n '29,55p' .work/con-956-open-wraps-seals-under-key/driver.ts
```

```output
/** One RSA key pair per version, so opening a v1 wrap under v2 fails for the reason it fails in Cloud KMS. */
function createKeyService(versions: string[]) {
  const material = new Map(versions.map(version => [version, generateKeyPairSync("rsa", { modulusLength: 3072 })]));
  const disabled = new Set<string>();
  const calls: string[] = [];

  const client: SdlSecretsKmsClient = {
    async getPublicKey({ name }) {
      const pem = material.get(name.split("/").pop()!)!.publicKey.export({ type: "spki", format: "pem" }).toString();

      return [{ name, pem, algorithm: "RSA_DECRYPT_OAEP_3072_SHA256", pemCrc32c: { value: String(crc32c.calculate(pem)) } }];
    },
    async asymmetricDecrypt({ name, ciphertext }) {
      const version = name.split("/").pop()!;
      calls.push(shortName(name));

      if (!material.has(version)) throw grpcError(`5 NOT_FOUND: ${name}`, grpc.status.NOT_FOUND);
      if (disabled.has(version)) throw grpcError(`9 FAILED_PRECONDITION: ${name} is not enabled`, grpc.status.FAILED_PRECONDITION);

      const plaintext = privateDecrypt(
        { key: material.get(version)!.privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" },
        Buffer.from(ciphertext)
      );

      return [{ plaintext, plaintextCrc32c: { value: String(crc32c.calculate(plaintext)) }, verifiedCiphertextCrc32c: true }];
    }
  };
```

## Before this change: raising the configured version strands the data

Run against the parent commit `3c9de47d9`, checked out in a throwaway worktree. An operator raises `GCP_KMS_KEY_VERSION` from 1 to 2. Nothing about the stored rows changes — but nothing opens either.

```bash
BEFORE=.work/con-956-open-wraps-seals-under-key/before
[ -d "$BEFORE/apps/api" ] || git worktree add --detach "$BEFORE" 3c9de47d9 >/dev/null 2>&1
cd "$BEFORE/apps/api" && npx tsx --tsconfig tsconfig.json ../../../driver-before.ts 2>/dev/null
```

```output
BEFORE ROTATION — the console is configured at version 1
  published sealing key kid : sdl-secrets.v1
  stored data key row       : wrappedByKid=sdl-secrets.v1
  a client seals with kid   : sdl-secrets.v1

--- an operator raises GCP_KMS_KEY_VERSION from 1 to 2 (no code change, no data touched) ---

1. the data key stored under sdl-secrets.v1 is read back
  outcome                   : REFUSED 503
  key service asked for     : nothing
  data key bytes recovered  : 0
  ERROR USER_DATA_KEY_WRAPPED_UNDER_UNKNOWN_KID received=sdl-secrets.v1 expected=sdl-secrets.v2

2. an in-flight client seal made under sdl-secrets.v1 arrives after the switch
  outcome                   : REFUSED 409 — Sealed to a key the console no longer holds; refetch the SDL secrets context
  key service asked for     : nothing
  secrets recovered         : none
  warn  SDL_SECRETS_SEAL_KID_UNKNOWN received=sdl-secrets.v1 expected=sdl-secrets.v2

```

## After this change: the same rotation, on this branch

The configured version now means only two things — the version new wraps use, and the public key clients are served for sealing. Reads follow the version the JWE's own header names.

```bash
cd apps/api && npx tsx --tsconfig tsconfig.json ../../.work/con-956-open-wraps-seals-under-key/driver.ts rotation 2>/dev/null
```

```output
BEFORE ROTATION — the console is configured at version 1
  published sealing key kid : sdl-secrets.v1
  stored data key row       : wrappedByKid=sdl-secrets.v1
  a client seals with kid   : sdl-secrets.v1

--- an operator raises GCP_KMS_KEY_VERSION from 1 to 2 (no code change, no data touched) ---

AFTER ROTATION — the console is configured at version 2
  published sealing key kid : sdl-secrets.v2
  new wraps target          : sdl-secrets/cryptoKeyVersions/2

1. the data key stored under sdl-secrets.v1 is read back
  outcome                   : opened
  key service asked for     : sdl-secrets/cryptoKeyVersions/1
  data key bytes recovered  : 32
  info  USER_DATA_KEY_UNWRAPPED

2. the same stored blob offered to version 2 instead, to show the two versions are not one key
  outcome                   : REFUSED — the v2 private key cannot open a v1 wrap
  key service asked for     : sdl-secrets/cryptoKeyVersions/2

3. a user who signs up after the switch gets a data key under the new version
  stored data key row       : wrappedByKid=sdl-secrets.v2
  info  USER_DATA_KEY_CREATED

```

## The transport seal path

A client that fetched the sealing key just before the switch submits a seal under the old version. It is accepted for as long as that version stays enabled. A seal naming a key that is not the console's is refused exactly as before — and refused for free, without spending a key service call.

```bash
cd apps/api && npx tsx --tsconfig tsconfig.json ../../.work/con-956-open-wraps-seals-under-key/driver.ts seals 2>/dev/null
```

```output
BEFORE ROTATION — the console is configured at version 1
  published sealing key kid : sdl-secrets.v1
  stored data key row       : wrappedByKid=sdl-secrets.v1
  a client seals with kid   : sdl-secrets.v1

--- an operator raises GCP_KMS_KEY_VERSION from 1 to 2 (no code change, no data touched) ---

AFTER ROTATION — the console is configured at version 2
  published sealing key kid : sdl-secrets.v2
  new wraps target          : sdl-secrets/cryptoKeyVersions/2

1. an in-flight client seal made under sdl-secrets.v1 arrives after the switch
  outcome                   : accepted
  key service asked for     : sdl-secrets/cryptoKeyVersions/1
  secrets recovered         : {"DB_PASSWORD":"<demo-password>","API_TOKEN":"<demo-token>"}
  info  SDL_SECRETS_SEAL_OPENED

2. a seal naming a crypto key that is not the console's
  outcome                   : REFUSED 409 — Sealed to a key the console no longer holds; refetch the SDL secrets context
  key service asked for     : nothing
  warn  SDL_SECRETS_SEAL_KID_UNKNOWN received=other-key.v1 expected=sdl-secrets.v2

3. a seal whose version alias cannot be parsed
  outcome                   : REFUSED 409 — Sealed to a key the console no longer holds; refetch the SDL secrets context
  key service asked for     : nothing
  warn  SDL_SECRETS_SEAL_KID_UNKNOWN received=sdl-secrets.v01 expected=sdl-secrets.v2

```

## Which aliases are readable at all

The gate is no longer "is this the configured alias" but "does this name a version of the console's single crypto key". Whether that version exists and is enabled is the key service's answer, not the console's — so `sdl-secrets.v9` resolves locally and is refused by the key service, while anything that is not a well-formed version of `sdl-secrets` is refused before a call is made.

```bash
cd apps/api && npx tsx --tsconfig tsconfig.json ../../.work/con-956-open-wraps-seals-under-key/alias-table.ts 2>/dev/null
```

```output
the console's crypto key is "sdl-secrets", configured at version 2

  "sdl-secrets.v2"           the configured version                   reads under sdl-secrets/cryptoKeyVersions/2
  "sdl-secrets.v1"           an older version of the same key         reads under sdl-secrets/cryptoKeyVersions/1
  "sdl-secrets.v9"           a version far above the configured one   reads under sdl-secrets/cryptoKeyVersions/9
  "other-key.v1"             a foreign crypto key                     REFUSED locally, no key service call
  "sdl-secrets-old.v1"       a key the alias only prefixes            REFUSED locally, no key service call
  "sdl-secrets"              no version at all                        REFUSED locally, no key service call
  "sdl-secrets.v"            an empty version                         REFUSED locally, no key service call
  "sdl-secrets.v0"           version zero                             REFUSED locally, no key service call
  "sdl-secrets.v01"          a leading zero                           REFUSED locally, no key service call
  "sdl-secrets.vx"           a non-numeric version                    REFUSED locally, no key service call
  "sdl-secrets.v1/../../2"   a path traversal                         REFUSED locally, no key service call
  "sdl-secrets.v99999999999" more digits than Cloud KMS assigns       REFUSED locally, no key service call
  undefined                  no kid at all                            REFUSED locally, no key service call
```

## Disabling a version still fails closed

This is the gate the rotation census exists to protect: once an operator disables version 1, everything still wrapped under it stops opening.

Note the asymmetry, which is a deliberate call recorded as a load-bearing assumption in the plan. The **stored data key** path answers 503 and logs at ERROR — that is the signal PRD-0004's "any failed token open" alert pages on. The **transport seal** path answers 409 with a warn, because for a client holding a version the console has since disabled, "refetch the SDL secrets context" is the true and actionable answer.

```bash
cd apps/api && npx tsx --tsconfig tsconfig.json ../../.work/con-956-open-wraps-seals-under-key/driver.ts fail-closed 2>/dev/null
```

```output
BEFORE ROTATION — the console is configured at version 1
  published sealing key kid : sdl-secrets.v1
  stored data key row       : wrappedByKid=sdl-secrets.v1
  a client seals with kid   : sdl-secrets.v1

--- an operator raises GCP_KMS_KEY_VERSION from 1 to 2 (no code change, no data touched) ---

AFTER ROTATION — the console is configured at version 2
  published sealing key kid : sdl-secrets.v2
  new wraps target          : sdl-secrets/cryptoKeyVersions/2

--- the operator disables version 1 at the key service ---

1. the data key stored under sdl-secrets.v1 is read again
  outcome                   : REFUSED 503
  key service asked for     : sdl-secrets/cryptoKeyVersions/1
  ERROR USER_DATA_KEY_WRAPPED_UNDER_UNKNOWN_KID versionName=sdl-secrets/cryptoKeyVersions/1

2. a client seal still naming sdl-secrets.v1 arrives
  outcome                   : REFUSED 409 — Sealed to a key the console no longer holds; refetch the SDL secrets context
  warn  SDL_SECRETS_SEAL_KID_UNKNOWN

```

## The three checks

Reported separately; these remain the pass/fail gate.

```bash
cd apps/api && NO_COLOR=1 npx vitest run --project=unit --reporter=dot 2>&1 | sed -E "s/\x1b\[[0-9;]*m//g" | grep -aE "^ *(Test Files|Tests) " | sed -E "s/ +$//"
```

```output
 Test Files  217 passed (217)
      Tests  3270 passed (3270)
```

```bash
cd apps/api && npx tsc --noEmit 2>/dev/null && echo "tsc --noEmit: clean" || echo "tsc --noEmit: FAILED"
```

```output
tsc --noEmit: clean
```

```bash
cd apps/api && npx eslint --quiet src/deployment/providers src/deployment/services/kms-wrapped-jwe src/deployment/services/sdl-secrets-unsealer src/deployment/services/sdl-secrets-sealing-key src/secret/services test/mocks/sdl-secrets-kms.mock.ts 2>/dev/null && echo "eslint --quiet: clean" || echo "eslint --quiet: FAILED"
```

```output
eslint --quiet: clean
```

The integration coverage against the real Cloud KMS emulator with two enabled versions is AC4, and lands as slice 2 of this stack — it needs the emulator started by `test:ci-setup`, which is a separate concern from the behavior above.

Anyone re-running this locally can drop the scratch worktree afterwards with `git worktree remove --force .work/con-956-open-wraps-seals-under-key/before`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - SDL secrets and wrapped data keys can now be opened using the specific KMS key version recorded when sealed.
  - Older enabled KMS key versions remain supported during unsealing.
  - Unknown, missing, disabled, or destroyed KMS versions now return clear unavailable-version errors.
  - Key identifiers are validated more reliably, including malformed or unrelated values.
  - Error reporting and audit logs now identify the actual wrapping-key version used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->