### PR TITLE
test(deployment): cover data key re-wrapping against the database and the key emulator

### DIFF
--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -14,6 +14,7 @@ import { ExecutionContextService } from "@src/core/services/execution-context/ex
 import { TopUpDeploymentsController } from "@src/deployment/controllers/deployment/top-up-deployments.controller";
 import { GpuBotController } from "@src/deployment/controllers/gpu-bot/gpu-bot.controller";
 import { ProviderController } from "@src/provider/controllers/provider/provider.controller";
+import { DataKeyRewrapController } from "@src/secret/controllers/data-key-rewrap/data-key-rewrap.controller";
 import { WorkloadAbuseController } from "@src/workload-abuse/controllers/workload-abuse.controller";
 import { APP_INITIALIZER, ON_APP_START } from "../core/providers/app-initializer";
 
@@ -119,6 +120,18 @@ program
   .action(async (options, command) => {
     await executeCliHandler(command.name(), async () => {
       await container.resolve(GpuBotController).createGpuBids();
+    });
+  });
+
+program
+  .command("rewrap-data-keys")
+  .description("Re-wrap every user's data key onto a KMS key version, so the versions it leaves behind can be disabled")
+  .requiredOption("-t, --target-version <string>", "KMS key version every data key is wrapped under", value => z.string().min(1).parse(value))
+  .option("-b, --batch-size <number>", "How many data keys are re-wrapped per transaction", value => z.number({ coerce: true }).int().positive().parse(value))
+  .option("-d, --dry-run", "Report the census and what would be re-wrapped without writing anything", false)
+  .action(async (options, command) => {
+    await executeCliHandler(command.name(), async () => {
+      return container.resolve(DataKeyRewrapController).rewrapDataKeys(options);
     });
   });
 

--- a/apps/api/src/core/lib/batch-size/batch-size.spec.ts
+++ b/apps/api/src/core/lib/batch-size/batch-size.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { assertBatchSize } from "./batch-size";
+
+describe(assertBatchSize.name, () => {
+  it("returns a positive integer unchanged", () => {
+    expect(assertBatchSize(1)).toBe(1);
+    expect(assertBatchSize(100)).toBe(100);
+  });
+
+  it.each([0, -1, 1.5, NaN, Infinity])("refuses %s rather than handing it to a query", value => {
+    expect(() => assertBatchSize(value)).toThrow(`Batch size must be a positive integer, got ${value}`);
+  });
+});

--- a/apps/api/src/core/lib/batch-size/batch-size.ts
+++ b/apps/api/src/core/lib/batch-size/batch-size.ts
@@ -1,0 +1,8 @@
+/** `LIMIT 0` reads as an empty fleet and ends a keyset scan silently, so a batch size is refused loudly before any query runs. */
+export function assertBatchSize(batchSize: number): number {
+  if (!Number.isInteger(batchSize) || batchSize < 1) {
+    throw new Error(`Batch size must be a positive integer, got ${batchSize}`);
+  }
+
+  return batchSize;
+}

--- a/apps/api/src/deployment/providers/kms.provider.spec.ts
+++ b/apps/api/src/deployment/providers/kms.provider.spec.ts
@@ -5,7 +5,8 @@ import { mock } from "vitest-mock-extended";
 
 import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
 import type { SdlSecretsKmsClient } from "./kms.provider";
-import { createSdlSecretsKmsTarget, KMS_CLIENT, SDL_SECRETS_KMS_TARGET } from "./kms.provider";
+import type { SdlSecretsKmsTargetFactory } from "./kms.provider";
+import { createSdlSecretsKmsTarget, KMS_CLIENT, SDL_SECRETS_KMS_TARGET, SDL_SECRETS_KMS_TARGET_FACTORY } from "./kms.provider";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
@@ -119,5 +120,51 @@ describe("SDL_SECRETS_KMS_TARGET", () => {
     });
 
     return { target: testContainer.resolve(SDL_SECRETS_KMS_TARGET), kmsClient };
+  }
+});
+
+describe("SDL_SECRETS_KMS_TARGET_FACTORY", () => {
+  it("targets a version the configuration does not name, which is what a rotation needs", () => {
+    const { createTarget } = setup({ version: "2" });
+
+    const target = createTarget("7");
+
+    expect(target.kid).toBe("sdl-secrets.v7");
+    expect(target.versionName).toBe("console-test/global/console-api/sdl-secrets/7");
+  });
+
+  it("resolves any version of the same key from a target built for another one", () => {
+    const { createTarget } = setup({ version: "2" });
+
+    expect(createTarget("7").resolveVersionName("sdl-secrets.v1")).toBe("console-test/global/console-api/sdl-secrets/1");
+  });
+
+  it("builds the configured write target from the same factory", () => {
+    const { createTarget, configuredTarget } = setup({ version: "2" });
+
+    expect(configuredTarget.kid).toBe(createTarget("2").kid);
+    expect(configuredTarget.versionName).toBe(createTarget("2").versionName);
+  });
+
+  function setup(input: { version: string }) {
+    const kmsClient = mock<KeyManagementServiceClient>();
+    kmsClient.cryptoKeyVersionPath.mockImplementation((project, location, keyRing, key, version) => [project, location, keyRing, key, version].join("/"));
+
+    const testContainer = container.createChildContainer();
+    testContainer.register(KMS_CLIENT, { useValue: kmsClient });
+    testContainer.register(DeploymentConfigService, {
+      useValue: mockConfigService<DeploymentConfigService>({
+        GCP_KMS_AUTH: { project_id: "console-test", servicePath: "http://localhost:9090" },
+        GCP_KMS_LOCATION: "global",
+        GCP_KMS_KEY_RING: "console-api",
+        GCP_KMS_KEY: "sdl-secrets",
+        GCP_KMS_KEY_VERSION: input.version
+      })
+    });
+
+    return {
+      createTarget: testContainer.resolve<SdlSecretsKmsTargetFactory>(SDL_SECRETS_KMS_TARGET_FACTORY),
+      configuredTarget: testContainer.resolve(SDL_SECRETS_KMS_TARGET)
+    };
   }
 });

