### PR TITLE
feat(deployment): re-wrap data keys onto a new kms key version from the console cli

### DIFF
--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -14,6 +14,7 @@ import { ExecutionContextService } from "@src/core/services/execution-context/ex
 import { TopUpDeploymentsController } from "@src/deployment/controllers/deployment/top-up-deployments.controller";
 import { GpuBotController } from "@src/deployment/controllers/gpu-bot/gpu-bot.controller";
 import { ProviderController } from "@src/provider/controllers/provider/provider.controller";
+import { DataKeyRewrapController } from "@src/secret/controllers/data-key-rewrap/data-key-rewrap.controller";
 import { WorkloadAbuseController } from "@src/workload-abuse/controllers/workload-abuse.controller";
 import { APP_INITIALIZER, ON_APP_START } from "../core/providers/app-initializer";
 
@@ -119,6 +120,18 @@ program
   .action(async (options, command) => {
     await executeCliHandler(command.name(), async () => {
       await container.resolve(GpuBotController).createGpuBids();
+    });
+  });
+
+program
+  .command("rewrap-data-keys")
+  .description("Re-wrap every user's data key onto a KMS key version, so the versions it leaves behind can be disabled")
+  .requiredOption("-t, --target-version <string>", "KMS key version every data key is wrapped under", value => z.string().min(1).parse(value))
+  .option("-b, --batch-size <number>", "How many data keys are re-wrapped per transaction", value => z.number({ coerce: true }).int().positive().parse(value))
+  .option("-d, --dry-run", "Report the census and what would be re-wrapped without writing anything", false)
+  .action(async (options, command) => {
+    await executeCliHandler(command.name(), async () => {
+      return container.resolve(DataKeyRewrapController).rewrapDataKeys(options);
     });
   });
 

--- a/apps/api/src/core/lib/batch-size/batch-size.spec.ts
+++ b/apps/api/src/core/lib/batch-size/batch-size.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { assertBatchSize } from "./batch-size";
+
+describe(assertBatchSize.name, () => {
+  it("returns a positive integer unchanged", () => {
+    expect(assertBatchSize(1)).toBe(1);
+    expect(assertBatchSize(100)).toBe(100);
+  });
+
+  it.each([0, -1, 1.5, NaN, Infinity])("refuses %s rather than handing it to a query", value => {
+    expect(() => assertBatchSize(value)).toThrow(`Batch size must be a positive integer, got ${value}`);
+  });
+});

--- a/apps/api/src/core/lib/batch-size/batch-size.ts
+++ b/apps/api/src/core/lib/batch-size/batch-size.ts
@@ -1,0 +1,8 @@
+/** `LIMIT 0` reads as an empty fleet and ends a keyset scan silently, so a batch size is refused loudly before any query runs. */
+export function assertBatchSize(batchSize: number): number {
+  if (!Number.isInteger(batchSize) || batchSize < 1) {
+    throw new Error(`Batch size must be a positive integer, got ${batchSize}`);
+  }
+
+  return batchSize;
+}

--- a/apps/api/src/deployment/providers/kms.provider.spec.ts
+++ b/apps/api/src/deployment/providers/kms.provider.spec.ts
@@ -5,7 +5,8 @@ import { mock } from "vitest-mock-extended";
 
 import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { SdlSecretsKmsClient } from "./kms.provider";
-import { createSdlSecretsKmsTarget, KMS_CLIENT, SDL_SECRETS_KMS_TARGET } from "./kms.provider";
+import type { SdlSecretsKmsTargetFactory } from "./kms.provider";
+import { createSdlSecretsKmsTarget, KMS_CLIENT, SDL_SECRETS_KMS_TARGET, SDL_SECRETS_KMS_TARGET_FACTORY } from "./kms.provider";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
@@ -119,5 +120,51 @@ describe("SDL_SECRETS_KMS_TARGET", () => {
     });
 
     return { target: testContainer.resolve(SDL_SECRETS_KMS_TARGET), kmsClient };
+  }
+});
+
+describe("SDL_SECRETS_KMS_TARGET_FACTORY", () => {
+  it("targets a version the configuration does not name, which is what a rotation needs", () => {
+    const { createTarget } = setup({ version: "2" });
+
+    const target = createTarget("7");
+
+    expect(target.kid).toBe("sdl-secrets.v7");
+    expect(target.versionName).toBe("console-test/global/console-api/sdl-secrets/7");
+  });
+
+  it("resolves any version of the same key from a target built for another one", () => {
+    const { createTarget } = setup({ version: "2" });
+
+    expect(createTarget("7").resolveVersionName("sdl-secrets.v1")).toBe("console-test/global/console-api/sdl-secrets/1");
+  });
+
+  it("builds the configured write target from the same factory", () => {
+    const { createTarget, configuredTarget } = setup({ version: "2" });
+
+    expect(configuredTarget.kid).toBe(createTarget("2").kid);
+    expect(configuredTarget.versionName).toBe(createTarget("2").versionName);
+  });
+
+  function setup(input: { version: string }) {
+    const kmsClient = mock<KeyManagementServiceClient>();
+    kmsClient.cryptoKeyVersionPath.mockImplementation((project, location, keyRing, key, version) => [project, location, keyRing, key, version].join("/"));
+
+    const testContainer = container.createChildContainer();
+    testContainer.register(KMS_CLIENT, { useValue: kmsClient });
+    testContainer.register(DeploymentConfigService, {
+      useValue: mockConfigService<DeploymentConfigService>({
+        GCP_KMS_AUTH: { project_id: "console-test", servicePath: "http://localhost:9090" },
+        GCP_KMS_LOCATION: "global",
+        GCP_KMS_KEY_RING: "console-api",
+        GCP_KMS_KEY: "sdl-secrets",
+        GCP_KMS_KEY_VERSION: input.version
+      })
+    });
+
+    return {
+      createTarget: testContainer.resolve<SdlSecretsKmsTargetFactory>(SDL_SECRETS_KMS_TARGET_FACTORY),
+      configuredTarget: testContainer.resolve(SDL_SECRETS_KMS_TARGET)
+    };
   }
 });

