### PR TITLE
test(dx): widen seeded dseqs beyond a single digit

### DIFF
--- a/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
+++ b/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
@@ -8,7 +8,7 @@ export function createAutoTopUpDeployment(overrides: Partial<AutoTopUpDeployment
     id: faker.string.uuid(),
     userId: faker.string.uuid(),
     walletId: faker.number.int(),
-    dseq: faker.string.numeric(),
+    dseq: faker.string.numeric({ length: 8, allowLeadingZeros: false }),
     address: createAkashAddress(),
     isWalletAutoTopUpEnabled: false,
     walletIsTrialing: false,

--- a/apps/api/test/seeders/deployment-info.seeder.ts
+++ b/apps/api/test/seeders/deployment-info.seeder.ts
@@ -24,7 +24,7 @@ export interface DeploymentInfoErrorSeederInput {
 export function createDeploymentInfoSeed(input: DeploymentInfoSeederInput = {}): RestAkashDeploymentInfoResponse {
   const {
     owner = createAkashAddress(),
-    dseq = faker.string.numeric(),
+    dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false }),
     state = "active",
     version = deploymentVersion,
     createdAt = "2021-01-01T00:00:00Z",

--- a/apps/deploy-web/tests/seeders/deploymentAlert.ts
+++ b/apps/deploy-web/tests/seeders/deploymentAlert.ts
@@ -5,7 +5,7 @@ export function buildDeploymentAlert(
   overrides?: Partial<components["schemas"]["DeploymentAlertsResponse"]["data"]>
 ): components["schemas"]["DeploymentAlertsResponse"]["data"] {
   return {
-    dseq: faker.string.numeric(),
+    dseq: faker.string.numeric({ length: 8, allowLeadingZeros: false }),
     alerts: {
       deploymentBalance: {
         id: faker.string.uuid(),

--- a/apps/notifications/src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller.spec.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller.spec.ts
@@ -14,7 +14,7 @@ import { MockProvider } from "@test/mocks/provider.mock";
 describe(DeploymentAlertController.name, () => {
   it("should call deploymentAlertService.upsert() and return result", async () => {
     const { controller, service, authService } = await setup();
-    const dseq = faker.string.numeric();
+    const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
     const input = generateMock(DeploymentAlertCreateInput.schema);
     const output = generateMock(DeploymentAlertsResponse.schema);
 
@@ -28,7 +28,7 @@ describe(DeploymentAlertController.name, () => {
 
   it("should call deploymentAlertService.get() and return result", async () => {
     const { controller, service, authService } = await setup();
-    const dseq = faker.string.numeric();
+    const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
     const output = generateMock(DeploymentAlertsResponse.schema);
 
     service.get.mockResolvedValue(output.data);

--- a/apps/notifications/src/modules/alert/services/deployment-alert/deployment-alert.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/deployment-alert/deployment-alert.service.spec.ts
@@ -184,7 +184,7 @@ describe(DeploymentAlertService.name, () => {
   describe("get", () => {
     it("should retrieve and summarise alerts", async () => {
       const { alertRepository, service } = await setup();
-      const dseq = faker.string.numeric();
+      const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
       const owner = mockAkashAddress();
       const deploymentBalanceRawAlert = generateDeploymentBalanceAlert({
         params: {
@@ -246,7 +246,7 @@ describe(DeploymentAlertService.name, () => {
     it("should retrieve and summarise empty result", async () => {
       const { alertRepository, service } = await setup();
       alertRepository.findAllDeploymentAlerts.mockResolvedValueOnce([]);
-      const dseq = faker.string.numeric();
+      const dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false });
 
       expect(await service.get(dseq, {} as MongoAbility)).toEqual({
         dseq,

--- a/apps/notifications/test/seeders/deployment-alert.seeder.ts
+++ b/apps/notifications/test/seeders/deployment-alert.seeder.ts
@@ -5,7 +5,7 @@ import type { DeploymentAlertInput, DeploymentAlertOutput } from "@src/modules/a
 import { mockAkashAddress } from "@test/seeders/akash-address.seeder";
 
 export const generateDeploymentBalanceAlertInput = ({
-  dseq = faker.string.numeric(),
+  dseq = faker.string.numeric({ length: 8, allowLeadingZeros: false }),
   owner = mockAkashAddress(),
   notificationChannelId = faker.string.uuid(),
   enabled = true,


### PR DESCRIPTION
## Why

Follow-up to #3916. `faker.string.numeric()` with no length argument returns a
**single digit**, so any two values drawn for a dseq collide about 10% of the time
(measured: 10.04% over 100k draws).

#3916 fixes the one site where that already breaks a test in the merge queue. These
eight are the rest of the pattern. Each draws a single dseq today, so none are failing
now, but the footgun is the default itself: the moment someone seeds a second entity
and compares the two, they inherit a 10% flake that looks like it belongs to whoever
is merging.

## What

Every remaining no-argument `faker.string.numeric()` becomes
`faker.string.numeric({ length: 8, allowLeadingZeros: false })`, matching the form
already used elsewhere in the repo.

Leading zeros are excluded because `faker.string.numeric(8)` allows them by default
(measured: 345 of 4000 samples start with `0`), and a dseq with a leading zero does not
survive a round trip through a number.

| file | sites | status today |
|---|---|---|
| `apps/api/test/seeders/auto-top-up-deployment.seeder.ts` | 1 | latent |
| `apps/api/test/seeders/deployment-info.seeder.ts` | 1 | latent |
| `apps/deploy-web/tests/seeders/deploymentAlert.ts` | 1 | latent |
| `apps/notifications/test/seeders/deployment-alert.seeder.ts` | 1 | latent |
| `apps/notifications/.../deployment-alert.controller.spec.ts` | 2 | cosmetic, fully mocked |
| `apps/notifications/.../deployment-alert.service.spec.ts` | 2 | cosmetic, fully mocked |

The four seeders are the ones that actually matter, since a seeder is what gets called
twice. The four spec sites are consistency so the pattern does not get copied forward.

## Verification

- **apps/api**: `tsc` clean, `eslint` clean, unit 219 files / 3352 tests pass.
- **apps/notifications**: `eslint` clean. `tsc` and unit results are byte-identical to
  clean `origin/main` in my environment (a pre-existing `tsup-plugins.ts` `import.meta`
  error and 9 files that fail to load locally), so the delta from this change is zero.
- **apps/deploy-web**: `tsc` produces the same 229 pre-existing errors before and after,
  same list. Its tests could not run in my worktree (`@vitejs/plugin-react` is not
  installed there), so CI covers that one.

`deployments.spec.ts` still holds the last no-argument call; it is being fixed by #3916,
which is already queued, so touching it here would conflict.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized generated deployment sequence values in test data to eight-digit numeric strings without leading zeros.
  * Updated deployment, auto top-up, and deployment alert test scenarios to use the corrected sequence format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->