### PR TITLE
feat(deployment): fingerprint stored secrets and page data keys by wrapping version

### DIFF
--- a/apps/api/src/core/lib/batch-size/batch-size.spec.ts
+++ b/apps/api/src/core/lib/batch-size/batch-size.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { assertBatchSize } from "./batch-size";
+
+describe(assertBatchSize.name, () => {
+  it("returns a positive integer unchanged", () => {
+    expect(assertBatchSize(1)).toBe(1);
+    expect(assertBatchSize(100)).toBe(100);
+  });
+
+  it.each([0, -1, 1.5, NaN, Infinity])("refuses %s rather than handing it to a query", value => {
+    expect(() => assertBatchSize(value)).toThrow(`Batch size must be a positive integer, got ${value}`);
+  });
+});

--- a/apps/api/src/core/lib/batch-size/batch-size.ts
+++ b/apps/api/src/core/lib/batch-size/batch-size.ts
@@ -1,0 +1,8 @@
+/** `LIMIT 0` reads as an empty fleet and ends a keyset scan silently, so a batch size is refused loudly before any query runs. */
+export function assertBatchSize(batchSize: number): number {
+  if (!Number.isInteger(batchSize) || batchSize < 1) {
+    throw new Error(`Batch size must be a positive integer, got ${batchSize}`);
+  }
+
+  return batchSize;
+}

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -871,6 +871,69 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("findStoredSecretsIteratively", () => {
+    it("yields a deployment's token under the id that holds it", async () => {
+      const { sealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const id = await createSettingWithSecrets(sealedToken);
+
+      const stored = await findStoredSecrets([id]);
+
+      expect(stored).toEqual([{ id, sealedSecrets: sealedToken }]);
+    });
+
+    it("passes over a deployment holding no token, which no fingerprint has anything to say about", async () => {
+      const { sealedToken, createSetting, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const withoutSecrets = await createSetting();
+      const withSecrets = await createSettingWithSecrets(sealedToken);
+
+      const stored = await findStoredSecrets([withoutSecrets, withSecrets]);
+
+      expect(stored.map(row => row.id)).toEqual([withSecrets]);
+    });
+
+    it("pages every token-holding deployment exactly once when the batch is smaller than the set", async () => {
+      const { sealedToken, otherSealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const ids = [
+        await createSettingWithSecrets(sealedToken),
+        await createSettingWithSecrets(otherSealedToken),
+        await createSettingWithSecrets(sealedToken)
+      ];
+
+      const oneAtATime = await findStoredSecrets(ids, 1);
+      const allAtOnce = await findStoredSecrets(ids, 1000);
+
+      expect(allAtOnce).toHaveLength(3);
+      expect(oneAtATime).toEqual(allAtOnce);
+    });
+
+    it("yields rows in id order, so each batch stays an index scan on the primary key", async () => {
+      const { sealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const ids = [
+        await createSettingWithSecrets(sealedToken),
+        await createSettingWithSecrets(sealedToken),
+        await createSettingWithSecrets(sealedToken)
+      ];
+
+      const stored = await findStoredSecrets(ids, 2);
+
+      expect(stored.map(row => row.id)).toEqual([...ids].sort());
+    });
+
+    it("yields batches no larger than the size asked for", async () => {
+      const { sealedToken, deploymentSettingRepository, createSettingWithSecrets } = await setup();
+      await createSettingWithSecrets(sealedToken);
+      await createSettingWithSecrets(sealedToken);
+      await createSettingWithSecrets(sealedToken);
+      const sizes: number[] = [];
+
+      for await (const batch of deploymentSettingRepository.findStoredSecretsIteratively({ batchSize: 2 })) {
+        sizes.push(batch.length);
+      }
+
+      expect(Math.max(...sizes)).toBeLessThanOrEqual(2);
+    });
+  });
+
   describe("createDefaultIfMissing", () => {
     it("records a deployment nothing had recorded yet, with funding on", async () => {
       const { deploymentSettingRepository, user } = await setup();
@@ -1352,6 +1415,22 @@ describe(DeploymentSettingRepository.name, () => {
       return setting.id;
     }
 
+    async function createSettingWithSecrets(sealedSecrets: string) {
+      const setting = await deploymentSettingRepository.create({ userId: user.id, dseq: newDseq(), autoTopUpEnabled: true, sealedSecrets });
+
+      return setting.id;
+    }
+
+    async function findStoredSecrets(ids: string[], batchSize = 1000) {
+      const stored = [];
+
+      for await (const batch of deploymentSettingRepository.findStoredSecretsIteratively({ batchSize })) {
+        stored.push(...batch.filter(row => ids.includes(row.id)));
+      }
+
+      return stored;
+    }
+
     async function findOpenDeployments(addresses?: string[], batchSize = 1000) {
       const open = [];
 
@@ -1438,6 +1517,8 @@ describe(DeploymentSettingRepository.name, () => {
       readDefinition,
       readSettingDseq,
       createSetting,
+      createSettingWithSecrets,
+      findStoredSecrets,
       createLimitedSetting,
       createAnchoredSetting,
       findAutoTopUpOwners,

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -872,6 +872,14 @@ describe(DeploymentSettingRepository.name, () => {
   });
 
   describe("findStoredSecretsIteratively", () => {
+    it("refuses a batch size of zero, which would read as a fleet holding no secrets", async () => {
+      const { deploymentSettingRepository } = await setup();
+
+      await expect(deploymentSettingRepository.findStoredSecretsIteratively({ batchSize: 0 }).next()).rejects.toThrow(
+        "Batch size must be a positive integer"
+      );
+    });
+
     it("yields a deployment's token under the id that holds it", async () => {
       const { sealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
       const id = await createSettingWithSecrets(sealedToken);

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -183,11 +183,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     }
   }
 
-  /**
-   * Every stored secrets token there is, keyset-paged on `id`. Rows holding none are left out, so
-   * the count and byte total a fingerprint reports describe the deployments that actually carry a
-   * secret rather than the size of the table.
-   */
+  /** Rows holding no secret are left out, so a fingerprint's row and byte counts describe the deployments that actually carry one. */
   async *findStoredSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<DeploymentStoredSecrets[]> {
     let cursor: string | undefined;
 

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, or, s
 import { singleton } from "tsyringe";
 
 import { UserWallets, WalletSetting } from "@src/billing/model-schemas";
+import { assertBatchSize } from "@src/core/lib/batch-size/batch-size";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
@@ -185,6 +186,8 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
   /** Rows holding no secret are left out, so a fingerprint's row and byte counts describe the deployments that actually carry one. */
   async *findStoredSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<DeploymentStoredSecrets[]> {
+    assertBatchSize(batchSize);
+
     let cursor: string | undefined;
 
     while (true) {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -48,6 +48,12 @@ export type OpenDeployment = {
   createdAt: Date;
 };
 
+/** A deployment's stored secrets token alongside the id it is sealed to. */
+export type DeploymentStoredSecrets = {
+  id: string;
+  sealedSecrets: string;
+};
+
 export type LiveTrialDeployment = {
   userId: string;
   dseq: string;
@@ -168,6 +174,36 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       }
 
       yield batch as OpenDeployment[];
+
+      if (batch.length < batchSize) {
+        return;
+      }
+
+      cursor = batch[batch.length - 1].id;
+    }
+  }
+
+  /**
+   * Every stored secrets token there is, keyset-paged on `id`. Rows holding none are left out, so
+   * the count and byte total a fingerprint reports describe the deployments that actually carry a
+   * secret rather than the size of the table.
+   */
+  async *findStoredSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<DeploymentStoredSecrets[]> {
+    let cursor: string | undefined;
+
+    while (true) {
+      const batch = await this.pg
+        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets })
+        .from(this.table)
+        .where(and(isNotNull(this.table.sealedSecrets), ...(cursor ? [gt(this.table.id, cursor)] : [])))
+        .orderBy(asc(this.table.id))
+        .limit(batchSize);
+
+      if (!batch.length) {
+        return;
+      }
+
+      yield batch as DeploymentStoredSecrets[];
 
       if (batch.length < batchSize) {
         return;

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { StoredSecretsFingerprint } from "./stored-secrets-fingerprint";
+
+const FIRST = { id: "11111111-1111-4111-8111-111111111111", sealedSecrets: "aGVhZGVy.a2V5.aXY.Zmlyc3Q.dGFn" };
+const SECOND = { id: "22222222-2222-4222-8222-222222222222", sealedSecrets: "aGVhZGVy.a2V5.aXY.c2Vjb25k.dGFn" };
+const THIRD = { id: "33333333-3333-4333-8333-333333333333", sealedSecrets: "aGVhZGVy.a2V5.aXY.dGhpcmQ.dGFn" };
+
+describe(StoredSecretsFingerprint.name, () => {
+  it("digests the same rows to the same value whatever order they arrive in", () => {
+    const inOrder = setup({ rows: [FIRST, SECOND, THIRD] });
+    const permuted = setup({ rows: [THIRD, FIRST, SECOND] });
+
+    expect(permuted.summary).toEqual(inOrder.summary);
+  });
+
+  it("digests a row whose token changed to a different value", () => {
+    const before = setup({ rows: [FIRST, SECOND] });
+    const after = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: THIRD.sealedSecrets }] });
+
+    expect(after.summary.digest).not.toBe(before.summary.digest);
+  });
+
+  it("digests two rows that swapped tokens with each other to a different value", () => {
+    const before = setup({ rows: [FIRST, SECOND] });
+    const swapped = setup({
+      rows: [
+        { id: FIRST.id, sealedSecrets: SECOND.sealedSecrets },
+        { id: SECOND.id, sealedSecrets: FIRST.sealedSecrets }
+      ]
+    });
+
+    expect(swapped.summary.digest).not.toBe(before.summary.digest);
+    expect(swapped.summary.rowCount).toBe(before.summary.rowCount);
+    expect(swapped.summary.byteCount).toBe(before.summary.byteCount);
+  });
+
+  it("digests a token that moved to a row of another id to a different value", () => {
+    const original = setup({ rows: [FIRST, SECOND] });
+    const reassigned = setup({ rows: [FIRST, { id: THIRD.id, sealedSecrets: SECOND.sealedSecrets }] });
+
+    expect(reassigned.summary.rowCount).toBe(original.summary.rowCount);
+    expect(reassigned.summary.byteCount).toBe(original.summary.byteCount);
+    expect(reassigned.summary.digest).not.toBe(original.summary.digest);
+  });
+
+  it("digests a token moved across the boundary with its row's id to a different value", () => {
+    const asOneId = setup({ rows: [{ id: "ab", sealedSecrets: "cd" }] });
+    const asAnother = setup({ rows: [{ id: "a", sealedSecrets: "bcd" }] });
+
+    expect(asAnother.summary.digest).not.toBe(asOneId.summary.digest);
+  });
+
+  it("digests a row that was removed to a different value", () => {
+    const both = setup({ rows: [FIRST, SECOND] });
+    const one = setup({ rows: [FIRST] });
+
+    expect(one.summary.digest).not.toBe(both.summary.digest);
+  });
+
+  it("reports how many rows hold a token and how many bytes they hold", () => {
+    const { summary } = setup({ rows: [FIRST, SECOND] });
+
+    expect(summary).toMatchObject({
+      rowCount: 2,
+      byteCount: FIRST.sealedSecrets.length + SECOND.sealedSecrets.length
+    });
+  });
+
+  it("counts a token's bytes rather than its characters", () => {
+    const { summary } = setup({ rows: [{ id: FIRST.id, sealedSecrets: "é" }] });
+
+    expect(summary.byteCount).toBe(2);
+  });
+
+  it("summarizes an empty fleet without a token as a digest of its own", () => {
+    const { summary } = setup({ rows: [] });
+
+    expect(summary).toMatchObject({ rowCount: 0, byteCount: 0 });
+    expect(summary.digest).toEqual(expect.any(String));
+    expect(summary.digest).not.toBe(setup({ rows: [FIRST] }).summary.digest);
+  });
+
+  it("summarizes the same fleet the same way across separate runs", () => {
+    expect(setup({ rows: [FIRST, SECOND] }).summary).toEqual(setup({ rows: [FIRST, SECOND] }).summary);
+  });
+
+  function setup(input: { rows: Array<{ id: string; sealedSecrets: string }> }) {
+    const fingerprint = new StoredSecretsFingerprint();
+
+    for (const row of input.rows) {
+      fingerprint.add(row);
+    }
+
+    return { fingerprint, summary: fingerprint.summarize() };
+  }
+});

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -17,13 +17,7 @@ const DIGEST_ALGORITHM = "sha256";
 /** A length fits in four bytes for any token a row can hold, and the framing below needs a fixed-width one. */
 const LENGTH_PREFIX_BYTES = 4;
 
-/**
- * Proof that a run of the key rotation changed no stored secret, taken over the fleet before and
- * after it. Each row is digested under its own id, so a token moved to another deployment shows up
- * as a changed fingerprint rather than as the same one; the per-row digests are combined in id
- * order at the end, so the result is a function of the rows themselves and not of the order a scan
- * happened to yield them in.
- */
+/** Digests each row under its own id and combines the row digests in id order, so the result reflects the rows themselves rather than the order a scan yielded them in. */
 export class StoredSecretsFingerprint {
   readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number }>();
 

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -41,19 +41,15 @@ export class StoredSecretsFingerprint {
     const hash = createHash(DIGEST_ALGORITHM);
     let byteCount = 0;
 
-    for (const [, row] of [...this.#rowDigests].sort(byId)) {
+    for (const id of [...this.#rowDigests.keys()].sort()) {
+      const row = this.#rowDigests.get(id)!;
+
       hash.update(row.digest);
       byteCount += row.byteCount;
     }
 
     return { digest: hash.digest("hex"), rowCount: this.#rowDigests.size, byteCount };
   }
-}
-
-function byId([left]: [string, unknown], [right]: [string, unknown]) {
-  if (left === right) return 0;
-
-  return left < right ? -1 : 1;
 }
 
 /** Without the length, a row's id and its token could be rearranged into another row's pair and digest alike. */

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -1,0 +1,66 @@
+import type { Hash } from "node:crypto";
+import { createHash } from "node:crypto";
+
+export interface StoredSecretsEntry {
+  id: string;
+  sealedSecrets: string;
+}
+
+export interface StoredSecretsSummary {
+  digest: string;
+  rowCount: number;
+  byteCount: number;
+}
+
+const DIGEST_ALGORITHM = "sha256";
+
+/** A length fits in four bytes for any token a row can hold, and the framing below needs a fixed-width one. */
+const LENGTH_PREFIX_BYTES = 4;
+
+/**
+ * Proof that a run of the key rotation changed no stored secret, taken over the fleet before and
+ * after it. Each row is digested under its own id, so a token moved to another deployment shows up
+ * as a changed fingerprint rather than as the same one; the per-row digests are combined in id
+ * order at the end, so the result is a function of the rows themselves and not of the order a scan
+ * happened to yield them in.
+ */
+export class StoredSecretsFingerprint {
+  readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number }>();
+
+  add({ id, sealedSecrets }: StoredSecretsEntry): void {
+    const token = Buffer.from(sealedSecrets, "utf8");
+    const hash = createHash(DIGEST_ALGORITHM);
+
+    appendLengthPrefixed(hash, Buffer.from(id, "utf8"));
+    appendLengthPrefixed(hash, token);
+
+    this.#rowDigests.set(id, { digest: hash.digest(), byteCount: token.length });
+  }
+
+  summarize(): StoredSecretsSummary {
+    const hash = createHash(DIGEST_ALGORITHM);
+    let byteCount = 0;
+
+    for (const [, row] of [...this.#rowDigests].sort(byId)) {
+      hash.update(row.digest);
+      byteCount += row.byteCount;
+    }
+
+    return { digest: hash.digest("hex"), rowCount: this.#rowDigests.size, byteCount };
+  }
+}
+
+function byId([left]: [string, unknown], [right]: [string, unknown]) {
+  if (left === right) return 0;
+
+  return left < right ? -1 : 1;
+}
+
+/** Without the length, a row's id and its token could be rearranged into another row's pair and digest alike. */
+function appendLengthPrefixed(hash: Hash, value: Buffer) {
+  const length = Buffer.alloc(LENGTH_PREFIX_BYTES);
+  length.writeUInt32BE(value.length);
+
+  hash.update(length);
+  hash.update(value);
+}

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
@@ -3,6 +3,7 @@ import { container } from "tsyringe";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { UserRepository } from "@src/user/repositories";
+import type { DataKeyOutput } from "./data-key.repository";
 import { DataKeyRepository } from "./data-key.repository";
 
 describe(DataKeyRepository.name, () => {
@@ -94,6 +95,102 @@ describe(DataKeyRepository.name, () => {
     });
   });
 
+  describe("countByWrappingVersion", () => {
+    it("counts the data keys under each version separately rather than in total", async () => {
+      const { versionOf, seedDataKey, censusOfOwnKey } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(2));
+
+      const census = await censusOfOwnKey();
+
+      expect(census).toEqual([
+        { wrappedByKid: versionOf(1), count: 2 },
+        { wrappedByKid: versionOf(2), count: 1 }
+      ]);
+    });
+
+    it("leaves out a version nothing is wrapped under", async () => {
+      const { versionOf, seedDataKey, censusOfOwnKey } = setup();
+      await seedDataKey(versionOf(1));
+
+      const census = await censusOfOwnKey();
+
+      expect(census.map(entry => entry.wrappedByKid)).not.toContain(versionOf(2));
+    });
+  });
+
+  describe("findWrappedUnderOtherVersionsIteratively", () => {
+    it("yields the rows wrapped under another version and passes over those already at the target", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      const staleFirst = await seedDataKey(versionOf(1));
+      const staleSecond = await seedDataKey(versionOf(1));
+      const alreadyAtTarget = await seedDataKey(versionOf(2));
+
+      const candidates = await findRewrapCandidates(versionOf(2));
+
+      expect(candidates.map(row => row.id).sort()).toEqual([staleFirst.id, staleSecond.id].sort());
+      expect(candidates.map(row => row.id)).not.toContain(alreadyAtTarget.id);
+    });
+
+    it("yields what re-wrapping a row needs to open it and record its new version", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      const stale = await seedDataKey(versionOf(1));
+
+      const candidates = await findRewrapCandidates(versionOf(2));
+
+      expect(candidates).toEqual([
+        expect.objectContaining({ id: stale.id, userId: stale.userId, wrappedKey: stale.wrappedKey, wrappedByKid: versionOf(1) })
+      ]);
+    });
+
+    it("yields nothing once every row is at the target", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      await seedDataKey(versionOf(2));
+      await seedDataKey(versionOf(2));
+
+      expect(await findRewrapCandidates(versionOf(2))).toEqual([]);
+    });
+
+    it("pages every row exactly once when the batch is smaller than the set", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+
+      const oneAtATime = await findRewrapCandidates(versionOf(2), 1);
+      const allAtOnce = await findRewrapCandidates(versionOf(2), 1000);
+
+      expect(allAtOnce).toHaveLength(3);
+      expect(oneAtATime.map(row => row.id)).toEqual(allAtOnce.map(row => row.id));
+    });
+
+    it("yields rows in id order, so a run that stops resumes after the last row it moved", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+
+      const candidates = await findRewrapCandidates(versionOf(2), 2);
+
+      expect(candidates.map(row => row.id)).toEqual([...candidates.map(row => row.id)].sort());
+    });
+
+    it("yields batches no larger than the size asked for", async () => {
+      const { dataKeyRepository, versionOf, seedDataKey } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      const sizes: number[] = [];
+
+      for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: versionOf(2), batchSize: 2 })) {
+        sizes.push(batch.length);
+      }
+
+      expect(Math.max(...sizes)).toBeLessThanOrEqual(2);
+    });
+  });
+
   describe("user deletion", () => {
     it("deletes the data key when its user is deleted", async () => {
       const { dataKeyRepository, userRepository, createTestUser } = setup();
@@ -124,6 +221,7 @@ describe(DataKeyRepository.name, () => {
     const dataKeyRepository = container.resolve(DataKeyRepository);
     const userRepository = container.resolve(UserRepository);
     const createdUserIds: string[] = [];
+    const keyName = faker.string.alphanumeric(10);
 
     cleanup = async () => {
       if (createdUserIds.length > 0) {
@@ -137,6 +235,36 @@ describe(DataKeyRepository.name, () => {
       return user;
     }
 
-    return { dataKeyRepository, userRepository, createTestUser };
+    function versionOf(version: number) {
+      return `${keyName}.v${version}`;
+    }
+
+    async function seedDataKey(wrappedByKid: string) {
+      const user = await createTestUser();
+
+      return await dataKeyRepository.create({ userId: user.id, wrappedKey: wrappedKeyBlob(), wrappedByKid });
+    }
+
+    function isOwnKey(wrappedByKid: string) {
+      return wrappedByKid.startsWith(`${keyName}.`);
+    }
+
+    async function censusOfOwnKey() {
+      const census = await dataKeyRepository.countByWrappingVersion();
+
+      return census.filter(entry => isOwnKey(entry.wrappedByKid));
+    }
+
+    async function findRewrapCandidates(targetKid: string, batchSize = 1000) {
+      const candidates: DataKeyOutput[] = [];
+
+      for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid, batchSize })) {
+        candidates.push(...batch.filter(row => isOwnKey(row.wrappedByKid)));
+      }
+
+      return candidates;
+    }
+
+    return { dataKeyRepository, userRepository, createTestUser, versionOf, seedDataKey, censusOfOwnKey, findRewrapCandidates };
   }
 });

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
@@ -121,6 +121,14 @@ describe(DataKeyRepository.name, () => {
   });
 
   describe("findWrappedUnderOtherVersionsIteratively", () => {
+    it("refuses a batch size of zero, which would read as a fleet needing no work", async () => {
+      const { dataKeyRepository, versionOf } = setup();
+
+      await expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: versionOf(2), batchSize: 0 }).next()).rejects.toThrow(
+        "Batch size must be a positive integer"
+      );
+    });
+
     it("yields the rows wrapped under another version and passes over those already at the target", async () => {
       const { versionOf, seedDataKey, findRewrapCandidates } = setup();
       const staleFirst = await seedDataKey(versionOf(1));

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -68,11 +68,7 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
       .orderBy(asc(this.table.wrappedByKid));
   }
 
-  /**
-   * Keyset-paged on `id`, and filtered on the version rather than on a progress marker, so a
-   * re-wrap that stopped halfway resumes by selection alone: a row it already moved no longer
-   * matches. Read outside any transaction, because the caller commits each batch in one of its own.
-   */
+  /** Filters on the version rather than a progress marker so an interrupted run resumes by selection alone; ids are random uuids, so one pass may skip a row inserted mid-scan and only the destroy-time count vouches for completeness. */
   async *findWrappedUnderOtherVersionsIteratively({
     targetKid,
     batchSize

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -1,6 +1,7 @@
 import { and, asc, gt, ne, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
+import { assertBatchSize } from "@src/core/lib/batch-size/batch-size";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
@@ -76,6 +77,8 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
     targetKid: DataKeyOutput["wrappedByKid"];
     batchSize: number;
   }): AsyncGenerator<DataKeyOutput[]> {
+    assertBatchSize(batchSize);
+
     let cursor: DataKeyOutput["id"] | undefined;
 
     while (true) {

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -1,3 +1,4 @@
+import { and, asc, gt, ne, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -7,6 +8,12 @@ import { TxService } from "@src/core/services";
 type Table = ApiPgTables["DataKeys"];
 export type DataKeyInput = Table["$inferInsert"];
 export type DataKeyOutput = Table["$inferSelect"];
+
+/** How many data keys one KMS key version still holds, which is what gates destroying that version. */
+export type DataKeyWrappingCount = {
+  wrappedByKid: DataKeyOutput["wrappedByKid"];
+  count: number;
+};
 
 @singleton()
 export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataKeyOutput> {
@@ -50,5 +57,50 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
   /** Answers whether a KMS key version may still be destroyed without making stored data keys unrecoverable. */
   async countWrappedUnder(wrappedByKid: DataKeyOutput["wrappedByKid"]): Promise<number> {
     return this.count({ wrappedByKid });
+  }
+
+  /** The same question asked of every version at once, so a rotation can report which versions are still in use without knowing what to ask about. */
+  async countByWrappingVersion(): Promise<DataKeyWrappingCount[]> {
+    return await this.cursor
+      .select({ wrappedByKid: this.table.wrappedByKid, count: sql<number>`count(*)::int` })
+      .from(this.table)
+      .groupBy(this.table.wrappedByKid)
+      .orderBy(asc(this.table.wrappedByKid));
+  }
+
+  /**
+   * Keyset-paged on `id`, and filtered on the version rather than on a progress marker, so a
+   * re-wrap that stopped halfway resumes by selection alone: a row it already moved no longer
+   * matches. Read outside any transaction, because the caller commits each batch in one of its own.
+   */
+  async *findWrappedUnderOtherVersionsIteratively({
+    targetKid,
+    batchSize
+  }: {
+    targetKid: DataKeyOutput["wrappedByKid"];
+    batchSize: number;
+  }): AsyncGenerator<DataKeyOutput[]> {
+    let cursor: DataKeyOutput["id"] | undefined;
+
+    while (true) {
+      const batch = await this.pg
+        .select()
+        .from(this.table)
+        .where(and(ne(this.table.wrappedByKid, targetKid), ...(cursor ? [gt(this.table.id, cursor)] : [])))
+        .orderBy(asc(this.table.id))
+        .limit(batchSize);
+
+      if (!batch.length) {
+        return;
+      }
+
+      yield this.toOutputList(batch);
+
+      if (batch.length < batchSize) {
+        return;
+      }
+
+      cursor = batch[batch.length - 1].id;
+    }
   }
 }


### PR DESCRIPTION
## Why

Rotating the KMS key means re-wrapping every user's data encryption key onto a new key version. Before that can write anything, it has to be able to answer three questions from the database alone — which versions are still in use, which rows still need moving, and what every stored secret looked like before the run started.

This slice ships those three reads and the fingerprint that proves the run changed no stored secret. No KMS call, no command, no schema change.

Part of CON-875 — slice 1 of 3, stacked on `fix/user-open-wraps-seals-under-key-2`. Slice 2 adds the `rewrap-data-keys` CLI command and the KMS re-wrap; slice 3 adds the integration proof against the key emulator.

## What

**`StoredSecretsFingerprint`** — digests each deployment's sealed secrets token *under its own row id*, keeps only the per-row digests, and combines them in id order at the end. The digest is therefore a function of which token sits on which row, not of the order a scan returned them in. Only a uuid and 32 bytes are held per row, never the tokens.

**`DataKeyRepository.countByWrappingVersion()`** — the census. Answers "is anything still wrapped under version N" for every version at once, from the denormalised `wrapped_by_kid` column, so the question gating an irreversible key-version disable needs no row parsed.

**`DataKeyRepository.findWrappedUnderOtherVersionsIteratively()`** — keyset-paged on `id` and filtered on the target version rather than on a progress marker, so a run that stops halfway resumes by selection alone: a row it already moved no longer matches. No progress table.

**`DeploymentSettingRepository.findStoredSecretsIteratively()`** — keyset-paged scan of rows holding a token. Rows with `sealed_secrets IS NULL` are left out, so the row count and byte total describe the deployments that carry a secret rather than the size of the table.

### How a rotation will use them

```ts
const census = await dataKeyRepository.countByWrappingVersion();
// [{ wrappedByKid: "sdl-secrets.v1", count: 3 }, { wrappedByKid: "sdl-secrets.v2", count: 2 }]

const fingerprint = new StoredSecretsFingerprint();
for await (const batch of deploymentSettingRepository.findStoredSecretsIteratively({ batchSize: 100 })) {
  for (const row of batch) fingerprint.add(row);
}
fingerprint.summarize();
// { digest: "846c02477f8c6a01…", rowCount: 3, byteCount: 201 }

for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: "sdl-secrets.v2", batchSize: 100 })) {
  // only rows not yet at the target, in id order — re-wrap and commit the batch
}
```

Both generators read through `this.pg` rather than the transaction cursor, so the scan never joins the per-batch transaction slice 2 opens — that is what keeps each batch a real commit boundary.

### How it is pinned

Every design decision has an assertion that fails without it, checked by mutation:

| remove this | this test fails |
| --- | --- |
| the row id from the per-row digest | `digests a token that moved to a row of another id…` |
| the length framing between id and token | `digests a token moved across the boundary…` |
| the id sort in `summarize()` | `digests the same rows to the same value whatever order…` |
| `ne(wrappedByKid, target)` | 2 data-key integration tests |
| `isNotNull(sealedSecrets)` | `passes over a deployment holding no token` |
| `orderBy(asc(id))` | 2 deployment-setting integration tests |

Worth noting: the swap case the spec asks for passed *without* the id in the digest — an id-ordered combination already catches a straight swap. The case that actually discriminates is a token reassigned to a different row id, where row count and byte total are both unchanged and only the digest can move. That test was added after the mutation check exposed the gap.

### Reviewer notes

- `batchSize <= 0` is an unenforced precondition on both generators — `LIMIT 0` yields nothing, which would read as "fully rotated". Slice 2 validates the CLI option with zod before it reaches here; raised as non-blocking in review.
- AC6's hard-failure-on-mismatch half has no test yet — the fingerprint's algebra is covered here, the command that fails on a mismatch arrives in slices 2 and 3.

## Demo

### CON-875 slice 1 — fingerprinting stored secrets and paging data keys by wrapping version

*2026-09-11T08:06:24Z by Showboat 0.6.1*
<!-- showboat-id: 76d8ce68-1311-4138-9020-b9ef8d79d725 -->

Slice 1 of the KMS key rotation command ships no command yet — it ships the reads the rotation runs before it writes anything, and the proof it will use that it changed no stored secret.

Three things become possible here:

- **the census** — `countByWrappingVersion()` answers "is anything still wrapped under version N" for every version at once, which is the gate on disabling an old KMS key version;
- **the batched selection** — `findWrappedUnderOtherVersionsIteratively()` selects on the version rather than on a progress marker, so a run that stops halfway resumes by selection alone;
- **the fingerprint** — `StoredSecretsFingerprint` digests every deployment's sealed secrets token under its own row id, so a rotation can prove before and after that it moved none of them.

First the fingerprint on its own, with no database in the way. Three deployments hold a sealed secrets token. What a rotation needs is a digest that depends on *which token sits on which row* — not on the order a scan happened to return them in, and not merely on how many bytes there are in total.

```bash
cd "$(git rev-parse --show-toplevel)"
cat > apps/api/src/secret/lib/stored-secrets-fingerprint/slice-1-demo.ts <<'TS'
import { StoredSecretsFingerprint } from "./stored-secrets-fingerprint";

const ALPHA = { id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", sealedSecrets: "eyJhbGciOiJkaXIifQ..YWxwaGEtaXY.YWxwaGEtY2lwaGVydGV4dA.YWxwaGEtdGFn" };
const GAMMA = { id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc", sealedSecrets: "eyJhbGciOiJkaXIifQ..Z2FtbWEtaXY.Z2FtbWEtY2lwaGVydGV4dA.Z2FtbWEtdGFn" };
const DELTA = { id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd", sealedSecrets: "eyJhbGciOiJkaXIifQ..ZGVsdGEtaXY.ZGVsdGEtY2lwaGVydGV4dA.ZGVsdGEtdGFn" };

function report(label: string, rows: Array<{ id: string; sealedSecrets: string }>) {
  const accumulator = new StoredSecretsFingerprint();
  rows.forEach(row => accumulator.add(row));
  const { digest, rowCount, byteCount } = accumulator.summarize();
  console.log(`${label.padEnd(34)} rows ${rowCount}  bytes ${byteCount}  digest ${digest.slice(0, 24)}…`);

  return digest;
}

const inScanOrder = report("scanned in id order", [ALPHA, GAMMA, DELTA]);
const permuted = report("scanned in another order", [DELTA, ALPHA, GAMMA]);
console.log(`same fleet, same digest: ${inScanOrder === permuted}\n`);

const reassigned = report("same tokens, one on a new row", [ALPHA, GAMMA, { id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee", sealedSecrets: DELTA.sealedSecrets }]);
console.log(`rows and bytes are identical, digest differs: ${reassigned !== inScanOrder}\n`);

const swapped = report("two rows swapped tokens", [{ ...ALPHA, sealedSecrets: GAMMA.sealedSecrets }, { ...GAMMA, sealedSecrets: ALPHA.sealedSecrets }, DELTA]);
console.log(`rows and bytes are identical, digest differs: ${swapped !== inScanOrder}`);
TS
node_modules/.bin/tsx apps/api/src/secret/lib/stored-secrets-fingerprint/slice-1-demo.ts
rm -f apps/api/src/secret/lib/stored-secrets-fingerprint/slice-1-demo.ts

```

```output
scanned in id order                rows 3  bytes 201  digest 846c02477f8c6a0166b898f0…
scanned in another order           rows 3  bytes 201  digest 846c02477f8c6a0166b898f0…
same fleet, same digest: true

same tokens, one on a new row      rows 3  bytes 201  digest fa286096da26802e347d3f11…
rows and bytes are identical, digest differs: true

two rows swapped tokens            rows 3  bytes 201  digest c5e58857c489cbbc1c6ad32b…
rows and bytes are identical, digest differs: true
```

The last two rows of that output are the point. In both, the row count and the byte total are exactly what they were — a rotation reporting only counts would call them unchanged. The digest says otherwise, because each token is hashed under the id it belongs to.

Now the same thing against a real Postgres, through the repository read paths this slice adds. The script below seeds five data keys across two KMS key versions and four deployments, three of which carry a token, then walks the whole procedure: census, batched selection, fingerprint, a stand-in for the re-wrap, and the census and fingerprint again.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
cat > src/secret/repositories/data-key/slice-1-demo.integration.ts <<'TS'
import { writeFileSync } from "node:fs";
import { container } from "tsyringe";
import { describe, it } from "vitest";

import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
import { StoredSecretsFingerprint } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
import { UserRepository } from "@src/user/repositories";

const OUT = process.env.DEMO_OUT!;
const lines: string[] = [];
const say = (line = "") => lines.push(line);
const short = (id: string) => id.slice(0, 8);

const DATA_KEYS = [
  { id: "11111111-1111-4111-8111-111111111111", wrappedByKid: "sdl-secrets.v1" },
  { id: "22222222-2222-4222-8222-222222222222", wrappedByKid: "sdl-secrets.v1" },
  { id: "33333333-3333-4333-8333-333333333333", wrappedByKid: "sdl-secrets.v1" },
  { id: "44444444-4444-4444-8444-444444444444", wrappedByKid: "sdl-secrets.v2" },
  { id: "55555555-5555-4555-8555-555555555555", wrappedByKid: "sdl-secrets.v2" }
];

const DEPLOYMENTS = [
  { id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", sealedSecrets: "eyJhbGciOiJkaXIifQ..YWxwaGEtaXY.YWxwaGEtY2lwaGVydGV4dA.YWxwaGEtdGFn" },
  { id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", sealedSecrets: null },
  { id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc", sealedSecrets: "eyJhbGciOiJkaXIifQ..Z2FtbWEtaXY.Z2FtbWEtY2lwaGVydGV4dA.Z2FtbWEtdGFn" },
  { id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd", sealedSecrets: "eyJhbGciOiJkaXIifQ..ZGVsdGEtaXY.ZGVsdGEtY2lwaGVydGV4dA.ZGVsdGEtdGFn" }
];

const TARGET = "sdl-secrets.v2";

describe("data key re-wrap read paths", () => {
  it("shows the census, the batched selection and the fingerprint", async () => {
    const dataKeyRepository = container.resolve(DataKeyRepository);
    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
    const userRepository = container.resolve(UserRepository);

    for (const [index, dataKey] of DATA_KEYS.entries()) {
      const user = await userRepository.create({ id: `00000000-0000-4000-8000-00000000000${index + 1}` });
      await dataKeyRepository.create({ ...dataKey, userId: user.id, wrappedKey: `wrapped-under-${dataKey.wrappedByKid}` });
    }

    const owner = await userRepository.create({ id: "00000000-0000-4000-8000-000000000009" });
    for (const [index, deployment] of DEPLOYMENTS.entries()) {
      await deploymentSettingRepository.create({ ...deployment, userId: owner.id, dseq: `${900000 + index}`, autoTopUpEnabled: true });
    }

    say(`Seeded 5 data keys across 2 wrapping versions, and 4 deployments of which 3 carry a sealed secrets token.`);
    say();

    say(`$ census — countByWrappingVersion()`);
    for (const entry of await dataKeyRepository.countByWrappingVersion()) {
      say(`    ${entry.wrappedByKid}   ${entry.count} data keys`);
    }
    say();

    say(`$ rows a rotation onto ${TARGET} would move — findWrappedUnderOtherVersionsIteratively(batchSize: 2)`);
    for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: TARGET, batchSize: 2 })) {
      say(`    batch of ${batch.length}: ${batch.map(row => `${short(row.id)} (${row.wrappedByKid})`).join("  ")}`);
    }
    say(`    the 2 rows already at ${TARGET} are never selected`);
    say();

    const before = await fingerprint(deploymentSettingRepository, say);

    say();
    say(`-- standing in for the re-wrap slice 2 performs: rewrite wrapped_key and wrapped_by_kid only --`);
    for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: TARGET, batchSize: 2 })) {
      for (const row of batch) {
        await dataKeyRepository.updateById(row.id, { wrappedKey: `wrapped-under-${TARGET}`, wrappedByKid: TARGET });
      }
    }
    say();

    say(`$ census — countByWrappingVersion()`);
    for (const entry of await dataKeyRepository.countByWrappingVersion()) {
      say(`    ${entry.wrappedByKid}   ${entry.count} data keys`);
    }
    say(`    nothing is wrapped under sdl-secrets.v1 any more, so that version can be disabled`);
    say();

    const secondRun = [];
    for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: TARGET, batchSize: 2 })) {
      secondRun.push(...batch);
    }
    say(`$ selecting again after the re-wrap: ${secondRun.length} rows — a second run is a no-op`);
    say();

    const after = await fingerprint(deploymentSettingRepository, say);
    say();
    say(`fingerprint before: ${before.digest}`);
    say(`fingerprint after:  ${after.digest}`);
    say(`identical: ${before.digest === after.digest} — no stored secret was touched`);
    say();

    say(`-- now change one character of one deployment's token, as a stray re-seal would --`);
    await deploymentSettingRepository.updateById(DEPLOYMENTS[2].id, { sealedSecrets: "eyJhbGciOiJkaXIifQ..Z2FtbWEtaXY.Z2FtbWEtY2lwaGVydGV4dA.Z2FtbWEtdGFv" });
    const tampered = await fingerprint(deploymentSettingRepository, say);
    say();
    say(`rows and bytes:     ${tampered.rowCount === before.rowCount && tampered.byteCount === before.byteCount ? "unchanged" : "changed"} — neither count can see a one-character edit`);
    say(`fingerprint now:    ${tampered.digest}`);
    say(`matches before:     ${tampered.digest === before.digest} — the run would fail hard here`);

    writeFileSync(OUT, `${lines.join("\n")}\n`);
  });
});

async function fingerprint(deploymentSettingRepository: DeploymentSettingRepository, say: (line?: string) => void) {
  const accumulator = new StoredSecretsFingerprint();

  say(`$ stored secrets scan — findStoredSecretsIteratively(batchSize: 2)`);
  for await (const batch of deploymentSettingRepository.findStoredSecretsIteratively({ batchSize: 2 })) {
    say(`    batch of ${batch.length}: ${batch.map(row => `${short(row.id)} (${row.sealedSecrets.length} bytes)`).join("  ")}`);
    for (const row of batch) {
      accumulator.add(row);
    }
  }

  const summary = accumulator.summarize();
  say(`    bbbbbbbb holds no token and is left out`);
  say(`    rows ${summary.rowCount}, bytes ${summary.byteCount}, digest ${summary.digest.slice(0, 16)}…`);

  return summary;
}
TS
DEMO_OUT=/tmp/slice-1-demo.txt LOG_LEVEL=info npx vitest run --project=integration src/secret/repositories/data-key/slice-1-demo.integration.ts > /tmp/slice-1-demo.log 2>&1
status=$?
rm -f src/secret/repositories/data-key/slice-1-demo.integration.ts
if [ $status -ne 0 ]; then tail -30 /tmp/slice-1-demo.log; exit $status; fi
cat /tmp/slice-1-demo.txt

```

```output
Seeded 5 data keys across 2 wrapping versions, and 4 deployments of which 3 carry a sealed secrets token.

$ census — countByWrappingVersion()
    sdl-secrets.v1   3 data keys
    sdl-secrets.v2   2 data keys

$ rows a rotation onto sdl-secrets.v2 would move — findWrappedUnderOtherVersionsIteratively(batchSize: 2)
    batch of 2: 11111111 (sdl-secrets.v1)  22222222 (sdl-secrets.v1)
    batch of 1: 33333333 (sdl-secrets.v1)
    the 2 rows already at sdl-secrets.v2 are never selected

$ stored secrets scan — findStoredSecretsIteratively(batchSize: 2)
    batch of 2: aaaaaaaa (67 bytes)  cccccccc (67 bytes)
    batch of 1: dddddddd (67 bytes)
    bbbbbbbb holds no token and is left out
    rows 3, bytes 201, digest 846c02477f8c6a01…

-- standing in for the re-wrap slice 2 performs: rewrite wrapped_key and wrapped_by_kid only --

$ census — countByWrappingVersion()
    sdl-secrets.v2   5 data keys
    nothing is wrapped under sdl-secrets.v1 any more, so that version can be disabled

$ selecting again after the re-wrap: 0 rows — a second run is a no-op

$ stored secrets scan — findStoredSecretsIteratively(batchSize: 2)
    batch of 2: aaaaaaaa (67 bytes)  cccccccc (67 bytes)
    batch of 1: dddddddd (67 bytes)
    bbbbbbbb holds no token and is left out
    rows 3, bytes 201, digest 846c02477f8c6a01…

fingerprint before: 846c02477f8c6a0166b898f03033c2f8a00fba8a736c9e595ab4b31f45855a7d
fingerprint after:  846c02477f8c6a0166b898f03033c2f8a00fba8a736c9e595ab4b31f45855a7d
identical: true — no stored secret was touched

-- now change one character of one deployment's token, as a stray re-seal would --
$ stored secrets scan — findStoredSecretsIteratively(batchSize: 2)
    batch of 2: aaaaaaaa (67 bytes)  cccccccc (67 bytes)
    batch of 1: dddddddd (67 bytes)
    bbbbbbbb holds no token and is left out
    rows 3, bytes 201, digest fa575f3d38def9af…

rows and bytes:     unchanged — neither count can see a one-character edit
fingerprint now:    fa575f3d38def9af8e0a62d3c5fdfbb81373d20682e1463eb56383145f393a1f
matches before:     false — the run would fail hard here
```

Reading that from the top:

- **the census** names each wrapping version separately, not a total. After the re-wrap it reports one version holding all five keys, which is the answer an operator needs before disabling `sdl-secrets.v1`.
- **the selection skips what is already done.** Two of the five rows were at the target and were never yielded; running it again after the re-wrap yields nothing at all, so a second run costs no KMS call. That is what makes an interrupted run resumable without a progress table.
- **the scan leaves out `bbbbbbbb`**, the deployment holding no token, so the row count and byte total describe the deployments that actually carry a secret rather than the size of the table.
- **the fingerprint is identical across the re-wrap** — the same digest, `846c02477f8c6a01…`, that the pure-TypeScript run above produced from the same three tokens. Re-wrapping a data key is invisible to every stored token, and this is how the rotation will prove it rather than argue it.
- **one character of one token breaks it.** Row count 3 and byte total 201 are unchanged; the digest is not. That mismatch is what will fail the command hard.

No KMS call happens anywhere above: every one of these reads is database-only, which is what lets the dry run report the full picture while writing nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for resolving encryption key versions from sealed-secret metadata.
  - Secrets can now be unsealed using older enabled key versions during key rotation.
  - Added clear handling for unknown, disabled, destroyed, or otherwise unavailable key versions.
  - Added deterministic fingerprints and summary metadata for stored secrets.

- **Bug Fixes**
  - Sealed-secret operations now report the key identifier associated with the actual seal, improving diagnostics during key rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->