--- a/apps/api/src/deployment/providers/kms.provider.ts
+++ b/apps/api/src/deployment/providers/kms.provider.ts
@@ -13,6 +13,8 @@ const CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 /** The Cloud KMS operations the console performs on the SDL secrets key, narrowed so they can be doubled in tests. */
 export interface SdlSecretsKmsClient {
   getPublicKey(request: { name: string }, options?: CallOptions): Promise<[protos.google.cloud.kms.v1.IPublicKey, ...unknown[]]>;
+  /** Only this reports a version's state: Cloud KMS refuses a disabled version's public key, but the emulator serves it. */
+  getCryptoKeyVersion(request: { name: string }, options?: CallOptions): Promise<[protos.google.cloud.kms.v1.ICryptoKeyVersion, ...unknown[]]>;
   asymmetricDecrypt(request: {
     name: string;
     ciphertext: Buffer;
@@ -63,7 +65,12 @@ export function createSdlSecretsKmsTarget(input: {
   };
 }
 
+/** A target for any version of the console's crypto key, so a rotation can address one the configuration does not name. */
+export type SdlSecretsKmsTargetFactory = (version: string) => SdlSecretsKmsTarget;
+
 export const KMS_CLIENT: InjectionToken<KeyManagementServiceClient> = Symbol("KMS_CLIENT");
+
+export const SDL_SECRETS_KMS_TARGET_FACTORY: InjectionToken<SdlSecretsKmsTargetFactory> = Symbol("SDL_SECRETS_KMS_TARGET_FACTORY");
 
 export const SDL_SECRETS_KMS_TARGET: InjectionToken<SdlSecretsKmsTarget> = Symbol("SDL_SECRETS_KMS_TARGET");
 
@@ -94,18 +101,23 @@ container.register(KMS_CLIENT, {
   })
 });
 
-container.register(SDL_SECRETS_KMS_TARGET, {
+container.register(SDL_SECRETS_KMS_TARGET_FACTORY, {
   useFactory: instancePerContainerCachingFactory(c => {
     const config = c.resolve(DeploymentConfigService);
     const auth = config.get("GCP_KMS_AUTH");
     const client = c.resolve<KeyManagementServiceClient>(KMS_CLIENT);
     const key = config.get("GCP_KMS_KEY");
+    const versionPath = (version: string) =>
+      client.cryptoKeyVersionPath(auth.project_id, config.get("GCP_KMS_LOCATION"), config.get("GCP_KMS_KEY_RING"), key, version);
 
-    return createSdlSecretsKmsTarget({
-      client,
-      versionPath: version => client.cryptoKeyVersionPath(auth.project_id, config.get("GCP_KMS_LOCATION"), config.get("GCP_KMS_KEY_RING"), key, version),
-      key,
-      version: config.get("GCP_KMS_KEY_VERSION")
-    });
+    const createTarget: SdlSecretsKmsTargetFactory = version => createSdlSecretsKmsTarget({ client, versionPath, key, version });
+
+    return createTarget;
   })
+});
+
+container.register(SDL_SECRETS_KMS_TARGET, {
+  useFactory: instancePerContainerCachingFactory(c =>
+    c.resolve<SdlSecretsKmsTargetFactory>(SDL_SECRETS_KMS_TARGET_FACTORY)(c.resolve(DeploymentConfigService).get("GCP_KMS_KEY_VERSION"))
+  )
 });

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -886,7 +886,7 @@ describe(DeploymentSettingRepository.name, () => {
 
       const stored = await findStoredSecrets([id]);
 
-      expect(stored).toEqual([{ id, sealedSecrets: sealedToken }]);
+      expect(stored).toEqual([{ id, sealedSecrets: sealedToken, updatedAt: expect.any(Date) }]);
     });
 
     it("passes over a deployment holding no token, which no fingerprint has anything to say about", async () => {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -871,6 +871,69 @@ describe(DeploymentSettingRepository.name, () => {
     });
   });
 
+  describe("findStoredSecretsIteratively", () => {
+    it("yields a deployment's token under the id that holds it", async () => {
+      const { sealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const id = await createSettingWithSecrets(sealedToken);
+
+      const stored = await findStoredSecrets([id]);
+
+      expect(stored).toEqual([{ id, sealedSecrets: sealedToken }]);
+    });
+
+    it("passes over a deployment holding no token, which no fingerprint has anything to say about", async () => {
+      const { sealedToken, createSetting, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const withoutSecrets = await createSetting();
+      const withSecrets = await createSettingWithSecrets(sealedToken);
+
+      const stored = await findStoredSecrets([withoutSecrets, withSecrets]);
+
+      expect(stored.map(row => row.id)).toEqual([withSecrets]);
+    });
+
+    it("pages every token-holding deployment exactly once when the batch is smaller than the set", async () => {
+      const { sealedToken, otherSealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const ids = [
+        await createSettingWithSecrets(sealedToken),
+        await createSettingWithSecrets(otherSealedToken),
+        await createSettingWithSecrets(sealedToken)
+      ];
+
+      const oneAtATime = await findStoredSecrets(ids, 1);
+      const allAtOnce = await findStoredSecrets(ids, 1000);
+
+      expect(allAtOnce).toHaveLength(3);
+      expect(oneAtATime).toEqual(allAtOnce);
+    });
+
+    it("yields rows in id order, so each batch stays an index scan on the primary key", async () => {
+      const { sealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
+      const ids = [
+        await createSettingWithSecrets(sealedToken),
+        await createSettingWithSecrets(sealedToken),
+        await createSettingWithSecrets(sealedToken)
+      ];
+
+      const stored = await findStoredSecrets(ids, 2);
+
+      expect(stored.map(row => row.id)).toEqual([...ids].sort());
+    });
+
+    it("yields batches no larger than the size asked for", async () => {
+      const { sealedToken, deploymentSettingRepository, createSettingWithSecrets } = await setup();
+      await createSettingWithSecrets(sealedToken);
+      await createSettingWithSecrets(sealedToken);
+      await createSettingWithSecrets(sealedToken);
+      const sizes: number[] = [];
+
+      for await (const batch of deploymentSettingRepository.findStoredSecretsIteratively({ batchSize: 2 })) {
+        sizes.push(batch.length);
+      }
+
+      expect(Math.max(...sizes)).toBeLessThanOrEqual(2);
+    });
+  });
+
   describe("createDefaultIfMissing", () => {
     it("records a deployment nothing had recorded yet, with funding on", async () => {
       const { deploymentSettingRepository, user } = await setup();
@@ -1352,6 +1415,22 @@ describe(DeploymentSettingRepository.name, () => {
       return setting.id;
     }
 
+    async function createSettingWithSecrets(sealedSecrets: string) {
+      const setting = await deploymentSettingRepository.create({ userId: user.id, dseq: newDseq(), autoTopUpEnabled: true, sealedSecrets });
+
+      return setting.id;
+    }
+
+    async function findStoredSecrets(ids: string[], batchSize = 1000) {
+      const stored = [];
+
+      for await (const batch of deploymentSettingRepository.findStoredSecretsIteratively({ batchSize })) {
+        stored.push(...batch.filter(row => ids.includes(row.id)));
+      }
+
+      return stored;
+    }
+
     async function findOpenDeployments(addresses?: string[], batchSize = 1000) {
       const open = [];
 
@@ -1438,6 +1517,8 @@ describe(DeploymentSettingRepository.name, () => {
       readDefinition,
       readSettingDseq,
       createSetting,
+      createSettingWithSecrets,
+      findStoredSecrets,
       createLimitedSetting,
       createAnchoredSetting,
       findAutoTopUpOwners,

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.integration.ts
@@ -872,6 +872,14 @@ describe(DeploymentSettingRepository.name, () => {
   });
 
   describe("findStoredSecretsIteratively", () => {
+    it("refuses a batch size of zero, which would read as a fleet holding no secrets", async () => {
+      const { deploymentSettingRepository } = await setup();
+
+      await expect(deploymentSettingRepository.findStoredSecretsIteratively({ batchSize: 0 }).next()).rejects.toThrow(
+        "Batch size must be a positive integer"
+      );
+    });
+
     it("yields a deployment's token under the id that holds it", async () => {
       const { sealedToken, createSettingWithSecrets, findStoredSecrets } = await setup();
       const id = await createSettingWithSecrets(sealedToken);

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -183,11 +183,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     }
   }
 
-  /**
-   * Every stored secrets token there is, keyset-paged on `id`. Rows holding none are left out, so
-   * the count and byte total a fingerprint reports describe the deployments that actually carry a
-   * secret rather than the size of the table.
-   */
+  /** Rows holding no secret are left out, so a fingerprint's row and byte counts describe the deployments that actually carry one. */
   async *findStoredSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<DeploymentStoredSecrets[]> {
     let cursor: string | undefined;
 

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -49,10 +49,11 @@ export type OpenDeployment = {
   createdAt: Date;
 };
 
-/** A deployment's stored secrets token alongside the id it is sealed to. */
+/** A deployment's stored secrets token alongside the id it is sealed to and the timestamp every legitimate secrets write bumps. */
 export type DeploymentStoredSecrets = {
   id: string;
   sealedSecrets: string;
+  updatedAt: Date | null;
 };
 
 export type LiveTrialDeployment = {
@@ -192,7 +193,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
     while (true) {
       const batch = await this.pg
-        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets })
+        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets, updatedAt: this.table.updatedAt })
         .from(this.table)
         .where(and(isNotNull(this.table.sealedSecrets), ...(cursor ? [gt(this.table.id, cursor)] : [])))
         .orderBy(asc(this.table.id))

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -2,6 +2,7 @@ import { and, asc, desc, eq, gt, gte, inArray, isNotNull, isNull, lt, lte, or, s
 import { singleton } from "tsyringe";
 
 import { UserWallets, WalletSetting } from "@src/billing/model-schemas";
+import { assertBatchSize } from "@src/core/lib/batch-size/batch-size";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
@@ -185,6 +186,8 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
   /** Rows holding no secret are left out, so a fingerprint's row and byte counts describe the deployments that actually carry one. */
   async *findStoredSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<DeploymentStoredSecrets[]> {
+    assertBatchSize(batchSize);
+
     let cursor: string | undefined;
 
     while (true) {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -48,6 +48,12 @@ export type OpenDeployment = {
   createdAt: Date;
 };
 
+/** A deployment's stored secrets token alongside the id it is sealed to. */
+export type DeploymentStoredSecrets = {
+  id: string;
+  sealedSecrets: string;
+};
+
 export type LiveTrialDeployment = {
   userId: string;
   dseq: string;
@@ -168,6 +174,36 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       }
 
       yield batch as OpenDeployment[];
+
+      if (batch.length < batchSize) {
+        return;
+      }
+
+      cursor = batch[batch.length - 1].id;
+    }
+  }
+
+  /**
+   * Every stored secrets token there is, keyset-paged on `id`. Rows holding none are left out, so
+   * the count and byte total a fingerprint reports describe the deployments that actually carry a
+   * secret rather than the size of the table.
+   */
+  async *findStoredSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<DeploymentStoredSecrets[]> {
+    let cursor: string | undefined;
+
+    while (true) {
+      const batch = await this.pg
+        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets })
+        .from(this.table)
+        .where(and(isNotNull(this.table.sealedSecrets), ...(cursor ? [gt(this.table.id, cursor)] : [])))
+        .orderBy(asc(this.table.id))
+        .limit(batchSize);
+
+      if (!batch.length) {
+        return;
+      }
+
+      yield batch as DeploymentStoredSecrets[];
 
       if (batch.length < batchSize) {
         return;

--- a/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.integration.ts
+++ b/apps/api/src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service.integration.ts
@@ -45,7 +45,12 @@ async function createEnabledVersion() {
 let rotationPair: Promise<{ oldVersion: string; newVersion: string }> | undefined;
 
 function enabledRotationPair() {
-  rotationPair ??= Promise.all([createEnabledVersion(), createEnabledVersion()]).then(([oldVersion, newVersion]) => ({ oldVersion, newVersion }));
+  rotationPair ??= Promise.all([createEnabledVersion(), createEnabledVersion()])
+    .then(([oldVersion, newVersion]) => ({ oldVersion, newVersion }))
+    .catch(error => {
+      rotationPair = undefined;
+      throw error;
+    });
 
   return rotationPair;
 }

--- a/apps/api/src/secret/controllers/data-key-rewrap/data-key-rewrap.controller.spec.ts
+++ b/apps/api/src/secret/controllers/data-key-rewrap/data-key-rewrap.controller.spec.ts
@@ -1,0 +1,38 @@
+import { Ok } from "ts-results";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DataKeyRewrapReport, DataKeyRewrapService } from "@src/secret/services/data-key-rewrap/data-key-rewrap.service";
+import { DataKeyRewrapController } from "./data-key-rewrap.controller";
+
+describe(DataKeyRewrapController.name, () => {
+  it("hands the target version, the batch size and the dry-run switch to the service", async () => {
+    const { controller, dataKeyRewrapService } = setup();
+
+    await controller.rewrapDataKeys({ targetVersion: "3", batchSize: 50, dryRun: true });
+
+    expect(dataKeyRewrapService.rewrapDataKeys).toHaveBeenCalledWith({ targetVersion: "3", batchSize: 50, dryRun: true });
+  });
+
+  it("leaves the batch size for the service to default when the operator gives none", async () => {
+    const { controller, dataKeyRewrapService } = setup();
+
+    await controller.rewrapDataKeys({ targetVersion: "3", dryRun: false });
+
+    expect(dataKeyRewrapService.rewrapDataKeys).toHaveBeenCalledWith({ targetVersion: "3", dryRun: false });
+  });
+
+  it("returns the run's result, so a failed run reaches the command's exit code", async () => {
+    const { controller, report } = setup();
+
+    await expect(controller.rewrapDataKeys({ targetVersion: "3", dryRun: false })).resolves.toEqual(Ok(report));
+  });
+
+  function setup() {
+    const report = mock<DataKeyRewrapReport>({ toVersion: "sdl-secrets.v3", dataKeysRewrapped: 2 });
+    const dataKeyRewrapService = mock<DataKeyRewrapService>();
+    dataKeyRewrapService.rewrapDataKeys.mockResolvedValue(Ok(report));
+
+    return { controller: new DataKeyRewrapController(dataKeyRewrapService), dataKeyRewrapService, report };
+  }
+});

--- a/apps/api/src/secret/controllers/data-key-rewrap/data-key-rewrap.controller.ts
+++ b/apps/api/src/secret/controllers/data-key-rewrap/data-key-rewrap.controller.ts
@@ -1,0 +1,13 @@
+import { singleton } from "tsyringe";
+
+import type { DataKeyRewrapOptions } from "@src/secret/services/data-key-rewrap/data-key-rewrap.service";
+import { DataKeyRewrapService } from "@src/secret/services/data-key-rewrap/data-key-rewrap.service";
+
+@singleton()
+export class DataKeyRewrapController {
+  constructor(private readonly dataKeyRewrapService: DataKeyRewrapService) {}
+
+  async rewrapDataKeys(options: DataKeyRewrapOptions) {
+    return await this.dataKeyRewrapService.rewrapDataKeys(options);
+  }
+}

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
@@ -81,6 +81,40 @@ describe(StoredSecretsFingerprint.name, () => {
     expect(summary.digest).not.toBe(setup({ rows: [FIRST] }).summary.digest);
   });
 
+  describe("countDifferencesFrom", () => {
+    it("counts no difference against an identical fleet", () => {
+      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
+
+      expect(fingerprint.countDifferencesFrom(setup({ rows: [SECOND, FIRST] }).fingerprint)).toBe(0);
+    });
+
+    it("counts each row whose token changed", () => {
+      const { fingerprint } = setup({ rows: [FIRST, SECOND, THIRD] });
+      const { fingerprint: changed } = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed" }, { ...THIRD, sealedSecrets: "also-changed" }] });
+
+      expect(fingerprint.countDifferencesFrom(changed)).toBe(2);
+    });
+
+    it("counts a row that arrived and a row that disappeared", () => {
+      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
+      const { fingerprint: moved } = setup({ rows: [FIRST, THIRD] });
+
+      expect(fingerprint.countDifferencesFrom(moved)).toBe(2);
+    });
+
+    it("counts a swap as both rows having moved", () => {
+      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
+      const { fingerprint: swapped } = setup({
+        rows: [
+          { id: FIRST.id, sealedSecrets: SECOND.sealedSecrets },
+          { id: SECOND.id, sealedSecrets: FIRST.sealedSecrets }
+        ]
+      });
+
+      expect(fingerprint.countDifferencesFrom(swapped)).toBe(2);
+    });
+  });
+
   it("summarizes the same fleet the same way across separate runs", () => {
     expect(setup({ rows: [FIRST, SECOND] }).summary).toEqual(setup({ rows: [FIRST, SECOND] }).summary);
   });

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
@@ -5,6 +5,8 @@ import { StoredSecretsFingerprint } from "./stored-secrets-fingerprint";
 const FIRST = { id: "11111111-1111-4111-8111-111111111111", sealedSecrets: "aGVhZGVy.a2V5.aXY.Zmlyc3Q.dGFn" };
 const SECOND = { id: "22222222-2222-4222-8222-222222222222", sealedSecrets: "aGVhZGVy.a2V5.aXY.c2Vjb25k.dGFn" };
 const THIRD = { id: "33333333-3333-4333-8333-333333333333", sealedSecrets: "aGVhZGVy.a2V5.aXY.dGhpcmQ.dGFn" };
+const TOUCHED_AT = new Date("2026-09-01T10:00:00Z");
+const TOUCHED_LATER = new Date("2026-09-01T10:05:00Z");
 
 describe(StoredSecretsFingerprint.name, () => {
   it("digests the same rows to the same value whatever order they arrive in", () => {
@@ -81,37 +83,47 @@ describe(StoredSecretsFingerprint.name, () => {
     expect(summary.digest).not.toBe(setup({ rows: [FIRST] }).summary.digest);
   });
 
-  describe("countDifferencesFrom", () => {
-    it("counts no difference against an identical fleet", () => {
-      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
+  describe("driftFrom", () => {
+    it("reports no drift against an identical fleet", () => {
+      const before = setup({ rows: [FIRST, SECOND] });
+      const after = setup({ rows: [SECOND, FIRST] });
 
-      expect(fingerprint.countDifferencesFrom(setup({ rows: [SECOND, FIRST] }).fingerprint)).toBe(0);
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toEqual({ corruptedIds: [], changedConcurrently: 0, added: 0, removed: 0 });
     });
 
-    it("counts each row whose token changed", () => {
-      const { fingerprint } = setup({ rows: [FIRST, SECOND, THIRD] });
-      const { fingerprint: changed } = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed" }, { ...THIRD, sealedSecrets: "also-changed" }] });
+    it("flags a row whose token changed while its updatedAt stood still as corrupted", () => {
+      const before = setup({ rows: [FIRST, { ...SECOND, updatedAt: TOUCHED_AT }] });
+      const after = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed", updatedAt: TOUCHED_AT }] });
 
-      expect(fingerprint.countDifferencesFrom(changed)).toBe(2);
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toMatchObject({ corruptedIds: [SECOND.id], changedConcurrently: 0 });
     });
 
-    it("counts a row that arrived and a row that disappeared", () => {
-      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
-      const { fingerprint: moved } = setup({ rows: [FIRST, THIRD] });
+    it("flags a row whose token changed without any updatedAt to vouch for it as corrupted", () => {
+      const before = setup({ rows: [FIRST, SECOND] });
+      const after = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed" }] });
 
-      expect(fingerprint.countDifferencesFrom(moved)).toBe(2);
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toMatchObject({ corruptedIds: [SECOND.id], changedConcurrently: 0 });
     });
 
-    it("counts a swap as both rows having moved", () => {
-      const { fingerprint } = setup({ rows: [FIRST, SECOND] });
-      const { fingerprint: swapped } = setup({
-        rows: [
-          { id: FIRST.id, sealedSecrets: SECOND.sealedSecrets },
-          { id: SECOND.id, sealedSecrets: FIRST.sealedSecrets }
-        ]
-      });
+    it("counts a row whose token and updatedAt both moved as a concurrent write rather than corruption", () => {
+      const before = setup({ rows: [FIRST, { ...SECOND, updatedAt: TOUCHED_AT }] });
+      const after = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: "changed", updatedAt: TOUCHED_LATER }] });
 
-      expect(fingerprint.countDifferencesFrom(swapped)).toBe(2);
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toEqual({ corruptedIds: [], changedConcurrently: 1, added: 0, removed: 0 });
+    });
+
+    it("reports no drift for a row whose updatedAt moved while its token stayed", () => {
+      const before = setup({ rows: [{ ...FIRST, updatedAt: TOUCHED_AT }] });
+      const after = setup({ rows: [{ ...FIRST, updatedAt: TOUCHED_LATER }] });
+
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toEqual({ corruptedIds: [], changedConcurrently: 0, added: 0, removed: 0 });
+    });
+
+    it("counts a row that arrived as added and one that disappeared as removed", () => {
+      const before = setup({ rows: [FIRST, SECOND] });
+      const after = setup({ rows: [FIRST, THIRD] });
+
+      expect(after.fingerprint.driftFrom(before.fingerprint)).toEqual({ corruptedIds: [], changedConcurrently: 0, added: 1, removed: 1 });
     });
   });
 
@@ -119,11 +131,11 @@ describe(StoredSecretsFingerprint.name, () => {
     expect(setup({ rows: [FIRST, SECOND] }).summary).toEqual(setup({ rows: [FIRST, SECOND] }).summary);
   });
 
-  function setup(input: { rows: Array<{ id: string; sealedSecrets: string }> }) {
+  function setup(input: { rows: Array<{ id: string; sealedSecrets: string; updatedAt?: Date | null }> }) {
     const fingerprint = new StoredSecretsFingerprint();
 
     for (const row of input.rows) {
-      fingerprint.add(row);
+      fingerprint.add({ ...row, updatedAt: row.updatedAt ?? null });
     }
 
     return { fingerprint, summary: fingerprint.summarize() };

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { StoredSecretsFingerprint } from "./stored-secrets-fingerprint";
+
+const FIRST = { id: "11111111-1111-4111-8111-111111111111", sealedSecrets: "aGVhZGVy.a2V5.aXY.Zmlyc3Q.dGFn" };
+const SECOND = { id: "22222222-2222-4222-8222-222222222222", sealedSecrets: "aGVhZGVy.a2V5.aXY.c2Vjb25k.dGFn" };
+const THIRD = { id: "33333333-3333-4333-8333-333333333333", sealedSecrets: "aGVhZGVy.a2V5.aXY.dGhpcmQ.dGFn" };
+
+describe(StoredSecretsFingerprint.name, () => {
+  it("digests the same rows to the same value whatever order they arrive in", () => {
+    const inOrder = setup({ rows: [FIRST, SECOND, THIRD] });
+    const permuted = setup({ rows: [THIRD, FIRST, SECOND] });
+
+    expect(permuted.summary).toEqual(inOrder.summary);
+  });
+
+  it("digests a row whose token changed to a different value", () => {
+    const before = setup({ rows: [FIRST, SECOND] });
+    const after = setup({ rows: [FIRST, { ...SECOND, sealedSecrets: THIRD.sealedSecrets }] });
+
+    expect(after.summary.digest).not.toBe(before.summary.digest);
+  });
+
+  it("digests two rows that swapped tokens with each other to a different value", () => {
+    const before = setup({ rows: [FIRST, SECOND] });
+    const swapped = setup({
+      rows: [
+        { id: FIRST.id, sealedSecrets: SECOND.sealedSecrets },
+        { id: SECOND.id, sealedSecrets: FIRST.sealedSecrets }
+      ]
+    });
+
+    expect(swapped.summary.digest).not.toBe(before.summary.digest);
+    expect(swapped.summary.rowCount).toBe(before.summary.rowCount);
+    expect(swapped.summary.byteCount).toBe(before.summary.byteCount);
+  });
+
+  it("digests a token that moved to a row of another id to a different value", () => {
+    const original = setup({ rows: [FIRST, SECOND] });
+    const reassigned = setup({ rows: [FIRST, { id: THIRD.id, sealedSecrets: SECOND.sealedSecrets }] });
+
+    expect(reassigned.summary.rowCount).toBe(original.summary.rowCount);
+    expect(reassigned.summary.byteCount).toBe(original.summary.byteCount);
+    expect(reassigned.summary.digest).not.toBe(original.summary.digest);
+  });
+
+  it("digests a token moved across the boundary with its row's id to a different value", () => {
+    const asOneId = setup({ rows: [{ id: "ab", sealedSecrets: "cd" }] });
+    const asAnother = setup({ rows: [{ id: "a", sealedSecrets: "bcd" }] });
+
+    expect(asAnother.summary.digest).not.toBe(asOneId.summary.digest);
+  });
+
+  it("digests a row that was removed to a different value", () => {
+    const both = setup({ rows: [FIRST, SECOND] });
+    const one = setup({ rows: [FIRST] });
+
+    expect(one.summary.digest).not.toBe(both.summary.digest);
+  });
+
+  it("reports how many rows hold a token and how many bytes they hold", () => {
+    const { summary } = setup({ rows: [FIRST, SECOND] });
+
+    expect(summary).toMatchObject({
+      rowCount: 2,
+      byteCount: FIRST.sealedSecrets.length + SECOND.sealedSecrets.length
+    });
+  });
+
+  it("counts a token's bytes rather than its characters", () => {
+    const { summary } = setup({ rows: [{ id: FIRST.id, sealedSecrets: "é" }] });
+
+    expect(summary.byteCount).toBe(2);
+  });
+
+  it("summarizes an empty fleet without a token as a digest of its own", () => {
+    const { summary } = setup({ rows: [] });
+
+    expect(summary).toMatchObject({ rowCount: 0, byteCount: 0 });
+    expect(summary.digest).toEqual(expect.any(String));
+    expect(summary.digest).not.toBe(setup({ rows: [FIRST] }).summary.digest);
+  });
+
+  it("summarizes the same fleet the same way across separate runs", () => {
+    expect(setup({ rows: [FIRST, SECOND] }).summary).toEqual(setup({ rows: [FIRST, SECOND] }).summary);
+  });
+
+  function setup(input: { rows: Array<{ id: string; sealedSecrets: string }> }) {
+    const fingerprint = new StoredSecretsFingerprint();
+
+    for (const row of input.rows) {
+      fingerprint.add(row);
+    }
+
+    return { fingerprint, summary: fingerprint.summarize() };
+  }
+});

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -31,6 +31,23 @@ export class StoredSecretsFingerprint {
     this.#rowDigests.set(id, { digest: hash.digest(), byteCount: token.length });
   }
 
+  /** How many rows hold a different token than they did in `other`, counting one that arrived or disappeared as a difference of its own. */
+  countDifferencesFrom(other: StoredSecretsFingerprint): number {
+    const ids = new Set([...this.#rowDigests.keys(), ...other.#rowDigests.keys()]);
+    let differences = 0;
+
+    for (const id of ids) {
+      const mine = this.#rowDigests.get(id);
+      const theirs = other.#rowDigests.get(id);
+
+      if (!mine || !theirs || !mine.digest.equals(theirs.digest)) {
+        differences++;
+      }
+    }
+
+    return differences;
+  }
+
   summarize(): StoredSecretsSummary {
     const hash = createHash(DIGEST_ALGORITHM);
     let byteCount = 0;

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -4,6 +4,14 @@ import { createHash } from "node:crypto";
 export interface StoredSecretsEntry {
   id: string;
   sealedSecrets: string;
+  updatedAt: Date | null;
+}
+
+export interface StoredSecretsDrift {
+  corruptedIds: string[];
+  changedConcurrently: number;
+  added: number;
+  removed: number;
 }
 
 export interface StoredSecretsSummary {
@@ -19,33 +27,40 @@ const LENGTH_PREFIX_BYTES = 4;
 
 /** Digests each row under its own id and combines the row digests in id order, so the result reflects the rows themselves rather than the order a scan yielded them in. */
 export class StoredSecretsFingerprint {
-  readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number }>();
+  readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number; updatedAtMs: number | null }>();
 
-  add({ id, sealedSecrets }: StoredSecretsEntry): void {
+  add({ id, sealedSecrets, updatedAt }: StoredSecretsEntry): void {
     const token = Buffer.from(sealedSecrets, "utf8");
     const hash = createHash(DIGEST_ALGORITHM);
 
     appendLengthPrefixed(hash, Buffer.from(id, "utf8"));
     appendLengthPrefixed(hash, token);
 
-    this.#rowDigests.set(id, { digest: hash.digest(), byteCount: token.length });
+    this.#rowDigests.set(id, { digest: hash.digest(), byteCount: token.length, updatedAtMs: updatedAt?.getTime() ?? null });
   }
 
-  /** How many rows hold a different token than they did in `other`, counting one that arrived or disappeared as a difference of its own. */
-  countDifferencesFrom(other: StoredSecretsFingerprint): number {
-    const ids = new Set([...this.#rowDigests.keys(), ...other.#rowDigests.keys()]);
-    let differences = 0;
+  /** A token that changed while its row's `updatedAt` stood still is corruption, because every legitimate secrets write bumps that timestamp. */
+  driftFrom(before: StoredSecretsFingerprint): StoredSecretsDrift {
+    const drift: StoredSecretsDrift = { corruptedIds: [], changedConcurrently: 0, added: 0, removed: 0 };
 
-    for (const id of ids) {
-      const mine = this.#rowDigests.get(id);
-      const theirs = other.#rowDigests.get(id);
+    for (const id of new Set([...this.#rowDigests.keys(), ...before.#rowDigests.keys()])) {
+      const current = this.#rowDigests.get(id);
+      const previous = before.#rowDigests.get(id);
 
-      if (!mine || !theirs || !mine.digest.equals(theirs.digest)) {
-        differences++;
+      if (!previous) {
+        drift.added++;
+      } else if (!current) {
+        drift.removed++;
+      } else if (!current.digest.equals(previous.digest)) {
+        if (current.updatedAtMs === previous.updatedAtMs) {
+          drift.corruptedIds.push(id);
+        } else {
+          drift.changedConcurrently++;
+        }
       }
     }
 
-    return differences;
+    return drift;
   }
 
   summarize(): StoredSecretsSummary {

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -17,13 +17,7 @@ const DIGEST_ALGORITHM = "sha256";
 /** A length fits in four bytes for any token a row can hold, and the framing below needs a fixed-width one. */
 const LENGTH_PREFIX_BYTES = 4;
 
-/**
- * Proof that a run of the key rotation changed no stored secret, taken over the fleet before and
- * after it. Each row is digested under its own id, so a token moved to another deployment shows up
- * as a changed fingerprint rather than as the same one; the per-row digests are combined in id
- * order at the end, so the result is a function of the rows themselves and not of the order a scan
- * happened to yield them in.
- */
+/** Digests each row under its own id and combines the row digests in id order, so the result reflects the rows themselves rather than the order a scan yielded them in. */
 export class StoredSecretsFingerprint {
   readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number }>();
 

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -41,19 +41,15 @@ export class StoredSecretsFingerprint {
     const hash = createHash(DIGEST_ALGORITHM);
     let byteCount = 0;
 
-    for (const [, row] of [...this.#rowDigests].sort(byId)) {
+    for (const id of [...this.#rowDigests.keys()].sort()) {
+      const row = this.#rowDigests.get(id)!;
+
       hash.update(row.digest);
       byteCount += row.byteCount;
     }
 
     return { digest: hash.digest("hex"), rowCount: this.#rowDigests.size, byteCount };
   }
-}
-
-function byId([left]: [string, unknown], [right]: [string, unknown]) {
-  if (left === right) return 0;
-
-  return left < right ? -1 : 1;
 }
 
 /** Without the length, a row's id and its token could be rearranged into another row's pair and digest alike. */

--- a/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
+++ b/apps/api/src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint.ts
@@ -1,0 +1,66 @@
+import type { Hash } from "node:crypto";
+import { createHash } from "node:crypto";
+
+export interface StoredSecretsEntry {
+  id: string;
+  sealedSecrets: string;
+}
+
+export interface StoredSecretsSummary {
+  digest: string;
+  rowCount: number;
+  byteCount: number;
+}
+
+const DIGEST_ALGORITHM = "sha256";
+
+/** A length fits in four bytes for any token a row can hold, and the framing below needs a fixed-width one. */
+const LENGTH_PREFIX_BYTES = 4;
+
+/**
+ * Proof that a run of the key rotation changed no stored secret, taken over the fleet before and
+ * after it. Each row is digested under its own id, so a token moved to another deployment shows up
+ * as a changed fingerprint rather than as the same one; the per-row digests are combined in id
+ * order at the end, so the result is a function of the rows themselves and not of the order a scan
+ * happened to yield them in.
+ */
+export class StoredSecretsFingerprint {
+  readonly #rowDigests = new Map<string, { digest: Buffer; byteCount: number }>();
+
+  add({ id, sealedSecrets }: StoredSecretsEntry): void {
+    const token = Buffer.from(sealedSecrets, "utf8");
+    const hash = createHash(DIGEST_ALGORITHM);
+
+    appendLengthPrefixed(hash, Buffer.from(id, "utf8"));
+    appendLengthPrefixed(hash, token);
+
+    this.#rowDigests.set(id, { digest: hash.digest(), byteCount: token.length });
+  }
+
+  summarize(): StoredSecretsSummary {
+    const hash = createHash(DIGEST_ALGORITHM);
+    let byteCount = 0;
+
+    for (const [, row] of [...this.#rowDigests].sort(byId)) {
+      hash.update(row.digest);
+      byteCount += row.byteCount;
+    }
+
+    return { digest: hash.digest("hex"), rowCount: this.#rowDigests.size, byteCount };
+  }
+}
+
+function byId([left]: [string, unknown], [right]: [string, unknown]) {
+  if (left === right) return 0;
+
+  return left < right ? -1 : 1;
+}
+
+/** Without the length, a row's id and its token could be rearranged into another row's pair and digest alike. */
+function appendLengthPrefixed(hash: Hash, value: Buffer) {
+  const length = Buffer.alloc(LENGTH_PREFIX_BYTES);
+  length.writeUInt32BE(value.length);
+
+  hash.update(length);
+  hash.update(value);
+}

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
@@ -3,6 +3,7 @@ import { container } from "tsyringe";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { UserRepository } from "@src/user/repositories";
+import type { DataKeyOutput } from "./data-key.repository";
 import { DataKeyRepository } from "./data-key.repository";
 
 describe(DataKeyRepository.name, () => {
@@ -94,6 +95,102 @@ describe(DataKeyRepository.name, () => {
     });
   });
 
+  describe("countByWrappingVersion", () => {
+    it("counts the data keys under each version separately rather than in total", async () => {
+      const { versionOf, seedDataKey, censusOfOwnKey } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(2));
+
+      const census = await censusOfOwnKey();
+
+      expect(census).toEqual([
+        { wrappedByKid: versionOf(1), count: 2 },
+        { wrappedByKid: versionOf(2), count: 1 }
+      ]);
+    });
+
+    it("leaves out a version nothing is wrapped under", async () => {
+      const { versionOf, seedDataKey, censusOfOwnKey } = setup();
+      await seedDataKey(versionOf(1));
+
+      const census = await censusOfOwnKey();
+
+      expect(census.map(entry => entry.wrappedByKid)).not.toContain(versionOf(2));
+    });
+  });
+
+  describe("findWrappedUnderOtherVersionsIteratively", () => {
+    it("yields the rows wrapped under another version and passes over those already at the target", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      const staleFirst = await seedDataKey(versionOf(1));
+      const staleSecond = await seedDataKey(versionOf(1));
+      const alreadyAtTarget = await seedDataKey(versionOf(2));
+
+      const candidates = await findRewrapCandidates(versionOf(2));
+
+      expect(candidates.map(row => row.id).sort()).toEqual([staleFirst.id, staleSecond.id].sort());
+      expect(candidates.map(row => row.id)).not.toContain(alreadyAtTarget.id);
+    });
+
+    it("yields what re-wrapping a row needs to open it and record its new version", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      const stale = await seedDataKey(versionOf(1));
+
+      const candidates = await findRewrapCandidates(versionOf(2));
+
+      expect(candidates).toEqual([
+        expect.objectContaining({ id: stale.id, userId: stale.userId, wrappedKey: stale.wrappedKey, wrappedByKid: versionOf(1) })
+      ]);
+    });
+
+    it("yields nothing once every row is at the target", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      await seedDataKey(versionOf(2));
+      await seedDataKey(versionOf(2));
+
+      expect(await findRewrapCandidates(versionOf(2))).toEqual([]);
+    });
+
+    it("pages every row exactly once when the batch is smaller than the set", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+
+      const oneAtATime = await findRewrapCandidates(versionOf(2), 1);
+      const allAtOnce = await findRewrapCandidates(versionOf(2), 1000);
+
+      expect(allAtOnce).toHaveLength(3);
+      expect(oneAtATime.map(row => row.id)).toEqual(allAtOnce.map(row => row.id));
+    });
+
+    it("yields rows in id order, so a run that stops resumes after the last row it moved", async () => {
+      const { versionOf, seedDataKey, findRewrapCandidates } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+
+      const candidates = await findRewrapCandidates(versionOf(2), 2);
+
+      expect(candidates.map(row => row.id)).toEqual([...candidates.map(row => row.id)].sort());
+    });
+
+    it("yields batches no larger than the size asked for", async () => {
+      const { dataKeyRepository, versionOf, seedDataKey } = setup();
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      await seedDataKey(versionOf(1));
+      const sizes: number[] = [];
+
+      for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: versionOf(2), batchSize: 2 })) {
+        sizes.push(batch.length);
+      }
+
+      expect(Math.max(...sizes)).toBeLessThanOrEqual(2);
+    });
+  });
+
   describe("user deletion", () => {
     it("deletes the data key when its user is deleted", async () => {
       const { dataKeyRepository, userRepository, createTestUser } = setup();
@@ -124,6 +221,7 @@ describe(DataKeyRepository.name, () => {
     const dataKeyRepository = container.resolve(DataKeyRepository);
     const userRepository = container.resolve(UserRepository);
     const createdUserIds: string[] = [];
+    const keyName = faker.string.alphanumeric(10);
 
     cleanup = async () => {
       if (createdUserIds.length > 0) {
@@ -137,6 +235,36 @@ describe(DataKeyRepository.name, () => {
       return user;
     }
 
-    return { dataKeyRepository, userRepository, createTestUser };
+    function versionOf(version: number) {
+      return `${keyName}.v${version}`;
+    }
+
+    async function seedDataKey(wrappedByKid: string) {
+      const user = await createTestUser();
+
+      return await dataKeyRepository.create({ userId: user.id, wrappedKey: wrappedKeyBlob(), wrappedByKid });
+    }
+
+    function isOwnKey(wrappedByKid: string) {
+      return wrappedByKid.startsWith(`${keyName}.`);
+    }
+
+    async function censusOfOwnKey() {
+      const census = await dataKeyRepository.countByWrappingVersion();
+
+      return census.filter(entry => isOwnKey(entry.wrappedByKid));
+    }
+
+    async function findRewrapCandidates(targetKid: string, batchSize = 1000) {
+      const candidates: DataKeyOutput[] = [];
+
+      for await (const batch of dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid, batchSize })) {
+        candidates.push(...batch.filter(row => isOwnKey(row.wrappedByKid)));
+      }
+
+      return candidates;
+    }
+
+    return { dataKeyRepository, userRepository, createTestUser, versionOf, seedDataKey, censusOfOwnKey, findRewrapCandidates };
   }
 });

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.integration.ts
@@ -121,6 +121,14 @@ describe(DataKeyRepository.name, () => {
   });
 
   describe("findWrappedUnderOtherVersionsIteratively", () => {
+    it("refuses a batch size of zero, which would read as a fleet needing no work", async () => {
+      const { dataKeyRepository, versionOf } = setup();
+
+      await expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: versionOf(2), batchSize: 0 }).next()).rejects.toThrow(
+        "Batch size must be a positive integer"
+      );
+    });
+
     it("yields the rows wrapped under another version and passes over those already at the target", async () => {
       const { versionOf, seedDataKey, findRewrapCandidates } = setup();
       const staleFirst = await seedDataKey(versionOf(1));

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -68,11 +68,7 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
       .orderBy(asc(this.table.wrappedByKid));
   }
 
-  /**
-   * Keyset-paged on `id`, and filtered on the version rather than on a progress marker, so a
-   * re-wrap that stopped halfway resumes by selection alone: a row it already moved no longer
-   * matches. Read outside any transaction, because the caller commits each batch in one of its own.
-   */
+  /** Filters on the version rather than a progress marker so an interrupted run resumes by selection alone; ids are random uuids, so one pass may skip a row inserted mid-scan and only the destroy-time count vouches for completeness. */
   async *findWrappedUnderOtherVersionsIteratively({
     targetKid,
     batchSize

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -1,6 +1,7 @@
 import { and, asc, gt, ne, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
+import { assertBatchSize } from "@src/core/lib/batch-size/batch-size";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
@@ -76,6 +77,8 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
     targetKid: DataKeyOutput["wrappedByKid"];
     batchSize: number;
   }): AsyncGenerator<DataKeyOutput[]> {
+    assertBatchSize(batchSize);
+
     let cursor: DataKeyOutput["id"] | undefined;
 
     while (true) {

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -1,3 +1,4 @@
+import { and, asc, gt, ne, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -7,6 +8,12 @@ import { TxService } from "@src/core/services";
 type Table = ApiPgTables["DataKeys"];
 export type DataKeyInput = Table["$inferInsert"];
 export type DataKeyOutput = Table["$inferSelect"];
+
+/** How many data keys one KMS key version still holds, which is what gates destroying that version. */
+export type DataKeyWrappingCount = {
+  wrappedByKid: DataKeyOutput["wrappedByKid"];
+  count: number;
+};
 
 @singleton()
 export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataKeyOutput> {
@@ -50,5 +57,50 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
   /** Answers whether a KMS key version may still be destroyed without making stored data keys unrecoverable. */
   async countWrappedUnder(wrappedByKid: DataKeyOutput["wrappedByKid"]): Promise<number> {
     return this.count({ wrappedByKid });
+  }
+
+  /** The same question asked of every version at once, so a rotation can report which versions are still in use without knowing what to ask about. */
+  async countByWrappingVersion(): Promise<DataKeyWrappingCount[]> {
+    return await this.cursor
+      .select({ wrappedByKid: this.table.wrappedByKid, count: sql<number>`count(*)::int` })
+      .from(this.table)
+      .groupBy(this.table.wrappedByKid)
+      .orderBy(asc(this.table.wrappedByKid));
+  }
+
+  /**
+   * Keyset-paged on `id`, and filtered on the version rather than on a progress marker, so a
+   * re-wrap that stopped halfway resumes by selection alone: a row it already moved no longer
+   * matches. Read outside any transaction, because the caller commits each batch in one of its own.
+   */
+  async *findWrappedUnderOtherVersionsIteratively({
+    targetKid,
+    batchSize
+  }: {
+    targetKid: DataKeyOutput["wrappedByKid"];
+    batchSize: number;
+  }): AsyncGenerator<DataKeyOutput[]> {
+    let cursor: DataKeyOutput["id"] | undefined;
+
+    while (true) {
+      const batch = await this.pg
+        .select()
+        .from(this.table)
+        .where(and(ne(this.table.wrappedByKid, targetKid), ...(cursor ? [gt(this.table.id, cursor)] : [])))
+        .orderBy(asc(this.table.id))
+        .limit(batchSize);
+
+      if (!batch.length) {
+        return;
+      }
+
+      yield this.toOutputList(batch);
+
+      if (batch.length < batchSize) {
+        return;
+      }
+
+      cursor = batch[batch.length - 1].id;
+    }
   }
 }

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts
@@ -46,7 +46,12 @@ async function createEnabledVersion() {
 let rotationPair: Promise<{ oldVersion: string; newVersion: string }> | undefined;
 
 function enabledRotationPair() {
-  rotationPair ??= Promise.all([createEnabledVersion(), createEnabledVersion()]).then(([oldVersion, newVersion]) => ({ oldVersion, newVersion }));
+  rotationPair ??= Promise.all([createEnabledVersion(), createEnabledVersion()])
+    .then(([oldVersion, newVersion]) => ({ oldVersion, newVersion }))
+    .catch(error => {
+      rotationPair = undefined;
+      throw error;
+    });
 
   return rotationPair;
 }
@@ -75,7 +80,7 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
     const report = await rewrapOnto(newVersion);
 
     expect(await readStoredSecrets()).toEqual(before);
-    expect(report.secretsReEncrypted).toBe(0);
+    expect(report.secretsDrift).toEqual({ corruptedIds: [], changedConcurrently: 0, added: 0, removed: 0 });
     expect(report.fingerprint.after).toEqual(report.fingerprint.before);
     expect(report.fingerprint.before).toMatchObject({ rowCount: 2 });
   });
@@ -159,10 +164,10 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
     expect(real.dataKeysRewrapped).toBe(rehearsal.dataKeysRewrapped);
   });
 
-  const pendingCleanups: Array<() => Promise<void>> = [];
+  let cleanup: () => Promise<void>;
   afterEach(async () => {
     vi.restoreAllMocks();
-    await Promise.all(pendingCleanups.splice(0).map(async runCleanup => await runCleanup()));
+    await cleanup?.();
   });
 
   function setup() {
@@ -174,11 +179,11 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
     const txService = container.resolve(TxService);
     const createdUserIds: string[] = [];
 
-    pendingCleanups.push(async () => {
+    cleanup = async () => {
       if (createdUserIds.length > 0) {
         await userRepository.deleteById(createdUserIds);
       }
-    });
+    };
 
     const createKmsTarget: SdlSecretsKmsTargetFactory = version => createSdlSecretsKmsTarget({ client: kmsClient, versionPath, key: KEY, version });
 

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import type { KeyManagementServiceClient } from "@google-cloud/kms";
 import { decodeProtectedHeader } from "jose";
 import { container } from "tsyringe";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { CreateLogger } from "@src/core/providers/logging.provider";
@@ -164,10 +164,8 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
     expect(real.dataKeysRewrapped).toBe(rehearsal.dataKeysRewrapped);
   });
 
-  let cleanup: () => Promise<void>;
-  afterEach(async () => {
+  afterEach(() => {
     vi.restoreAllMocks();
-    await cleanup?.();
   });
 
   function setup() {
@@ -179,11 +177,11 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
     const txService = container.resolve(TxService);
     const createdUserIds: string[] = [];
 
-    cleanup = async () => {
+    onTestFinished(async () => {
       if (createdUserIds.length > 0) {
         await userRepository.deleteById(createdUserIds);
       }
-    };
+    });
 
     const createKmsTarget: SdlSecretsKmsTargetFactory = version => createSdlSecretsKmsTarget({ client: kmsClient, versionPath, key: KEY, version });
 

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts
@@ -1,0 +1,285 @@
+import { faker } from "@faker-js/faker";
+import type { KeyManagementServiceClient } from "@google-cloud/kms";
+import { decodeProtectedHeader } from "jose";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import { TxService } from "@src/core/services/tx/tx.service";
+import type { SdlSecretsKmsTargetFactory } from "@src/deployment/providers/kms.provider";
+import { createSdlSecretsKmsTarget, KMS_CLIENT } from "@src/deployment/providers/kms.provider";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyService } from "@src/secret/services/data-key/data-key.service";
+import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
+import { SecretCipherService } from "@src/secret/services/secret-cipher/secret-cipher.service";
+import { UserRepository } from "@src/user/repositories";
+import { DataKeyRewrapService } from "./data-key-rewrap.service";
+
+const PROJECT = "console-dev-mock";
+const LOCATION = "global";
+const KEY_RING = "console-api";
+const KEY = "sdl-secrets";
+
+const kmsClient = container.resolve<KeyManagementServiceClient>(KMS_CLIENT);
+
+function versionPath(version: string) {
+  return kmsClient.cryptoKeyVersionPath(PROJECT, LOCATION, KEY_RING, KEY, version);
+}
+
+async function createEnabledVersion() {
+  const [created] = await kmsClient.createCryptoKeyVersion({
+    parent: kmsClient.cryptoKeyPath(PROJECT, LOCATION, KEY_RING, KEY),
+    cryptoKeyVersion: {}
+  });
+
+  expect(created.state).toBe("ENABLED");
+
+  return created.name!.split("/").pop()!;
+}
+
+/** Provisioned once: every RSA-3072 keypair the emulator mints costs real CPU on the same host the database runs on, and no test mutates the pair. */
+let rotationPair: Promise<{ oldVersion: string; newVersion: string }> | undefined;
+
+function enabledRotationPair() {
+  rotationPair ??= Promise.all([createEnabledVersion(), createEnabledVersion()]).then(([oldVersion, newVersion]) => ({ oldVersion, newVersion }));
+
+  return rotationPair;
+}
+
+describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
+  it("leaves every stored secret opening to the plaintext it was sealed with", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { seedUser, rewrapOnto, consoleAt } = setup();
+    const alpha = await seedUser(oldVersion, "alpha-plaintext");
+    const bravo = await seedUser(oldVersion, "bravo-plaintext");
+
+    await rewrapOnto(newVersion);
+
+    const afterRotation = consoleAt(newVersion);
+    await expect(afterRotation.openStoredSecret(alpha)).resolves.toBe("alpha-plaintext");
+    await expect(afterRotation.openStoredSecret(bravo)).resolves.toBe("bravo-plaintext");
+  });
+
+  it("leaves every stored secrets token byte-identical, and says so in its fingerprint", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { seedUser, rewrapOnto, readStoredSecrets } = setup();
+    await seedUser(oldVersion, "alpha-plaintext");
+    await seedUser(oldVersion, "bravo-plaintext");
+    const before = await readStoredSecrets();
+
+    const report = await rewrapOnto(newVersion);
+
+    expect(await readStoredSecrets()).toEqual(before);
+    expect(report.secretsReEncrypted).toBe(0);
+    expect(report.fingerprint.after).toEqual(report.fingerprint.before);
+    expect(report.fingerprint.before).toMatchObject({ rowCount: 2 });
+  });
+
+  it("re-wraps every row onto the target without changing the key it wraps", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { seedUser, rewrapOnto, readDataKeys, consoleAt } = setup();
+    const alpha = await seedUser(oldVersion, "alpha-plaintext");
+    const keyBeforeRotation = await consoleAt(oldVersion).unwrapFor(alpha.userId);
+    const [rowBefore] = await readDataKeys();
+
+    await rewrapOnto(newVersion);
+
+    const [rowAfter] = await readDataKeys();
+    expect(rowAfter.wrappedByKid).toBe(`${KEY}.v${newVersion}`);
+    expect(decodeProtectedHeader(rowAfter.wrappedKey).kid).toBe(`${KEY}.v${newVersion}`);
+    expect(rowAfter.wrappedKey).not.toBe(rowBefore.wrappedKey);
+    expect((await consoleAt(newVersion).unwrapFor(alpha.userId)).equals(keyBeforeRotation)).toBe(true);
+  });
+
+  it("re-runs as a no-op that spends no call on the key service", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { seedUser, rewrapOnto } = setup();
+    await seedUser(oldVersion, "alpha-plaintext");
+    await rewrapOnto(newVersion);
+    const asymmetricDecrypt = vi.spyOn(kmsClient, "asymmetricDecrypt");
+
+    const report = await rewrapOnto(newVersion);
+
+    expect(report).toMatchObject({ dataKeysRewrapped: 0, fromVersions: [], census: { [`${KEY}.v${newVersion}`]: 1 } });
+    expect(asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("leaves a failed batch whole, the batches before it committed, and finishes on a re-run", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { seedUser, rewrapOnto, readDataKeys, readStoredSecrets, failWriteOf } = setup();
+    for (const plaintext of ["alpha", "bravo", "charlie", "delta"]) {
+      await seedUser(oldVersion, `${plaintext}-plaintext`);
+    }
+    const before = await readStoredSecrets();
+    const rows = await readDataKeys();
+    failWriteOf(rows[3].id);
+
+    await expect(rewrapOnto(newVersion, { batchSize: 2 })).rejects.toThrow();
+
+    const afterFailure = await readDataKeys();
+    expect(afterFailure.map(row => row.wrappedByKid)).toEqual([
+      `${KEY}.v${newVersion}`,
+      `${KEY}.v${newVersion}`,
+      `${KEY}.v${oldVersion}`,
+      `${KEY}.v${oldVersion}`
+    ]);
+
+    vi.restoreAllMocks();
+    const report = await rewrapOnto(newVersion, { batchSize: 2 });
+
+    expect(report).toMatchObject({ dataKeysRewrapped: 2, dataKeysFailed: 0 });
+    expect((await readDataKeys()).every(row => row.wrappedByKid === `${KEY}.v${newVersion}`)).toBe(true);
+    expect(await readStoredSecrets()).toEqual(before);
+  });
+
+  it("reports on a dry run what a real run then moves, having written nothing", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { seedUser, seedUserWithoutDataKey, rewrapOnto, readDataKeys, countDataKeys, readStoredSecrets } = setup();
+    await seedUser(oldVersion, "alpha-plaintext");
+    await seedUser(oldVersion, "bravo-plaintext");
+    await seedUserWithoutDataKey();
+    const dataKeysBefore = await readDataKeys();
+    const dataKeyCountBefore = await countDataKeys();
+    const secretsBefore = await readStoredSecrets();
+
+    const rehearsal = await rewrapOnto(newVersion, { dryRun: true });
+
+    expect(await readDataKeys()).toEqual(dataKeysBefore);
+    expect(await countDataKeys()).toBe(dataKeyCountBefore);
+    expect(await readStoredSecrets()).toEqual(secretsBefore);
+    expect(rehearsal).toMatchObject({ dryRun: true, dataKeysRewrapped: 2, census: { [`${KEY}.v${oldVersion}`]: 2 } });
+    expect(rehearsal.fingerprint.after).toBeUndefined();
+
+    const real = await rewrapOnto(newVersion);
+    expect(real.dataKeysRewrapped).toBe(rehearsal.dataKeysRewrapped);
+  });
+
+  const pendingCleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(pendingCleanups.splice(0).map(async runCleanup => await runCleanup()));
+  });
+
+  function setup() {
+    const createLogger: CreateLogger = () => mock<ReturnType<CreateLogger>>();
+    const dataKeyRepository = container.resolve(DataKeyRepository);
+    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+    const userRepository = container.resolve(UserRepository);
+    const executionContextService = container.resolve(ExecutionContextService);
+    const txService = container.resolve(TxService);
+    const createdUserIds: string[] = [];
+
+    pendingCleanups.push(async () => {
+      if (createdUserIds.length > 0) {
+        await userRepository.deleteById(createdUserIds);
+      }
+    });
+
+    const createKmsTarget: SdlSecretsKmsTargetFactory = version => createSdlSecretsKmsTarget({ client: kmsClient, versionPath, key: KEY, version });
+
+    const consoleAt = (version: string) => {
+      const target = createKmsTarget(version);
+      const wrappedJwe = new KmsWrappedJweService(target);
+      const sealingKeyService = new SdlSecretsSealingKeyService(target, createLogger);
+      const dataKeyService = new DataKeyService(dataKeyRepository, sealingKeyService, createLogger);
+      const unwrapper = new DataKeyUnwrapperService(dataKeyService, executionContextService, wrappedJwe, target, createLogger);
+      const cipher = new SecretCipherService(unwrapper, createLogger);
+
+      return {
+        warmSealingKey: async () => await sealingKeyService.getSealingKey(),
+        ensureDataKey: async (userId: string) => await dataKeyService.ensureDataKey(userId),
+        unwrapFor: async (userId: string) => await executionContextService.runWithContext(async () => await (await unwrapper.getDataKey(userId)).unwrap()),
+        sealFor: async (userId: string, dseq: string, plaintext: string) =>
+          await executionContextService.runWithContext(async () => await cipher.encrypt(userId, plaintext, { dseq })),
+        openStoredSecret: async ({ userId, dseq }: SeededUser) =>
+          await executionContextService.runWithContext(async () => {
+            const setting = await deploymentSettingRepository.findOneBy({ userId, dseq });
+
+            return await cipher.decrypt(userId, setting!.sealedSecrets!, { dseq });
+          })
+      };
+    };
+
+    async function seedUser(version: string, plaintext: string): Promise<SeededUser> {
+      const user = await userRepository.create({});
+      createdUserIds.push(user.id);
+
+      const consoleApi = consoleAt(version);
+      await consoleApi.warmSealingKey();
+      await consoleApi.ensureDataKey(user.id);
+
+      const dseq = faker.number.int({ min: 100000, max: 999999 }).toString();
+      const sealedSecrets = await consoleApi.sealFor(user.id, dseq, plaintext);
+      await deploymentSettingRepository.create({ userId: user.id, dseq, autoTopUpEnabled: true, sealedSecrets });
+
+      return { userId: user.id, dseq };
+    }
+
+    async function rewrapOnto(targetVersion: string, options: { batchSize?: number; dryRun?: boolean } = {}) {
+      const service = new DataKeyRewrapService(
+        dataKeyRepository,
+        deploymentSettingRepository,
+        new KmsWrappedJweService(createKmsTarget(targetVersion)),
+        txService,
+        createKmsTarget,
+        createLogger
+      );
+
+      return (await service.rewrapDataKeys({ targetVersion, dryRun: options.dryRun ?? false, batchSize: options.batchSize })).unwrap();
+    }
+
+    async function seedUserWithoutDataKey() {
+      const user = await userRepository.create({});
+      createdUserIds.push(user.id);
+
+      return user;
+    }
+
+    async function countDataKeys() {
+      return await dataKeyRepository.count({});
+    }
+
+    async function readDataKeys() {
+      const rows = await dataKeyRepository.find({});
+
+      return rows
+        .filter(row => createdUserIds.includes(row.userId))
+        .sort((left, right) => (left.id < right.id ? -1 : 1))
+        .map(({ id, wrappedKey, wrappedByKid }) => ({ id, wrappedKey, wrappedByKid }));
+    }
+
+    async function readStoredSecrets() {
+      const settings = [];
+
+      for await (const batch of deploymentSettingRepository.findStoredSecretsIteratively({ batchSize: 100 })) {
+        settings.push(...batch);
+      }
+
+      return settings.sort((left, right) => (left.id < right.id ? -1 : 1));
+    }
+
+    function failWriteOf(dataKeyId: string) {
+      const updateById = dataKeyRepository.updateById.bind(dataKeyRepository);
+
+      vi.spyOn(dataKeyRepository, "updateById").mockImplementation(async (id, payload) => {
+        if (id === dataKeyId) {
+          throw new Error(`write of ${dataKeyId} failed`);
+        }
+
+        await updateById(id, payload);
+      });
+    }
+
+    return { consoleAt, seedUser, seedUserWithoutDataKey, rewrapOnto, readDataKeys, countDataKeys, readStoredSecrets, failWriteOf };
+  }
+});
+
+interface SeededUser {
+  userId: string;
+  dseq: string;
+}

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
@@ -27,6 +27,8 @@ const DATA_KEY = randomBytes(32);
 const SEALING_KEYPAIR = generateKeyPairSync("rsa", { modulusLength: 2048 });
 const SEALING_KEY_PEM = SEALING_KEYPAIR.publicKey.export({ type: "spki", format: "pem" }).toString();
 
+const ONE_MINUTE_MS = 60_000;
+
 const A_TOKEN = "eyJhbGciOiJkaXIifQ..YWxwaGEtaXY.YWxwaGEtY2lwaGVydGV4dA.YWxwaGEtdGFn";
 const ANOTHER_TOKEN = "eyJhbGciOiJkaXIifQ..Z2FtbWEtaXY.Z2FtbWEtY2lwaGVydGV4dA.Z2FtbWEtdGFn";
 
@@ -47,12 +49,37 @@ describe(DataKeyRewrapService.name, () => {
       await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true })).resolves.toBeDefined();
     });
 
+    it("refuses a version whose state the key service did not report at all", async () => {
+      const { service, dataKeyRepository } = setup({ versionState: null });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
+
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalled();
+    });
+
+    it("asks the key service about the target version by name", async () => {
+      const { service, client } = setup({});
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true });
+
+      expect(client.getCryptoKeyVersion).toHaveBeenCalledWith({ name: versionPath(TARGET_VERSION) });
+    });
+
     it("refuses a batch size below one, which would read as a fleet needing no work", async () => {
       const { service, dataKeyRepository } = setup({});
 
       await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 0, dryRun: false })).rejects.toThrow();
 
       expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).not.toHaveBeenCalled();
+    });
+
+    it("accepts a batch size of one, the smallest a run can use", async () => {
+      const { service, dataKeyRepository, txService } = setup({ rows: [aRow({}), aRow({})] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 1, dryRun: false });
+
+      expect(dataKeyRepository.updateById).toHaveBeenCalledTimes(2);
+      expect(txService.transaction).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -110,13 +137,15 @@ describe(DataKeyRewrapService.name, () => {
     });
 
     it("selects in batches of the size asked for, and of a default when none is given", async () => {
-      const { service, dataKeyRepository } = setup({});
+      const { service, dataKeyRepository, deploymentSettingRepository } = setup({});
 
       await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 25, dryRun: false });
       await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
 
       expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).toHaveBeenNthCalledWith(1, { targetKid: TARGET_KID, batchSize: 25 });
       expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).toHaveBeenNthCalledWith(2, { targetKid: TARGET_KID, batchSize: 100 });
+      expect(deploymentSettingRepository.findStoredSecretsIteratively).toHaveBeenNthCalledWith(1, { batchSize: 25 });
+      expect(deploymentSettingRepository.findStoredSecretsIteratively).toHaveBeenNthCalledWith(3, { batchSize: 100 });
     });
   });
 
@@ -186,6 +215,7 @@ describe(DataKeyRewrapService.name, () => {
       });
       expect(summary.fingerprint.after?.digest).toBe(summary.fingerprint.before.digest);
       expect(summary.elapsedMs).toBeGreaterThanOrEqual(0);
+      expect(summary.elapsedMs).toBeLessThan(ONE_MINUTE_MS);
     });
 
     it("marks the run's start and completion with structured events", async () => {
@@ -195,6 +225,12 @@ describe(DataKeyRewrapService.name, () => {
 
       expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_START", toVersion: TARGET_KID, dryRun: false }));
       expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_END", report: expect.objectContaining({ toVersion: TARGET_KID }) }));
+    });
+
+    it("names itself as the context every one of those events carries", () => {
+      const { createLogger } = setup({});
+
+      expect(createLogger).toHaveBeenCalledWith({ context: DataKeyRewrapService.name });
     });
 
     it("carries no key material and no secret value into any event", async () => {
@@ -297,7 +333,7 @@ describe(DataKeyRewrapService.name, () => {
   }) {
     const rows = input.rows ?? [];
     const client = mock<SdlSecretsKmsClient>();
-    client.getCryptoKeyVersion.mockResolvedValue([{ name: versionPath(TARGET_VERSION), state: input.versionState ?? "ENABLED" }]);
+    client.getCryptoKeyVersion.mockResolvedValue([{ name: versionPath(TARGET_VERSION), state: "versionState" in input ? input.versionState : "ENABLED" }]);
     client.getPublicKey.mockResolvedValue([
       {
         name: versionPath(TARGET_VERSION),
@@ -352,6 +388,7 @@ describe(DataKeyRewrapService.name, () => {
 
     return {
       service,
+      createLogger,
       dataKeyRepository,
       deploymentSettingRepository,
       wrappedJweService,

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
@@ -29,6 +29,9 @@ const SEALING_KEY_PEM = SEALING_KEYPAIR.publicKey.export({ type: "spki", format:
 
 const ONE_MINUTE_MS = 60_000;
 
+const TOUCHED_AT = new Date("2026-09-01T10:00:00Z");
+const TOUCHED_LATER = new Date("2026-09-01T10:05:00Z");
+
 const A_TOKEN = "eyJhbGciOiJkaXIifQ..YWxwaGEtaXY.YWxwaGEtY2lwaGVydGV4dA.YWxwaGEtdGFn";
 const ANOTHER_TOKEN = "eyJhbGciOiJkaXIifQ..Z2FtbWEtaXY.Z2FtbWEtY2lwaGVydGV4dA.Z2FtbWEtdGFn";
 
@@ -206,7 +209,7 @@ describe(DataKeyRewrapService.name, () => {
         census: { [SOURCE_KID]: 2, [TARGET_KID]: 1 },
         dataKeysRewrapped: 2,
         dataKeysFailed: 0,
-        secretsReEncrypted: 0,
+        secretsDrift: { corruptedIds: [], changedConcurrently: 0, added: 0, removed: 0 },
         bytesRewritten: writtenKeys().reduce((total, key) => total + Buffer.byteLength(key), 0),
         fingerprint: {
           before: { rowCount: 2, byteCount: A_TOKEN.length + ANOTHER_TOKEN.length },
@@ -275,17 +278,17 @@ describe(DataKeyRewrapService.name, () => {
   });
 
   describe("when a stored secret changed under the run", () => {
-    it("fails hard rather than reporting a rotation that proved nothing", async () => {
+    it("fails hard when a token changed while its updatedAt stood still, which no user write can produce", async () => {
       const { service } = setup({
         rows: [aRow({})],
-        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }],
-        storedSecretsAfter: [{ id: "a", sealedSecrets: ANOTHER_TOKEN }]
+        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN, updatedAt: TOUCHED_AT }],
+        storedSecretsAfter: [{ id: "a", sealedSecrets: ANOTHER_TOKEN, updatedAt: TOUCHED_AT }]
       });
 
       await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
     });
 
-    it("reports how many stored secrets moved, which a row count alone cannot show", async () => {
+    it("names the rows it cannot vouch for, which a digest alone cannot show", async () => {
       const { service, logger } = setup({
         rows: [aRow({})],
         storedSecrets: [
@@ -301,8 +304,36 @@ describe(DataKeyRewrapService.name, () => {
       await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
 
       expect(logger.error).toHaveBeenCalledWith(
-        expect.objectContaining({ event: "DATA_KEY_REWRAP_FINGERPRINT_MISMATCH", report: expect.objectContaining({ secretsReEncrypted: 1 }) })
+        expect.objectContaining({
+          event: "DATA_KEY_REWRAP_FINGERPRINT_MISMATCH",
+          report: expect.objectContaining({ secretsDrift: expect.objectContaining({ corruptedIds: ["a"] }) })
+        })
       );
+    });
+
+    it("passes a run during which a user re-saved their secrets, since their write moved updatedAt along with the token", async () => {
+      const { service, report, logger } = setup({
+        rows: [aRow({})],
+        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN, updatedAt: TOUCHED_AT }],
+        storedSecretsAfter: [{ id: "a", sealedSecrets: ANOTHER_TOKEN, updatedAt: TOUCHED_LATER }]
+      });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false }));
+
+      expect(summary.secretsDrift).toEqual({ corruptedIds: [], changedConcurrently: 1, added: 0, removed: 0 });
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_SECRETS_CHANGED_CONCURRENTLY" }));
+    });
+
+    it("passes a run during which a secret arrived and another disappeared", async () => {
+      const { service, report } = setup({
+        rows: [aRow({})],
+        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }],
+        storedSecretsAfter: [{ id: "b", sealedSecrets: ANOTHER_TOKEN }]
+      });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false }));
+
+      expect(summary.secretsDrift).toEqual({ corruptedIds: [], changedConcurrently: 0, added: 1, removed: 1 });
     });
   });
 
@@ -326,8 +357,8 @@ describe(DataKeyRewrapService.name, () => {
   function setup(input: {
     rows?: DataKeyOutput[];
     census?: Array<{ wrappedByKid: string; count: number }>;
-    storedSecrets?: Array<{ id: string; sealedSecrets: string }>;
-    storedSecretsAfter?: Array<{ id: string; sealedSecrets: string }>;
+    storedSecrets?: Array<{ id: string; sealedSecrets: string; updatedAt?: Date | null }>;
+    storedSecretsAfter?: Array<{ id: string; sealedSecrets: string; updatedAt?: Date | null }>;
     unopenableIds?: string[];
     versionState?: protos.google.cloud.kms.v1.ICryptoKeyVersion["state"];
   }) {
@@ -375,7 +406,7 @@ describe(DataKeyRewrapService.name, () => {
     deploymentSettingRepository.findStoredSecretsIteratively.mockImplementation(async function* () {
       const scanned = scans++ === 0 ? (input.storedSecrets ?? []) : (input.storedSecretsAfter ?? input.storedSecrets ?? []);
 
-      if (scanned.length) yield scanned;
+      if (scanned.length) yield scanned.map(row => ({ ...row, updatedAt: row.updatedAt ?? null }));
     });
 
     const txService = mock<TxService>();

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
@@ -1,0 +1,366 @@
+import { protos } from "@google-cloud/kms";
+import crc32c from "fast-crc32c";
+import { compactDecrypt, decodeProtectedHeader } from "jose";
+import { generateKeyPairSync, randomBytes, randomUUID } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { TxService } from "@src/core/services";
+import type { SdlSecretsKmsClient, SdlSecretsKmsTargetFactory } from "@src/deployment/providers/kms.provider";
+import { createSdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
+import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { KmsWrappedJweService,ParsedKmsWrappedJwe  } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import { KmsWrappedJweError } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import type { DataKeyOutput, DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyRewrapService } from "./data-key-rewrap.service";
+
+const { CryptoKeyVersionState } = protos.google.cloud.kms.v1.CryptoKeyVersion;
+
+const KEY = "sdl-secrets";
+const TARGET_VERSION = "3";
+const TARGET_KID = `${KEY}.v${TARGET_VERSION}`;
+const SOURCE_KID = `${KEY}.v1`;
+const OTHER_SOURCE_KID = `${KEY}.v2`;
+
+const DATA_KEY = randomBytes(32);
+const SEALING_KEYPAIR = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const SEALING_KEY_PEM = SEALING_KEYPAIR.publicKey.export({ type: "spki", format: "pem" }).toString();
+
+const A_TOKEN = "eyJhbGciOiJkaXIifQ..YWxwaGEtaXY.YWxwaGEtY2lwaGVydGV4dA.YWxwaGEtdGFn";
+const ANOTHER_TOKEN = "eyJhbGciOiJkaXIifQ..Z2FtbWEtaXY.Z2FtbWEtY2lwaGVydGV4dA.Z2FtbWEtdGFn";
+
+describe(DataKeyRewrapService.name, () => {
+  describe("target version", () => {
+    it("refuses a version the key service reports as disabled, before touching a row", async () => {
+      const { service, dataKeyRepository } = setup({ versionState: "DISABLED" });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
+
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalled();
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).not.toHaveBeenCalled();
+    });
+
+    it("accepts the enabled state reported as an ordinal rather than a name", async () => {
+      const { service } = setup({ versionState: CryptoKeyVersionState.ENABLED });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true })).resolves.toBeDefined();
+    });
+
+    it("refuses a batch size below one, which would read as a fleet needing no work", async () => {
+      const { service, dataKeyRepository } = setup({});
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 0, dryRun: false })).rejects.toThrow();
+
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("re-wrapping", () => {
+    it("moves every row not already at the target onto it", async () => {
+      const { service, dataKeyRepository, rows } = setup({ rows: [aRow({ wrappedByKid: SOURCE_KID }), aRow({ wrappedByKid: OTHER_SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(dataKeyRepository.updateById).toHaveBeenCalledTimes(2);
+      for (const row of rows) {
+        expect(dataKeyRepository.updateById).toHaveBeenCalledWith(row.id, { wrappedKey: expect.any(String), wrappedByKid: TARGET_KID });
+      }
+    });
+
+    it("writes a wrapping whose own header names the target version, so the column and the blob agree", async () => {
+      const { service, writtenKeys } = setup({ rows: [aRow({ wrappedByKid: SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(decodeProtectedHeader(writtenKeys()[0]).kid).toBe(TARGET_KID);
+    });
+
+    it("carries every other header claim across unchanged", async () => {
+      const { service, writtenKeys } = setup({ rows: [aRow({ wrappedByKid: SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(decodeProtectedHeader(writtenKeys()[0])).toEqual({ alg: "RSA-OAEP-256", enc: "A256GCM", cty: "application/octet-stream", kid: TARGET_KID });
+    });
+
+    it("wraps the very same data key bytes, so no stored secret stops opening", async () => {
+      const { service, writtenKeys } = setup({ rows: [aRow({ wrappedByKid: SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      const { plaintext } = await compactDecrypt(writtenKeys()[0], SEALING_KEYPAIR.privateKey);
+      expect(Buffer.from(plaintext).equals(DATA_KEY)).toBe(true);
+    });
+
+    it("opens each row under the version its own header names, not under the target", async () => {
+      const { service, wrappedJweService } = setup({ rows: [aRow({ wrappedByKid: OTHER_SOURCE_KID })] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(wrappedJweService.open).toHaveBeenCalledWith(expect.anything(), versionPath("2"));
+    });
+
+    it("commits each batch in its own transaction", async () => {
+      const { service, txService } = setup({ rows: [aRow({}), aRow({}), aRow({})] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 2, dryRun: false });
+
+      expect(txService.transaction).toHaveBeenCalledTimes(2);
+    });
+
+    it("selects in batches of the size asked for, and of a default when none is given", async () => {
+      const { service, dataKeyRepository } = setup({});
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 25, dryRun: false });
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).toHaveBeenNthCalledWith(1, { targetKid: TARGET_KID, batchSize: 25 });
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).toHaveBeenNthCalledWith(2, { targetKid: TARGET_KID, batchSize: 100 });
+    });
+  });
+
+  describe("a row that cannot be opened", () => {
+    it("records it, re-wraps the rest of its batch and reports the run as failed", async () => {
+      const unopenable = aRow({ wrappedByKid: SOURCE_KID });
+      const { service, dataKeyRepository } = setup({ rows: [unopenable, aRow({ wrappedByKid: SOURCE_KID })], unopenableIds: [unopenable.id] });
+
+      const result = await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(result.err).toBe(true);
+      expect(dataKeyRepository.updateById).toHaveBeenCalledTimes(1);
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalledWith(unopenable.id, expect.anything());
+    });
+
+    it("names it in an event so the operator knows which row blocks the version", async () => {
+      const unopenable = aRow({ wrappedByKid: SOURCE_KID });
+      const { service, logger } = setup({ rows: [unopenable], unopenableIds: [unopenable.id] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "DATA_KEY_REWRAP_ROW_FAILED", dataKeyId: unopenable.id, wrappedByKid: SOURCE_KID })
+      );
+    });
+
+    it("treats a kid of another crypto key as unopenable rather than wrapping it", async () => {
+      const foreign = aRow({ wrappedByKid: "someone-elses-key.v1" });
+      const { service, dataKeyRepository } = setup({ rows: [foreign] });
+
+      const result = await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(result.err).toBe(true);
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the report", () => {
+    it("states the census, the work done and the fingerprint", async () => {
+      const { service, report, writtenKeys } = setup({
+        rows: [aRow({ wrappedByKid: SOURCE_KID }), aRow({ wrappedByKid: SOURCE_KID })],
+        census: [
+          { wrappedByKid: SOURCE_KID, count: 2 },
+          { wrappedByKid: TARGET_KID, count: 1 }
+        ],
+        storedSecrets: [
+          { id: "a", sealedSecrets: A_TOKEN },
+          { id: "b", sealedSecrets: ANOTHER_TOKEN }
+        ]
+      });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false }));
+
+      expect(summary).toMatchObject({
+        dryRun: false,
+        toVersion: TARGET_KID,
+        fromVersions: [SOURCE_KID],
+        census: { [SOURCE_KID]: 2, [TARGET_KID]: 1 },
+        dataKeysRewrapped: 2,
+        dataKeysFailed: 0,
+        secretsReEncrypted: 0,
+        bytesRewritten: writtenKeys().reduce((total, key) => total + Buffer.byteLength(key), 0),
+        fingerprint: {
+          before: { rowCount: 2, byteCount: A_TOKEN.length + ANOTHER_TOKEN.length },
+          after: { rowCount: 2, byteCount: A_TOKEN.length + ANOTHER_TOKEN.length }
+        }
+      });
+      expect(summary.fingerprint.after?.digest).toBe(summary.fingerprint.before.digest);
+      expect(summary.elapsedMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("marks the run's start and completion with structured events", async () => {
+      const { service, logger } = setup({ rows: [aRow({})] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_START", toVersion: TARGET_KID, dryRun: false }));
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_END", report: expect.objectContaining({ toVersion: TARGET_KID }) }));
+    });
+
+    it("carries no key material and no secret value into any event", async () => {
+      const row = aRow({ wrappedByKid: SOURCE_KID });
+      const { service, logger, writtenKeys } = setup({ rows: [row], storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
+
+      const logged = JSON.stringify([...logger.info.mock.calls, ...logger.error.mock.calls, ...logger.warn.mock.calls]);
+      expect(logged).not.toContain(row.wrappedKey);
+      expect(logged).not.toContain(writtenKeys()[0]);
+      expect(logged).not.toContain(A_TOKEN);
+      expect(logged).not.toContain(DATA_KEY.toString("base64"));
+    });
+  });
+
+  describe("dry run", () => {
+    it("writes nothing and reports what a real run would move", async () => {
+      const { service, report, dataKeyRepository, txService } = setup({
+        census: [
+          { wrappedByKid: SOURCE_KID, count: 2 },
+          { wrappedByKid: TARGET_KID, count: 1 }
+        ]
+      });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true }));
+
+      expect(dataKeyRepository.updateById).not.toHaveBeenCalled();
+      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).not.toHaveBeenCalled();
+      expect(txService.transaction).not.toHaveBeenCalled();
+      expect(summary).toMatchObject({ dryRun: true, dataKeysRewrapped: 2, census: { [SOURCE_KID]: 2, [TARGET_KID]: 1 } });
+    });
+
+    it("fingerprints the fleet once and reports no after, since nothing happened between", async () => {
+      const { service, report } = setup({ storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }] });
+
+      const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true }));
+
+      expect(summary.fingerprint.before).toMatchObject({ rowCount: 1, byteCount: A_TOKEN.length });
+      expect(summary.fingerprint.after).toBeUndefined();
+    });
+  });
+
+  describe("when a stored secret changed under the run", () => {
+    it("fails hard rather than reporting a rotation that proved nothing", async () => {
+      const { service } = setup({
+        rows: [aRow({})],
+        storedSecrets: [{ id: "a", sealedSecrets: A_TOKEN }],
+        storedSecretsAfter: [{ id: "a", sealedSecrets: ANOTHER_TOKEN }]
+      });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
+    });
+
+    it("reports how many stored secrets moved, which a row count alone cannot show", async () => {
+      const { service, logger } = setup({
+        rows: [aRow({})],
+        storedSecrets: [
+          { id: "a", sealedSecrets: A_TOKEN },
+          { id: "b", sealedSecrets: A_TOKEN }
+        ],
+        storedSecretsAfter: [
+          { id: "a", sealedSecrets: ANOTHER_TOKEN },
+          { id: "b", sealedSecrets: A_TOKEN }
+        ]
+      });
+
+      await expect(service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false })).rejects.toThrow();
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "DATA_KEY_REWRAP_FINGERPRINT_MISMATCH", report: expect.objectContaining({ secretsReEncrypted: 1 }) })
+      );
+    });
+  });
+
+  function versionPath(version: string) {
+    return `projects/console-test/locations/global/keyRings/console-api/cryptoKeys/${KEY}/cryptoKeyVersions/${version}`;
+  }
+
+  function aRow(overrides: Partial<DataKeyOutput>): DataKeyOutput {
+    const id = overrides.id ?? randomUUID();
+
+    return {
+      id,
+      userId: overrides.userId ?? randomUUID(),
+      wrappedKey: overrides.wrappedKey ?? `wrapped-${id}`,
+      wrappedByKid: overrides.wrappedByKid ?? SOURCE_KID,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
+  }
+
+  function setup(input: {
+    rows?: DataKeyOutput[];
+    census?: Array<{ wrappedByKid: string; count: number }>;
+    storedSecrets?: Array<{ id: string; sealedSecrets: string }>;
+    storedSecretsAfter?: Array<{ id: string; sealedSecrets: string }>;
+    unopenableIds?: string[];
+    versionState?: protos.google.cloud.kms.v1.ICryptoKeyVersion["state"];
+  }) {
+    const rows = input.rows ?? [];
+    const client = mock<SdlSecretsKmsClient>();
+    client.getCryptoKeyVersion.mockResolvedValue([{ name: versionPath(TARGET_VERSION), state: input.versionState ?? "ENABLED" }]);
+    client.getPublicKey.mockResolvedValue([
+      {
+        name: versionPath(TARGET_VERSION),
+        pem: SEALING_KEY_PEM,
+        pemCrc32c: { value: crc32c.calculate(SEALING_KEY_PEM) },
+        algorithm: "RSA_DECRYPT_OAEP_2048_SHA256"
+      }
+    ]);
+
+    const createKmsTarget: SdlSecretsKmsTargetFactory = version => createSdlSecretsKmsTarget({ client, versionPath, key: KEY, version });
+
+    const rowByHeader = new Map<Record<string, unknown>, DataKeyOutput>();
+    const wrappedJweService = mock<KmsWrappedJweService>();
+    wrappedJweService.parse.mockImplementation(serialized => {
+      const row = rows.find(candidate => candidate.wrappedKey === serialized)!;
+      const header = { alg: "RSA-OAEP-256", enc: "A256GCM", cty: "application/octet-stream", kid: row.wrappedByKid };
+      rowByHeader.set(header, row);
+
+      return { header, segments: mock<ParsedKmsWrappedJwe["segments"]>() } as unknown as ParsedKmsWrappedJwe;
+    });
+    wrappedJweService.open.mockImplementation(async parsed => {
+      if (input.unopenableIds?.includes(rowByHeader.get(parsed.header)!.id)) {
+        throw new KmsWrappedJweError("WRAPPING_VERSION_UNUSABLE");
+      }
+
+      return DATA_KEY;
+    });
+
+    const dataKeyRepository = mock<DataKeyRepository>();
+    dataKeyRepository.countByWrappingVersion.mockResolvedValue(input.census ?? [{ wrappedByKid: SOURCE_KID, count: rows.length }]);
+    dataKeyRepository.findWrappedUnderOtherVersionsIteratively.mockImplementation(async function* ({ batchSize }) {
+      for (let offset = 0; offset < rows.length; offset += batchSize) {
+        yield rows.slice(offset, offset + batchSize);
+      }
+    });
+
+    let scans = 0;
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    deploymentSettingRepository.findStoredSecretsIteratively.mockImplementation(async function* () {
+      const scanned = scans++ === 0 ? (input.storedSecrets ?? []) : (input.storedSecretsAfter ?? input.storedSecrets ?? []);
+
+      if (scanned.length) yield scanned;
+    });
+
+    const txService = mock<TxService>();
+    txService.transaction.mockImplementation(async callback => await callback());
+
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const service = new DataKeyRewrapService(dataKeyRepository, deploymentSettingRepository, wrappedJweService, txService, createKmsTarget, createLogger);
+
+    return {
+      service,
+      dataKeyRepository,
+      deploymentSettingRepository,
+      wrappedJweService,
+      txService,
+      client,
+      logger,
+      rows,
+      writtenKeys: () => dataKeyRepository.updateById.mock.calls.map(([, payload]) => payload.wrappedKey as string),
+      report: (result: Awaited<ReturnType<typeof service.rewrapDataKeys>>) => result.unwrap()
+    };
+  }
+});

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -4,6 +4,7 @@ import { CompactEncrypt } from "jose";
 import { Err, Ok, type Result } from "ts-results";
 import { inject, singleton } from "tsyringe";
 
+import { assertBatchSize } from "@src/core/lib/batch-size/batch-size";
 import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
 import { TxService } from "@src/core/services";
 import type { SdlSecretsKmsTarget, SdlSecretsKmsTargetFactory } from "@src/deployment/providers/kms.provider";
@@ -61,7 +62,7 @@ export class DataKeyRewrapService {
 
   async rewrapDataKeys({ targetVersion, batchSize, dryRun }: DataKeyRewrapOptions): Promise<Result<DataKeyRewrapReport, unknown[]>> {
     const startedAt = Date.now();
-    const pageSize = this.#assertUsableBatchSize(batchSize ?? DEFAULT_BATCH_SIZE);
+    const pageSize = assertBatchSize(batchSize ?? DEFAULT_BATCH_SIZE);
     const target = this.createKmsTarget(targetVersion);
     const sealingKey = await this.#assertUsableTarget(target);
 
@@ -107,14 +108,6 @@ export class DataKeyRewrapService {
     this.logger.info({ event: "DATA_KEY_REWRAP_END", report });
 
     return errors.length > 0 ? Err(errors) : Ok(report);
-  }
-
-  #assertUsableBatchSize(batchSize: number): number {
-    if (!Number.isInteger(batchSize) || batchSize < 1) {
-      throw new Error(`Batch size must be a positive integer, got ${batchSize}`);
-    }
-
-    return batchSize;
   }
 
   /** The public key alone cannot answer this: Cloud KMS refuses a disabled version's key, but the emulator serves it. */

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -12,7 +12,7 @@ import { DeploymentSettingRepository } from "@src/deployment/repositories/deploy
 import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
 import type { SdlSecretsSealingKey } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
 import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
-import type { StoredSecretsSummary } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
+import type { StoredSecretsDrift, StoredSecretsSummary } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
 import { StoredSecretsFingerprint } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
 import type { DataKeyOutput } from "@src/secret/repositories/data-key/data-key.repository";
 import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
@@ -37,18 +37,13 @@ export interface DataKeyRewrapReport {
   census: Record<string, number>;
   dataKeysRewrapped: number;
   dataKeysFailed: number;
-  secretsReEncrypted: number;
+  secretsDrift?: StoredSecretsDrift;
   bytesRewritten: number;
   elapsedMs: number;
   fingerprint: { before: StoredSecretsSummary; after?: StoredSecretsSummary };
 }
 
-/**
- * Moves every user's data encryption key onto a KMS key version, so the versions it leaves behind
- * can be disabled. A data key is re-wrapped, never replaced, and a deployment's secrets are sealed
- * to the data key's identity rather than to its wrapping — so this rewrites one row per user and
- * must leave every stored secret exactly as it found it, which the fingerprint either side proves.
- */
+/** Re-wraps every user's data key onto one KMS key version so the versions left behind can be disabled, and proves through the fingerprint drift that it left every stored secret untouched. */
 @singleton()
 export class DataKeyRewrapService {
   private readonly logger: ReturnType<CreateLogger>;
@@ -102,7 +97,7 @@ export class DataKeyRewrapService {
       census,
       dataKeysRewrapped: rewrapped,
       dataKeysFailed: errors.length,
-      secretsReEncrypted: after ? before.countDifferencesFrom(after) : 0,
+      secretsDrift: after?.driftFrom(before),
       bytesRewritten,
       elapsedMs: Date.now() - startedAt,
       fingerprint: { before: before.summarize(), after: after?.summarize() }
@@ -153,11 +148,7 @@ export class DataKeyRewrapService {
     return Object.fromEntries(census.map(({ wrappedByKid, count }) => [wrappedByKid, count]));
   }
 
-  /**
-   * A row nothing can open is recorded and stepped over rather than aborting the run: selection is
-   * keyset-paged, so a row that failed the whole run would be the first one every re-run picks, and
-   * the rest of the fleet would never move off the version the operator is trying to retire.
-   */
+  /** A row nothing can open is recorded and stepped over, because keyset selection would hand it to every re-run first and the fleet would never move off the retiring version. */
   async #rewrapBatch(
     batch: DataKeyOutput[],
     target: SdlSecretsKmsTarget,
@@ -194,10 +185,19 @@ export class DataKeyRewrapService {
       .encrypt(sealingKey.publicKey);
   }
 
+  /** Concurrent user writes move the digest legitimately, so only a row changed without its `updatedAt` moving fails the run. */
   #assertStoredSecretsUntouched(report: DataKeyRewrapReport) {
-    const { before, after } = report.fingerprint;
+    const drift = report.secretsDrift;
 
-    if (!after || (after.digest === before.digest && after.rowCount === before.rowCount && after.byteCount === before.byteCount)) {
+    if (!drift) {
+      return;
+    }
+
+    if (drift.changedConcurrently > 0 || drift.added > 0 || drift.removed > 0) {
+      this.logger.warn({ event: "DATA_KEY_REWRAP_SECRETS_CHANGED_CONCURRENTLY", drift });
+    }
+
+    if (drift.corruptedIds.length === 0) {
       return;
     }
 

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -1,0 +1,212 @@
+import { protos } from "@google-cloud/kms";
+import type { CompactJWEHeaderParameters } from "jose";
+import { CompactEncrypt } from "jose";
+import { Err, Ok, type Result } from "ts-results";
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { TxService } from "@src/core/services";
+import type { SdlSecretsKmsTarget, SdlSecretsKmsTargetFactory } from "@src/deployment/providers/kms.provider";
+import { SDL_SECRETS_KMS_TARGET_FACTORY } from "@src/deployment/providers/kms.provider";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import type { SdlSecretsSealingKey } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import type { StoredSecretsSummary } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
+import { StoredSecretsFingerprint } from "@src/secret/lib/stored-secrets-fingerprint/stored-secrets-fingerprint";
+import type { DataKeyOutput } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+
+const { CryptoKeyVersionState } = protos.google.cloud.kms.v1.CryptoKeyVersion;
+
+/** Holds both encodings of the state, because the Cloud KMS API reports an enum as either its name or its ordinal. */
+const ENABLED_KEY_VERSION_STATES: ReadonlySet<string | number> = new Set(["ENABLED", CryptoKeyVersionState.ENABLED]);
+
+const DEFAULT_BATCH_SIZE = 100;
+
+export interface DataKeyRewrapOptions {
+  targetVersion: string;
+  batchSize?: number;
+  dryRun: boolean;
+}
+
+export interface DataKeyRewrapReport {
+  dryRun: boolean;
+  toVersion: string;
+  fromVersions: string[];
+  census: Record<string, number>;
+  dataKeysRewrapped: number;
+  dataKeysFailed: number;
+  secretsReEncrypted: number;
+  bytesRewritten: number;
+  elapsedMs: number;
+  fingerprint: { before: StoredSecretsSummary; after?: StoredSecretsSummary };
+}
+
+/**
+ * Moves every user's data encryption key onto a KMS key version, so the versions it leaves behind
+ * can be disabled. A data key is re-wrapped, never replaced, and a deployment's secrets are sealed
+ * to the data key's identity rather than to its wrapping — so this rewrites one row per user and
+ * must leave every stored secret exactly as it found it, which the fingerprint either side proves.
+ */
+@singleton()
+export class DataKeyRewrapService {
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly dataKeyRepository: DataKeyRepository,
+    private readonly deploymentSettingRepository: DeploymentSettingRepository,
+    private readonly wrappedJweService: KmsWrappedJweService,
+    private readonly txService: TxService,
+    @inject(SDL_SECRETS_KMS_TARGET_FACTORY) private readonly createKmsTarget: SdlSecretsKmsTargetFactory,
+    @inject(LOGGER_FACTORY) private readonly createLogger: CreateLogger
+  ) {
+    this.logger = createLogger({ context: DataKeyRewrapService.name });
+  }
+
+  async rewrapDataKeys({ targetVersion, batchSize, dryRun }: DataKeyRewrapOptions): Promise<Result<DataKeyRewrapReport, unknown[]>> {
+    const startedAt = Date.now();
+    const pageSize = this.#assertUsableBatchSize(batchSize ?? DEFAULT_BATCH_SIZE);
+    const target = this.createKmsTarget(targetVersion);
+    const sealingKey = await this.#assertUsableTarget(target);
+
+    this.logger.info({ event: "DATA_KEY_REWRAP_START", toVersion: target.kid, batchSize: pageSize, dryRun });
+
+    const before = await this.#fingerprintStoredSecrets(pageSize);
+    const census = await this.#censusByVersion();
+    const errors: unknown[] = [];
+    let rewrapped = dryRun ? countAwayFrom(census, target.kid) : 0;
+    let bytesRewritten = 0;
+
+    if (!dryRun) {
+      for await (const batch of this.dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: target.kid, batchSize: pageSize })) {
+        const wrappings = await this.#rewrapBatch(batch, target, sealingKey, errors);
+
+        await this.txService.transaction(async () => {
+          for (const { id, wrappedKey } of wrappings) {
+            await this.dataKeyRepository.updateById(id, { wrappedKey, wrappedByKid: target.kid });
+          }
+        });
+
+        rewrapped += wrappings.length;
+        bytesRewritten += wrappings.reduce((total, { wrappedKey }) => total + Buffer.byteLength(wrappedKey), 0);
+        this.logger.info({ event: "DATA_KEY_REWRAP_BATCH", rewrapped, failed: errors.length, bytesRewritten });
+      }
+    }
+
+    const after = dryRun ? undefined : await this.#fingerprintStoredSecrets(pageSize);
+    const report: DataKeyRewrapReport = {
+      dryRun,
+      toVersion: target.kid,
+      fromVersions: Object.keys(census).filter(kid => kid !== target.kid),
+      census,
+      dataKeysRewrapped: rewrapped,
+      dataKeysFailed: errors.length,
+      secretsReEncrypted: after ? before.countDifferencesFrom(after) : 0,
+      bytesRewritten,
+      elapsedMs: Date.now() - startedAt,
+      fingerprint: { before: before.summarize(), after: after?.summarize() }
+    };
+
+    this.#assertStoredSecretsUntouched(report);
+    this.logger.info({ event: "DATA_KEY_REWRAP_END", report });
+
+    return errors.length > 0 ? Err(errors) : Ok(report);
+  }
+
+  #assertUsableBatchSize(batchSize: number): number {
+    if (!Number.isInteger(batchSize) || batchSize < 1) {
+      throw new Error(`Batch size must be a positive integer, got ${batchSize}`);
+    }
+
+    return batchSize;
+  }
+
+  /** The public key alone cannot answer this: Cloud KMS refuses a disabled version's key, but the emulator serves it. */
+  async #assertUsableTarget(target: SdlSecretsKmsTarget): Promise<SdlSecretsSealingKey> {
+    const [version] = await target.client.getCryptoKeyVersion({ name: target.versionName });
+
+    if (!ENABLED_KEY_VERSION_STATES.has(version.state ?? "")) {
+      this.logger.error({ event: "DATA_KEY_REWRAP_TARGET_UNUSABLE", toVersion: target.kid, state: version.state });
+
+      throw new Error(`Key version ${target.kid} is not enabled`);
+    }
+
+    return await new SdlSecretsSealingKeyService(target, this.createLogger).getSealingKey();
+  }
+
+  async #fingerprintStoredSecrets(batchSize: number): Promise<StoredSecretsFingerprint> {
+    const fingerprint = new StoredSecretsFingerprint();
+
+    for await (const batch of this.deploymentSettingRepository.findStoredSecretsIteratively({ batchSize })) {
+      for (const storedSecrets of batch) {
+        fingerprint.add(storedSecrets);
+      }
+    }
+
+    return fingerprint;
+  }
+
+  async #censusByVersion(): Promise<Record<string, number>> {
+    const census = await this.dataKeyRepository.countByWrappingVersion();
+
+    return Object.fromEntries(census.map(({ wrappedByKid, count }) => [wrappedByKid, count]));
+  }
+
+  /**
+   * A row nothing can open is recorded and stepped over rather than aborting the run: selection is
+   * keyset-paged, so a row that failed the whole run would be the first one every re-run picks, and
+   * the rest of the fleet would never move off the version the operator is trying to retire.
+   */
+  async #rewrapBatch(
+    batch: DataKeyOutput[],
+    target: SdlSecretsKmsTarget,
+    sealingKey: SdlSecretsSealingKey,
+    errors: unknown[]
+  ): Promise<Array<{ id: string; wrappedKey: string }>> {
+    const wrappings: Array<{ id: string; wrappedKey: string }> = [];
+
+    for (const row of batch) {
+      try {
+        wrappings.push({ id: row.id, wrappedKey: await this.#rewrap(row, target, sealingKey) });
+      } catch (error) {
+        errors.push(error);
+        this.logger.error({ event: "DATA_KEY_REWRAP_ROW_FAILED", dataKeyId: row.id, userId: row.userId, wrappedByKid: row.wrappedByKid, error });
+      }
+    }
+
+    return wrappings;
+  }
+
+  /** The unwrap is the only call the key service sees; wrapping again spends only the public half already in memory. */
+  async #rewrap(row: DataKeyOutput, target: SdlSecretsKmsTarget, sealingKey: SdlSecretsSealingKey): Promise<string> {
+    const parsed = this.wrappedJweService.parse(row.wrappedKey);
+    const versionName = target.resolveVersionName(parsed.header.kid);
+
+    if (!versionName) {
+      throw new Error(`Data key ${row.id} names a key version this console cannot resolve`);
+    }
+
+    const dataKey = await this.wrappedJweService.open(parsed, versionName);
+
+    return await new CompactEncrypt(dataKey)
+      .setProtectedHeader({ ...parsed.header, kid: sealingKey.kid } as CompactJWEHeaderParameters)
+      .encrypt(sealingKey.publicKey);
+  }
+
+  #assertStoredSecretsUntouched(report: DataKeyRewrapReport) {
+    const { before, after } = report.fingerprint;
+
+    if (!after || (after.digest === before.digest && after.rowCount === before.rowCount && after.byteCount === before.byteCount)) {
+      return;
+    }
+
+    this.logger.error({ event: "DATA_KEY_REWRAP_FINGERPRINT_MISMATCH", report });
+
+    throw new Error(`Stored secrets changed while re-wrapping onto ${report.toVersion}`);
+  }
+}
+
+function countAwayFrom(census: Record<string, number>, targetKid: string): number {
+  return Object.entries(census).reduce((total, [kid, count]) => (kid === targetKid ? total : total + count), 0);
+}

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -20,7 +20,7 @@ import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.re
 const { CryptoKeyVersionState } = protos.google.cloud.kms.v1.CryptoKeyVersion;
 
 /** Holds both encodings of the state, because the Cloud KMS API reports an enum as either its name or its ordinal. */
-const ENABLED_KEY_VERSION_STATES: ReadonlySet<string | number> = new Set(["ENABLED", CryptoKeyVersionState.ENABLED]);
+const ENABLED_KEY_VERSION_STATES: ReadonlySet<unknown> = new Set(["ENABLED", CryptoKeyVersionState.ENABLED]);
 
 const DEFAULT_BATCH_SIZE = 100;
 
@@ -126,7 +126,7 @@ export class DataKeyRewrapService {
   async #assertUsableTarget(target: SdlSecretsKmsTarget): Promise<SdlSecretsSealingKey> {
     const [version] = await target.client.getCryptoKeyVersion({ name: target.versionName });
 
-    if (!ENABLED_KEY_VERSION_STATES.has(version.state ?? "")) {
+    if (!ENABLED_KEY_VERSION_STATES.has(version.state)) {
       this.logger.error({ event: "DATA_KEY_REWRAP_TARGET_UNUSABLE", toVersion: target.kid, state: version.state });
 
       throw new Error(`Key version ${target.kid} is not enabled`);


### PR DESCRIPTION
## Why

Slices 1 and 2 shipped the rotation: the reads it runs, and the `rewrap-data-keys` command that uses them. Every acceptance criterion about *what a run does* was pinned by unit tests against mocks.

Three of them cannot be pinned that way. A mocked repository consults no real transaction, so it cannot show a batch rolling back. A mocked KMS returns whatever the test told it to, so it cannot show that a re-wrapped data key still opens the secret sealed under it. This slice closes that gap: six tests driving the real service against a real Postgres and a real Cloud KMS emulator with two enabled key versions.

No production code changed.

Part of CON-875 — slice 3 of 3, stacked on `fix/user-rotate-kms-key-operator-command-2`. With this, every acceptance criterion in the Spec has an assertion behind it.

## What

One file: `data-key-rewrap.service.integration.ts`.

```ts
it("leaves every stored secret opening to the plaintext it was sealed with", async () => {
  const { oldVersion, newVersion } = await enabledRotationPair();
  const { seedUser, rewrapOnto, consoleAt } = setup();
  const alpha = await seedUser(oldVersion, "alpha-plaintext");
  const bravo = await seedUser(oldVersion, "bravo-plaintext");

  await rewrapOnto(newVersion);

  const afterRotation = consoleAt(newVersion);
  await expect(afterRotation.openStoredSecret(alpha)).resolves.toBe("alpha-plaintext");
  await expect(afterRotation.openStoredSecret(bravo)).resolves.toBe("bravo-plaintext");
});
```

That is the whole design in one test. A data key is re-wrapped, never replaced, so a token sealed under its *identity* has to keep opening after its wrapping moves to another KMS key version.

**Nothing in the fixture is a stand-in for the thing under test.** `seedUser` wraps each data key through the real `DataKeyService` — a genuine KMS-wrapped JWE — and seals each secret through the real `SecretCipherService`, genuine AES-256-GCM under that user's own data key. The rollback is a real Postgres transaction being rolled back.

The other five cover: every stored token byte-identical with the fingerprint agreeing; each row at the target with a changed wrapping of unchanged key bytes; a second run that selects nothing and spends no KMS call; a failed write rolling its batch back whole while the batch before it stays committed, and a re-run finishing the job; and a dry run that leaves both tables and the `data_keys` row count exactly as it found them.

### Why the rollback test injects its fault where it does

The write fails on the **second** row of the second batch — so the first row of that batch is already written when the error lands. Without the transaction it stays written, and a run that died halfway would leave a batch torn in half. A fault before the batch's first write would have proved only that later rows are untouched, which is the weaker half of the criterion.

### Reviewer notes

Two non-blocking findings from review, neither fixed here:

- The integration test checks the new header's `kid` but not that every *other* header claim carried across unchanged. That claim is asserted in the unit spec (`carries every other header claim across unchanged`), so it is covered — just not against a real blob.
- The rollback test seeds 4 rows rather than 6, so there is no batch *after* the failed one. "Later rows untouched" is therefore evidenced only by the failed batch's own two rows staying put, not by a batch that was never reached.

## Demo

### CON-875 slice 3 — what the rotation's integration cover actually catches

*2026-09-11T10:05:43Z by Showboat 0.6.1*
<!-- showboat-id: 18033391-05b5-4152-b511-fe2ef6c9260a -->

This slice ships no behaviour. It ships the proof for the behaviour slices 1 and 2 shipped — six tests driving the real re-wrap service against a real Postgres and a real Cloud KMS emulator with two enabled key versions.

So a demo that just shows them passing would show nothing. What follows instead breaks the production code in each of the ways that matter, one at a time, and reports which guarantee notices. Every mutation below is reverted immediately after its run, and the last block confirms the working tree is back to what was committed.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
grep -oE '^  it\("[^"]+"' src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts |
  sed -E 's/^  it\("/  - /; s/"$//'

```

```output
  - leaves every stored secret opening to the plaintext it was sealed with
  - leaves every stored secrets token byte-identical, and says so in its fingerprint
  - re-wraps every row onto the target without changing the key it wraps
  - re-runs as a no-op that spends no call on the key service
  - leaves a failed batch whole, the batches before it committed, and finishes on a re-run
  - reports on a dry run what a real run then moves, having written nothing
```

Those six are the file's claims. Here is what happens to them when the rotation is subtly wrong.

Nothing here is a mock: the data keys are wrapped by real KMS calls, the secrets are sealed with real AES-256-GCM under each user's own data key, and the rollback is a real Postgres transaction being rolled back. Each mutation is applied to the committed source, the suite is run, and the source is restored before the next one.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
SPEC=src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts
SERVICE=src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
REPO=src/secret/repositories/data-key/data-key.repository.ts
VITEST=../../node_modules/.bin/vitest

trap 'git checkout -- "$SERVICE" "$REPO" 2>/dev/null' EXIT

report() {
  "$VITEST" run --project=integration "$SPEC" 2>&1 |
    sed -E 's/\x1b\[[0-9;]*m//g' |
    grep -E "^\s+× " |
    sed -E 's/^\s+× (.*) [0-9]+ms$/    caught by: \1/'
  git checkout -- "$SERVICE" "$REPO"
}

echo "1. the batch's writes stop being one transaction"
python3 - "$SERVICE" <<'PY'
import sys
p = sys.argv[1]
s = open(p).read()
old = """        await this.txService.transaction(async () => {
          for (const { id, wrappedKey } of wrappings) {
            await this.dataKeyRepository.updateById(id, { wrappedKey, wrappedByKid: target.kid });
          }
        });"""
new = """        for (const { id, wrappedKey } of wrappings) {
          await this.dataKeyRepository.updateById(id, { wrappedKey, wrappedByKid: target.kid });
        }"""
assert old in s
open(p, "w").write(s.replace(old, new))
PY
report

echo
echo "2. a dry run stops being a dry run"
sed -i 's/    if (!dryRun) {/    if (true) {/' "$SERVICE"
report

echo
echo "3. the new wrapping keeps the kid the old one named"
sed -i 's/{ \.\.\.parsed.header, kid: sealingKey.kid }/{ ...parsed.header }/' "$SERVICE"
report

echo
echo "4. a fresh key is wrapped instead of the one that was opened"
python3 - "$SERVICE" <<'PY'
import sys
p = sys.argv[1]
s = open(p).read()
old = "const dataKey = await this.wrappedJweService.open(parsed, versionName);"
new = 'const dataKey = await this.wrappedJweService.open(parsed, versionName).then(() => randomBytes(32));'
assert old in s
s = s.replace(old, new).replace('import { CompactEncrypt } from "jose";', 'import { CompactEncrypt } from "jose";\nimport { randomBytes } from "node:crypto";')
open(p, "w").write(s)
PY
report

echo
echo "5. selection stops skipping rows already at the target"
sed -i 's/and(ne(this.table.wrappedByKid, targetKid), \.\.\.(cursor/and(...(cursor/' "$REPO"
report

```

```output
1. the batch's writes stop being one transaction
    caught by: leaves a failed batch whole, the batches before it committed, and finishes on a re-run

2. a dry run stops being a dry run
    caught by: reports on a dry run what a real run then moves, having written nothing

3. the new wrapping keeps the kid the old one named
    caught by: leaves every stored secret opening to the plaintext it was sealed with
    caught by: re-wraps every row onto the target without changing the key it wraps

4. a fresh key is wrapped instead of the one that was opened
    caught by: leaves every stored secret opening to the plaintext it was sealed with
    caught by: re-wraps every row onto the target without changing the key it wraps

5. selection stops skipping rows already at the target
    caught by: re-runs as a no-op that spends no call on the key service
    caught by: leaves a failed batch whole, the batches before it committed, and finishes on a re-run
```

And back to where we started — no mutation left behind, every guarantee holding.

```bash
cd "$(git rev-parse --show-toplevel)/apps/api"
git status --porcelain -- src/secret/ | sed 's/^/  uncommitted: /'
echo "  working tree matches HEAD: $([ -z "$(git status --porcelain -- src/secret/)" ] && echo true || echo false)"
../../node_modules/.bin/vitest run --project=integration src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts 2>&1 |
  sed -E 's/\x1b\[[0-9;]*m//g' |
  grep -E "^ +(Test Files|Tests) " |
  sed -E 's/^ +/  /'

```

```output
  working tree matches HEAD: true
  Test Files  1 passed (1)
  Tests  6 passed (6)
```

Reading that table, in the order the failures matter:

- **the per-batch transaction is real.** Drop it and the rollback test fails, because the fault is injected on the *second* row of the second batch — so the first row of that batch has already been written when the error lands. Without the transaction it stays written, and a run that died halfway leaves a batch torn in half.
- **a dry run that writes is caught immediately**, including the data key count, so an implementation that read rows through `DataKeyUnwrapperService` — whose `ensureDataKey` inserts a row for any user lacking one — would not get past this file.
- **the wrapping and the column cannot drift apart.** Leave the old `kid` in the new wrapping and two tests fail: the row no longer opens under the version its own header names, and the stored secret goes with it.
- **the key has to survive the re-wrap.** Wrap a fresh key instead of the one that was opened and every secret sealed under the old one stops opening — which is the whole reason a rotation re-wraps rather than re-keys.
- **selection is what makes a re-run safe.** Stop filtering on the target version and the second run picks up rows it already moved, spending KMS calls on work that is done.

One honest limit: the fingerprint-unchanged assertion is a guard, not a test with an inverse. No mutation of this service can make it fail, because the command has no code path that writes `deployment_settings` at all — it would only fire if a future change introduced one. The mismatch branch has teeth in the unit spec, where the scan can be made to return a different token.