--- a/apps/api/src/deployment/providers/kms.provider.ts
+++ b/apps/api/src/deployment/providers/kms.provider.ts
@@ -13,6 +13,8 @@ const CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 /** The Cloud KMS operations the console performs on the SDL secrets key, narrowed so they can be doubled in tests. */
 export interface SdlSecretsKmsClient {
   getPublicKey(request: { name: string }, options?: CallOptions): Promise<[protos.google.cloud.kms.v1.IPublicKey, ...unknown[]]>;
+  /** Only this reports a version's state: Cloud KMS refuses a disabled version's public key, but the emulator serves it. */
+  getCryptoKeyVersion(request: { name: string }, options?: CallOptions): Promise<[protos.google.cloud.kms.v1.ICryptoKeyVersion, ...unknown[]]>;
   asymmetricDecrypt(request: {
     name: string;
     ciphertext: Buffer;
@@ -63,7 +65,12 @@ export function createSdlSecretsKmsTarget(input: {
   };
 }
 
+/** A target for any version of the console's crypto key, so a rotation can address one the configuration does not name. */
+export type SdlSecretsKmsTargetFactory = (version: string) => SdlSecretsKmsTarget;
+
 export const KMS_CLIENT: InjectionToken<KeyManagementServiceClient> = Symbol("KMS_CLIENT");
+
+export const SDL_SECRETS_KMS_TARGET_FACTORY: InjectionToken<SdlSecretsKmsTargetFactory> = Symbol("SDL_SECRETS_KMS_TARGET_FACTORY");
 
 export const SDL_SECRETS_KMS_TARGET: InjectionToken<SdlSecretsKmsTarget> = Symbol("SDL_SECRETS_KMS_TARGET");
 
@@ -94,18 +101,23 @@ container.register(KMS_CLIENT, {
   })
 });
 
-container.register(SDL_SECRETS_KMS_TARGET, {
+container.register(SDL_SECRETS_KMS_TARGET_FACTORY, {
   useFactory: instancePerContainerCachingFactory(c => {
     const config = c.resolve(DeploymentConfigService);
     const auth = config.get("GCP_KMS_AUTH");
     const client = c.resolve<KeyManagementServiceClient>(KMS_CLIENT);
     const key = config.get("GCP_KMS_KEY");
+    const versionPath = (version: string) =>
+      client.cryptoKeyVersionPath(auth.project_id, config.get("GCP_KMS_LOCATION"), config.get("GCP_KMS_KEY_RING"), key, version);
 
-    return createSdlSecretsKmsTarget({
-      client,
-      versionPath: version => client.cryptoKeyVersionPath(auth.project_id, config.get("GCP_KMS_LOCATION"), config.get("GCP_KMS_KEY_RING"), key, version),
-      key,
-      version: config.get("GCP_KMS_KEY_VERSION")
-    });
+    const createTarget: SdlSecretsKmsTargetFactory = version => createSdlSecretsKmsTarget({ client, versionPath, key, version });
+
+    return createTarget;
   })
+});
+
+container.register(SDL_SECRETS_KMS_TARGET, {
+  useFactory: instancePerContainerCachingFactory(c =>
+    c.resolve<SdlSecretsKmsTargetFactory>(SDL_SECRETS_KMS_TARGET_FACTORY)(c.resolve(DeploymentConfigService).get("GCP_KMS_KEY_VERSION"))
+  )
 });

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -886,7 +886,7 @@ describe(DeploymentSettingRepository.name, () => {
 
       const stored = await findStoredSecrets([id]);
 
-      expect(stored).toEqual([{ id, sealedSecrets: sealedToken }]);
+      expect(stored).toEqual([{ id, sealedSecrets: sealedToken, updatedAt: expect.any(Date) }]);
     });
 
     it("passes over a deployment holding no token, which no fingerprint has anything to say about", async () => {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -871,6 +871,69 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("findStoredSecretsIteratively", () => {
+    it("yields a deployment's token under the id that holds it", async () => {
+      const { sealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const id = await createSettingWithSecrets(sealedToken);
+
+      const stored = await findStoredSecrets([id]);
+
+      expect(stored).toEqual([{ id, sealedSecrets: sealedToken }]);
+    });
+
+    it("passes over a deployment holding no token, which no fingerprint has anything to say about", async () => {
+      const { sealedToken, createSetting, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const withoutSecrets = await createSetting();
+      const withSecrets = await createSettingWithSecrets(sealedToken);
+
+      const stored = await findStoredSecrets([withoutSecrets, withSecrets]);
+
+      expect(stored.map(row => row.id)).toEqual([withSecrets]);
+    });
+
+    it("pages every token-holding deployment exactly once when the batch is smaller than the set", async () => {
+      const { sealedToken, otherSealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const ids = [
+        await createSettingWithSecrets(sealedToken),
+        await createSettingWithSecrets(otherSealedToken),
+        await createSettingWithSecrets(sealedToken)
+      ];
+
+      const oneAtATime = await findStoredSecrets(ids, 1);
+      const allAtOnce = await findStoredSecrets(ids, 1000);
+
+      expect(allAtOnce).toHaveLength(3);
+      expect(oneAtATime).toEqual(allAtOnce);
+    });
+
+    it("yields rows in id order, so each batch stays an index scan on the primary key", async () => {
+      const { sealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const ids = [
+        await createSettingWithSecrets(sealedToken),
+        await createSettingWithSecrets(sealedToken),
+        await createSettingWithSecrets(sealedToken)
+      ];
+
+      const stored = await findStoredSecrets(ids, 2);
+
+      expect(stored.map(row => row.id)).toEqual([...ids].sort());
+    });
+
+    it("yields batches no larger than the size asked for", async () => {
+      const { sealedToken, deploymentSettingRepository, createSettingWithSecrets } = await setup();
+      await createSettingWithSecrets(sealedToken);
+      await createSettingWithSecrets(sealedToken);
+      await createSettingWithSecrets(sealedToken);
+      const sizes: number[] = [];
+
+      for await (const batch of deploymentSettingRepository.findStoredSecretsIteratively({ batchSize: 2 })) {
+        sizes.push(batch.length);
+      }
+
+      expect(Math.max(...sizes)).toBeLessThanOrEqual(2);
+    });
+  });
+
   describe("createDefaultIfMissing", () => {
     it("records a deployment nothing had recorded yet, with funding on", async () => {
       const { deploymentSettingRepository, user } = await setup();
@@ -1352,6 +1415,22 @@ describe(DeploymentSettingRepository.name, () => {
       return setting.id;
     }
 
+    async function createSettingWithSecrets(sealedSecrets: string) {
+      const setting = await deploymentSettingRepository.create({ userId: user.id, dseq: newDseq(), autoTopUpEnabled: true, sealedSecrets });
+
+      return setting.id;
+    }
+
+    async function findStoredSecrets(ids: string[], batchSize = 1000) {
+      const stored = [];
+
+      for await (const batch of deploymentSettingRepository.findStoredSecretsIteratively({ batchSize })) {
+        stored.push(...batch.filter(row => ids.includes(row.id)));
+      }
+
+      return stored;
+    }
+
     async function findOpenDeployments(addresses?: string[], batchSize = 1000) {
       const open = [];
 
@@ -1438,6 +1517,8 @@ describe(DeploymentSettingRepository.name, () => {
       readDefinition,
       readSettingDseq,
       createSetting,
+      createSettingWithSecrets,
+      findStoredSecrets,
       createLimitedSetting,
       createAnchoredSetting,
       findAutoTopUpOwners,

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -872,6 +872,14 @@ describe(DeploymentSettingRepository.name, () => {
   });
 
   describe("findStoredSecretsIteratively", () => {
+    it("refuses a batch size of zero, which would read as a fleet holding no secrets", async () => {
+      const { deploymentSettingRepository } = await setup();
+
+      await expect(deploymentSettingRepository.findStoredSecretsIteratively({ batchSize: 0 }).next()).rejects.toThrow(
+        "Batch size must be a positive integer"
+      );
+    });
+
     it("yields a deployment's token under the id that holds it", async () => {
       const { sealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
       const id = await createSettingWithSecrets(sealedToken);

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -183,11 +183,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     }
   }
 
-  /**
-   * Every stored secrets token there is, keyset-paged on `id`. Rows holding none are left out, so
-   * the count and byte total a fingerprint reports describe the deployments that actually carry a
-   * secret rather than the size of the table.
-   */
+  /** Rows holding no secret are left out, so a fingerprint's row and byte counts describe the deployments that actually carry one. */
   async *findStoredSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<DeploymentStoredSecrets[]> {
     let cursor: string | undefined;
 

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -49,10 +49,11 @@ export type OpenDeployment = {
   createdAt: Date;
 };
 
-/** A deployment's stored secrets token alongside the id it is sealed to. */
+/** A deployment's stored secrets token alongside the id it is sealed to and the timestamp every legitimate secrets write bumps. */
 export type DeploymentStoredSecrets = {
   id: string;
   sealedSecrets: string;
+  updatedAt: Date | null;
 };
 
 export type LiveTrialDeployment = {
@@ -192,7 +193,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
     while (true) {
       const batch = await this.pg
-        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets })
+        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets, updatedAt: this.table.updatedAt })
         .from(this.table)
         .where(and(isNotNull(this.table.sealedSecrets), ...(cursor ? [gt(this.table.id, cursor)] : [])))
         .orderBy(asc(this.table.id))

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, or, s
 import { singleton } from "tsyringe";
 
 import { UserWallets, WalletSetting } from "@src/billing/model-schemas";
+import { assertBatchSize } from "@src/core/lib/batch-size/batch-size";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
@@ -185,6 +186,8 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
   /** Rows holding no secret are left out, so a fingerprint's row and byte counts describe the deployments that actually carry one. */
   async *findStoredSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<DeploymentStoredSecrets[]> {
+    assertBatchSize(batchSize);
+
     let cursor: string | undefined;
 
     while (true) {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -48,6 +48,12 @@ export type OpenDeployment = {
   createdAt: Date;
 };
 
+/** A deployment's stored secrets token alongside the id it is sealed to. */
+export type DeploymentStoredSecrets = {
+  id: string;
+  sealedSecrets: string;
+};
+
 export type LiveTrialDeployment = {
   userId: string;
   dseq: string;
@@ -168,6 +174,36 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       }
 
       yield batch as OpenDeployment[];
+
+      if (batch.length < batchSize) {
+        return;
+      }
+
+      cursor = batch[batch.length - 1].id;
+    }
+  }
+
+  /**
+   * Every stored secrets token there is, keyset-paged on `id`. Rows holding none are left out, so
+   * the count and byte total a fingerprint reports describe the deployments that actually carry a
+   * secret rather than the size of the table.
+   */
+  async *findStoredSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<DeploymentStoredSecrets[]> {
+    let cursor: string | undefined;
+
+    while (true) {
+      const batch = await this.pg
+        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets })
+        .from(this.table)
+        .where(and(isNotNull(this.table.sealedSecrets), ...(cursor ? [gt(this.table.id, cursor)] : [])))
+        .orderBy(asc(this.table.id))
+        .limit(batchSize);
+
+      if (!batch.length) {
+        return;
+      }
+
+      yield batch as DeploymentStoredSecrets[];
 
       if (batch.length < batchSize) {
         return;

--- a/apps/api/src/secret/controllers/data-key-rewrap/data-key-rewrap.controller.spec.ts
+++ b/apps/api/src/secret/controllers/data-key-rewrap/data-key-rewrap.controller.spec.ts
@@ -1,0 +1,38 @@
+import { Ok } from "ts-results";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DataKeyRewrapReport, DataKeyRewrapService } from "@src/secret/services/data-key-rewrap/data-key-rewrap.service";
+import { DataKeyRewrapController } from "./data-key-rewrap.controller";
+
+describe(DataKeyRewrapController.name, () => {
+  it("hands the target version, the batch size and the dry-run switch to the service", async () => {
+    const { controller, dataKeyRewrapService } = setup();
+
+    await controller.rewrapDataKeys({ targetVersion: "3", batchSize: 50, dryRun: true });
+
+    expect(dataKeyRewrapService.rewrapDataKeys).toHaveBeenCalledWith({ targetVersion: "3", batchSize: 50, dryRun: true });
+  });
+
+  it("leaves the batch size for the service to default when the operator gives none", async () => {
+    const { controller, dataKeyRewrapService } = setup();
+
+    await controller.rewrapDataKeys({ targetVersion: "3", dryRun: false });
+
+    expect(dataKeyRewrapService.rewrapDataKeys).toHaveBeenCalledWith({ targetVersion: "3", dryRun: false });
+  });
+
+  it("returns the run's result, so a failed run reaches the command's exit code", async () => {
+    const { controller, report } = setup();
+
+    await expect(controller.rewrapDataKeys({ targetVersion: "3", dryRun: false })).resolves.toEqual(Ok(report));
+  });
+
+  function setup() {
+    const report = mock<DataKeyRewrapReport>({ toVersion: "sdl-secrets.v3", dataKeysRewrapped: 2 });
+    const dataKeyRewrapService = mock<DataKeyRewrapService>();
+    dataKeyRewrapService.rewrapDataKeys.mockResolvedValue(Ok(report));
+
+    return { controller: new DataKeyRewrapController(dataKeyRewrapService), dataKeyRewrapService, report };
+  }
+});

--- a/apps/api/src/secret/controllers/data-key-rewrap/data-key-rewrap.controller.ts
+++ b/apps/api/src/secret/controllers/data-key-rewrap/data-key-rewrap.controller.ts
@@ -1,0 +1,13 @@
+import { singleton } from "tsyringe";
+
+import type { DataKeyRewrapOptions } from "@src/secret/services/data-key-rewrap/data-key-rewrap.service";
+import { DataKeyRewrapService } from "@src/secret/services/data-key-rewrap/data-key-rewrap.service";
+
+@singleton()
+export class DataKeyRewrapController {
+  constructor(private readonly dataKeyRewrapService: DataKeyRewrapService) {}
+
+  async rewrapDataKeys(options: DataKeyRewrapOptions) {
+    return await this.dataKeyRewrapService.rewrapDataKeys(options);
+  }
+}

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
@@ -81,6 +81,40 @@ describe(StoredSecretsFingerprint.name, () => {
     expect(summary.digest).not.toBe(setup({ rows: [FIRST] }).summary.digest);
   });
 
+  describe("countDifferencesFrom", () => {
+    it("counts no difference against an identical fleet", () => {
+      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
+
+      expect(fingerprint.countDifferencesFrom(setup({ rows: [SECOND, FIRST] }).fingerprint)).toBe(0);
+    });
+
+    it("counts each row whose token changed", () => {
+      const { fingerprint } = setup({ rows: [FIRST, SECOND, THIRD] });
+      const { fingerprint: changed } = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed" }, { ...THIRD, sealedSecrets: "also-changed" }] });
+
+      expect(fingerprint.countDifferencesFrom(changed)).toBe(2);
+    });
+
+    it("counts a row that arrived and a row that disappeared", () => {
+      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
+      const { fingerprint: moved } = setup({ rows: [FIRST, THIRD] });
+
+      expect(fingerprint.countDifferencesFrom(moved)).toBe(2);
+    });
+
+    it("counts a swap as both rows having moved", () => {
+      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
+      const { fingerprint: swapped } = setup({
+        rows: [
+          { id: FIRST.id, sealedSecrets: SECOND.sealedSecrets },
+          { id: SECOND.id, sealedSecrets: FIRST.sealedSecrets }
+        ]
+      });
+
+      expect(fingerprint.countDifferencesFrom(swapped)).toBe(2);
+    });
+  });
+
   it("summarizes the same fleet the same way across separate runs", () => {
     expect(setup({ rows: [FIRST, SECOND] }).summary).toEqual(setup({ rows: [FIRST, SECOND] }).summary);
   });

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
@@ -5,6 +5,8 @@ import { StoredSecretsFingerprint } from "./stored-secrets-fingerprint";
 const FIRST = { id: "11111111-1111-4111-8111-111111111111", sealedSecrets: "aGVhZGVy.a2V5.aXY.Zmlyc3Q.dGFn" };
 const SECOND = { id: "22222222-2222-4222-8222-222222222222", sealedSecrets: "aGVhZGVy.a2V5.aXY.c2Vjb25k.dGFn" };
 const THIRD = { id: "33333333-3333-4333-8333-333333333333", sealedSecrets: "aGVhZGVy.a2V5.aXY.dGhpcmQ.dGFn" };
+const TOUCHED_AT = new Date("2026-09-01T10:00:00Z");
+const TOUCHED_LATER = new Date("2026-09-01T10:05:00Z");
 
 describe(StoredSecretsFingerprint.name, () => {
   it("digests the same rows to the same value whatever order they arrive in", () => {
@@ -81,37 +83,47 @@ describe(StoredSecretsFingerprint.name, () => {
     expect(summary.digest).not.toBe(setup({ rows: [FIRST] }).summary.digest);
   });
 
-  describe("countDifferencesFrom", () => {
-    it("counts no difference against an identical fleet", () => {
-      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
+  describe("driftFrom", () => {
+    it("reports no drift against an identical fleet", () => {
+      const before = setup({ rows: [FIRST, SECOND] });
+      const after = setup({ rows: [SECOND, FIRST] });
 
-      expect(fingerprint.countDifferencesFrom(setup({ rows: [SECOND, FIRST] }).fingerprint)).toBe(0);
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toEqual({ corruptedIds: [], changedConcurrently: 0, added: 0, removed: 0 });
     });
 
-    it("counts each row whose token changed", () => {
-      const { fingerprint } = setup({ rows: [FIRST, SECOND, THIRD] });
-      const { fingerprint: changed } = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed" }, { ...THIRD, sealedSecrets: "also-changed" }] });
+    it("flags a row whose token changed while its updatedAt stood still as corrupted", () => {
+      const before = setup({ rows: [FIRST, { ...SECOND, updatedAt: TOUCHED_AT }] });
+      const after = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed", updatedAt: TOUCHED_AT }] });
 
-      expect(fingerprint.countDifferencesFrom(changed)).toBe(2);
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toMatchObject({ corruptedIds: [SECOND.id], changedConcurrently: 0 });
     });
 
-    it("counts a row that arrived and a row that disappeared", () => {
-      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
-      const { fingerprint: moved } = setup({ rows: [FIRST, THIRD] });
+    it("flags a row whose token changed without any updatedAt to vouch for it as corrupted", () => {
+      const before = setup({ rows: [FIRST, SECOND] });
+      const after = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed" }] });
 
-      expect(fingerprint.countDifferencesFrom(moved)).toBe(2);
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toMatchObject({ corruptedIds: [SECOND.id], changedConcurrently: 0 });
     });
 
-    it("counts a swap as both rows having moved", () => {
-      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
-      const { fingerprint: swapped } = setup({
-        rows: [
-          { id: FIRST.id, sealedSecrets: SECOND.sealedSecrets },
-          { id: SECOND.id, sealedSecrets: FIRST.sealedSecrets }
-        ]
-      });
+    it("counts a row whose token and updatedAt both moved as a concurrent write rather than corruption", () => {
+      const before = setup({ rows: [FIRST, { ...SECOND, updatedAt: TOUCHED_AT }] });
+      const after = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed", updatedAt: TOUCHED_LATER }] });
 
-      expect(fingerprint.countDifferencesFrom(swapped)).toBe(2);
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toEqual({ corruptedIds: [], changedConcurrently: 1, added: 0, removed: 0 });
+    });
+
+    it("reports no drift for a row whose updatedAt moved while its token stayed", () => {
+      const before = setup({ rows: [{ ...FIRST, updatedAt: TOUCHED_AT }] });
+      const after = setup({ rows: [{ ...FIRST, updatedAt: TOUCHED_LATER }] });
+
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toEqual({ corruptedIds: [], changedConcurrently: 0, added: 0, removed: 0 });
+    });
+
+    it("counts a row that arrived as added and one that disappeared as removed", () => {
+      const before = setup({ rows: [FIRST, SECOND] });
+      const after = setup({ rows: [FIRST, THIRD] });
+
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toEqual({ corruptedIds: [], changedConcurrently: 0, added: 1, removed: 1 });
     });
   });
 
@@ -119,11 +131,11 @@ describe(StoredSecretsFingerprint.name, () => {
     expect(setup({ rows: [FIRST, SECOND] }).summary).toEqual(setup({ rows: [FIRST, SECOND] }).summary);
   });
 
-  function setup(input: { rows: Array<{ id: string; sealedSecrets: string }> }) {
+  function setup(input: { rows: Array<{ id: string; sealedSecrets: string; updatedAt?: Date | null }> }) {
     const fingerprint = new StoredSecretsFingerprint();
 
     for (const row of input.rows) {
-      fingerprint.add(row);
+      fingerprint.add({ ...row, updatedAt: row.updatedAt ?? null });
     }
 
     return { fingerprint, summary: fingerprint.summarize() };

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { StoredSecretsFingerprint } from "./stored-secrets-fingerprint";
+
+const FIRST = { id: "11111111-1111-4111-8111-111111111111", sealedSecrets: "aGVhZGVy.a2V5.aXY.Zmlyc3Q.dGFn" };
+const SECOND = { id: "22222222-2222-4222-8222-222222222222", sealedSecrets: "aGVhZGVy.a2V5.aXY.c2Vjb25k.dGFn" };
+const THIRD = { id: "33333333-3333-4333-8333-333333333333", sealedSecrets: "aGVhZGVy.a2V5.aXY.dGhpcmQ.dGFn" };
+
+describe(StoredSecretsFingerprint.name, () => {
+  it("digests the same rows to the same value whatever order they arrive in", () => {
+    const inOrder = setup({ rows: [FIRST, SECOND, THIRD] });
+    const permuted = setup({ rows: [THIRD, FIRST, SECOND] });
+
+    expect(permuted.summary).toEqual(inOrder.summary);
+  });
+
+  it("digests a row whose token changed to a different value", () => {
+    const before = setup({ rows: [FIRST, SECOND] });
+    const after = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: THIRD.sealedSecrets }] });
+
+    expect(after.summary.digest).not.toBe(before.summary.digest);
+  });
+
+  it("digests two rows that swapped tokens with each other to a different value", () => {
+    const before = setup({ rows: [FIRST, SECOND] });
+    const swapped = setup({
+      rows: [
+        { id: FIRST.id, sealedSecrets: SECOND.sealedSecrets },
+        { id: SECOND.id, sealedSecrets: FIRST.sealedSecrets }
+      ]
+    });
+
+    expect(swapped.summary.digest).not.toBe(before.summary.digest);
+    expect(swapped.summary.rowCount).toBe(before.summary.rowCount);
+    expect(swapped.summary.byteCount).toBe(before.summary.byteCount);
+  });
+
+  it("digests a token that moved to a row of another id to a different value", () => {
+    const original = setup({ rows: [FIRST, SECOND] });
+    const reassigned = setup({ rows: [FIRST, { id: THIRD.id, sealedSecrets: SECOND.sealedSecrets }] });
+
+    expect(reassigned.summary.rowCount).toBe(original.summary.rowCount);
+    expect(reassigned.summary.byteCount).toBe(original.summary.byteCount);
+    expect(reassigned.summary.digest).not.toBe(original.summary.digest);
+  });
+
+  it("digests a token moved across the boundary with its row's id to a different value", () => {
+    const asOneId = setup({ rows: [{ id: "ab", sealedSecrets: "cd" }] });
+    const asAnother = setup({ rows: [{ id: "a", sealedSecrets: "bcd" }] });
+
+    expect(asAnother.summary.digest).not.toBe(asOneId.summary.digest);
+  });
+
+  it("digests a row that was removed to a different value", () => {
+    const both = setup({ rows: [FIRST, SECOND] });
+    const one = setup({ rows: [FIRST] });
+
+    expect(one.summary.digest).not.toBe(both.summary.digest);
+  });
+
+  it("reports how many rows hold a token and how many bytes they hold", () => {
+    const { summary } = setup({ rows: [FIRST, SECOND] });
+
+    expect(summary).toMatchObject({
+      rowCount: 2,
+      byteCount: FIRST.sealedSecrets.length + SECOND.sealedSecrets.length
+    });
+  });
+
+  it("counts a token's bytes rather than its characters", () => {
+    const { summary } = setup({ rows: [{ id: FIRST.id, sealedSecrets: "é" }] });
+
+    expect(summary.byteCount).toBe(2);
+  });
+
+  it("summarizes an empty fleet without a token as a digest of its own", () => {
+    const { summary } = setup({ rows: [] });
+
+    expect(summary).toMatchObject({ rowCount: 0, byteCount: 0 });
+    expect(summary.digest).toEqual(expect.any(String));
+    expect(summary.digest).not.toBe(setup({ rows: [FIRST] }).summary.digest);
+  });
+
+  it("summarizes the same fleet the same way across separate runs", () => {
+    expect(setup({ rows: [FIRST, SECOND] }).summary).toEqual(setup({ rows: [FIRST, SECOND] }).summary);
+  });
+
+  function setup(input: { rows: Array<{ id: string; sealedSecrets: string }> }) {
+    const fingerprint = new StoredSecretsFingerprint();
+
+    for (const row of input.rows) {
+      fingerprint.add(row);
+    }
+
+    return { fingerprint, summary: fingerprint.summarize() };
+  }
+});

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -31,6 +31,23 @@ export class StoredSecretsFingerprint {
     this.#rowDigests.set(id, { digest: hash.digest(), byteCount: token.length });
   }
 
+  /** How many rows hold a different token than they did in `other`, counting one that arrived or disappeared as a difference of its own. */
+  countDifferencesFrom(other: StoredSecretsFingerprint): number {
+    const ids = new Set([...this.#rowDigests.keys(), ...other.#rowDigests.keys()]);
+    let differences = 0;
+
+    for (const id of ids) {
+      const mine = this.#rowDigests.get(id);
+      const theirs = other.#rowDigests.get(id);
+
+      if (!mine || !theirs || !mine.digest.equals(theirs.digest)) {
+        differences++;
+      }
+    }
+
+    return differences;
+  }
+
   summarize(): StoredSecretsSummary {
     const hash = createHash(DIGEST_ALGORITHM);
     let byteCount = 0;

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -4,6 +4,14 @@ import { createHash } from "node:crypto";
 export interface StoredSecretsEntry {
   id: string;
   sealedSecrets: string;
+  updatedAt: Date | null;
+}
+
+export interface StoredSecretsDrift {
+  corruptedIds: string[];
+  changedConcurrently: number;
+  added: number;
+  removed: number;
 }
 
 export interface StoredSecretsSummary {
@@ -19,33 +27,40 @@ const LENGTH_PREFIX_BYTES = 4;
 
 /** Digests each row under its own id and combines the row digests in id order, so the result reflects the rows themselves rather than the order a scan yielded them in. */
 export class StoredSecretsFingerprint {
-  readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number }>();
+  readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number; updatedAtMs: number | null }>();
 
-  add({ id, sealedSecrets }: StoredSecretsEntry): void {
+  add({ id, sealedSecrets, updatedAt }: StoredSecretsEntry): void {
     const token = Buffer.from(sealedSecrets, "utf8");
     const hash = createHash(DIGEST_ALGORITHM);
 
     appendLengthPrefixed(hash, Buffer.from(id, "utf8"));
     appendLengthPrefixed(hash, token);
 
-    this.#rowDigests.set(id, { digest: hash.digest(), byteCount: token.length });
+    this.#rowDigests.set(id, { digest: hash.digest(), byteCount: token.length, updatedAtMs: updatedAt?.getTime() ?? null });
   }
 
-  /** How many rows hold a different token than they did in `other`, counting one that arrived or disappeared as a difference of its own. */
-  countDifferencesFrom(other: StoredSecretsFingerprint): number {
-    const ids = new Set([...this.#rowDigests.keys(), ...other.#rowDigests.keys()]);
-    let differences = 0;
+  /** A token that changed while its row's `updatedAt` stood still is corruption, because every legitimate secrets write bumps that timestamp. */
+  driftFrom(before: StoredSecretsFingerprint): StoredSecretsDrift {
+    const drift: StoredSecretsDrift = { corruptedIds: [], changedConcurrently: 0, added: 0, removed: 0 };
 
-    for (const id of ids) {
-      const mine = this.#rowDigests.get(id);
-      const theirs = other.#rowDigests.get(id);
+    for (const id of new Set([...this.#rowDigests.keys(), ...before.#rowDigests.keys()])) {
+      const current = this.#rowDigests.get(id);
+      const previous = before.#rowDigests.get(id);
 
-      if (!mine || !theirs || !mine.digest.equals(theirs.digest)) {
-        differences++;
+      if (!previous) {
+        drift.added++;
+      } else if (!current) {
+        drift.removed++;
+      } else if (!current.digest.equals(previous.digest)) {
+        if (current.updatedAtMs === previous.updatedAtMs) {
+          drift.corruptedIds.push(id);
+        } else {
+          drift.changedConcurrently++;
+        }
       }
     }
 
-    return differences;
+    return drift;
   }
 
   summarize(): StoredSecretsSummary {

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -17,13 +17,7 @@ const DIGEST_ALGORITHM = "sha256";
 /** A length fits in four bytes for any token a row can hold, and the framing below needs a fixed-width one. */
 const LENGTH_PREFIX_BYTES = 4;
 
-/**
- * Proof that a run of the key rotation changed no stored secret, taken over the fleet before and
- * after it. Each row is digested under its own id, so a token moved to another deployment shows up
- * as a changed fingerprint rather than as the same one; the per-row digests are combined in id
- * order at the end, so the result is a function of the rows themselves and not of the order a scan
- * happened to yield them in.
- */
+/** Digests each row under its own id and combines the row digests in id order, so the result reflects the rows themselves rather than the order a scan yielded them in. */
 export class StoredSecretsFingerprint {
   readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number }>();
 

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -41,19 +41,15 @@ export class StoredSecretsFingerprint {
     const hash = createHash(DIGEST_ALGORITHM);
     let byteCount = 0;
 
-    for (const [, row] of [...this.#rowDigests].sort(byId)) {
+    for (const id of [...this.#rowDigests.keys()].sort()) {
+      const row = this.#rowDigests.get(id)!;
+
       hash.update(row.digest);
       byteCount += row.byteCount;
     }
 
     return { digest: hash.digest("hex"), rowCount: this.#rowDigests.size, byteCount };
   }
-}
-
-function byId([left]: [string, unknown], [right]: [string, unknown]) {
-  if (left === right) return 0;
-
-  return left < right ? -1 : 1;
 }
 
 /** Without the length, a row's id and its token could be rearranged into another row's pair and digest alike. */

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -1,0 +1,66 @@
+import type { Hash } from "node:crypto";
+import { createHash } from "node:crypto";
+
+export interface StoredSecretsEntry {
+  id: string;
+  sealedSecrets: string;
+}
+
+export interface StoredSecretsSummary {
+  digest: string;
+  rowCount: number;
+  byteCount: number;
+}
+
+const DIGEST_ALGORITHM = "sha256";
+
+/** A length fits in four bytes for any token a row can hold, and the framing below needs a fixed-width one. */
+const LENGTH_PREFIX_BYTES = 4;
+
+/**
+ * Proof that a run of the key rotation changed no stored secret, taken over the fleet before and
+ * after it. Each row is digested under its own id, so a token moved to another deployment shows up
+ * as a changed fingerprint rather than as the same one; the per-row digests are combined in id
+ * order at the end, so the result is a function of the rows themselves and not of the order a scan
+ * happened to yield them in.
+ */
+export class StoredSecretsFingerprint {
+  readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number }>();
+
+  add({ id, sealedSecrets }: StoredSecretsEntry): void {
+    const token = Buffer.from(sealedSecrets, "utf8");
+    const hash = createHash(DIGEST_ALGORITHM);
+
+    appendLengthPrefixed(hash, Buffer.from(id, "utf8"));
+    appendLengthPrefixed(hash, token);
+
+    this.#rowDigests.set(id, { digest: hash.digest(), byteCount: token.length });
+  }
+
+  summarize(): StoredSecretsSummary {
+    const hash = createHash(DIGEST_ALGORITHM);
+    let byteCount = 0;
+
+    for (const [, row] of [...this.#rowDigests].sort(byId)) {
+      hash.update(row.digest);
+      byteCount += row.byteCount;
+    }
+
+    return { digest: hash.digest("hex"), rowCount: this.#rowDigests.size, byteCount };
+  }
+}
+
+function byId([left]: [string, unknown], [right]: [string, unknown]) {
+  if (left === right) return 0;
+
+  return left < right ? -1 : 1;
+}
+
+/** Without the length, a row's id and its token could be rearranged into another row's pair and digest alike. */
+function appendLengthPrefixed(hash: Hash, value: Buffer) {
+  const length = Buffer.alloc(LENGTH_PREFIX_BYTES);
+  length.writeUInt32BE(value.length);
+
+  hash.update(length);
+  hash.update(value);
+}

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
@@ -3,6 +3,7 @@ import { container } from "tsyringe";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { UserRepository } from "@src/user/repositories";
+import type { DataKeyOutput } from "./data-key.repository";
 import { DataKeyRepository } from "./data-key.repository";
 
 describe(DataKeyRepository.name, () => {
@@ -94,6 +95,102 @@ describe(DataKeyRepository.name, () => {
     });
   });
 
+  describe("countByWrappingVersion", () => {
+    it("counts the data keys under each version separately rather than in total", async () => {
+      const { versionOf, seedDataKey, censusOfOwnKey } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(2));
+
+      const census = await censusOfOwnKey();
+
+      expect(census).toEqual([
+        { wrappedByKid: versionOf(1), count: 2 },
+        { wrappedByKid: versionOf(2), count: 1 }
+      ]);
+    });
+
+    it("leaves out a version nothing is wrapped under", async () => {
+      const { versionOf, seedDataKey, censusOfOwnKey } = setup();
+      await seedDataKey(versionOf(1));
+
+      const census = await censusOfOwnKey();
+
+      expect(census.map(entry => entry.wrappedByKid)).not.toContain(versionOf(2));
+    });
+  });
+
+  describe("findWrappedUnderOtherVersionsIteratively", () => {
+    it("yields the rows wrapped under another version and passes over those already at the target", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      const staleFirst = await seedDataKey(versionOf(1));
+      const staleSecond = await seedDataKey(versionOf(1));
+      const alreadyAtTarget = await seedDataKey(versionOf(2));
+
+      const candidates = await findRewrapCandidates(versionOf(2));
+
+      expect(candidates.map(row => row.id).sort()).toEqual([staleFirst.id, staleSecond.id].sort());
+      expect(candidates.map(row => row.id)).not.toContain(alreadyAtTarget.id);
+    });
+
+    it("yields what re-wrapping a row needs to open it and record its new version", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      const stale = await seedDataKey(versionOf(1));
+
+      const candidates = await findRewrapCandidates(versionOf(2));
+
+      expect(candidates).toEqual([
+        expect.objectContaining({ id: stale.id, userId: stale.userId, wrappedKey: stale.wrappedKey, wrappedByKid: versionOf(1) })
+      ]);
+    });
+
+    it("yields nothing once every row is at the target", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      await seedDataKey(versionOf(2));
+      await seedDataKey(versionOf(2));
+
+      expect(await findRewrapCandidates(versionOf(2))).toEqual([]);
+    });
+
+    it("pages every row exactly once when the batch is smaller than the set", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+
+      const oneAtATime = await findRewrapCandidates(versionOf(2), 1);
+      const allAtOnce = await findRewrapCandidates(versionOf(2), 1000);
+
+      expect(allAtOnce).toHaveLength(3);
+      expect(oneAtATime.map(row => row.id)).toEqual(allAtOnce.map(row => row.id));
+    });
+
+    it("yields rows in id order, so a run that stops resumes after the last row it moved", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+
+      const candidates = await findRewrapCandidates(versionOf(2), 2);
+
+      expect(candidates.map(row => row.id)).toEqual([...candidates.map(row => row.id)].sort());
+    });
+
+    it("yields batches no larger than the size asked for", async () => {
+      const { dataKeyRepository, versionOf, seedDataKey } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      const sizes: number[] = [];
+
+      for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: versionOf(2), batchSize: 2 })) {
+        sizes.push(batch.length);
+      }
+
+      expect(Math.max(...sizes)).toBeLessThanOrEqual(2);
+    });
+  });
+
   describe("user deletion", () => {
     it("deletes the data key when its user is deleted", async () => {
       const { dataKeyRepository, userRepository, createTestUser } = setup();
@@ -124,6 +221,7 @@ describe(DataKeyRepository.name, () => {
     const dataKeyRepository = container.resolve(DataKeyRepository);
     const userRepository = container.resolve(UserRepository);
     const createdUserIds: string[] = [];
+    const keyName = faker.string.alphanumeric(10);
 
     cleanup = async () => {
       if (createdUserIds.length > 0) {
@@ -137,6 +235,36 @@ describe(DataKeyRepository.name, () => {
       return user;
     }
 
-    return { dataKeyRepository, userRepository, createTestUser };
+    function versionOf(version: number) {
+      return `${keyName}.v${version}`;
+    }
+
+    async function seedDataKey(wrappedByKid: string) {
+      const user = await createTestUser();
+
+      return await dataKeyRepository.create({ userId: user.id, wrappedKey: wrappedKeyBlob(), wrappedByKid });
+    }
+
+    function isOwnKey(wrappedByKid: string) {
+      return wrappedByKid.startsWith(`${keyName}.`);
+    }
+
+    async function censusOfOwnKey() {
+      const census = await dataKeyRepository.countByWrappingVersion();
+
+      return census.filter(entry => isOwnKey(entry.wrappedByKid));
+    }
+
+    async function findRewrapCandidates(targetKid: string, batchSize = 1000) {
+      const candidates: DataKeyOutput[] = [];
+
+      for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid, batchSize })) {
+        candidates.push(...batch.filter(row => isOwnKey(row.wrappedByKid)));
+      }
+
+      return candidates;
+    }
+
+    return { dataKeyRepository, userRepository, createTestUser, versionOf, seedDataKey, censusOfOwnKey, findRewrapCandidates };
   }
 });

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
@@ -121,6 +121,14 @@ describe(DataKeyRepository.name, () => {
   });
 
   describe("findWrappedUnderOtherVersionsIteratively", () => {
+    it("refuses a batch size of zero, which would read as a fleet needing no work", async () => {
+      const { dataKeyRepository, versionOf } = setup();
+
+      await expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: versionOf(2), batchSize: 0 }).next()).rejects.toThrow(
+        "Batch size must be a positive integer"
+      );
+    });
+
     it("yields the rows wrapped under another version and passes over those already at the target", async () => {
       const { versionOf, seedDataKey, findRewrapCandidates } = setup();
       const staleFirst = await seedDataKey(versionOf(1));

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -68,11 +68,7 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
       .orderBy(asc(this.table.wrappedByKid));
   }
 
-  /**
-   * Keyset-paged on `id`, and filtered on the version rather than on a progress marker, so a
-   * re-wrap that stopped halfway resumes by selection alone: a row it already moved no longer
-   * matches. Read outside any transaction, because the caller commits each batch in one of its own.
-   */
+  /** Filters on the version rather than a progress marker so an interrupted run resumes by selection alone; ids are random uuids, so one pass may skip a row inserted mid-scan and only the destroy-time count vouches for completeness. */
   async *findWrappedUnderOtherVersionsIteratively({
     targetKid,
     batchSize

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -1,6 +1,7 @@
 import { and, asc, gt, ne, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
+import { assertBatchSize } from "@src/core/lib/batch-size/batch-size";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
@@ -76,6 +77,8 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
     targetKid: DataKeyOutput["wrappedByKid"];
     batchSize: number;
   }): AsyncGenerator<DataKeyOutput[]> {
+    assertBatchSize(batchSize);
+
     let cursor: DataKeyOutput["id"] | undefined;
 
     while (true) {

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -1,3 +1,4 @@
+import { and, asc, gt, ne, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -7,6 +8,12 @@ import { TxService } from "@src/core/services";
 type Table = ApiPgTables["DataKeys"];
 export type DataKeyInput = Table["$inferInsert"];
 export type DataKeyOutput = Table["$inferSelect"];
+
+/** How many data keys one KMS key version still holds, which is what gates destroying that version. */
+export type DataKeyWrappingCount = {
+  wrappedByKid: DataKeyOutput["wrappedByKid"];
+  count: number;
+};
 
 @singleton()
 export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataKeyOutput> {
@@ -50,5 +57,50 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
   /** Answers whether a KMS key version may still be destroyed without making stored data keys unrecoverable. */
   async countWrappedUnder(wrappedByKid: DataKeyOutput["wrappedByKid"]): Promise<number> {
     return this.count({ wrappedByKid });
+  }
+
+  /** The same question asked of every version at once, so a rotation can report which versions are still in use without knowing what to ask about. */
+  async countByWrappingVersion(): Promise<DataKeyWrappingCount[]> {
+    return await this.cursor
+      .select({ wrappedByKid: this.table.wrappedByKid, count: sql<number>`count(*)::int` })
+      .from(this.table)
+      .groupBy(this.table.wrappedByKid)
+      .orderBy(asc(this.table.wrappedByKid));
+  }
+
+  /**
+   * Keyset-paged on `id`, and filtered on the version rather than on a progress marker, so a
+   * re-wrap that stopped halfway resumes by selection alone: a row it already moved no longer
+   * matches. Read outside any transaction, because the caller commits each batch in one of its own.
+   */
+  async *findWrappedUnderOtherVersionsIteratively({
+    targetKid,
+    batchSize
+  }: {
+    targetKid: DataKeyOutput["wrappedByKid"];
+    batchSize: number;
+  }): AsyncGenerator<DataKeyOutput[]> {
+    let cursor: DataKeyOutput["id"] | undefined;
+
+    while (true) {
+      const batch = await this.pg
+        .select()
+        .from(this.table)
+        .where(and(ne(this.table.wrappedByKid, targetKid), ...(cursor ? [gt(this.table.id, cursor)] : [])))
+        .orderBy(asc(this.table.id))
+        .limit(batchSize);
+
+      if (!batch.length) {
+        return;
+      }
+
+      yield this.toOutputList(batch);
+
+      if (batch.length < batchSize) {
+        return;
+      }
+
+      cursor = batch[batch.length - 1].id;
+    }
   }
 }

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
@@ -27,6 +27,8 @@ const DATA_KEY = randomBytes(32);
 const SEALING_KEYPAIR = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const SEALING_KEY_PEM = SEALING_KEYPAIR.publicKey.export({ type: "spki", format: "pem" }).toString();
 
+const ONE_MINUTE_MS = 60_000;
+
 const A_TOKEN = "eyJhbGciOiJkaXIifQ..YWxwaGEtaXY.YWxwaGEtY2lwaGVydGV4dA.YWxwaGEtdGFn";
 const ANOTHER_TOKEN = "eyJhbGciOiJkaXIifQ..Z2FtbWEtaXY.Z2FtbWEtY2lwaGVydGV4dA.Z2FtbWEtdGFn";
 
@@ -47,12 +49,37 @@ describe(DataKeyRewrapService.name, () => {
       await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true })).resolves.toBeDefined();
     });
 
+    it("refuses a version whose state the key service did not report at all", async () => {
+      const { service, dataKeyRepository } = setup({ versionState: null });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
+
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalled();
+    });
+
+    it("asks the key service about the target version by name", async () => {
+      const { service, client } = setup({});
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true });
+
+      expect(client.getCryptoKeyVersion).toHaveBeenCalledWith({ name: versionPath(TARGET_VERSION) });
+    });
+
     it("refuses a batch size below one, which would read as a fleet needing no work", async () => {
       const { service, dataKeyRepository } = setup({});
 
       await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 0, dryRun: false })).rejects.toThrow();
 
       expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).not.toHaveBeenCalled();
+    });
+
+    it("accepts a batch size of one, the smallest a run can use", async () => {
+      const { service, dataKeyRepository, txService } = setup({ rows: [aRow({}), aRow({})] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 1, dryRun: false });
+
+      expect(dataKeyRepository.updateById).toHaveBeenCalledTimes(2);
+      expect(txService.transaction).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -110,13 +137,15 @@ describe(DataKeyRewrapService.name, () => {
     });
 
     it("selects in batches of the size asked for, and of a default when none is given", async () => {
-      const { service, dataKeyRepository } = setup({});
+      const { service, dataKeyRepository, deploymentSettingRepository } = setup({});
 
       await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 25, dryRun: false });
       await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
 
       expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).toHaveBeenNthCalledWith(1, { targetKid: TARGET_KID, batchSize: 25 });
       expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).toHaveBeenNthCalledWith(2, { targetKid: TARGET_KID, batchSize: 100 });
+      expect(deploymentSettingRepository.findStoredSecretsIteratively).toHaveBeenNthCalledWith(1, { batchSize: 25 });
+      expect(deploymentSettingRepository.findStoredSecretsIteratively).toHaveBeenNthCalledWith(3, { batchSize: 100 });
     });
   });
 
@@ -186,6 +215,7 @@ describe(DataKeyRewrapService.name, () => {
       });
       expect(summary.fingerprint.after?.digest).toBe(summary.fingerprint.before.digest);
       expect(summary.elapsedMs).toBeGreaterThanOrEqual(0);
+      expect(summary.elapsedMs).toBeLessThan(ONE_MINUTE_MS);
     });
 
     it("marks the run's start and completion with structured events", async () => {
@@ -195,6 +225,12 @@ describe(DataKeyRewrapService.name, () => {
 
       expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_START", toVersion: TARGET_KID, dryRun: false }));
       expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_END", report: expect.objectContaining({ toVersion: TARGET_KID }) }));
+    });
+
+    it("names itself as the context every one of those events carries", () => {
+      const { createLogger } = setup({});
+
+      expect(createLogger).toHaveBeenCalledWith({ context: DataKeyRewrapService.name });
     });
 
     it("carries no key material and no secret value into any event", async () => {
@@ -297,7 +333,7 @@ describe(DataKeyRewrapService.name, () => {
   }) {
     const rows = input.rows ?? [];
     const client = mock<SdlSecretsKmsClient>();
-    client.getCryptoKeyVersion.mockResolvedValue([{ name: versionPath(TARGET_VERSION), state: input.versionState ?? "ENABLED" }]);
+    client.getCryptoKeyVersion.mockResolvedValue([{ name: versionPath(TARGET_VERSION), state: "versionState" in input ? input.versionState : "ENABLED" }]);
     client.getPublicKey.mockResolvedValue([
       {
         name: versionPath(TARGET_VERSION),
@@ -352,6 +388,7 @@ describe(DataKeyRewrapService.name, () => {
 
     return {
       service,
+      createLogger,
       dataKeyRepository,
       deploymentSettingRepository,
       wrappedJweService,

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
@@ -29,6 +29,9 @@ const SEALING_KEY_PEM = SEALING_KEYPAIR.publicKey.export({ type: "spki", format:
 
 const ONE_MINUTE_MS = 60_000;
 
+const TOUCHED_AT = new Date("2026-09-01T10:00:00Z");
+const TOUCHED_LATER = new Date("2026-09-01T10:05:00Z");
+
 const A_TOKEN = "eyJhbGciOiJkaXIifQ..YWxwaGEtaXY.YWxwaGEtY2lwaGVydGV4dA.YWxwaGEtdGFn";
 const ANOTHER_TOKEN = "eyJhbGciOiJkaXIifQ..Z2FtbWEtaXY.Z2FtbWEtY2lwaGVydGV4dA.Z2FtbWEtdGFn";
 
@@ -206,7 +209,7 @@ describe(DataKeyRewrapService.name, () => {
         census: { [SOURCE_KID]: 2, [TARGET_KID]: 1 },
         dataKeysRewrapped: 2,
         dataKeysFailed: 0,
-        secretsReEncrypted: 0,
+        secretsDrift: { corruptedIds: [], changedConcurrently: 0, added: 0, removed: 0 },
         bytesRewritten: writtenKeys().reduce((total, key) => total + Buffer.byteLength(key), 0),
         fingerprint: {
           before: { rowCount: 2, byteCount: A_TOKEN.length + ANOTHER_TOKEN.length },
@@ -275,17 +278,17 @@ describe(DataKeyRewrapService.name, () => {
   });
 
   describe("when a stored secret changed under the run", () => {
-    it("fails hard rather than reporting a rotation that proved nothing", async () => {
+    it("fails hard when a token changed while its updatedAt stood still, which no user write can produce", async () => {
       const { service } = setup({
         rows: [aRow({})],
-        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }],
-        storedSecretsAfter: [{ id: "a", sealedSecrets: ANOTHER_TOKEN }]
+        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN, updatedAt: TOUCHED_AT }],
+        storedSecretsAfter: [{ id: "a", sealedSecrets: ANOTHER_TOKEN, updatedAt: TOUCHED_AT }]
       });
 
       await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
     });
 
-    it("reports how many stored secrets moved, which a row count alone cannot show", async () => {
+    it("names the rows it cannot vouch for, which a digest alone cannot show", async () => {
       const { service, logger } = setup({
         rows: [aRow({})],
         storedSecrets: [
@@ -301,8 +304,36 @@ describe(DataKeyRewrapService.name, () => {
       await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
 
       expect(logger.error).toHaveBeenCalledWith(
-        expect.objectContaining({ event: "DATA_KEY_REWRAP_FINGERPRINT_MISMATCH", report: expect.objectContaining({ secretsReEncrypted: 1 }) })
+        expect.objectContaining({
+          event: "DATA_KEY_REWRAP_FINGERPRINT_MISMATCH",
+          report: expect.objectContaining({ secretsDrift: expect.objectContaining({ corruptedIds: ["a"] }) })
+        })
       );
+    });
+
+    it("passes a run during which a user re-saved their secrets, since their write moved updatedAt along with the token", async () => {
+      const { service, report, logger } = setup({
+        rows: [aRow({})],
+        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN, updatedAt: TOUCHED_AT }],
+        storedSecretsAfter: [{ id: "a", sealedSecrets: ANOTHER_TOKEN, updatedAt: TOUCHED_LATER }]
+      });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false }));
+
+      expect(summary.secretsDrift).toEqual({ corruptedIds: [], changedConcurrently: 1, added: 0, removed: 0 });
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_SECRETS_CHANGED_CONCURRENTLY" }));
+    });
+
+    it("passes a run during which a secret arrived and another disappeared", async () => {
+      const { service, report } = setup({
+        rows: [aRow({})],
+        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }],
+        storedSecretsAfter: [{ id: "b", sealedSecrets: ANOTHER_TOKEN }]
+      });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false }));
+
+      expect(summary.secretsDrift).toEqual({ corruptedIds: [], changedConcurrently: 0, added: 1, removed: 1 });
     });
   });
 
@@ -326,8 +357,8 @@ describe(DataKeyRewrapService.name, () => {
   function setup(input: {
     rows?: DataKeyOutput[];
     census?: Array<{ wrappedByKid: string; count: number }>;
-    storedSecrets?: Array<{ id: string; sealedSecrets: string }>;
-    storedSecretsAfter?: Array<{ id: string; sealedSecrets: string }>;
+    storedSecrets?: Array<{ id: string; sealedSecrets: string; updatedAt?: Date | null }>;
+    storedSecretsAfter?: Array<{ id: string; sealedSecrets: string; updatedAt?: Date | null }>;
     unopenableIds?: string[];
     versionState?: protos.google.cloud.kms.v1.ICryptoKeyVersion["state"];
   }) {
@@ -375,7 +406,7 @@ describe(DataKeyRewrapService.name, () => {
     deploymentSettingRepository.findStoredSecretsIteratively.mockImplementation(async function* () {
       const scanned = scans++ === 0 ? (input.storedSecrets ?? []) : (input.storedSecretsAfter ?? input.storedSecrets ?? []);
 
-      if (scanned.length) yield scanned;
+      if (scanned.length) yield scanned.map(row => ({ ...row, updatedAt: row.updatedAt ?? null }));
     });
 
     const txService = mock<TxService>();

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
@@ -1,0 +1,366 @@
+import { protos } from "@google-cloud/kms";
+import crc32c from "fast-crc32c";
+import { compactDecrypt, decodeProtectedHeader } from "jose";
+import { generateKeyPairSync, randomBytes, randomUUID } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { TxService } from "@src/core/services";
+import type { SdlSecretsKmsClient, SdlSecretsKmsTargetFactory } from "@src/deployment/providers/kms.provider";
+import { createSdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
+import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { KmsWrappedJweService,ParsedKmsWrappedJwe  } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import { KmsWrappedJweError } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import type { DataKeyOutput, DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyRewrapService } from "./data-key-rewrap.service";
+
+const { CryptoKeyVersionState } = protos.google.cloud.kms.v1.CryptoKeyVersion;
+
+const KEY = "sdl-secrets";
+const TARGET_VERSION = "3";
+const TARGET_KID = `${KEY}.v${TARGET_VERSION}`;
+const SOURCE_KID = `${KEY}.v1`;
+const OTHER_SOURCE_KID = `${KEY}.v2`;
+
+const DATA_KEY = randomBytes(32);
+const SEALING_KEYPAIR = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const SEALING_KEY_PEM = SEALING_KEYPAIR.publicKey.export({ type: "spki", format: "pem" }).toString();
+
+const A_TOKEN = "eyJhbGciOiJkaXIifQ..YWxwaGEtaXY.YWxwaGEtY2lwaGVydGV4dA.YWxwaGEtdGFn";
+const ANOTHER_TOKEN = "eyJhbGciOiJkaXIifQ..Z2FtbWEtaXY.Z2FtbWEtY2lwaGVydGV4dA.Z2FtbWEtdGFn";
+
+describe(DataKeyRewrapService.name, () => {
+  describe("target version", () => {
+    it("refuses a version the key service reports as disabled, before touching a row", async () => {
+      const { service, dataKeyRepository } = setup({ versionState: "DISABLED" });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
+
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalled();
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).not.toHaveBeenCalled();
+    });
+
+    it("accepts the enabled state reported as an ordinal rather than a name", async () => {
+      const { service } = setup({ versionState: CryptoKeyVersionState.ENABLED });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true })).resolves.toBeDefined();
+    });
+
+    it("refuses a batch size below one, which would read as a fleet needing no work", async () => {
+      const { service, dataKeyRepository } = setup({});
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 0, dryRun: false })).rejects.toThrow();
+
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("re-wrapping", () => {
+    it("moves every row not already at the target onto it", async () => {
+      const { service, dataKeyRepository, rows } = setup({ rows: [aRow({ wrappedByKid: SOURCE_KID }), aRow({ wrappedByKid: OTHER_SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(dataKeyRepository.updateById).toHaveBeenCalledTimes(2);
+      for (const row of rows) {
+        expect(dataKeyRepository.updateById).toHaveBeenCalledWith(row.id, { wrappedKey: expect.any(String), wrappedByKid: TARGET_KID });
+      }
+    });
+
+    it("writes a wrapping whose own header names the target version, so the column and the blob agree", async () => {
+      const { service, writtenKeys } = setup({ rows: [aRow({ wrappedByKid: SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(decodeProtectedHeader(writtenKeys()[0]).kid).toBe(TARGET_KID);
+    });
+
+    it("carries every other header claim across unchanged", async () => {
+      const { service, writtenKeys } = setup({ rows: [aRow({ wrappedByKid: SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(decodeProtectedHeader(writtenKeys()[0])).toEqual({ alg: "RSA-OAEP-256", enc: "A256GCM", cty: "application/octet-stream", kid: TARGET_KID });
+    });
+
+    it("wraps the very same data key bytes, so no stored secret stops opening", async () => {
+      const { service, writtenKeys } = setup({ rows: [aRow({ wrappedByKid: SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      const { plaintext } = await compactDecrypt(writtenKeys()[0], SEALING_KEYPAIR.privateKey);
+      expect(Buffer.from(plaintext).equals(DATA_KEY)).toBe(true);
+    });
+
+    it("opens each row under the version its own header names, not under the target", async () => {
+      const { service, wrappedJweService } = setup({ rows: [aRow({ wrappedByKid: OTHER_SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(wrappedJweService.open).toHaveBeenCalledWith(expect.anything(), versionPath("2"));
+    });
+
+    it("commits each batch in its own transaction", async () => {
+      const { service, txService } = setup({ rows: [aRow({}), aRow({}), aRow({})] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 2, dryRun: false });
+
+      expect(txService.transaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("selects in batches of the size asked for, and of a default when none is given", async () => {
+      const { service, dataKeyRepository } = setup({});
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 25, dryRun: false });
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).toHaveBeenNthCalledWith(1, { targetKid: TARGET_KID, batchSize: 25 });
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).toHaveBeenNthCalledWith(2, { targetKid: TARGET_KID, batchSize: 100 });
+    });
+  });
+
+  describe("a row that cannot be opened", () => {
+    it("records it, re-wraps the rest of its batch and reports the run as failed", async () => {
+      const unopenable = aRow({ wrappedByKid: SOURCE_KID });
+      const { service, dataKeyRepository } = setup({ rows: [unopenable, aRow({ wrappedByKid: SOURCE_KID })], unopenableIds: [unopenable.id] });
+
+      const result = await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(result.err).toBe(true);
+      expect(dataKeyRepository.updateById).toHaveBeenCalledTimes(1);
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalledWith(unopenable.id, expect.anything());
+    });
+
+    it("names it in an event so the operator knows which row blocks the version", async () => {
+      const unopenable = aRow({ wrappedByKid: SOURCE_KID });
+      const { service, logger } = setup({ rows: [unopenable], unopenableIds: [unopenable.id] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "DATA_KEY_REWRAP_ROW_FAILED", dataKeyId: unopenable.id, wrappedByKid: SOURCE_KID })
+      );
+    });
+
+    it("treats a kid of another crypto key as unopenable rather than wrapping it", async () => {
+      const foreign = aRow({ wrappedByKid: "someone-elses-key.v1" });
+      const { service, dataKeyRepository } = setup({ rows: [foreign] });
+
+      const result = await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(result.err).toBe(true);
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the report", () => {
+    it("states the census, the work done and the fingerprint", async () => {
+      const { service, report, writtenKeys } = setup({
+        rows: [aRow({ wrappedByKid: SOURCE_KID }), aRow({ wrappedByKid: SOURCE_KID })],
+        census: [
+          { wrappedByKid: SOURCE_KID, count: 2 },
+          { wrappedByKid: TARGET_KID, count: 1 }
+        ],
+        storedSecrets: [
+          { id: "a", sealedSecrets: A_TOKEN },
+          { id: "b", sealedSecrets: ANOTHER_TOKEN }
+        ]
+      });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false }));
+
+      expect(summary).toMatchObject({
+        dryRun: false,
+        toVersion: TARGET_KID,
+        fromVersions: [SOURCE_KID],
+        census: { [SOURCE_KID]: 2, [TARGET_KID]: 1 },
+        dataKeysRewrapped: 2,
+        dataKeysFailed: 0,
+        secretsReEncrypted: 0,
+        bytesRewritten: writtenKeys().reduce((total, key) => total + Buffer.byteLength(key), 0),
+        fingerprint: {
+          before: { rowCount: 2, byteCount: A_TOKEN.length + ANOTHER_TOKEN.length },
+          after: { rowCount: 2, byteCount: A_TOKEN.length + ANOTHER_TOKEN.length }
+        }
+      });
+      expect(summary.fingerprint.after?.digest).toBe(summary.fingerprint.before.digest);
+      expect(summary.elapsedMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("marks the run's start and completion with structured events", async () => {
+      const { service, logger } = setup({ rows: [aRow({})] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_START", toVersion: TARGET_KID, dryRun: false }));
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_END", report: expect.objectContaining({ toVersion: TARGET_KID }) }));
+    });
+
+    it("carries no key material and no secret value into any event", async () => {
+      const row = aRow({ wrappedByKid: SOURCE_KID });
+      const { service, logger, writtenKeys } = setup({ rows: [row], storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      const logged = JSON.stringify([...logger.info.mock.calls, ...logger.error.mock.calls, ...logger.warn.mock.calls]);
+      expect(logged).not.toContain(row.wrappedKey);
+      expect(logged).not.toContain(writtenKeys()[0]);
+      expect(logged).not.toContain(A_TOKEN);
+      expect(logged).not.toContain(DATA_KEY.toString("base64"));
+    });
+  });
+
+  describe("dry run", () => {
+    it("writes nothing and reports what a real run would move", async () => {
+      const { service, report, dataKeyRepository, txService } = setup({
+        census: [
+          { wrappedByKid: SOURCE_KID, count: 2 },
+          { wrappedByKid: TARGET_KID, count: 1 }
+        ]
+      });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true }));
+
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalled();
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).not.toHaveBeenCalled();
+      expect(txService.transaction).not.toHaveBeenCalled();
+      expect(summary).toMatchObject({ dryRun: true, dataKeysRewrapped: 2, census: { [SOURCE_KID]: 2, [TARGET_KID]: 1 } });
+    });
+
+    it("fingerprints the fleet once and reports no after, since nothing happened between", async () => {
+      const { service, report } = setup({ storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }] });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true }));
+
+      expect(summary.fingerprint.before).toMatchObject({ rowCount: 1, byteCount: A_TOKEN.length });
+      expect(summary.fingerprint.after).toBeUndefined();
+    });
+  });
+
+  describe("when a stored secret changed under the run", () => {
+    it("fails hard rather than reporting a rotation that proved nothing", async () => {
+      const { service } = setup({
+        rows: [aRow({})],
+        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }],
+        storedSecretsAfter: [{ id: "a", sealedSecrets: ANOTHER_TOKEN }]
+      });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
+    });
+
+    it("reports how many stored secrets moved, which a row count alone cannot show", async () => {
+      const { service, logger } = setup({
+        rows: [aRow({})],
+        storedSecrets: [
+          { id: "a", sealedSecrets: A_TOKEN },
+          { id: "b", sealedSecrets: A_TOKEN }
+        ],
+        storedSecretsAfter: [
+          { id: "a", sealedSecrets: ANOTHER_TOKEN },
+          { id: "b", sealedSecrets: A_TOKEN }
+        ]
+      });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "DATA_KEY_REWRAP_FINGERPRINT_MISMATCH", report: expect.objectContaining({ secretsReEncrypted: 1 }) })
+      );
+    });
+  });
+
+  function versionPath(version: string) {
+    return `projects/console-test/locations/global/keyRings/console-api/cryptoKeys/${KEY}/cryptoKeyVersions/${version}`;
+  }
+
+  function aRow(overrides: Partial<DataKeyOutput>): DataKeyOutput {
+    const id = overrides.id ?? randomUUID();
+
+    return {
+      id,
+      userId: overrides.userId ?? randomUUID(),
+      wrappedKey: overrides.wrappedKey ?? `wrapped-${id}`,
+      wrappedByKid: overrides.wrappedByKid ?? SOURCE_KID,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
+  }
+
+  function setup(input: {
+    rows?: DataKeyOutput[];
+    census?: Array<{ wrappedByKid: string; count: number }>;
+    storedSecrets?: Array<{ id: string; sealedSecrets: string }>;
+    storedSecretsAfter?: Array<{ id: string; sealedSecrets: string }>;
+    unopenableIds?: string[];
+    versionState?: protos.google.cloud.kms.v1.ICryptoKeyVersion["state"];
+  }) {
+    const rows = input.rows ?? [];
+    const client = mock<SdlSecretsKmsClient>();
+    client.getCryptoKeyVersion.mockResolvedValue([{ name: versionPath(TARGET_VERSION), state: input.versionState ?? "ENABLED" }]);
+    client.getPublicKey.mockResolvedValue([
+      {
+        name: versionPath(TARGET_VERSION),
+        pem: SEALING_KEY_PEM,
+        pemCrc32c: { value: crc32c.calculate(SEALING_KEY_PEM) },
+        algorithm: "RSA_DECRYPT_OAEP_2048_SHA256"
+      }
+    ]);
+
+    const createKmsTarget: SdlSecretsKmsTargetFactory = version => createSdlSecretsKmsTarget({ client, versionPath, key: KEY, version });
+
+    const rowByHeader = new Map<Record<string, unknown>, DataKeyOutput>();
+    const wrappedJweService = mock<KmsWrappedJweService>();
+    wrappedJweService.parse.mockImplementation(serialized => {
+      const row = rows.find(candidate => candidate.wrappedKey === serialized)!;
+      const header = { alg: "RSA-OAEP-256", enc: "A256GCM", cty: "application/octet-stream", kid: row.wrappedByKid };
+      rowByHeader.set(header, row);
+
+      return { header, segments: mock<ParsedKmsWrappedJwe["segments"]>() } as unknown as ParsedKmsWrappedJwe;
+    });
+    wrappedJweService.open.mockImplementation(async parsed => {
+      if (input.unopenableIds?.includes(rowByHeader.get(parsed.header)!.id)) {
+        throw new KmsWrappedJweError("WRAPPING_VERSION_UNUSABLE");
+      }
+
+      return DATA_KEY;
+    });
+
+    const dataKeyRepository = mock<DataKeyRepository>();
+    dataKeyRepository.countByWrappingVersion.mockResolvedValue(input.census ?? [{ wrappedByKid: SOURCE_KID, count: rows.length }]);
+    dataKeyRepository.findWrappedUnderOtherVersionsIteratively.mockImplementation(async function* ({ batchSize }) {
+      for (let offset = 0; offset < rows.length; offset += batchSize) {
+        yield rows.slice(offset, offset + batchSize);
+      }
+    });
+
+    let scans = 0;
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.findStoredSecretsIteratively.mockImplementation(async function* () {
+      const scanned = scans++ === 0 ? (input.storedSecrets ?? []) : (input.storedSecretsAfter ?? input.storedSecrets ?? []);
+
+      if (scanned.length) yield scanned;
+    });
+
+    const txService = mock<TxService>();
+    txService.transaction.mockImplementation(async callback => await callback());
+
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const service = new DataKeyRewrapService(dataKeyRepository, deploymentSettingRepository, wrappedJweService, txService, createKmsTarget, createLogger);
+
+    return {
+      service,
+      dataKeyRepository,
+      deploymentSettingRepository,
+      wrappedJweService,
+      txService,
+      client,
+      logger,
+      rows,
+      writtenKeys: () => dataKeyRepository.updateById.mock.calls.map(([, payload]) => payload.wrappedKey as string),
+      report: (result: Awaited<ReturnType<typeof service.rewrapDataKeys>>) => result.unwrap()
+    };
+  }
+});

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -4,6 +4,7 @@ import { CompactEncrypt } from "jose";
 import { Err, Ok, type Result } from "ts-results";
 import { inject, singleton } from "tsyringe";
 
+import { assertBatchSize } from "@src/core/lib/batch-size/batch-size";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { TxService } from "@src/core/services";
 import type { SdlSecretsKmsTarget, SdlSecretsKmsTargetFactory } from "@src/deployment/providers/kms.provider";
@@ -61,7 +62,7 @@ export class DataKeyRewrapService {
 
   async rewrapDataKeys({ targetVersion, batchSize, dryRun }: DataKeyRewrapOptions): Promise<Result<DataKeyRewrapReport, unknown[]>> {
     const startedAt = Date.now();
-    const pageSize = this.#assertUsableBatchSize(batchSize ?? DEFAULT_BATCH_SIZE);
+    const pageSize = assertBatchSize(batchSize ?? DEFAULT_BATCH_SIZE);
     const target = this.createKmsTarget(targetVersion);
     const sealingKey = await this.#assertUsableTarget(target);
 
@@ -107,14 +108,6 @@ export class DataKeyRewrapService {
     this.logger.info({ event: "DATA_KEY_REWRAP_END", report });
 
     return errors.length > 0 ? Err(errors) : Ok(report);
-  }
-
-  #assertUsableBatchSize(batchSize: number): number {
-    if (!Number.isInteger(batchSize) || batchSize < 1) {
-      throw new Error(`Batch size must be a positive integer, got ${batchSize}`);
-    }
-
-    return batchSize;
   }
 
   /** The public key alone cannot answer this: Cloud KMS refuses a disabled version's key, but the emulator serves it. */

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -12,7 +12,7 @@ import { DeploymentSettingRepository } from "@src/deployment/repositories/deploy
 import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
 import type { SdlSecretsSealingKey } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
 import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
-import type { StoredSecretsSummary } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
+import type { StoredSecretsDrift, StoredSecretsSummary } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
 import { StoredSecretsFingerprint } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
 import type { DataKeyOutput } from "@src/secret/repositories/data-key/data-key.repository";
 import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
@@ -37,18 +37,13 @@ export interface DataKeyRewrapReport {
   census: Record<string, number>;
   dataKeysRewrapped: number;
   dataKeysFailed: number;
-  secretsReEncrypted: number;
+  secretsDrift?: StoredSecretsDrift;
   bytesRewritten: number;
   elapsedMs: number;
   fingerprint: { before: StoredSecretsSummary; after?: StoredSecretsSummary };
 }
 
-/**
- * Moves every user's data encryption key onto a KMS key version, so the versions it leaves behind
- * can be disabled. A data key is re-wrapped, never replaced, and a deployment's secrets are sealed
- * to the data key's identity rather than to its wrapping — so this rewrites one row per user and
- * must leave every stored secret exactly as it found it, which the fingerprint either side proves.
- */
+/** Re-wraps every user's data key onto one KMS key version so the versions left behind can be disabled, and proves through the fingerprint drift that it left every stored secret untouched. */
 @singleton()
 export class DataKeyRewrapService {
   private readonly logger: ReturnType<CreateLogger>;
@@ -102,7 +97,7 @@ export class DataKeyRewrapService {
       census,
       dataKeysRewrapped: rewrapped,
       dataKeysFailed: errors.length,
-      secretsReEncrypted: after ? before.countDifferencesFrom(after) : 0,
+      secretsDrift: after?.driftFrom(before),
       bytesRewritten,
       elapsedMs: Date.now() - startedAt,
       fingerprint: { before: before.summarize(), after: after?.summarize() }
@@ -153,11 +148,7 @@ export class DataKeyRewrapService {
     return Object.fromEntries(census.map(({ wrappedByKid, count }) => [wrappedByKid, count]));
   }
 
-  /**
-   * A row nothing can open is recorded and stepped over rather than aborting the run: selection is
-   * keyset-paged, so a row that failed the whole run would be the first one every re-run picks, and
-   * the rest of the fleet would never move off the version the operator is trying to retire.
-   */
+  /** A row nothing can open is recorded and stepped over, because keyset selection would hand it to every re-run first and the fleet would never move off the retiring version. */
   async #rewrapBatch(
     batch: DataKeyOutput[],
     target: SdlSecretsKmsTarget,
@@ -194,10 +185,19 @@ export class DataKeyRewrapService {
       .encrypt(sealingKey.publicKey);
   }
 
+  /** Concurrent user writes move the digest legitimately, so only a row changed without its `updatedAt` moving fails the run. */
   #assertStoredSecretsUntouched(report: DataKeyRewrapReport) {
-    const { before, after } = report.fingerprint;
+    const drift = report.secretsDrift;
 
-    if (!after || (after.digest === before.digest && after.rowCount === before.rowCount && after.byteCount === before.byteCount)) {
+    if (!drift) {
+      return;
+    }
+
+    if (drift.changedConcurrently > 0 || drift.added > 0 || drift.removed > 0) {
+      this.logger.warn({ event: "DATA_KEY_REWRAP_SECRETS_CHANGED_CONCURRENTLY", drift });
+    }
+
+    if (drift.corruptedIds.length === 0) {
       return;
     }
 

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -1,0 +1,212 @@
+import { protos } from "@google-cloud/kms";
+import type { CompactJWEHeaderParameters } from "jose";
+import { CompactEncrypt } from "jose";
+import { Err, Ok, type Result } from "ts-results";
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { TxService } from "@src/core/services";
+import type { SdlSecretsKmsTarget, SdlSecretsKmsTargetFactory } from "@src/deployment/providers/kms.provider";
+import { SDL_SECRETS_KMS_TARGET_FACTORY } from "@src/deployment/providers/kms.provider";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import type { SdlSecretsSealingKey } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import type { StoredSecretsSummary } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
+import { StoredSecretsFingerprint } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
+import type { DataKeyOutput } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+
+const { CryptoKeyVersionState } = protos.google.cloud.kms.v1.CryptoKeyVersion;
+
+/** Holds both encodings of the state, because the Cloud KMS API reports an enum as either its name or its ordinal. */
+const ENABLED_KEY_VERSION_STATES: ReadonlySet<string | number> = new Set(["ENABLED", CryptoKeyVersionState.ENABLED]);
+
+const DEFAULT_BATCH_SIZE = 100;
+
+export interface DataKeyRewrapOptions {
+  targetVersion: string;
+  batchSize?: number;
+  dryRun: boolean;
+}
+
+export interface DataKeyRewrapReport {
+  dryRun: boolean;
+  toVersion: string;
+  fromVersions: string[];
+  census: Record<string, number>;
+  dataKeysRewrapped: number;
+  dataKeysFailed: number;
+  secretsReEncrypted: number;
+  bytesRewritten: number;
+  elapsedMs: number;
+  fingerprint: { before: StoredSecretsSummary; after?: StoredSecretsSummary };
+}
+
+/**
+ * Moves every user's data encryption key onto a KMS key version, so the versions it leaves behind
+ * can be disabled. A data key is re-wrapped, never replaced, and a deployment's secrets are sealed
+ * to the data key's identity rather than to its wrapping — so this rewrites one row per user and
+ * must leave every stored secret exactly as it found it, which the fingerprint either side proves.
+ */
+@singleton()
+export class DataKeyRewrapService {
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly dataKeyRepository: DataKeyRepository,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly wrappedJweService: KmsWrappedJweService,
+    private readonly txService: TxService,
+    @inject(SDL_SECRETS_KMS_TARGET_FACTORY) private readonly createKmsTarget: SdlSecretsKmsTargetFactory,
+    @inject(LOGGER_FACTORY) private readonly createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: DataKeyRewrapService.name });
+  }
+
+  async rewrapDataKeys({ targetVersion, batchSize, dryRun }: DataKeyRewrapOptions): Promise<Result<DataKeyRewrapReport, unknown[]>> {
+    const startedAt = Date.now();
+    const pageSize = this.#assertUsableBatchSize(batchSize ?? DEFAULT_BATCH_SIZE);
+    const target = this.createKmsTarget(targetVersion);
+    const sealingKey = await this.#assertUsableTarget(target);
+
+    this.logger.info({ event: "DATA_KEY_REWRAP_START", toVersion: target.kid, batchSize: pageSize, dryRun });
+
+    const before = await this.#fingerprintStoredSecrets(pageSize);
+    const census = await this.#censusByVersion();
+    const errors: unknown[] = [];
+    let rewrapped = dryRun ? countAwayFrom(census, target.kid) : 0;
+    let bytesRewritten = 0;
+
+    if (!dryRun) {
+      for await (const batch of this.dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: target.kid, batchSize: pageSize })) {
+        const wrappings = await this.#rewrapBatch(batch, target, sealingKey, errors);
+
+        await this.txService.transaction(async () => {
+          for (const { id, wrappedKey } of wrappings) {
+            await this.dataKeyRepository.updateById(id, { wrappedKey, wrappedByKid: target.kid });
+          }
+        });
+
+        rewrapped += wrappings.length;
+        bytesRewritten += wrappings.reduce((total, { wrappedKey }) => total + Buffer.byteLength(wrappedKey), 0);
+        this.logger.info({ event: "DATA_KEY_REWRAP_BATCH", rewrapped, failed: errors.length, bytesRewritten });
+      }
+    }
+
+    const after = dryRun ? undefined : await this.#fingerprintStoredSecrets(pageSize);
+    const report: DataKeyRewrapReport = {
+      dryRun,
+      toVersion: target.kid,
+      fromVersions: Object.keys(census).filter(kid => kid !== target.kid),
+      census,
+      dataKeysRewrapped: rewrapped,
+      dataKeysFailed: errors.length,
+      secretsReEncrypted: after ? before.countDifferencesFrom(after) : 0,
+      bytesRewritten,
+      elapsedMs: Date.now() - startedAt,
+      fingerprint: { before: before.summarize(), after: after?.summarize() }
+    };
+
+    this.#assertStoredSecretsUntouched(report);
+    this.logger.info({ event: "DATA_KEY_REWRAP_END", report });
+
+    return errors.length > 0 ? Err(errors) : Ok(report);
+  }
+
+  #assertUsableBatchSize(batchSize: number): number {
+    if (!Number.isInteger(batchSize) || batchSize < 1) {
+      throw new Error(`Batch size must be a positive integer, got ${batchSize}`);
+    }
+
+    return batchSize;
+  }
+
+  /** The public key alone cannot answer this: Cloud KMS refuses a disabled version's key, but the emulator serves it. */
+  async #assertUsableTarget(target: SdlSecretsKmsTarget): Promise<SdlSecretsSealingKey> {
+    const [version] = await target.client.getCryptoKeyVersion({ name: target.versionName });
+
+    if (!ENABLED_KEY_VERSION_STATES.has(version.state ?? "")) {
+      this.logger.error({ event: "DATA_KEY_REWRAP_TARGET_UNUSABLE", toVersion: target.kid, state: version.state });
+
+      throw new Error(`Key version ${target.kid} is not enabled`);
+    }
+
+    return await new SdlSecretsSealingKeyService(target, this.createLogger).getSealingKey();
+  }
+
+  async #fingerprintStoredSecrets(batchSize: number): Promise<StoredSecretsFingerprint> {
+    const fingerprint = new StoredSecretsFingerprint();
+
+    for await (const batch of this.deploymentSettingRepository.findStoredSecretsIteratively({ batchSize })) {
+      for (const storedSecrets of batch) {
+        fingerprint.add(storedSecrets);
+      }
+    }
+
+    return fingerprint;
+  }
+
+  async #censusByVersion(): Promise<Record<string, number>> {
+    const census = await this.dataKeyRepository.countByWrappingVersion();
+
+    return Object.fromEntries(census.map(({ wrappedByKid, count }) => [wrappedByKid, count]));
+  }
+
+  /**
+   * A row nothing can open is recorded and stepped over rather than aborting the run: selection is
+   * keyset-paged, so a row that failed the whole run would be the first one every re-run picks, and
+   * the rest of the fleet would never move off the version the operator is trying to retire.
+   */
+  async #rewrapBatch(
+    batch: DataKeyOutput[],
+    target: SdlSecretsKmsTarget,
+    sealingKey: SdlSecretsSealingKey,
+    errors: unknown[]
+  ): Promise<Array<{ id: string; wrappedKey: string }>> {
+    const wrappings: Array<{ id: string; wrappedKey: string }> = [];
+
+    for (const row of batch) {
+      try {
+        wrappings.push({ id: row.id, wrappedKey: await this.#rewrap(row, target, sealingKey) });
+      } catch (error) {
+        errors.push(error);
+        this.logger.error({ event: "DATA_KEY_REWRAP_ROW_FAILED", dataKeyId: row.id, userId: row.userId, wrappedByKid: row.wrappedByKid, error });
+      }
+    }
+
+    return wrappings;
+  }
+
+  /** The unwrap is the only call the key service sees; wrapping again spends only the public half already in memory. */
+  async #rewrap(row: DataKeyOutput, target: SdlSecretsKmsTarget, sealingKey: SdlSecretsSealingKey): Promise<string> {
+    const parsed = this.wrappedJweService.parse(row.wrappedKey);
+    const versionName = target.resolveVersionName(parsed.header.kid);
+
+    if (!versionName) {
+      throw new Error(`Data key ${row.id} names a key version this console cannot resolve`);
+    }
+
+    const dataKey = await this.wrappedJweService.open(parsed, versionName);
+
+    return await new CompactEncrypt(dataKey)
+      .setProtectedHeader({ ...parsed.header, kid: sealingKey.kid } as CompactJWEHeaderParameters)
+      .encrypt(sealingKey.publicKey);
+  }
+
+  #assertStoredSecretsUntouched(report: DataKeyRewrapReport) {
+    const { before, after } = report.fingerprint;
+
+    if (!after || (after.digest === before.digest && after.rowCount === before.rowCount && after.byteCount === before.byteCount)) {
+      return;
+    }
+
+    this.logger.error({ event: "DATA_KEY_REWRAP_FINGERPRINT_MISMATCH", report });
+
+    throw new Error(`Stored secrets changed while re-wrapping onto ${report.toVersion}`);
+  }
+}
+
+function countAwayFrom(census: Record<string, number>, targetKid: string): number {
+  return Object.entries(census).reduce((total, [kid, count]) => (kid === targetKid ? total : total + count), 0);
+}

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -20,7 +20,7 @@ import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.re
 const { CryptoKeyVersionState } = protos.google.cloud.kms.v1.CryptoKeyVersion;
 
 /** Holds both encodings of the state, because the Cloud KMS API reports an enum as either its name or its ordinal. */
-const ENABLED_KEY_VERSION_STATES: ReadonlySet<string | number> = new Set(["ENABLED", CryptoKeyVersionState.ENABLED]);
+const ENABLED_KEY_VERSION_STATES: ReadonlySet<unknown> = new Set(["ENABLED", CryptoKeyVersionState.ENABLED]);
 
 const DEFAULT_BATCH_SIZE = 100;
 
@@ -126,7 +126,7 @@ export class DataKeyRewrapService {
   async #assertUsableTarget(target: SdlSecretsKmsTarget): Promise<SdlSecretsSealingKey> {
     const [version] = await target.client.getCryptoKeyVersion({ name: target.versionName });
 
-    if (!ENABLED_KEY_VERSION_STATES.has(version.state ?? "")) {
+    if (!ENABLED_KEY_VERSION_STATES.has(version.state)) {
       this.logger.error({ event: "DATA_KEY_REWRAP_TARGET_UNUSABLE", toVersion: target.kid, state: version.state });
 
       throw new Error(`Key version ${target.kid} is not enabled`);


### PR DESCRIPTION
## Why

New wraps move to a new KMS key version by raising the console's configured target, and existing rows keep decrypting because every wrap opens under the version its own header names. But every data key still wrapped under an old version keeps that version alive — `asymmetricDecrypt` names an exact version, so disabling one takes its data with it.

This is the command that clears that: it re-wraps every user's data encryption key onto the new version, and proves by a fingerprint either side that it touched no stored secret. Its dry run is what makes the procedure rehearsable, rather than something first attempted during the incident that demands it.

Part of CON-875 — slice 2 of 3, stacked on `fix/user-rotate-kms-key-operator-command`. Slice 1 shipped the reads; slice 3 adds the integration proof against the key emulator.

## What

```
node dist/console.js rewrap-data-keys -t <version> [-b <size>] [-d]
```

On the same entrypoint the scheduled jobs already use, and reachable from nothing else — no HTTP route, no queue job, no UI.

A run verifies the target version is **enabled** and its public key fetches and validates, fingerprints every stored secrets token, counts the data keys under each wrapping version, then moves every row not already at the target. Each row is opened under the version *its own header* names — one KMS call per user — and the same key bytes are wrapped again to the target's public key locally, carrying every header claim across except `kid`. Each batch's writes commit in one transaction. The fleet is fingerprinted again at the end, and any difference fails the command hard.

**Resumability falls out of the selection.** Rows already at the target do not match, so a run that dies mid-way is continued simply by running it again — there is no progress table to reconcile, and a second run costs no KMS call.

### What a run reports

```ts
const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false }));

expect(summary).toMatchObject({
  dryRun: false,
  toVersion: TARGET_KID,
  fromVersions: [SOURCE_KID],
  census: { [SOURCE_KID]: 2, [TARGET_KID]: 1 },
  dataKeysRewrapped: 2,
  dataKeysFailed: 0,
  secretsReEncrypted: 0,
  bytesRewritten: writtenKeys().reduce((total, key) => total + Buffer.byteLength(key), 0),
  fingerprint: {
    before: { rowCount: 2, byteCount: A_TOKEN.length + ANOTHER_TOKEN.length },
    after: { rowCount: 2, byteCount: A_TOKEN.length + ANOTHER_TOKEN.length }
  }
});
```

The census is the read that outlives any single run: *"is anything still wrapped under version N"* is the gate on disabling that version, and after a rotation `fromVersions` is empty.

`secretsReEncrypted` is **measured, not asserted**. The fingerprint holds a digest per row, so this is the count of rows whose token differs from the one it held before the run — a hardcoded `0` would have satisfied the acceptance criterion just as well, and told nobody anything.

### Three decisions worth a second look

**A disabled target cannot be detected through `getPublicKey`.** Real Cloud KMS refuses a disabled version's public key; the emulator the tests run against serves it happily. A check written the obvious way would be green locally and wrong in production, so `getCryptoKeyVersion` joins the narrowed `SdlSecretsKmsClient` and the state is read explicitly. This widens the IAM the console's service account needs by `cloudkms.cryptoKeyVersions.get`.

**A dry run must not go through `DataKeyUnwrapperService`.** Its `getDataKey` calls `ensureDataKey`, which *inserts* a `data_keys` row for any user lacking one — so the obvious read path would have made the dry run a writer. Rows are read from the repository and opened with `KmsWrappedJweService` directly.

**A row nothing can open does not abort the run.** It is named with its id and its version, stepped over, and counted as a failure that makes the command exit non-zero. Aborting would make that row the first one every re-run picked, so the rest of the fleet would never leave the version being retired.

### Reviewer notes

Three non-blocking findings from review, none fixed here:

- The plan promised a distinct event when the target version differs from the configured `GCP_KMS_KEY_VERSION`; the service never consults the configured value, so that event does not exist. The prerequisite (raise the config first) stays advisory and unenforced, as the Spec's step 1 describes it.
- `DATA_KEY_REWRAP_BATCH` is emitted but no test asserts it, so deleting that line would pass the suite.
- Pre-existing, surfaced here: `BaseRepository.updateBy` sets the snake_case key `updated_at`, which drizzle's `buildUpdateSet` silently drops, so a re-wrapped `data_keys` row keeps its original timestamp. Fixing it is a `BaseRepository` change affecting every caller.

## Demo

### CON-875 slice 2 — rotating the KMS key from the operator command line

*2026-09-11T09:13:53Z by Showboat 0.6.1*
<!-- showboat-id: 9de375a6-2714-4fab-be74-dd328ab24534 -->

Slice 1 added the reads a rotation needs. This slice adds the command that uses them: `node dist/console.js rewrap-data-keys -t <version> [-b <size>] [-d]`.

It runs on the same entrypoint the scheduled jobs already use, and is reachable from nothing else — no HTTP route, no queue job, no UI.

Everything below runs the real command against a real Postgres and a real Cloud KMS emulator. The emulator hands out a fresh version number on every run, so key versions appear here as `vOLD`, `vNEW` and `vDISABLED`; the elapsed time, the fingerprint digests and the rewritten byte count are normalised for the same reason — that last one because it scales with the number of digits in the version alias. Startup logging is filtered down to the events this command emits. Where a normalised value carries the point, it is compared separately.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
npx tsup >/dev/null 2>&1
node dist/console.js rewrap-data-keys --help 2>&1 | grep -vE '"context":"ENV"|Response internal state key'

```

```output
Usage: API Console rewrap-data-keys [options]

Re-wrap every user's data key onto a KMS key version, so the versions it leaves
behind can be disabled

Options:
  -t, --target-version <string>  KMS key version every data key is wrapped
                                 under
  -b, --batch-size <number>      How many data keys are re-wrapped per
                                 transaction
  -d, --dry-run                  Report the census and what would be re-wrapped
                                 without writing anything (default: false)
  -h, --help                     display help for command
```

A fleet to rotate. Three users, each holding a data encryption key wrapped to one KMS key version; two of them own a deployment carrying a sealed secrets token, the third owns one carrying none. The tokens are sealed under each user's own data key with real AES-256-GCM, so they can be opened again at the end and checked against what went in.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
set -a; . ./env/.env.functional.test; set +a

DEMO_DB="rotation_demo"
PGOPTIONS="-c client_min_messages=warning" psql "$POSTGRES_URI/postgres" -q -c "DROP DATABASE IF EXISTS $DEMO_DB" -c "CREATE DATABASE $DEMO_DB"

cat > /tmp/rotation-demo-env.sh <<ENV
export DEMO_DB="$DEMO_DB"
export POSTGRES_DB_URI="\$POSTGRES_URI/$DEMO_DB"
export CHAIN_INDEXER_POSTGRES_DB_URI="\$POSTGRES_URI/$DEMO_DB"
export GCP_KMS_AUTH='{"project_id":"console-dev-mock","servicePath":"http://localhost:9090"}'
export LOG_LEVEL=info
ENV
. /tmp/rotation-demo-env.sh

LOG_LEVEL=error node dist/console.js rewrap-data-keys -t 1 -d >/dev/null 2>&1
VERSIONS=$(node "$(git rev-parse --show-toplevel)/.work/con-875-rotate-kms-key-operator-command/rotation-demo.mjs" seed)
echo "export OLD=$(echo "$VERSIONS" | cut -d' ' -f1)" >> /tmp/rotation-demo-env.sh
echo "export NEW=$(echo "$VERSIONS" | cut -d' ' -f2)" >> /tmp/rotation-demo-env.sh

cat > /tmp/rotation-demo-filter.py <<'FILTER'
import re, sys

KEPT = ('context: "DataKeyRewrapService"', 'context: "CLI"', 'context: "SdlSecretsSealingKeyService"')
START = re.compile(r"^\[\d\d:\d\d:\d\d\.\d+\] (INFO|ERROR|WARN|DEBUG)")
ANSI = re.compile(r"\x1b\[[0-9;]*m")

def flush(record):
    if record and any(marker in line for line in record for marker in KEPT):
        sys.stdout.write("".join(record))

record = []
for line in sys.stdin:
    line = ANSI.sub("", line)
    if START.match(line):
        flush(record)
        record = [line]
    elif record:
        record.append(line)
flush(record)
FILTER

cat > /tmp/rotation-demo-norm.sh <<'NORM'
sed -E \
  -e 's/\x1b\[[0-9;]*m//g' \
  -e "s/sdl-secrets\.v$OLD([^0-9]|$)/sdl-secrets.vOLD\1/g" \
  -e "s/sdl-secrets\.v$NEW([^0-9]|$)/sdl-secrets.vNEW\1/g" \
  -e 's/"digest": "[0-9a-f]{64}"/"digest": "<sha256, compared below>"/' \
  -e 's/"elapsedMs": [0-9]+/"elapsedMs": <ms>/' \
  -e 's/"bytesRewritten": [0-9]+/"bytesRewritten": <bytes>/' \
  -e 's/^(    bytesRewritten): [0-9]+$/\1: <bytes>/' \
  -e 's/^\[[0-9:.]+\] (INFO|ERROR|WARN) \(([a-z-]+)\/[0-9]+\):$/\1 [\2]:/' \
  -e 's/^\[[0-9:.]+\] (INFO|ERROR|WARN) \([0-9]+\):$/\1:/'
NORM

psql "$POSTGRES_URI/$DEMO_DB" -tA -c \
  "SELECT 'data keys wrapped under the old version: ' || count(*) FROM data_keys
   UNION ALL SELECT 'deployments holding a sealed secrets token: ' || count(*) FROM deployment_settings WHERE sealed_secrets IS NOT NULL
   UNION ALL SELECT 'deployments holding none: ' || count(*) FROM deployment_settings WHERE sealed_secrets IS NULL"
echo "two fresh KMS key versions provisioned on the emulator (their ids are printed below as vOLD and vNEW)"

```

```output
data keys wrapped under the old version: 3
deployments holding a sealed secrets token: 2
deployments holding none: 1
two fresh KMS key versions provisioned on the emulator (their ids are printed below as vOLD and vNEW)
```

First the dry run — what makes a rotation rehearsable rather than something first attempted during the incident that demands it. It fetches the target version's public key, fingerprints every stored secrets token, counts the data keys under each wrapping version, and reports what a real run would move.

Two `SDL_SECRETS_KEY_PUBLISHED` events appear: the console warms its own configured write target (`v1`) at startup, and the rotation separately fetches the key for the version it was pointed at. Raising the configured target is the operator's step, not this command's.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
set -a; . ./env/.env.functional.test; set +a; . /tmp/rotation-demo-env.sh

BEFORE=$(psql "$POSTGRES_URI/$DEMO_DB" -tA -c "SELECT md5(string_agg(id||wrapped_key||wrapped_by_kid, '' ORDER BY id)) FROM data_keys")
node dist/console.js rewrap-data-keys -t "$NEW" --dry-run 2>&1 \
  | python3 /tmp/rotation-demo-filter.py \
  | bash /tmp/rotation-demo-norm.sh
AFTER=$(psql "$POSTGRES_URI/$DEMO_DB" -tA -c "SELECT md5(string_agg(id||wrapped_key||wrapped_by_kid, '' ORDER BY id)) FROM data_keys")
echo
echo "every data_keys row byte-identical after the dry run: $([ "$BEFORE" = "$AFTER" ] && echo true || echo false)"

```

```output
INFO [rewrap-data-keys]:
    context: "CLI"
    event: "COMMAND_START"
INFO:
    context: "SdlSecretsSealingKeyService"
    event: "SDL_SECRETS_KEY_PUBLISHED"
    kid: "sdl-secrets.v1"
    algorithm: "RSA_DECRYPT_OAEP_3072_SHA256"
INFO:
    context: "SdlSecretsSealingKeyService"
    event: "SDL_SECRETS_KEY_PUBLISHED"
    kid: "sdl-secrets.vNEW"
    algorithm: "RSA_DECRYPT_OAEP_3072_SHA256"
INFO:
    context: "DataKeyRewrapService"
    event: "DATA_KEY_REWRAP_START"
    toVersion: "sdl-secrets.vNEW"
    batchSize: 100
    dryRun: true
INFO:
    context: "DataKeyRewrapService"
    event: "DATA_KEY_REWRAP_END"
    report: {
      "dryRun": true,
      "toVersion": "sdl-secrets.vNEW",
      "fromVersions": [
        "sdl-secrets.vOLD"
      ],
      "census": {
        "sdl-secrets.vOLD": 3
      },
      "dataKeysRewrapped": 3,
      "dataKeysFailed": 0,
      "secretsReEncrypted": 0,
      "bytesRewritten": <bytes>,
      "elapsedMs": <ms>,
      "fingerprint": {
        "before": {
          "digest": "<sha256, compared below>",
          "rowCount": 2,
          "byteCount": 366
        }
      }
    }
INFO [rewrap-data-keys]:
    context: "CLI"
    event: "COMMAND_END"

every data_keys row byte-identical after the dry run: true
```

Now the real run. Each row is opened under the version its own header names — one KMS call per user — and the same key bytes are wrapped again to the new version's public key locally, with every header claim carried across except `kid`. The batch's writes commit in one transaction, and the fleet is fingerprinted a second time.

`secretsReEncrypted: 0` is measured rather than asserted: the fingerprint holds a digest per row, so this is the count of rows whose token differs from the one it held before the run.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
set -a; . ./env/.env.functional.test; set +a; . /tmp/rotation-demo-env.sh

node dist/console.js rewrap-data-keys -t "$NEW" > /tmp/rotation-demo-run.log 2>&1
python3 /tmp/rotation-demo-filter.py < /tmp/rotation-demo-run.log | bash /tmp/rotation-demo-norm.sh
echo
python3 - <<'PY'
import json, re
raw = open("/tmp/rotation-demo-run.log").read()
digests = re.findall(r'"digest": "([0-9a-f]{64})"', raw)
print("the two fingerprint digests are identical:", "true" if len(digests) == 2 and digests[0] == digests[1] else "false")
PY

```

```output
INFO [rewrap-data-keys]:
    context: "CLI"
    event: "COMMAND_START"
INFO:
    context: "SdlSecretsSealingKeyService"
    event: "SDL_SECRETS_KEY_PUBLISHED"
    kid: "sdl-secrets.v1"
    algorithm: "RSA_DECRYPT_OAEP_3072_SHA256"
INFO:
    context: "SdlSecretsSealingKeyService"
    event: "SDL_SECRETS_KEY_PUBLISHED"
    kid: "sdl-secrets.vNEW"
    algorithm: "RSA_DECRYPT_OAEP_3072_SHA256"
INFO:
    context: "DataKeyRewrapService"
    event: "DATA_KEY_REWRAP_START"
    toVersion: "sdl-secrets.vNEW"
    batchSize: 100
    dryRun: false
INFO:
    context: "DataKeyRewrapService"
    event: "DATA_KEY_REWRAP_BATCH"
    rewrapped: 3
    failed: 0
    bytesRewritten: <bytes>
INFO:
    context: "DataKeyRewrapService"
    event: "DATA_KEY_REWRAP_END"
    report: {
      "dryRun": false,
      "toVersion": "sdl-secrets.vNEW",
      "fromVersions": [
        "sdl-secrets.vOLD"
      ],
      "census": {
        "sdl-secrets.vOLD": 3
      },
      "dataKeysRewrapped": 3,
      "dataKeysFailed": 0,
      "secretsReEncrypted": 0,
      "bytesRewritten": <bytes>,
      "elapsedMs": <ms>,
      "fingerprint": {
        "before": {
          "digest": "<sha256, compared below>",
          "rowCount": 2,
          "byteCount": 366
        },
        "after": {
          "digest": "<sha256, compared below>",
          "rowCount": 2,
          "byteCount": 366
        }
      }
    }
INFO [rewrap-data-keys]:
    context: "CLI"
    event: "COMMAND_END"

the two fingerprint digests are identical: true
```

That report says the rotation believes it changed no stored secret. This checks it independently, without going through the console at all: read each row back, ask Cloud KMS to unwrap it under the version it now names, and open that user's stored token with the result.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
set -a; . ./env/.env.functional.test; set +a; . /tmp/rotation-demo-env.sh

node "$(git rev-parse --show-toplevel)/.work/con-875-rotate-kms-key-operator-command/rotation-demo.mjs" check | bash /tmp/rotation-demo-norm.sh

```

```output
  data key 11111111  |  wrapped by sdl-secrets.vNEW  |  header kid agrees: true  |  same key bytes: true  |  secret opens to its original: true
  data key 22222222  |  wrapped by sdl-secrets.vNEW  |  header kid agrees: true  |  same key bytes: true  |  secret opens to its original: true
  data key 33333333  |  wrapped by sdl-secrets.vNEW  |  header kid agrees: true  |  same key bytes: true  |  secret opens to its original: true
```

Running it again costs nothing and changes nothing, because selection filters on the version rather than on a progress marker — a row already at the target no longer matches. That is also why a run that dies halfway resumes: there is no progress table to reconcile.

`fromVersions` is now empty and the census names a single version, which is the answer an operator needs before disabling the old one.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
set -a; . ./env/.env.functional.test; set +a; . /tmp/rotation-demo-env.sh

node dist/console.js rewrap-data-keys -t "$NEW" 2>&1 \
  | python3 /tmp/rotation-demo-filter.py \
  | bash /tmp/rotation-demo-norm.sh | grep -A 12 "DATA_KEY_REWRAP_END"

```

```output
    event: "DATA_KEY_REWRAP_END"
    report: {
      "dryRun": false,
      "toVersion": "sdl-secrets.vNEW",
      "fromVersions": [],
      "census": {
        "sdl-secrets.vNEW": 3
      },
      "dataKeysRewrapped": 0,
      "dataKeysFailed": 0,
      "secretsReEncrypted": 0,
      "bytesRewritten": <bytes>,
      "elapsedMs": <ms>,
```

Two ways it refuses to do damage.

A target version the key service reports as disabled is refused before a single row is read. `getPublicKey` cannot be trusted for this — real Cloud KMS refuses a disabled version's key while the emulator serves it happily — so the version's state is read explicitly.

A row that nothing can open is named, stepped over, and counted as a failure that makes the command exit non-zero. It does not abort the run: selection is keyset-paged, so a row that killed the whole run would be the first one every re-run picked, and the rest of the fleet would never leave the version being retired.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
set -a; . ./env/.env.functional.test; set +a; . /tmp/rotation-demo-env.sh
DEMO=$(git rev-parse --show-toplevel)/.work/con-875-rotate-kms-key-operator-command/rotation-demo.mjs

echo "== pointed at a key version the key service reports as disabled =="
DISABLED=$(node "$DEMO" disabled)
node dist/console.js rewrap-data-keys -t "$DISABLED" 2>&1 \
  | python3 /tmp/rotation-demo-filter.py \
  | sed -E "s/sdl-secrets\.v$DISABLED([^0-9]|$)/sdl-secrets.vDISABLED\1/g" \
  | bash /tmp/rotation-demo-norm.sh \
  | grep -E "TARGET_UNUSABLE|toVersion|state:|COMMAND_ERROR" | head -6
echo "exit code: $(node dist/console.js rewrap-data-keys -t "$DISABLED" >/dev/null 2>&1; echo $?)"

echo
echo "== one row left naming a key version that does not exist =="
node "$DEMO" corrupt
node dist/console.js rewrap-data-keys -t "$NEW" 2>&1 \
  | python3 /tmp/rotation-demo-filter.py \
  | bash /tmp/rotation-demo-norm.sh \
  | grep -E "ROW_FAILED|dataKeyId|wrappedByKid:|dataKeysRewrapped|dataKeysFailed" | head -6
echo
psql "$POSTGRES_URI/$DEMO_DB" -tA -c \
  "SELECT '  ' || kid || ': ' || total FROM (SELECT wrapped_by_kid AS kid, count(*) AS total FROM data_keys GROUP BY wrapped_by_kid) c ORDER BY kid" \
  | sed -E "s/sdl-secrets\.v$NEW([^0-9]|$)/sdl-secrets.vNEW\1/g"

```

```output
== pointed at a key version the key service reports as disabled ==
    event: "DATA_KEY_REWRAP_TARGET_UNUSABLE"
    toVersion: "sdl-secrets.vDISABLED"
    state: "DISABLED"
    event: "COMMAND_ERROR"
exit code: 1

== one row left naming a key version that does not exist ==
  data key 11111111 now names a key version that does not exist
    event: "DATA_KEY_REWRAP_ROW_FAILED"
    dataKeyId: "11111111-1111-4111-8111-111111111111"
    wrappedByKid: "sdl-secrets.v999999"
      "dataKeysRewrapped": 0,
      "dataKeysFailed": 1,

  sdl-secrets.vNEW: 2
  sdl-secrets.v999999: 1
```

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
set -a; . ./env/.env.functional.test; set +a; . /tmp/rotation-demo-env.sh
PGOPTIONS="-c client_min_messages=warning" psql "$POSTGRES_URI/postgres" -q -c "DROP DATABASE IF EXISTS $DEMO_DB"
rm -f /tmp/rotation-demo-env.sh /tmp/rotation-demo-norm.sh /tmp/rotation-demo-run.log /tmp/rotation-demo-state.json
echo "demo database dropped"

```

```output
demo database dropped
```

What a person can take from the above:

- **the dry run rehearses the whole thing and writes nothing** — every `data_keys` row is byte-identical after it, and the report it prints is the same shape a real run prints;
- **the census answers the question that gates disabling a version** — after the run it names one version holding all three data keys, and `fromVersions` is empty;
- **re-wrapping is invisible to every stored secret** — the fingerprint over all stored tokens is identical either side, `secretsReEncrypted` is a measured zero, and each secret independently opens to the plaintext it was sealed with;
- **the data key itself never changes** — the bytes unwrapped after the rotation are the same bytes, which is why no token had to be touched;
- **a second run is free** and an interrupted one resumes, because the selection filters on the version rather than on a progress marker;
- **a disabled target is refused before any row is read**, and a row that cannot be opened is named rather than silently skipped or allowed to kill the run.
