### PR TITLE
test(deployment): give each mocked deployment a distinct dseq

### DIFF
--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -252,9 +252,10 @@ describe("Deployments API", () => {
   function setupDeploymentListMock(wallets: UserWalletOutput[], count: number = 2, state: string = "active") {
     const address = wallets[0].address;
     const deployments: RestAkashDeploymentInfoResponse[] = [];
+    const dseqs = faker.helpers.uniqueArray(() => faker.string.numeric(8), count);
 
     for (let i = 0; i < count; i++) {
-      const dseq = faker.string.numeric();
+      const dseq = dseqs[i];
       const deploymentInfo = createDeploymentInfoSeed({
         owner: address!,
         dseq,


### PR DESCRIPTION
## Why

`validate (api)` failed in the merge queue on a test that had nothing to do with the PR being merged:

```
FAIL functional test/functional/deployments.spec.ts > Deployments API > GET /v1/deployments
     > returns each listed deployment's name, and null for one recorded before the console named them
AssertionError: expected 'web' to be null
```

It re-ran green, which is the tell: this is a 10% flake on main, not a one-off.

`setupDeploymentListMock` draws every dseq from `faker.string.numeric()`. With no
length argument that returns a **single digit**, so the two deployments it creates
share a dseq about 10% of the time. Measured over 100k draws: 10.04%.

The list test added in #3905 is the first one that tells the two deployments apart,
so it is the first to notice. On a collision both `upsertDefinition` calls address the
same `(dseq, userId)` row. The second call passes no `name`, and `onConflictDoUpdate`
omits undefined keys from its SET clause, so the first call's `"web"` survives and the
deployment that should have no name reads back as `"web"`.

## What

Draw the dseqs as a `uniqueArray` of 8-digit strings, so a call for `count`
deployments returns `count` distinct ones by construction rather than by luck.

Verified by running the failing test 20 times against a real database on each side of
the change:

| | failures / 20 |
|---|---|
| before | **2** (both `expected 'web' to be null`) |
| after | **0** |

Collision rate for the generator itself: 10.04% over 100k draws before, 0 over 200k after.
Full `deployments.spec.ts` passes, 98/98.

The same no-argument `faker.string.numeric()` appears at 8 other sites. None of them
compare two dseqs within one test, so none are currently breaking, and I have left them
alone rather than widen this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved deployment test fixture generation by using unique, consistent identifiers across deployment and lease data.
  * Increased test reliability by avoiding potentially conflicting generated values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->