### PR TITLE
feat(deployment): resolve and record deployment names through the api

### DIFF
--- a/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.spec.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.spec.tsx
@@ -1,0 +1,112 @@
+import { createStore, Provider as JotaiStoreProvider } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+import { mock, mockDeep } from "vitest-mock-extended";
+
+import type { AppDIContainer } from "@src/context/ServicesProvider/ServicesProvider";
+import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
+import { settingsIdAtom } from "@src/store/settingsStore";
+import type { DEPENDENCIES } from "./DeploymentNameModal";
+import { DeploymentNameModal } from "./DeploymentNameModal";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe("DeploymentNameModal", () => {
+  it("renames the deployment through the api, so the name outlives this browser", async () => {
+    const { patchMutate } = setup({ storedName: "old-name" });
+
+    await rename("my-app");
+
+    expect(patchMutate).toHaveBeenCalledWith({ dseq: "12345", data: { name: "my-app" } }, expect.any(Object));
+  });
+
+  it("refreshes what the api holds for the deployment, so the detail page stops showing the old name", async () => {
+    const { queryClient, api } = setup({});
+
+    await rename("my-app");
+
+    await waitFor(() => expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: api.v1.getDeployment.getKey({ dseq: "12345" }) }));
+  });
+
+  it("records the new name in this browser too, which the deployments list still reads", async () => {
+    const { deploymentLocalStorage } = setup({});
+
+    await rename("my-app");
+
+    await waitFor(() => expect(deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "12345", { name: "my-app" }));
+  });
+
+  it("reports the rename as saved once the api accepted it", async () => {
+    const { onSaved, enqueueSnackbar } = setup({});
+
+    await rename("my-app");
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "success" }));
+  });
+
+  it.each(["", "   "])("refuses a name of %p, which the api rejects rather than reading as unnamed", async typed => {
+    const { patchMutate, deploymentLocalStorage, onSaved } = setup({ storedName: "old-name" });
+
+    await rename(typed);
+
+    expect(patchMutate).not.toHaveBeenCalled();
+    expect(deploymentLocalStorage.update).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("keeps the dialog open and reports a failed rename instead of claiming success", async () => {
+    const patchMutate = vi.fn((_variables, options) => options?.onError?.(new Error("nope")));
+    const { onSaved, deploymentLocalStorage, enqueueSnackbar } = setup({ patchMutate });
+
+    await rename("my-app");
+
+    await waitFor(() => expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "error" })));
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(deploymentLocalStorage.update).not.toHaveBeenCalled();
+  });
+
+  async function rename(name: string) {
+    const field = screen.getByRole("textbox", { name: "Name" });
+    await userEvent.clear(field);
+    if (name) await userEvent.type(field, name);
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+  }
+
+  function setup(input: { dseq?: string | null; storedName?: string | null; patchMutate?: ReturnType<typeof vi.fn> }) {
+    const dseq = input.dseq === undefined ? "12345" : input.dseq;
+    const patchMutate = input.patchMutate ?? vi.fn((_variables, options) => options?.onSuccess?.());
+
+    const api = mockDeep<AppDIContainer["api"]>();
+    api.v1.getDeployment.getKey.mockImplementation(request => ["getDeployment", request?.dseq ?? ""]);
+    api.v1.patchDeployment.useMutation.mockReturnValue(
+      mock<ReturnType<typeof api.v1.patchDeployment.useMutation>>({ mutate: patchMutate as never })
+    );
+
+    const deploymentLocalStorage = mock<DeploymentStorageService>();
+    const queryClient = mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>();
+    const enqueueSnackbar = vi.fn();
+    const onSaved = vi.fn();
+    const onClose = vi.fn();
+    const getDeploymentName = () => input.storedName ?? null;
+
+    const dependencies: typeof DEPENDENCIES = {
+      useSnackbar: () => ({ enqueueSnackbar, closeSnackbar: vi.fn() }),
+      useQueryClient: () => queryClient
+    };
+
+    const store = createStore();
+    store.set(settingsIdAtom, "akash1abc");
+
+    render(
+      <JotaiStoreProvider store={store}>
+        <TestContainerProvider services={{ api: () => api, deploymentLocalStorage: () => deploymentLocalStorage }}>
+          <DeploymentNameModal dseq={dseq} onClose={onClose} onSaved={onSaved} getDeploymentName={getDeploymentName} dependencies={dependencies} />
+        </TestContainerProvider>
+      </JotaiStoreProvider>
+    );
+
+    return { patchMutate, deploymentLocalStorage, queryClient, enqueueSnackbar, onSaved, onClose, api };
+  }
+});

--- a/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.spec.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.spec.tsx
@@ -119,6 +119,50 @@ describe("DeploymentNameModal", () => {
     expect(deploymentLocalStorage.update).not.toHaveBeenCalled();
   });
 
+  it("opens on the name of the deployment it was reopened for, not the one typed for another", async () => {
+    const { showDeployment } = setup({ dseq: "12345", resolvedName: "first-deployment" });
+    await type("typed-for-the-first");
+
+    showDeployment({ dseq: "67890", resolvedName: "second-deployment" });
+
+    await waitFor(() => expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("second-deployment"));
+  });
+
+  it("renames the deployment it was reopened for with that deployment's own name", async () => {
+    const { showDeployment, patchMutate } = setup({ dseq: "12345", resolvedName: "first-deployment" });
+    await type("typed-for-the-first");
+
+    showDeployment({ dseq: "67890", resolvedName: "second-deployment" });
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(patchMutate).toHaveBeenCalledWith({ dseq: "67890", data: { name: "second-deployment" } }, expect.any(Object));
+  });
+
+  it("opens on the deployment's own name once an edit was abandoned by closing the dialog", async () => {
+    const { showDeployment } = setup({ dseq: "12345", resolvedName: "old-name" });
+    await type("abandoned");
+
+    showDeployment({ dseq: null, resolvedName: "old-name" });
+    showDeployment({ dseq: "12345", resolvedName: "old-name" });
+
+    await waitFor(() => expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("old-name"));
+  });
+
+  it("keeps what the user typed when the api's name for the same deployment arrives afterwards", async () => {
+    const { showDeployment } = setup({ dseq: "12345" });
+    await type("typed-while-loading");
+
+    showDeployment({ dseq: "12345", resolvedName: "named-elsewhere" });
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("typed-while-loading");
+  });
+
+  async function type(name: string) {
+    const field = screen.getByRole("textbox", { name: "Name" });
+    await userEvent.clear(field);
+    await userEvent.type(field, name);
+  }
+
   async function rename(name: string) {
     const field = screen.getByRole("textbox", { name: "Name" });
     await userEvent.clear(field);
@@ -147,23 +191,30 @@ describe("DeploymentNameModal", () => {
     const enqueueSnackbar = vi.fn();
     const onSaved = vi.fn();
     const onClose = vi.fn();
+    let resolvedName = input.resolvedName;
     const dependencies: typeof DEPENDENCIES = {
       useSnackbar: () => ({ enqueueSnackbar, closeSnackbar: vi.fn() }),
       useQueryClient: () => queryClient,
-      useResolvedDeploymentName: () => input.resolvedName
+      useResolvedDeploymentName: () => resolvedName
     };
 
     const store = createStore();
     store.set(settingsIdAtom, "akash1abc");
 
-    render(
+    const modalFor = (shownDseq: string | number | null) => (
       <JotaiStoreProvider store={store}>
         <TestContainerProvider services={{ api: () => api, deploymentLocalStorage: () => deploymentLocalStorage }}>
-          <DeploymentNameModal dseq={dseq} onClose={onClose} onSaved={onSaved} dependencies={dependencies} />
+          <DeploymentNameModal dseq={shownDseq} onClose={onClose} onSaved={onSaved} dependencies={dependencies} />
         </TestContainerProvider>
       </JotaiStoreProvider>
     );
+    const { rerender } = render(modalFor(dseq));
 
-    return { patchMutate, deploymentLocalStorage, queryClient, enqueueSnackbar, onSaved, onClose, api };
+    const showDeployment = (shown: { dseq: string | number | null; resolvedName?: string }) => {
+      resolvedName = shown.resolvedName;
+      rerender(modalFor(shown.dseq));
+    };
+
+    return { patchMutate, deploymentLocalStorage, queryClient, enqueueSnackbar, onSaved, onClose, api, showDeployment };
   }
 });

--- a/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.spec.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.spec.tsx
@@ -1,20 +1,22 @@
 import { createStore, Provider as JotaiStoreProvider } from "jotai";
 import { describe, expect, it, vi } from "vitest";
+import type { MockProxy } from "vitest-mock-extended";
 import { mock, mockDeep } from "vitest-mock-extended";
 
+import { MAX_DEPLOYMENT_NAME_LENGTH } from "@src/config/deploy.config";
 import type { AppDIContainer } from "@src/context/ServicesProvider/ServicesProvider";
 import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
 import { settingsIdAtom } from "@src/store/settingsStore";
 import type { DEPENDENCIES } from "./DeploymentNameModal";
 import { DeploymentNameModal } from "./DeploymentNameModal";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
 describe("DeploymentNameModal", () => {
   it("renames the deployment through the api, so the name outlives this browser", async () => {
-    const { patchMutate } = setup({ storedName: "old-name" });
+    const { patchMutate } = setup({ resolvedName: "old-name" });
 
     await rename("my-app");
 
@@ -46,8 +48,58 @@ describe("DeploymentNameModal", () => {
     expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "success" }));
   });
 
+  it("opens on the name the api holds, not only the one this browser recorded", async () => {
+    setup({ resolvedName: "named-elsewhere" });
+
+    await waitFor(() => expect(screen.getByRole("textbox", { name: "Name" })).toHaveValue("named-elsewhere"));
+  });
+
+  it("caps the field at the length the api accepts", () => {
+    setup({});
+
+    expect(screen.getByRole("textbox", { name: "Name" })).toHaveAttribute("maxlength", String(MAX_DEPLOYMENT_NAME_LENGTH));
+  });
+
+  it("holds a typed-in over-long name to the length the api accepts, so the rename cannot fail on it", async () => {
+    const { patchMutate } = setup({ resolvedName: "old-name" });
+
+    await rename("a".repeat(MAX_DEPLOYMENT_NAME_LENGTH + 10));
+
+    expect(patchMutate).toHaveBeenCalledWith({ dseq: "12345", data: { name: "a".repeat(MAX_DEPLOYMENT_NAME_LENGTH) } }, expect.any(Object));
+  });
+
+  it("refuses an over-long name that reached the field without passing its own cap", async () => {
+    const { patchMutate } = setup({ resolvedName: "old-name" });
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Name" }), { target: { value: "a".repeat(MAX_DEPLOYMENT_NAME_LENGTH + 1) } });
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(patchMutate).not.toHaveBeenCalled();
+  });
+
+  it("ignores a second save while the first is still in flight, so the older name cannot land last", async () => {
+    const { patchMutate } = setup({ resolvedName: "old-name", isPending: true });
+
+    await rename("my-app");
+
+    expect(patchMutate).not.toHaveBeenCalled();
+  });
+
+  it("still refreshes and closes when this browser cannot record the new name", async () => {
+    const deploymentLocalStorage = mock<DeploymentStorageService>();
+    deploymentLocalStorage.update.mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    const { queryClient, onSaved } = setup({ deploymentLocalStorage });
+
+    await rename("my-app");
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(queryClient.invalidateQueries).toHaveBeenCalled();
+  });
+
   it.each(["", "   "])("refuses a name of %p, which the api rejects rather than reading as unnamed", async typed => {
-    const { patchMutate, deploymentLocalStorage, onSaved } = setup({ storedName: "old-name" });
+    const { patchMutate, deploymentLocalStorage, onSaved } = setup({ resolvedName: "old-name" });
 
     await rename(typed);
 
@@ -74,26 +126,31 @@ describe("DeploymentNameModal", () => {
     await userEvent.click(screen.getByRole("button", { name: "Save" }));
   }
 
-  function setup(input: { dseq?: string | null; storedName?: string | null; patchMutate?: ReturnType<typeof vi.fn> }) {
+  function setup(input: {
+    dseq?: string | null;
+    resolvedName?: string;
+    patchMutate?: ReturnType<typeof vi.fn>;
+    isPending?: boolean;
+    deploymentLocalStorage?: MockProxy<DeploymentStorageService>;
+  }) {
     const dseq = input.dseq === undefined ? "12345" : input.dseq;
     const patchMutate = input.patchMutate ?? vi.fn((_variables, options) => options?.onSuccess?.());
 
     const api = mockDeep<AppDIContainer["api"]>();
     api.v1.getDeployment.getKey.mockImplementation(request => ["getDeployment", request?.dseq ?? ""]);
     api.v1.patchDeployment.useMutation.mockReturnValue(
-      mock<ReturnType<typeof api.v1.patchDeployment.useMutation>>({ mutate: patchMutate as never })
+      mock<ReturnType<typeof api.v1.patchDeployment.useMutation>>({ mutate: patchMutate as never, isPending: input.isPending ?? false })
     );
 
-    const deploymentLocalStorage = mock<DeploymentStorageService>();
+    const deploymentLocalStorage = input.deploymentLocalStorage ?? mock<DeploymentStorageService>();
     const queryClient = mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>();
     const enqueueSnackbar = vi.fn();
     const onSaved = vi.fn();
     const onClose = vi.fn();
-    const getDeploymentName = () => input.storedName ?? null;
-
     const dependencies: typeof DEPENDENCIES = {
       useSnackbar: () => ({ enqueueSnackbar, closeSnackbar: vi.fn() }),
-      useQueryClient: () => queryClient
+      useQueryClient: () => queryClient,
+      useResolvedDeploymentName: () => input.resolvedName
     };
 
     const store = createStore();
@@ -102,7 +159,7 @@ describe("DeploymentNameModal", () => {
     render(
       <JotaiStoreProvider store={store}>
         <TestContainerProvider services={{ api: () => api, deploymentLocalStorage: () => deploymentLocalStorage }}>
-          <DeploymentNameModal dseq={dseq} onClose={onClose} onSaved={onSaved} getDeploymentName={getDeploymentName} dependencies={dependencies} />
+          <DeploymentNameModal dseq={dseq} onClose={onClose} onSaved={onSaved} dependencies={dependencies} />
         </TestContainerProvider>
       </JotaiStoreProvider>
     );

--- a/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.tsx
@@ -8,29 +8,35 @@ import { useAtom } from "jotai";
 import { useSnackbar } from "notistack";
 import { z } from "zod";
 
+import { MAX_DEPLOYMENT_NAME_LENGTH } from "@src/config/deploy.config";
 import { useServices } from "@src/context/ServicesProvider";
+import { useResolvedDeploymentName } from "@src/hooks/useResolvedDeploymentName/useResolvedDeploymentName";
 import { settingsIdAtom } from "@src/store/settingsStore";
 
-export const DEPENDENCIES = { useSnackbar, useQueryClient };
+export const DEPENDENCIES = { useSnackbar, useQueryClient, useResolvedDeploymentName };
 
 const formSchema = z.object({
-  name: z.string().trim().min(1, "Enter a name for this deployment")
+  name: z
+    .string()
+    .trim()
+    .min(1, "Enter a name for this deployment")
+    .max(MAX_DEPLOYMENT_NAME_LENGTH, `Use at most ${MAX_DEPLOYMENT_NAME_LENGTH} characters`)
 });
 
 type Props = {
   dseq: string | number | null | undefined;
   onClose: () => void;
   onSaved: () => void;
-  getDeploymentName: (dseq: string | number | null) => string | null;
   dependencies?: typeof DEPENDENCIES;
 };
 
-export const DeploymentNameModal: React.FC<Props> = ({ dseq, onClose, onSaved, getDeploymentName, dependencies: d = DEPENDENCIES }) => {
+export const DeploymentNameModal: React.FC<Props> = ({ dseq, onClose, onSaved, dependencies: d = DEPENDENCIES }) => {
   const { api, deploymentLocalStorage } = useServices();
   const [address] = useAtom(settingsIdAtom);
   const formRef = useRef<HTMLFormElement | null>(null);
   const { enqueueSnackbar } = d.useSnackbar();
   const queryClient = d.useQueryClient();
+  const resolvedName = d.useResolvedDeploymentName(dseq ? String(dseq) : null);
   const renameDeployment = api.v1.patchDeployment.useMutation();
   const form = useForm<z.infer<typeof formSchema>>({
     defaultValues: {
@@ -38,30 +44,38 @@ export const DeploymentNameModal: React.FC<Props> = ({ dseq, onClose, onSaved, g
     },
     resolver: zodResolver(formSchema)
   });
-  const { handleSubmit, control, setValue } = form;
+  const { handleSubmit, control, setValue, formState } = form;
+  const isEdited = formState.isDirty;
 
-  useEffect(() => {
-    if (dseq) {
-      const name = getDeploymentName(dseq);
-      setValue("name", name || "");
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dseq, getDeploymentName]);
+  useEffect(
+    function seedFromTheNameOnShow() {
+      if (dseq && !isEdited) setValue("name", resolvedName ?? "");
+    },
+    [dseq, resolvedName, isEdited, setValue]
+  );
 
   const onSaveClick = (event: React.MouseEvent) => {
     event.preventDefault();
     formRef.current?.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
   };
 
+  /** The deployments list still resolves names from this browser alone, so the record is kept in step until it reads the api too — and a full or blocked store must not strand a rename the api has already accepted. */
+  function recordNameInThisBrowser(name: string) {
+    try {
+      deploymentLocalStorage.update(address, dseq, { name });
+    } catch {
+      return;
+    }
+  }
+
   function onSubmit({ name }: z.infer<typeof formSchema>) {
-    if (!dseq) return;
+    if (!dseq || renameDeployment.isPending) return;
 
     renameDeployment.mutate(
       { dseq: String(dseq), data: { name } },
       {
         onSuccess: function recordRename() {
-          /** The deployments list still resolves names from this browser alone, so the record is kept in step until it reads the api too. */
-          deploymentLocalStorage.update(address, dseq, { name });
+          recordNameInThisBrowser(name);
           queryClient.invalidateQueries({ queryKey: api.v1.getDeployment.getKey({ dseq: String(dseq) }) });
           enqueueSnackbar(<Snackbar title="Success!" iconVariant="success" />, { variant: "success", autoHideDuration: 1000 });
           onSaved();
@@ -92,6 +106,7 @@ export const DeploymentNameModal: React.FC<Props> = ({ dseq, onClose, onSaved, g
           color: "primary",
           variant: "default",
           side: "right",
+          disabled: renameDeployment.isPending,
           onClick: onSaveClick
         }
       ]}
@@ -104,7 +119,7 @@ export const DeploymentNameModal: React.FC<Props> = ({ dseq, onClose, onSaved, g
             control={control}
             name="name"
             render={({ field }) => {
-              return <FormInput {...field} label="Name" autoFocus type="text" />;
+              return <FormInput {...field} label="Name" autoFocus type="text" maxLength={MAX_DEPLOYMENT_NAME_LENGTH} />;
             }}
           />
         </form>

--- a/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.tsx
@@ -44,14 +44,25 @@ export const DeploymentNameModal: React.FC<Props> = ({ dseq, onClose, onSaved, d
     },
     resolver: zodResolver(formSchema)
   });
-  const { handleSubmit, control, setValue, formState } = form;
+  const { handleSubmit, control, reset, formState } = form;
   const isEdited = formState.isDirty;
+  /** One modal instance serves every deployment, so a name typed for one must never be carried into another's field. */
+  const seededDseqRef = useRef<string | null>(null);
 
   useEffect(
     function seedFromTheNameOnShow() {
-      if (dseq && !isEdited) setValue("name", resolvedName ?? "");
+      if (!dseq) {
+        seededDseqRef.current = null;
+        return;
+      }
+
+      const shown = String(dseq);
+      if (seededDseqRef.current !== shown || !isEdited) {
+        seededDseqRef.current = shown;
+        reset({ name: resolvedName ?? "" });
+      }
     },
-    [dseq, resolvedName, isEdited, setValue]
+    [dseq, resolvedName, isEdited, reset]
   );
 
   const onSaveClick = (event: React.MouseEvent) => {

--- a/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/DeploymentNameModal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { Form, FormField, FormInput, Popup, Snackbar } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useSnackbar } from "notistack";
 import { z } from "zod";
@@ -10,8 +11,10 @@ import { z } from "zod";
 import { useServices } from "@src/context/ServicesProvider";
 import { settingsIdAtom } from "@src/store/settingsStore";
 
+export const DEPENDENCIES = { useSnackbar, useQueryClient };
+
 const formSchema = z.object({
-  name: z.string()
+  name: z.string().trim().min(1, "Enter a name for this deployment")
 });
 
 type Props = {
@@ -19,13 +22,16 @@ type Props = {
   onClose: () => void;
   onSaved: () => void;
   getDeploymentName: (dseq: string | number | null) => string | null;
+  dependencies?: typeof DEPENDENCIES;
 };
 
-export const DeploymentNameModal: React.FC<Props> = ({ dseq, onClose, onSaved, getDeploymentName }) => {
-  const { deploymentLocalStorage } = useServices();
+export const DeploymentNameModal: React.FC<Props> = ({ dseq, onClose, onSaved, getDeploymentName, dependencies: d = DEPENDENCIES }) => {
+  const { api, deploymentLocalStorage } = useServices();
   const [address] = useAtom(settingsIdAtom);
   const formRef = useRef<HTMLFormElement | null>(null);
-  const { enqueueSnackbar } = useSnackbar();
+  const { enqueueSnackbar } = d.useSnackbar();
+  const queryClient = d.useQueryClient();
+  const renameDeployment = api.v1.patchDeployment.useMutation();
   const form = useForm<z.infer<typeof formSchema>>({
     defaultValues: {
       name: ""
@@ -48,11 +54,23 @@ export const DeploymentNameModal: React.FC<Props> = ({ dseq, onClose, onSaved, g
   };
 
   function onSubmit({ name }: z.infer<typeof formSchema>) {
-    deploymentLocalStorage.update(address, dseq, { name: name });
+    if (!dseq) return;
 
-    enqueueSnackbar(<Snackbar title="Success!" iconVariant="success" />, { variant: "success", autoHideDuration: 1000 });
-
-    onSaved();
+    renameDeployment.mutate(
+      { dseq: String(dseq), data: { name } },
+      {
+        onSuccess: function recordRename() {
+          /** The deployments list still resolves names from this browser alone, so the record is kept in step until it reads the api too. */
+          deploymentLocalStorage.update(address, dseq, { name });
+          queryClient.invalidateQueries({ queryKey: api.v1.getDeployment.getKey({ dseq: String(dseq) }) });
+          enqueueSnackbar(<Snackbar title="Success!" iconVariant="success" />, { variant: "success", autoHideDuration: 1000 });
+          onSaved();
+        },
+        onError: function reportRenameFailure() {
+          enqueueSnackbar(<Snackbar title="Couldn't rename this deployment" iconVariant="error" />, { variant: "error" });
+        }
+      }
+    );
   }
 
   return (

--- a/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.spec.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.spec.tsx
@@ -66,19 +66,6 @@ describe(LocalNoteManager.name, () => {
     expect(selectDeployment).toHaveBeenCalledWith(null);
   });
 
-  it("passes getDeploymentName from useLocalNotes to modal", () => {
-    const DeploymentNameModalMock = vi.fn(ComponentMock as unknown as typeof DeploymentNameModal);
-    const getDeploymentName = vi.fn().mockReturnValue("my-deployment");
-    setup({
-      getDeploymentName,
-      dependencies: {
-        DeploymentNameModal: DeploymentNameModalMock
-      }
-    });
-
-    expect(DeploymentNameModalMock).toHaveBeenCalledWith(expect.objectContaining({ getDeploymentName }), expect.anything());
-  });
-
   it("initializes favorite providers on mount", () => {
     const initFavoriteProviders = vi.fn();
     setup({ initFavoriteProviders });

--- a/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.tsx
+++ b/apps/deploy-web/src/components/LocalNoteManager/LocalNoteManager.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export function LocalNoteManager({ dependencies: d = DEPENDENCIES }: Props) {
-  const { getDeploymentName, selectedDeploymentDseq, selectDeployment } = d.useLocalNotes();
+  const { selectedDeploymentDseq, selectDeployment } = d.useLocalNotes();
   const initFavoriteProviders = d.useInitFavoriteProviders();
   const resetSelectedDeployment = () => selectDeployment(null);
 
@@ -25,11 +25,6 @@ export function LocalNoteManager({ dependencies: d = DEPENDENCIES }: Props) {
   }, []);
 
   return (
-    <d.DeploymentNameModal
-      dseq={selectedDeploymentDseq}
-      onClose={resetSelectedDeployment}
-      onSaved={resetSelectedDeployment}
-      getDeploymentName={getDeploymentName}
-    />
+    <d.DeploymentNameModal dseq={selectedDeploymentDseq} onClose={resetSelectedDeployment} onSaved={resetSelectedDeployment} />
   );
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -460,9 +460,25 @@ describe(ConfigureDeploymentForm.name, () => {
     await waitFor(() => expect(save).toHaveBeenCalledWith(expect.stringContaining("node:18"), "my-app", undefined));
   });
 
+  it("persists only the name this session typed, never one the api derived for it", async () => {
+    const { save } = setup({ initialSdl: undefined, apiDerivedName: "web+postgres", Panes: SdlProbePanes });
+
+    await userEvent.click(screen.getByRole("button", { name: "change image" }));
+
+    await waitFor(() => expect(save).toHaveBeenCalledWith(expect.any(String), "", undefined));
+  });
+
+  it("shows the name the api derived while asking for quotes under none, so the api can derive it again", () => {
+    const { ConfigureDeploymentPanes, ConfigureDeploymentHeader } = setup({ initialSdl: undefined, apiDerivedName: "web+postgres" });
+
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ deploymentName: "web+postgres" }), expect.anything());
+    expect(ConfigureDeploymentHeader).toHaveBeenCalledWith(expect.objectContaining({ deploymentName: "" }), expect.anything());
+  });
+
   function setup(input: {
     initialSdl: string | undefined;
     initialName?: string;
+    apiDerivedName?: string;
     Panes?: typeof SdlProbePanes;
     draftId?: string;
     persistedRuntimeLimitHours?: number;
@@ -503,7 +519,11 @@ describe(ConfigureDeploymentForm.name, () => {
         clear
       })
     );
-    const useDeploymentName = ((args: { initialName?: string }) => ({ name: args.initialName ?? "", setName: setDeploymentName })) as never;
+    const useDeploymentName = ((args: { initialName?: string }) => ({
+      name: input.apiDerivedName ?? args.initialName ?? "",
+      typedName: args.initialName ?? "",
+      setName: setDeploymentName
+    })) as never;
     // The base flow is created upstream by the DeploymentFlowProvider now, so it arrives as a prop rather than a hook.
     const flow = mock<DeploymentFlow>({
       phase: input.phase ?? "configuring",

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -263,6 +263,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
               <d.ConfigureDeploymentHeader
                 flow={flow}
                 sdl={liveSdl}
+                deploymentName={deploymentName}
                 onDeploy={() => openReview(flow.selections)}
                 allPlacementsHaveBids={allPlacementsHaveBids}
               />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -73,7 +73,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
   const { enqueueSnackbar } = d.useSnackbar();
   const { analyticsService } = d.useServices();
   const draft = d.useConfigureDraft(intent);
-  const { name: deploymentName, setName: setDeploymentName } = d.useDeploymentName({ initialName, dseq: flow.dseq });
+  const { name: deploymentName, typedName: typedDeploymentName, setName: setDeploymentName } = d.useDeploymentName({ initialName, dseq: flow.dseq });
   const [runtimeLimitHours, setRuntimeLimitHours] = useState<number | undefined>(() => draft.persistedRuntimeLimitHours);
   const form = useForm<SdlBuilderFormValuesType>({
     defaultValues: initialState.values,
@@ -116,13 +116,13 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
     function debouncePreviewSdl() {
       const timeout = setTimeout(function commitDebouncedSdl() {
         setPreviewSdl(liveSdl);
-        draft.save(liveSdl, deploymentName, runtimeLimitHours);
+        draft.save(liveSdl, typedDeploymentName, runtimeLimitHours);
       }, SDL_SYNC_DEBOUNCE_MS);
       return function cancelPreviewDebounce() {
         clearTimeout(timeout);
       };
     },
-    [liveSdl, deploymentName, runtimeLimitHours, draft]
+    [liveSdl, typedDeploymentName, runtimeLimitHours, draft]
   );
 
   useEffect(
@@ -263,7 +263,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
               <d.ConfigureDeploymentHeader
                 flow={flow}
                 sdl={liveSdl}
-                deploymentName={deploymentName}
+                deploymentName={typedDeploymentName}
                 onDeploy={() => openReview(flow.selections)}
                 allPlacementsHaveBids={allPlacementsHaveBids}
               />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
@@ -24,8 +24,17 @@ describe(ConfigureDeploymentHeader.name, () => {
 
     fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
 
-    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL));
+    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL, ""));
     expect(enqueueSnackbar).not.toHaveBeenCalled();
+  });
+
+  it("requests quotes with the name typed into the deployment pane, so the api records it on create", async () => {
+    const requestQuotes = vi.fn();
+    setup({ phase: "configuring", requestQuotes, deploymentName: "my-app" });
+
+    fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
+
+    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL, "my-app"));
   });
 
   it("blocks a trial deployment whose GPU resolves to a blocked selection and surfaces the trial message", async () => {
@@ -57,7 +66,7 @@ describe(ConfigureDeploymentHeader.name, () => {
 
     fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
 
-    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL));
+    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL, ""));
   });
 
   it("does not apply the trial GPU guard for a non-trial user", async () => {
@@ -71,7 +80,7 @@ describe(ConfigureDeploymentHeader.name, () => {
 
     fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
 
-    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL));
+    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL, ""));
   });
 
   it("surfaces SDL validation errors and does not request quotes when the spec is invalid", async () => {
@@ -248,6 +257,7 @@ describe(ConfigureDeploymentHeader.name, () => {
     expiry?: QuoteExpiry | null;
     cancelAndEdit?: () => void;
     isRestricted?: boolean;
+    deploymentName?: string;
     services?: Array<{ profile: { hasGpu?: boolean; gpuModels?: Array<{ vendor: string; name?: string }> } }>;
   }) {
     const flow = mock<DeploymentFlow>({
@@ -281,6 +291,7 @@ describe(ConfigureDeploymentHeader.name, () => {
         <ConfigureDeploymentHeader
           flow={flow}
           sdl={input.sdl ?? ""}
+          deploymentName={input.deploymentName ?? ""}
           onDeploy={input.onDeploy ?? vi.fn()}
           allPlacementsHaveBids={input.allPlacementsHaveBids ?? false}
           dependencies={dependencies}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -35,9 +35,16 @@ export const DEPENDENCIES = {
   useTrialGate
 };
 
-type Props = { flow: DeploymentFlow; sdl: string; onDeploy: () => void; allPlacementsHaveBids: boolean; dependencies?: typeof DEPENDENCIES };
+type Props = {
+  flow: DeploymentFlow;
+  sdl: string;
+  deploymentName: string;
+  onDeploy: () => void;
+  allPlacementsHaveBids: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
 
-export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allPlacementsHaveBids, dependencies: d = DEPENDENCIES }) => {
+export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, deploymentName, onDeploy, allPlacementsHaveBids, dependencies: d = DEPENDENCIES }) => {
   const deploymentSummary = d.useDeploymentResourceSummary();
   const showAsHourly = d.useDeploymentHasGpu();
   const { control, handleSubmit, getValues } = useFormContext<SdlBuilderFormValuesType>();
@@ -97,7 +104,7 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
       );
       return;
     }
-    flow.actions.requestQuotes(sdl);
+    flow.actions.requestQuotes(sdl, deploymentName);
   });
 
   return (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { MAX_DEPLOYMENT_NAME_LENGTH } from "@src/config/deploy.config";
 import { DeploymentNameField } from "./DeploymentNameField";
 
 import { render, screen } from "@testing-library/react";
@@ -10,6 +11,12 @@ describe("DeploymentNameField", () => {
     setup({ disabled: true });
 
     expect(screen.getByRole("textbox", { name: "Deployment name" })).toBeDisabled();
+  });
+
+  it("caps the name at the length the api accepts, so a long name cannot fail the whole create", () => {
+    setup({ value: "" });
+
+    expect(screen.getByRole("textbox", { name: "Deployment name" })).toHaveAttribute("maxlength", String(MAX_DEPLOYMENT_NAME_LENGTH));
   });
 
   it("reports typed changes", async () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.tsx
@@ -1,6 +1,8 @@
 import type { FC } from "react";
 import { Input } from "@akashnetwork/ui/components";
 
+import { MAX_DEPLOYMENT_NAME_LENGTH } from "@src/config/deploy.config";
+
 type Props = {
   value: string;
   onChange: (value: string) => void;
@@ -15,6 +17,7 @@ export const DeploymentNameField: FC<Props> = ({ value, onChange, disabled }) =>
       inputClassName="h-9"
       aria-label="Deployment name"
       placeholder="Name your deployment"
+      maxLength={MAX_DEPLOYMENT_NAME_LENGTH}
       value={value}
       disabled={disabled}
       onChange={event => onChange(event.target.value)}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.tsx
@@ -38,6 +38,26 @@ describe(useDeploymentFlow.name, () => {
     expect(replace).toHaveBeenCalledWith("/new-deployment/configure/999?bid-strategy=select", undefined, { shallow: true });
   });
 
+  it("carries the typed name into the create request, so the api records the name the user chose", async () => {
+    const createMutate = vi.fn((_args, { onSuccess }) => onSuccess({ data: { dseq: "999", manifest: "m" } }));
+    const { result } = setup({ createMutate });
+
+    act(() => result.current.actions.requestQuotes("sdl-content", "  my-app  "));
+
+    await waitFor(() => expect(result.current.phase).toBe("quoting"));
+    expect(createMutate).toHaveBeenCalledWith({ data: { sdl: "sdl-content", name: "my-app", deposit: expect.any(Number) } }, expect.any(Object));
+  });
+
+  it.each([undefined, "", "   "])("omits a name of %p, which the api refuses rather than treating as unnamed", async name => {
+    const createMutate = vi.fn((_args, { onSuccess }) => onSuccess({ data: { dseq: "999", manifest: "m" } }));
+    const { result } = setup({ createMutate });
+
+    act(() => result.current.actions.requestQuotes("sdl-content", name));
+
+    await waitFor(() => expect(result.current.phase).toBe("quoting"));
+    expect(createMutate.mock.calls[0][0].data).not.toHaveProperty("name");
+  });
+
   it("mirrors the strategy current when a create resolves, not the one it was fired with", () => {
     const replace = vi.fn();
     let resolveCreate: ((result: { data: { dseq: string; manifest: string } }) => void) | undefined;

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -42,9 +42,9 @@ export interface DeploymentFlowState {
 }
 
 export interface DeploymentFlowActions {
-  /** Creates the deployment from the given SDL. The caller passes the SDL generated from the just-submitted
+  /** Creates the deployment from the given SDL and name. The caller passes the SDL generated from the just-submitted
    * form values so the request can never lag behind an in-flight edit. */
-  requestQuotes: (sdl: string) => void;
+  requestQuotes: (sdl: string, name?: string) => void;
   cancelAndEdit: () => void;
   setBidStrategy: (strategy: BidStrategy) => void;
   refreshQuotes: () => void;
@@ -252,7 +252,7 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
    * deployment is still open (a prior close failed), it is closed first so the single-open-deployment invariant holds.
    */
   const requestQuotes = useCallback(
-    function requestQuotes(sdl: string) {
+    function requestQuotes(sdl: string, name?: string) {
       const attempt = ++createAttemptRef.current;
       providersEverBidRef.current = false;
       bidsReceivedTrackedRef.current = false;
@@ -262,7 +262,7 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
         if (attempt !== createAttemptRef.current) return;
         setPhase("creating");
         createDeployment.mutate(
-          { data: { sdl, deposit: DEFAULT_DEPOSIT } },
+          { data: { sdl, ...namePayload(name), deposit: DEFAULT_DEPOSIT } },
           {
             onSuccess: function onCreated(result: { data: { dseq: string; manifest: string } }) {
               if (attempt !== createAttemptRef.current) {
@@ -456,6 +456,12 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
     error,
     actions: { requestQuotes, cancelAndEdit, setBidStrategy, refreshQuotes, retry, selectProvider, clearSelection, deploy }
   };
+}
+
+/** The api refuses a blank name rather than reading it as "unnamed", so a name the user left empty is left out of the request entirely. */
+function namePayload(name: string | undefined): { name?: string } {
+  const trimmed = name?.trim();
+  return trimmed ? { name: trimmed } : {};
 }
 
 /** Best-effort cache under owner + dseq (the key the detail page reads); failures are swallowed so storage issues never block deploy. */

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.spec.tsx
@@ -44,6 +44,21 @@ describe(useDeploymentName.name, () => {
     expect(result.current.name).toBe("my-app");
   });
 
+  it("reports no typed name of its own while the shown one came from the api, so nothing derived is persisted as the user's", () => {
+    const { result } = setup({ dseq: "12345", apiName: "web+postgres" });
+
+    expect(result.current.name).toBe("web+postgres");
+    expect(result.current.typedName).toBe("");
+  });
+
+  it("reports the typed name as its own once this session types over the api's", () => {
+    const { result } = setup({ dseq: "12345", apiName: "web+postgres" });
+
+    act(() => result.current.setName("my-app"));
+
+    expect(result.current.typedName).toBe("my-app");
+  });
+
   it("resolves to an empty name when neither the api nor this session holds one, leaving the field its placeholder", () => {
     const { result } = setup({ dseq: "12345" });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.spec.tsx
@@ -3,6 +3,7 @@ import { createStore, Provider as JotaiStoreProvider } from "jotai";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { MAX_DEPLOYMENT_NAME_LENGTH } from "@src/config/deploy.config";
 import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
 import { settingsIdAtom } from "@src/store/settingsStore";
 import type { DEPENDENCIES } from "./useDeploymentName";
@@ -17,10 +18,24 @@ describe(useDeploymentName.name, () => {
     expect(result.current.name).toBe("my-app");
   });
 
-  it("shows the name the api holds once the deployment exists", () => {
-    const { result } = setup({ initialName: "my-app", dseq: "12345", apiName: "named-elsewhere" });
+  it("holds a seeded name to the length the api accepts, so a legacy name cannot fail the create", () => {
+    const { result } = setup({ initialName: "a".repeat(MAX_DEPLOYMENT_NAME_LENGTH + 10) });
+
+    expect(result.current.name).toBe("a".repeat(MAX_DEPLOYMENT_NAME_LENGTH));
+  });
+
+  it("fills the field from the api when this session typed no name of its own", () => {
+    const { result } = setup({ dseq: "12345", apiName: "named-elsewhere" });
 
     expect(result.current.name).toBe("named-elsewhere");
+  });
+
+  it("keeps a name typed after the deployment exists, so an edit is never discarded", () => {
+    const { result } = setup({ initialName: "my-app", dseq: "12345", apiName: "named-elsewhere" });
+
+    act(() => result.current.setName("renamed-before-retrying"));
+
+    expect(result.current.name).toBe("renamed-before-retrying");
   });
 
   it("keeps showing the typed name while no deployment exists to carry it", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.spec.tsx
@@ -17,6 +17,24 @@ describe(useDeploymentName.name, () => {
     expect(result.current.name).toBe("my-app");
   });
 
+  it("shows the name the api holds once the deployment exists", () => {
+    const { result } = setup({ initialName: "my-app", dseq: "12345", apiName: "named-elsewhere" });
+
+    expect(result.current.name).toBe("named-elsewhere");
+  });
+
+  it("keeps showing the typed name while no deployment exists to carry it", () => {
+    const { result } = setup({ initialName: "my-app", dseq: null, apiName: "named-elsewhere" });
+
+    expect(result.current.name).toBe("my-app");
+  });
+
+  it("resolves to an empty name when neither the api nor this session holds one, leaving the field its placeholder", () => {
+    const { result } = setup({ dseq: "12345" });
+
+    expect(result.current.name).toBe("");
+  });
+
   it("updates the name via setName", () => {
     const { result } = setup({ initialName: "my-app" });
 
@@ -56,9 +74,10 @@ describe(useDeploymentName.name, () => {
     expect(deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "12345", { name: "my-app" });
   });
 
-  function setup(input: { initialName?: string; dseq?: string | null; settingsId?: string | null }) {
+  function setup(input: { initialName?: string; dseq?: string | null; settingsId?: string | null; apiName?: string }) {
     const deploymentLocalStorage = mock<DeploymentStorageService>();
     const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ deploymentLocalStorage });
+    const useResolvedDeploymentName: typeof DEPENDENCIES.useResolvedDeploymentName = dseq => (dseq ? input.apiName : undefined);
 
     const store = createStore();
     store.set(settingsIdAtom, input.settingsId ?? null);
@@ -66,7 +85,10 @@ describe(useDeploymentName.name, () => {
     const initialProps = { initialName: input.initialName, dseq: input.dseq ?? null };
 
     return {
-      ...renderHook((props: { initialName?: string; dseq: string | null }) => useDeploymentName(props, { useServices }), { wrapper, initialProps }),
+      ...renderHook((props: { initialName?: string; dseq: string | null }) => useDeploymentName(props, { useServices, useResolvedDeploymentName }), {
+        wrapper,
+        initialProps
+      }),
       deploymentLocalStorage,
       store
     };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useAtomValue } from "jotai";
 
+import { MAX_DEPLOYMENT_NAME_LENGTH } from "@src/config/deploy.config";
 import { useServices } from "@src/context/ServicesProvider";
 import { useResolvedDeploymentName } from "@src/hooks/useResolvedDeploymentName/useResolvedDeploymentName";
 import { settingsIdAtom } from "@src/store/settingsStore";
@@ -8,7 +9,7 @@ import { settingsIdAtom } from "@src/store/settingsStore";
 export const DEPENDENCIES = { useServices, useResolvedDeploymentName };
 
 export interface DeploymentName {
-  /** The name to show: the api's own once the deployment exists, and the one typed in this session before that. */
+  /** The name to show: the one typed in this session, and the api's own only where this session has none. */
   name: string;
   setName: (name: string) => void;
 }
@@ -24,7 +25,7 @@ interface UseDeploymentNameInput {
 export function useDeploymentName({ initialName, dseq }: UseDeploymentNameInput, dependencies = DEPENDENCIES): DeploymentName {
   const { deploymentLocalStorage } = dependencies.useServices();
   const settingsId = useAtomValue(settingsIdAtom);
-  const [typedName, setTypedName] = useState(() => initialName ?? "");
+  const [typedName, setTypedName] = useState(() => (initialName ?? "").slice(0, MAX_DEPLOYMENT_NAME_LENGTH));
   const nameRef = useRef(typedName);
   nameRef.current = typedName;
   const resolvedName = dependencies.useResolvedDeploymentName(dseq);
@@ -39,5 +40,5 @@ export function useDeploymentName({ initialName, dseq }: UseDeploymentNameInput,
     },
     [dseq, settingsId, deploymentLocalStorage]
   );
-  return { name: resolvedName ?? typedName, setName: setTypedName };
+  return { name: typedName || resolvedName || "", setName: setTypedName };
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.ts
@@ -2,12 +2,13 @@ import { useEffect, useRef, useState } from "react";
 import { useAtomValue } from "jotai";
 
 import { useServices } from "@src/context/ServicesProvider";
+import { useResolvedDeploymentName } from "@src/hooks/useResolvedDeploymentName/useResolvedDeploymentName";
 import { settingsIdAtom } from "@src/store/settingsStore";
 
-export const DEPENDENCIES = { useServices };
+export const DEPENDENCIES = { useServices, useResolvedDeploymentName };
 
 export interface DeploymentName {
-  /** The current deployment name; seeded from `initialName`, edited via `setName`. */
+  /** The name to show: the api's own once the deployment exists, and the one typed in this session before that. */
   name: string;
   setName: (name: string) => void;
 }
@@ -19,22 +20,15 @@ interface UseDeploymentNameInput {
   dseq: string | null;
 }
 
-/**
- * Owns the configure session's deployment name: its state (seeded once from `initialName`) and its write to the
- * wallet-scoped local record the rest of the app reads via `useLocalNotes.getDeploymentName(dseq)`. The record is
- * keyed by `settingsId` — which WalletProvider sets to the wallet address — so the name surfaces on the deployment
- * list/detail pages after deploy, the same store the legacy builder wrote to. It deliberately avoids `useWallet()`,
- * so no new dependency on the wallet provider is introduced. The write happens once `dseq` and `settingsId` are both
- * present (the deployment is created for a known wallet); until the wallet-scoped key exists the write is deferred
- * rather than dropped. A session that resumed already carrying a `dseq` has it present from mount and is treated as
- * already-written, so a resume never clobbers a name the user may have since edited on the deployment page.
- */
+/** Owns the configure session's deployment name: the api's own once the deployment exists, the typed one before that, and the write of the typed one to the wallet-scoped local record `settingsId` keys. */
 export function useDeploymentName({ initialName, dseq }: UseDeploymentNameInput, dependencies = DEPENDENCIES): DeploymentName {
   const { deploymentLocalStorage } = dependencies.useServices();
   const settingsId = useAtomValue(settingsIdAtom);
-  const [name, setName] = useState(() => initialName ?? "");
-  const nameRef = useRef(name);
-  nameRef.current = name;
+  const [typedName, setTypedName] = useState(() => initialName ?? "");
+  const nameRef = useRef(typedName);
+  nameRef.current = typedName;
+  const resolvedName = dependencies.useResolvedDeploymentName(dseq);
+  /** Seeded with the mounting `dseq`, so a session resumed already carrying one is treated as written and never clobbers a name edited since on the deployment page. */
   const writtenDseqRef = useRef(dseq);
   useEffect(
     function persistNameOnCreate() {
@@ -45,5 +39,5 @@ export function useDeploymentName({ initialName, dseq }: UseDeploymentNameInput,
     },
     [dseq, settingsId, deploymentLocalStorage]
   );
-  return { name, setName };
+  return { name: resolvedName ?? typedName, setName: setTypedName };
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.ts
@@ -11,6 +11,8 @@ export const DEPENDENCIES = { useServices, useResolvedDeploymentName };
 export interface DeploymentName {
   /** The name to show: the one typed in this session, and the api's own only where this session has none. */
   name: string;
+  /** The name this session typed, and only that: what the draft records and the next create carries, so a name the api derived is never persisted as the user's own nor sent back as one. */
+  typedName: string;
   setName: (name: string) => void;
 }
 
@@ -40,5 +42,5 @@ export function useDeploymentName({ initialName, dseq }: UseDeploymentNameInput,
     },
     [dseq, settingsId, deploymentLocalStorage]
   );
-  return { name: typedName || resolvedName || "", setName: setTypedName };
+  return { name: typedName || resolvedName || "", typedName, setName: setTypedName };
 }

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail/DeploymentDetailHeader.spec.tsx
@@ -48,13 +48,13 @@ describe(DeploymentDetailHeader.name, () => {
     expect(screen.getByText("3")).toBeInTheDocument();
   });
 
-  it("shows the deployment name recorded for this deployment in this browser", () => {
+  it("shows the resolved deployment name", () => {
     setup({ name: "My Storefront" });
 
     expect(screen.getByText("My Storefront")).toBeInTheDocument();
   });
 
-  it("falls back to a generated name when none is stored", () => {
+  it("falls back to a generated name when neither the api nor this browser holds one", () => {
     setup({ name: null });
 
     expect(screen.getByText("Deployment #1786440078202")).toBeInTheDocument();

--- a/apps/deploy-web/src/config/deploy.config.ts
+++ b/apps/deploy-web/src/config/deploy.config.ts
@@ -1,1 +1,4 @@
 export const USER_TEMPLATE_CODE = "USER_TEMPLATE";
+
+/** Mirrors `DeploymentNameSchema` in apps/api, which refuses a longer name and fails the whole create or rename rather than just the name. */
+export const MAX_DEPLOYMENT_NAME_LENGTH = 256;

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -175,7 +175,7 @@ describe(useDeploymentDefinition.name, () => {
     const services = { api, deploymentLocalStorage } satisfies Partial<ReturnType<typeof DEPENDENCIES.useServices>>;
     const useServices: typeof DEPENDENCIES.useServices = () => services as unknown as ReturnType<typeof DEPENDENCIES.useServices>;
 
-    const useResolvedName: typeof DEPENDENCIES.useResolvedDeploymentName = dseq => useResolvedDeploymentName(dseq, { useServices, useWallet });
+    const useResolvedName: typeof DEPENDENCIES.useResolvedDeploymentName = dseq => useResolvedDeploymentName(dseq, { useServices });
 
     const { result } = setupQuery(
       () => useDeploymentDefinition(input.dseq === undefined ? "123" : input.dseq, { useServices, useWallet, useResolvedDeploymentName: useResolvedName }),

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.spec.tsx
@@ -4,6 +4,7 @@ import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { useResolvedDeploymentName } from "@src/hooks/useResolvedDeploymentName/useResolvedDeploymentName";
 import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
 import type { DEPENDENCIES } from "./useDeploymentDefinition";
 import { isUsableDeploymentDefinition, useDeploymentDefinition } from "./useDeploymentDefinition";
@@ -34,14 +35,21 @@ describe(useDeploymentDefinition.name, () => {
     expect(result.current.sdl).toBeUndefined();
   });
 
-  it("carries the deployment name while the sdl is still resolving, since the name is never the api's to answer", () => {
+  it("carries the name from this browser while the api's answer is still resolving", () => {
     const { result } = setup({ apiSdl: API_SDL, localName: "my-deployment" });
 
     expect(result.current.source).toBe("resolving");
     expect(result.current.name).toBe("my-deployment");
   });
 
-  it("carries the deployment name from this browser even when the sdl comes from the api", async () => {
+  it("prefers the name the api holds over the one this browser recorded", async () => {
+    const { result } = setup({ apiSdl: API_SDL, apiName: "renamed-elsewhere", localSdl: LOCAL_SDL, localName: "my-deployment" });
+
+    await vi.waitFor(() => expect(result.current.name).toBe("renamed-elsewhere"));
+    expect(result.current.source).toBe("api");
+  });
+
+  it("carries the name from this browser when the api holds none", async () => {
     const { result } = setup({ apiSdl: API_SDL, localSdl: LOCAL_SDL, localName: "my-deployment" });
 
     await vi.waitFor(() => expect(result.current.source).toBe("api"));
@@ -131,6 +139,7 @@ describe(useDeploymentDefinition.name, () => {
   function setup(input: {
     dseq?: string | null;
     apiSdl?: string | null;
+    apiName?: string;
     apiError?: Error;
     chainManifestVersion?: string;
     recordedManifestVersion?: string;
@@ -144,6 +153,7 @@ describe(useDeploymentDefinition.name, () => {
       return Promise.resolve({
         data: {
           deployment: { hash: chainManifestVersion },
+          name: input.apiName ?? null,
           consoleSettings: input.apiSdl ? { sdl: input.apiSdl, manifestVersion: recordedManifestVersion } : null
         }
       });
@@ -165,9 +175,14 @@ describe(useDeploymentDefinition.name, () => {
     const services = { api, deploymentLocalStorage } satisfies Partial<ReturnType<typeof DEPENDENCIES.useServices>>;
     const useServices: typeof DEPENDENCIES.useServices = () => services as unknown as ReturnType<typeof DEPENDENCIES.useServices>;
 
-    const { result } = setupQuery(() => useDeploymentDefinition(input.dseq === undefined ? "123" : input.dseq, { useServices, useWallet }), {
-      services: { api: () => api, deploymentLocalStorage: () => deploymentLocalStorage, queryClient: () => queryClient }
-    });
+    const useResolvedName: typeof DEPENDENCIES.useResolvedDeploymentName = dseq => useResolvedDeploymentName(dseq, { useServices, useWallet });
+
+    const { result } = setupQuery(
+      () => useDeploymentDefinition(input.dseq === undefined ? "123" : input.dseq, { useServices, useWallet, useResolvedDeploymentName: useResolvedName }),
+      {
+        services: { api: () => api, deploymentLocalStorage: () => deploymentLocalStorage, queryClient: () => queryClient }
+      }
+    );
 
     return { result, getDeployment, deploymentLocalStorage, onQueryError };
   }

--- a/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
+++ b/apps/deploy-web/src/hooks/useDeploymentDefinition/useDeploymentDefinition.ts
@@ -3,6 +3,7 @@ import { ApiError } from "@akashnetwork/openapi-sdk";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useResolvedDeploymentName } from "@src/hooks/useResolvedDeploymentName/useResolvedDeploymentName";
 import { isStoredSdlSelfContained } from "@src/utils/sdl/storedDefinition";
 
 /** `absent` still carries the API's copy when it held one it could not stand behind, so the shape is visible even though the values are not. */
@@ -21,7 +22,7 @@ export function isUsableDeploymentDefinition(definition: DeploymentDefinition): 
   return !!definition.sdl && USABLE_SOURCES.includes(definition.source);
 }
 
-export const DEPENDENCIES = { useServices, useWallet };
+export const DEPENDENCIES = { useServices, useWallet, useResolvedDeploymentName };
 
 /** A deployment's SDL, from the console API when that copy is the one the chain is running, and from this browser otherwise. */
 export function useDeploymentDefinition(dseq: string | undefined | null, dependencies = DEPENDENCIES): DeploymentDefinition {
@@ -51,9 +52,8 @@ export function useDeploymentDefinition(dseq: string | undefined | null, depende
    * and serving it would present a superseded document as authoritative and re-ship it on the next update.
    */
   const isApiCopyOnChain = !!consoleSettings?.manifestVersion && consoleSettings.manifestVersion === query.data?.deployment?.hash;
-  const stored = deploymentLocalStorage.get(address, dseq);
-  const localSdl = stored?.manifest;
-  const name = stored?.name;
+  const localSdl = deploymentLocalStorage.get(address, dseq)?.manifest;
+  const name = dependencies.useResolvedDeploymentName(dseq);
 
   return useMemo(() => {
     if (isResolving) return { sdl: undefined, name, source: "resolving" };

--- a/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.spec.tsx
+++ b/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.spec.tsx
@@ -1,0 +1,92 @@
+import { ApiError } from "@akashnetwork/openapi-sdk";
+import { createProxy } from "@akashnetwork/react-query-proxy";
+import { QueryCache, QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
+import type { DEPENDENCIES } from "./useResolvedDeploymentName";
+import { useResolvedDeploymentName } from "./useResolvedDeploymentName";
+
+import { buildWallet } from "@tests/seeders/wallet";
+import { type RenderAppHookOptions, setupQuery } from "@tests/unit/query-client";
+
+type ApiService = ReturnType<NonNullable<NonNullable<RenderAppHookOptions["services"]>["api"]>>;
+
+describe(useResolvedDeploymentName.name, () => {
+  it("prefers the name the api holds over the one this browser recorded", async () => {
+    const { result } = setup({ apiName: "api-name", localName: "local-name" });
+
+    await vi.waitFor(() => expect(result.current).toBe("api-name"));
+  });
+
+  it("falls back to this browser's record when the api holds no name", async () => {
+    const { result, getDeployment } = setup({ apiName: null, localName: "local-name" });
+
+    await vi.waitFor(() => expect(getDeployment).toHaveBeenCalled());
+    expect(result.current).toBe("local-name");
+  });
+
+  it("serves this browser's record while the api's answer is still resolving", () => {
+    const { result } = setup({ apiName: "api-name", localName: "local-name" });
+
+    expect(result.current).toBe("local-name");
+  });
+
+  it("resolves to nothing when neither holds a name, leaving the caller its own placeholder", async () => {
+    const { result, getDeployment } = setup({ apiName: null });
+
+    await vi.waitFor(() => expect(getDeployment).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+  });
+
+  it.each([401, 403, 404])("falls back to this browser's record on a %s without reporting it", async status => {
+    const { result, onQueryError } = setup({ apiError: new ApiError(status, {}, `GET /v1/deployments/{dseq} → ${status}`), localName: "local-name" });
+
+    await vi.waitFor(() => expect(result.current).toBe("local-name"));
+    expect(onQueryError).not.toHaveBeenCalled();
+  });
+
+  it("reports a server error rather than silencing it, and still falls back", async () => {
+    const { result, onQueryError } = setup({ apiError: new ApiError(500, {}, "GET /v1/deployments/{dseq} → 500"), localName: "local-name" });
+
+    await vi.waitFor(() => expect(onQueryError).toHaveBeenCalled());
+    expect(result.current).toBe("local-name");
+  });
+
+  it("asks the api for nothing when there is no dseq", () => {
+    const { result, getDeployment } = setup({ dseq: null, apiName: "api-name", localName: "local-name" });
+
+    expect(getDeployment).not.toHaveBeenCalled();
+    expect(result.current).toBeUndefined();
+  });
+
+  function setup(input: { dseq?: string | null; apiName?: string | null; apiError?: Error; localName?: string }) {
+    const getDeployment = vi.fn(() => {
+      if (input.apiError) return Promise.reject(input.apiError);
+      return Promise.resolve({ data: { name: input.apiName ?? null } });
+    });
+    const api = createProxy({ v1: { getDeployment } }) as unknown as ApiService;
+
+    const deploymentLocalStorage = mock<DeploymentStorageService>({
+      get: vi.fn((_address, dseq) => (dseq && input.localName ? { name: input.localName } : null))
+    });
+
+    const onQueryError = vi.fn();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, refetchOnReconnect: false } },
+      queryCache: new QueryCache({ onError: onQueryError })
+    });
+
+    const useWallet: typeof DEPENDENCIES.useWallet = () => buildWallet({ address: "akash1test" });
+    /** `satisfies` type-checks both fields against the real container, but `api` is a recursive proxy that `mock<T>()` recurses into until the heap dies. */
+    const services = { api, deploymentLocalStorage } satisfies Partial<ReturnType<typeof DEPENDENCIES.useServices>>;
+    const useServices: typeof DEPENDENCIES.useServices = () => services as unknown as ReturnType<typeof DEPENDENCIES.useServices>;
+
+    const { result } = setupQuery(() => useResolvedDeploymentName(input.dseq === undefined ? "123" : input.dseq, { useServices, useWallet }), {
+      services: { api: () => api, deploymentLocalStorage: () => deploymentLocalStorage, queryClient: () => queryClient }
+    });
+
+    return { result, getDeployment, deploymentLocalStorage, onQueryError };
+  }
+});

--- a/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.spec.tsx
+++ b/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.spec.tsx
@@ -20,6 +20,12 @@ describe(useResolvedDeploymentName.name, () => {
     await vi.waitFor(() => expect(result.current).toBe("api-name"));
   });
 
+  it("asks the api for the deployment the caller named", async () => {
+    const { getDeployment } = setup({ apiName: "api-name" });
+
+    await vi.waitFor(() => expect(getDeployment).toHaveBeenCalledWith({ dseq: "123" }));
+  });
+
   it("falls back to this browser's record when the api holds no name", async () => {
     const { result, getDeployment } = setup({ apiName: null, localName: "local-name" });
 
@@ -40,17 +46,22 @@ describe(useResolvedDeploymentName.name, () => {
     expect(result.current).toBeUndefined();
   });
 
-  it.each([401, 403, 404])("falls back to this browser's record on a %s without reporting it", async status => {
-    const { result, onQueryError } = setup({ apiError: new ApiError(status, {}, `GET /v1/deployments/{dseq} → ${status}`), localName: "local-name" });
+  it.each([401, 403, 404])("recovers a %s into this browser's record instead of failing the query", async status => {
+    const { result, onQueryError, queryStatus } = setup({
+      apiError: new ApiError(status, {}, `GET /v1/deployments/{dseq} → ${status}`),
+      localName: "local-name"
+    });
 
-    await vi.waitFor(() => expect(result.current).toBe("local-name"));
+    await vi.waitFor(() => expect(queryStatus()).toBe("success"));
+    expect(result.current).toBe("local-name");
     expect(onQueryError).not.toHaveBeenCalled();
   });
 
   it("reports a server error rather than silencing it, and still falls back", async () => {
-    const { result, onQueryError } = setup({ apiError: new ApiError(500, {}, "GET /v1/deployments/{dseq} → 500"), localName: "local-name" });
+    const { result, onQueryError, queryStatus } = setup({ apiError: new ApiError(500, {}, "GET /v1/deployments/{dseq} → 500"), localName: "local-name" });
 
     await vi.waitFor(() => expect(onQueryError).toHaveBeenCalled());
+    expect(queryStatus()).toBe("error");
     expect(result.current).toBe("local-name");
   });
 
@@ -87,6 +98,12 @@ describe(useResolvedDeploymentName.name, () => {
       services: { api: () => api, deploymentLocalStorage: () => deploymentLocalStorage, queryClient: () => queryClient }
     });
 
-    return { result, getDeployment, deploymentLocalStorage, onQueryError };
+    return {
+      result,
+      getDeployment,
+      deploymentLocalStorage,
+      onQueryError,
+      queryStatus: () => queryClient.getQueryState(api.v1.getDeployment.getKey({ dseq: "123" }))?.status
+    };
   }
 });

--- a/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.spec.tsx
+++ b/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.spec.tsx
@@ -1,14 +1,15 @@
 import { ApiError } from "@akashnetwork/openapi-sdk";
 import { createProxy } from "@akashnetwork/react-query-proxy";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
+import { createStore, Provider as JotaiStoreProvider } from "jotai";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
+import { settingsIdAtom } from "@src/store/settingsStore";
 import type { DEPENDENCIES } from "./useResolvedDeploymentName";
 import { useResolvedDeploymentName } from "./useResolvedDeploymentName";
 
-import { buildWallet } from "@tests/seeders/wallet";
 import { type RenderAppHookOptions, setupQuery } from "@tests/unit/query-client";
 
 type ApiService = ReturnType<NonNullable<NonNullable<RenderAppHookOptions["services"]>["api"]>>;
@@ -31,6 +32,13 @@ describe(useResolvedDeploymentName.name, () => {
 
     await vi.waitFor(() => expect(getDeployment).toHaveBeenCalled());
     expect(result.current).toBe("local-name");
+  });
+
+  it("reads this browser's record under the wallet the app recorded, with no wallet provider above the hook", async () => {
+    const { result, deploymentLocalStorage } = setup({ apiName: null, localName: "local-name" });
+
+    await vi.waitFor(() => expect(result.current).toBe("local-name"));
+    expect(deploymentLocalStorage.get).toHaveBeenCalledWith("akash1test", "123");
   });
 
   it("serves this browser's record while the api's answer is still resolving", () => {
@@ -80,7 +88,7 @@ describe(useResolvedDeploymentName.name, () => {
     const api = createProxy({ v1: { getDeployment } }) as unknown as ApiService;
 
     const deploymentLocalStorage = mock<DeploymentStorageService>({
-      get: vi.fn((_address, dseq) => (dseq && input.localName ? { name: input.localName } : null))
+      get: vi.fn((address, dseq) => (address && dseq && input.localName ? { name: input.localName } : null))
     });
 
     const onQueryError = vi.fn();
@@ -89,13 +97,16 @@ describe(useResolvedDeploymentName.name, () => {
       queryCache: new QueryCache({ onError: onQueryError })
     });
 
-    const useWallet: typeof DEPENDENCIES.useWallet = () => buildWallet({ address: "akash1test" });
     /** `satisfies` type-checks both fields against the real container, but `api` is a recursive proxy that `mock<T>()` recurses into until the heap dies. */
     const services = { api, deploymentLocalStorage } satisfies Partial<ReturnType<typeof DEPENDENCIES.useServices>>;
     const useServices: typeof DEPENDENCIES.useServices = () => services as unknown as ReturnType<typeof DEPENDENCIES.useServices>;
 
-    const { result } = setupQuery(() => useResolvedDeploymentName(input.dseq === undefined ? "123" : input.dseq, { useServices, useWallet }), {
-      services: { api: () => api, deploymentLocalStorage: () => deploymentLocalStorage, queryClient: () => queryClient }
+    const store = createStore();
+    store.set(settingsIdAtom, "akash1test");
+
+    const { result } = setupQuery(() => useResolvedDeploymentName(input.dseq === undefined ? "123" : input.dseq, { useServices }), {
+      services: { api: () => api, deploymentLocalStorage: () => deploymentLocalStorage, queryClient: () => queryClient },
+      wrapper: ({ children }) => <JotaiStoreProvider store={store}>{children}</JotaiStoreProvider>
     });
 
     return {

--- a/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.ts
+++ b/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.ts
@@ -18,10 +18,9 @@ export function useResolvedDeploymentName(dseq: string | undefined | null, depen
       catchError(error) {
         if (error instanceof ApiError && error.status >= 500) throw error;
         return null;
-      },
-      select: response => response?.data?.name ?? null
+      }
     }
   );
 
-  return query.data ?? deploymentLocalStorage.get(address, dseq)?.name;
+  return query.data?.data.name ?? deploymentLocalStorage.get(address, dseq)?.name;
 }

--- a/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.ts
+++ b/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.ts
@@ -1,14 +1,16 @@
 import { ApiError } from "@akashnetwork/openapi-sdk";
+import { useAtomValue } from "jotai";
 
 import { useServices } from "@src/context/ServicesProvider";
-import { useWallet } from "@src/context/WalletProvider";
+import { settingsIdAtom } from "@src/store/settingsStore";
 
-export const DEPENDENCIES = { useServices, useWallet };
+export const DEPENDENCIES = { useServices };
 
 /** A deployment's name as the console api holds it, falling back to this browser's own record only where the api holds none. */
 export function useResolvedDeploymentName(dseq: string | undefined | null, dependencies = DEPENDENCIES): string | undefined {
   const { api, deploymentLocalStorage } = dependencies.useServices();
-  const { address } = dependencies.useWallet();
+  /** Read from the store rather than `useWallet`, since the rename dialog mounts outside the wallet provider and would resolve no address there at all. */
+  const address = useAtomValue(settingsIdAtom);
 
   const query = api.v1.getDeployment.useQuery(
     { dseq: dseq ?? "" },

--- a/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.ts
+++ b/apps/deploy-web/src/hooks/useResolvedDeploymentName/useResolvedDeploymentName.ts
@@ -1,0 +1,27 @@
+import { ApiError } from "@akashnetwork/openapi-sdk";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useWallet } from "@src/context/WalletProvider";
+
+export const DEPENDENCIES = { useServices, useWallet };
+
+/** A deployment's name as the console api holds it, falling back to this browser's own record only where the api holds none. */
+export function useResolvedDeploymentName(dseq: string | undefined | null, dependencies = DEPENDENCIES): string | undefined {
+  const { api, deploymentLocalStorage } = dependencies.useServices();
+  const { address } = dependencies.useWallet();
+
+  const query = api.v1.getDeployment.useQuery(
+    { dseq: dseq ?? "" },
+    {
+      enabled: !!dseq,
+      /** A server fault is reported like any other; a refusal or an offline browser is neither a bug nor a reason to leave a named deployment unnamed. */
+      catchError(error) {
+        if (error instanceof ApiError && error.status >= 500) throw error;
+        return null;
+      },
+      select: response => response?.data?.name ?? null
+    }
+  );
+
+  return query.data ?? deploymentLocalStorage.get(address, dseq)?.name;
+}


### PR DESCRIPTION
## Why

A deployment's name now lives on the deployment itself, but deploy-web read it only from this browser's `localStorage`. A user on a second device — or one who cleared their storage — saw `Deployment 4211337` where their deployment actually had a name.

Part of CON-954 — https://linear.app/ovrclk/issue/CON-954/show-the-apis-deployment-name-when-this-browser-has-none

Slice 1 of 3. Covers the deployment **detail page** and the **bid screening** page. The deployments list is slice 3 and still reads `localStorage` alone; see [What's not here](#whats-not-here).

## What

One precedence rule, everywhere: **the name the API holds** → **this browser's record** → **the placeholder each surface already had**. Reads and writes both move onto the API.

| | before | after |
| --- | --- | --- |
| Detail page heading | this browser's record only | API's name, falling back to this browser's |
| Bid screening name field | the draft in this browser | the name the deployment carries |
| Creating a deployment | name written to `localStorage` | name sent in `POST /v1/deployments` |
| Renaming a deployment | name written to `localStorage` | `PATCH /v1/deployments/{dseq}` |

### The rule, in one hook

`useResolvedDeploymentName` is the single place the precedence lives. `useDeploymentDefinition` delegates its `name` to it, so the detail header resolves through the API over the `getDeployment` query it already runs — no extra request.

```ts
export function useResolvedDeploymentName(dseq, dependencies = DEPENDENCIES) {
  const { api, deploymentLocalStorage } = dependencies.useServices();
  const { address } = dependencies.useWallet();

  const query = api.v1.getDeployment.useQuery({ dseq: dseq ?? "" }, { enabled: !!dseq, /* ... */ });

  return query.data ?? deploymentLocalStorage.get(address, dseq)?.name;
}
```

Read as behaviour (`useResolvedDeploymentName.spec.tsx`):

```ts
it("prefers the name the api holds over the one this browser recorded", async () => {
  const { result } = setup({ apiName: "api-name", localName: "local-name" });

  await vi.waitFor(() => expect(result.current).toBe("api-name"));
});

it("falls back to this browser's record when the api holds no name", async () => {
  const { result, getDeployment } = setup({ apiName: null, localName: "local-name" });

  await vi.waitFor(() => expect(getDeployment).toHaveBeenCalled());
  expect(result.current).toBe("local-name");
});

it("resolves to nothing when neither holds a name, leaving the caller its own placeholder", async () => {
  const { result, getDeployment } = setup({ apiName: null });

  await vi.waitFor(() => expect(getDeployment).toHaveBeenCalled());
  expect(result.current).toBeUndefined();
});
```

`undefined` rather than a string, deliberately: each surface keeps its own placeholder — `Deployment #4211337` on the detail page, `Name your deployment` in the bid screening field.

### What the browser sends now

Both writes had to land in this PR. The API has named every deployment it creates since #3904, so the read half alone would have let that derived name overwrite what the user typed — on create, and on rename.

- **Create** carries the trimmed name. A blank name is **omitted from the payload**, not sent as `""`: the schema is `trim().min(1)`, so an empty string fails the whole create rather than meaning "unnamed". Omitting it is what asks the API to name the deployment after its services.
- **Rename** uses `PATCH` with nothing but the name — the path that records a name without broadcasting or pushing a manifest, so it works on a deployment the console holds no SDL for. It then invalidates the exact query the heading reads, so the new name appears without a reload.

### Behaviour removed

**A name can no longer be cleared.** `PATCH` rejects a blank name and rejects a patch that assigns nothing, so clear-by-emptying cannot survive the move to the API. The dialog now refuses an empty name instead of silently erasing it. A user who wants the `Deployment #4211337` placeholder back has no way to ask for it.

Also: a failed rename now leaves the dialog open with an error instead of reporting success.

### What's not here

- **The deployments list** — the third surface in the spec. No API endpoint returns names in bulk today: `GET /v1/deployments` is hardcoded to `state: "active"`, and the per-deployment read costs a chain deployment fetch plus a chain lease-list fetch per row. Slice 2 adds a batch endpoint, slice 3 consumes it.
- **Removing the `localStorage` writes.** They are kept alongside the API writes on purpose — the list, the home screen, alert rows, billing usage and provider lease rows still resolve names from this browser alone. Dropping them now would trade one disagreement between surfaces for its mirror image. They go once those surfaces read the API.

### What a person sees

Real components and hooks driven in a DOM, with only the network boundary stubbed. Full reproducible walkthrough under [Demo](#demo).

```
renamed to 'checkout-api' on another device; this browser still remembers 'old-laptop-name'
  first paint, api still answering  ->  "old-laptop-name"
  once the api answers              ->  "checkout-api"
never named anywhere
  first paint, api still answering  ->  "Deployment #4211337"
  once the api answers              ->  "Deployment #4211337"
the user typed 'checkout-api' into the deployment pane
  POST /v1/deployments <- {"sdl":"...","name":"checkout-api","deposit":0.5}
the user left the name field empty
  POST /v1/deployments <- {"sdl":"...","deposit":0.5}
a quoting session reopened in a browser that holds no draft of it
  nothing created yet, nothing typed  ->  name field reads "" (placeholder "Name your deployment")
  the quoted deployment exists       ->  name field reads "checkout-api"
PATCH /v1/deployments/{dseq} <- {"dseq":"4211337","data":{"name":"checkout-api"}}
then refreshes the query the heading reads: {"queryKey":["v1","getDeployment",{"dseq":"4211337"}]}
clearing the name sends nothing: 0 request(s), the dialog stays open
```

The two lines per heading case are deliberate: the heading paints this browser's record first and swaps when the API answers, so nothing flickers through a blank heading.

### Verification

`apps/deploy-web`, 419 changes:

- `npm test` — **passed**
- `npm run lint -- --quiet` — **passed**
- `npx tsc --noEmit` — 85 errors, **all present at the merge base**, none in changed files

`DeploymentNameModal` had no spec; it has one now covering the `PATCH`, the invalidation, the refusal of an empty name and the failure path.

## Demo

<details>
<summary>Executable walkthrough — re-runnable with <code>uvx showboat verify</code></summary>

# CON-954 — deploy-web shows the name the API holds

*2026-09-11T13:08:03Z by Showboat 0.6.1*
<!-- showboat-id: 663c8c53-2ecf-411b-aacb-8768f4c32e49 -->

A deployment's name now lives on the deployment itself, but deploy-web read it only from this
browser's `localStorage`. A user on a second device — or one who cleared their storage — saw
`Deployment 4211337` where their deployment actually had a name.

This branch resolves a name by one precedence, everywhere: **the name the console API holds**,
then **this browser's own record**, then **the placeholder each surface already had**. It also
moves the writes onto the API, so the name a user chooses is what the API ends up holding.

Three things a person can see change:

1. the deployment **detail page** heading,
2. the name field on the **bid screening** page while quotes are live,
3. what leaves the browser when a deployment is **created** or **renamed**.

The deployments list is the fourth surface named in the spec. It is not in this slice: it needs a
batch name lookup the API does not expose yet, so it still reads `localStorage` alone and is
demonstrated in a later slice.

```bash
git log --format="%s" -3
```

```output
feat(deployment): rename a deployment through the api
feat(deployment): name the deployment the configure flow creates
feat(deployment): prefer the api's deployment name over this browser's
```

deploy-web is a Next.js app whose deployment pages need a signed-in wallet, the console API and a
live Akash chain behind them, none of which exist in this sandbox. So the demo drives the **real
production components and hooks** in a DOM, with only the network boundary stubbed: a
`getDeployment` response standing in for the API, and a `localStorage` record standing in for this
browser. Everything between those two edges — `useResolvedDeploymentName`,
`useDeploymentDefinition`, `DeploymentDetailHeader`, `useDeploymentName`, `DeploymentNameField`,
`useDeploymentFlow`, `DeploymentNameModal` — is the shipped code.

The block below writes that walkthrough, runs it, and removes it again. The walkthrough writes its
transcript straight to a file rather than the console, so what you read is its own output and not
the test reporter's framing of it. What it prints is the text rendered on screen and the request
bodies that left the browser.

```bash
set -o pipefail
cd "$(git rev-parse --show-toplevel)/apps/deploy-web"

cat > src/con954-demo.spec.tsx <<'TSX_EOF'
import { appendFileSync, writeFileSync } from "node:fs";
import type { ReactNode } from "react";
import { createProxy } from "@akashnetwork/react-query-proxy";
import { describe, expect, it, vi } from "vitest";
import { mock, mockDeep } from "vitest-mock-extended";

import { DeploymentNameModal } from "@src/components/LocalNoteManager/DeploymentNameModal";
import { DeploymentNameField } from "@src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField";
import type { DEPENDENCIES as FLOW_DEPENDENCIES } from "@src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow";
import { useDeploymentFlow } from "@src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow";
import { useDeploymentName } from "@src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName";
import { DEPENDENCIES as HEADER_DEPENDENCIES, DeploymentDetailHeader } from "@src/components/deployments/DeploymentDetail/DeploymentDetailHeader";
import type { AppDIContainer } from "@src/context/ServicesProvider/ServicesProvider";
import { useDeploymentDefinition } from "@src/hooks/useDeploymentDefinition/useDeploymentDefinition";
import { useResolvedDeploymentName } from "@src/hooks/useResolvedDeploymentName/useResolvedDeploymentName";
import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
import type { ApiProviderList } from "@src/types/provider";

import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
import userEvent from "@testing-library/user-event";
import { MockComponents } from "@tests/unit/mocks";
import { TestContainerProvider } from "@tests/unit/TestContainerProvider";

const DSEQ = "4211337";

/** Written straight to a file rather than the console: the test reporter's own framing is not part of what this demonstrates. */
const TRANSCRIPT = "/tmp/con954-demo.out";
writeFileSync(TRANSCRIPT, "");
const say = (line: string) => appendFileSync(TRANSCRIPT, `${line}\n`);

describe("CON-954", () => {
  it("scene 1 — the deployment detail page heading", async () => {
    await showHeading("renamed to 'checkout-api' on another device; this browser still remembers 'old-laptop-name'", {
      apiName: "checkout-api",
      localName: "old-laptop-name",
      settlesOn: "checkout-api"
    });
    await showHeading("named 'named-on-this-laptop' before names reached the api", {
      apiName: null,
      localName: "named-on-this-laptop",
      settlesOn: "named-on-this-laptop"
    });
    await showHeading("never named anywhere", { apiName: null, localName: undefined, settlesOn: `Deployment #${DSEQ}` });
  });

  it("scene 2 — what requesting quotes sends to the api", async () => {
    await showCreateRequest("the user typed 'checkout-api' into the deployment pane", "  checkout-api  ");
    await showCreateRequest("the user left the name field empty", "   ");
  });

  it("scene 3 — the name field on the bid screening page", async () => {
    const api = stubbedApi({ name: "checkout-api" });
    const deploymentLocalStorage = stubbedStorage(undefined);
    const useServices = stubbedServices(api, deploymentLocalStorage);
    say("a quoting session reopened in a browser that holds no draft of it");
    const useResolved: typeof HEADER_DEPENDENCIES.useDeploymentDefinition extends never ? never : typeof useResolvedDeploymentName = dseq =>
      useResolvedDeploymentName(dseq, { useServices, useWallet: stubbedWallet });

    function BidScreeningNameField({ dseq }: { dseq: string | null }) {
      const { name, setName } = useDeploymentName({ initialName: undefined, dseq }, { useServices, useResolvedDeploymentName: useResolved });
      return <DeploymentNameField value={name} onChange={setName} disabled={!!dseq} />;
    }

    const { rerender } = render(
      <TestContainerProvider services={{ api: () => api, deploymentLocalStorage: () => deploymentLocalStorage }}>
        <BidScreeningNameField dseq={null} />
      </TestContainerProvider>
    );
    say(`  nothing created yet, nothing typed  ->  name field reads "${nameFieldValue()}" (placeholder "Name your deployment")`);

    rerender(
      <TestContainerProvider services={{ api: () => api, deploymentLocalStorage: () => deploymentLocalStorage }}>
        <BidScreeningNameField dseq={DSEQ} />
      </TestContainerProvider>
    );
    await waitFor(() => expect(nameFieldValue()).toBe("checkout-api"));
    say(`  the quoted deployment exists       ->  name field reads "${nameFieldValue()}"`);
  });

  it("scene 4 — renaming from the deployment detail page", async () => {
    const patchBodies: unknown[] = [];
    const invalidated: unknown[] = [];
    const saved: boolean[] = [];
    const api = mockDeep<AppDIContainer["api"]>();
    api.v1.getDeployment.getKey.mockImplementation(request => ["v1", "getDeployment", { dseq: request?.dseq ?? "" }]);
    api.v1.patchDeployment.useMutation.mockReturnValue(
      mock<ReturnType<typeof api.v1.patchDeployment.useMutation>>({
        mutate: ((variables: unknown, options: { onSuccess?: () => void }) => {
          patchBodies.push(variables);
          options.onSuccess?.();
        }) as never
      })
    );
    const deploymentLocalStorage = mock<DeploymentStorageService>();
    const queryClient = mock<ReturnType<typeof FLOW_DEPENDENCIES.useQueryClient>>();
    queryClient.invalidateQueries.mockImplementation(((filters: unknown) => invalidated.push(filters)) as never);

    render(
      <TestContainerProvider services={{ api: () => api, deploymentLocalStorage: () => deploymentLocalStorage }}>
        <DeploymentNameModal
          dseq={DSEQ}
          onClose={vi.fn()}
          onSaved={() => saved.push(true)}
          getDeploymentName={() => "old-laptop-name"}
          dependencies={{ useSnackbar: () => ({ enqueueSnackbar: vi.fn(), closeSnackbar: vi.fn() }), useQueryClient: () => queryClient }}
        />
      </TestContainerProvider>
    );

    say('the dialog opens on the name this browser holds: "old-laptop-name"');
    await typeIntoNameDialog("checkout-api");
    say(`PATCH /v1/deployments/{dseq} <- ${JSON.stringify(patchBodies[0])}`);
    say(`then refreshes the query the heading reads: ${JSON.stringify(invalidated[0])}`);
    say(`the dialog reports success and closes: ${saved.length === 1}`);

    patchBodies.length = 0;
    await typeIntoNameDialog("");
    say(`clearing the name sends nothing: ${patchBodies.length} request(s), the dialog stays open`);
  });

  async function showHeading(situation: string, input: { apiName: string | null; localName: string | undefined; settlesOn: string }) {
    const api = stubbedApi({ name: input.apiName });
    const deploymentLocalStorage = stubbedStorage(input.localName);
    const useServices = stubbedServices(api, deploymentLocalStorage);
    const resolveDefinition: typeof HEADER_DEPENDENCIES.useDeploymentDefinition = dseq =>
      useDeploymentDefinition(dseq, {
        useServices,
        useWallet: stubbedWallet,
        useResolvedDeploymentName: seq => useResolvedDeploymentName(seq, { useServices, useWallet: stubbedWallet })
      });

    const { unmount } = render(
      <TestContainerProvider services={{ api: () => api, deploymentLocalStorage: () => deploymentLocalStorage }}>
        <DeploymentDetailHeader
          deployment={mock<DeploymentDto>({ dseq: DSEQ, state: "active", groups: [], escrowAccount: mock<DeploymentDto["escrowAccount"]>() })}
          leases={[mock<LeaseDto>({ id: "1", provider: "akash1provider", state: "active" })]}
          providers={[mock<ApiProviderList>({ owner: "akash1provider" })]}
          dependencies={headerDependencies(resolveDefinition)}
        />
      </TestContainerProvider>
    );

    const firstPaint = heading();
    await waitFor(() => expect(heading()).toBe(input.settlesOn));
    say(`${situation}`);
    say(`  first paint, api still answering  ->  "${firstPaint}"`);
    say(`  once the api answers              ->  "${heading()}"`);
    unmount();
  }

  async function showCreateRequest(situation: string, typedName: string) {
    const sent: unknown[] = [];
    const createDeployment = mock<{ mutate: ReturnType<typeof vi.fn> }>({
      mutate: vi.fn((variables, options) => {
        sent.push(variables);
        options.onSuccess({ data: { dseq: DSEQ, manifest: "manifest" } });
      })
    });
    const api = mockDeep<AppDIContainer["api"]>();
    api.v1.createDeployment.useMutation.mockReturnValue(createDeployment as never);
    const services = { api, deploymentLocalStorage: mock<DeploymentStorageService>(), analyticsService: mock<{ track: () => void }>() };
    const { result } = renderHook(() =>
      useDeploymentFlow(
        { intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, vm: false } },
        {
          useServices: (() => services) as never,
          useListBids: (() => ({ data: { data: [] }, isLoading: false, isError: false })) as never,
          useRouter: (() => mock<ReturnType<typeof FLOW_DEPENDENCIES.useRouter>>({ replace: vi.fn() as never })) as never,
          useQueryClient: (() => mock<ReturnType<typeof FLOW_DEPENDENCIES.useQueryClient>>()) as never,
          manifestFromSdl: () => "manifest",
          deploymentResourcesFromSdl: () => ({ gpuAmount: 0, cpuAmount: 0, memoryAmount: 0, storageAmount: 0 })
        }
      )
    );

    act(() => result.current.actions.requestQuotes("version: '2.0'\nservices:\n  web:\n  postgres:", typedName));
    await waitFor(() => expect(sent.length).toBe(1));
    say(`${situation}`);
    say(`  POST /v1/deployments <- ${JSON.stringify((sent[0] as { data: Record<string, unknown> }).data)}`);
  }

  async function typeIntoNameDialog(name: string) {
    const field = screen.getByRole("textbox", { name: "Name" });
    await userEvent.clear(field);
    if (name) await userEvent.type(field, name);
    await userEvent.click(screen.getByRole("button", { name: "Save" }));
  }

  function nameFieldValue() {
    return (screen.getByRole("textbox", { name: "Deployment name" }) as HTMLInputElement).value;
  }

  function heading() {
    return screen.getByRole("heading", { level: 1 }).textContent ?? "";
  }

  function stubbedApi(deployment: { name: string | null }) {
    return createProxy({
      v1: { getDeployment: () => Promise.resolve({ data: { ...deployment, deployment: { hash: "h" }, consoleSettings: null } }) }
    }) as unknown as AppDIContainer["api"];
  }

  function stubbedStorage(localName: string | undefined) {
    return mock<DeploymentStorageService>({ get: vi.fn(() => (localName ? { name: localName } : null)) });
  }

  function stubbedServices(api: AppDIContainer["api"], deploymentLocalStorage: DeploymentStorageService) {
    return (() => ({ api, deploymentLocalStorage })) as never;
  }

  function headerDependencies(useDeploymentDefinitionImpl: typeof HEADER_DEPENDENCIES.useDeploymentDefinition) {
    return MockComponents(HEADER_DEPENDENCIES, {
      useDeploymentDefinition: useDeploymentDefinitionImpl,
      useLocalNotes: () => mock<ReturnType<typeof HEADER_DEPENDENCIES.useLocalNotes>>({ changeDeploymentName: vi.fn() }),
      useWallet: () => mock<ReturnType<typeof HEADER_DEPENDENCIES.useWallet>>({ isTrialing: false }),
      useDeploymentEscrowBalance: () => ({ balanceUdenom: 0, denom: "uact" }),
      useDeploymentSettingQuery: () => mock<ReturnType<typeof HEADER_DEPENDENCIES.useDeploymentSettingQuery>>({ data: undefined }),
      useDeclaredTeeTypes: () => [],
      useDeclaredGpuInterconnect: () => ({ enabled: false, fabrics: [] }),
      CostRate: vi.fn(() => <span />),
      CostBreakdownTooltip: vi.fn(({ children }: { children?: ReactNode }) => <span>{children}</span>),
      DeploymentVisitControl: vi.fn(() => <span />)
    });
  }
});

function stubbedWallet() {
  return mock<ReturnType<typeof HEADER_DEPENDENCIES.useWallet>>({ address: "akash1demo" });
}
TSX_EOF

rm -f /tmp/con954-demo.out
if NODE_ENV=test DEPLOYMENT_ENV=staging npx vitest run src/con954-demo.spec.tsx --silent > /tmp/con954-vitest.log 2>&1; then
  cat /tmp/con954-demo.out
  status=0
else
  cat /tmp/con954-vitest.log
  status=1
fi
rm -f src/con954-demo.spec.tsx /tmp/con954-demo.out /tmp/con954-vitest.log
exit $status
```

```output
renamed to 'checkout-api' on another device; this browser still remembers 'old-laptop-name'
  first paint, api still answering  ->  "old-laptop-name"
  once the api answers              ->  "checkout-api"
named 'named-on-this-laptop' before names reached the api
  first paint, api still answering  ->  "named-on-this-laptop"
  once the api answers              ->  "named-on-this-laptop"
never named anywhere
  first paint, api still answering  ->  "Deployment #4211337"
  once the api answers              ->  "Deployment #4211337"
the user typed 'checkout-api' into the deployment pane
  POST /v1/deployments <- {"sdl":"version: '2.0'\nservices:\n  web:\n  postgres:","name":"checkout-api","deposit":0.5}
the user left the name field empty
  POST /v1/deployments <- {"sdl":"version: '2.0'\nservices:\n  web:\n  postgres:","deposit":0.5}
a quoting session reopened in a browser that holds no draft of it
  nothing created yet, nothing typed  ->  name field reads "" (placeholder "Name your deployment")
  the quoted deployment exists       ->  name field reads "checkout-api"
the dialog opens on the name this browser holds: "old-laptop-name"
PATCH /v1/deployments/{dseq} <- {"dseq":"4211337","data":{"name":"checkout-api"}}
then refreshes the query the heading reads: {"queryKey":["v1","getDeployment",{"dseq":"4211337"}]}
the dialog reports success and closes: true
clearing the name sends nothing: 0 request(s), the dialog stays open
```

Reading that back, surface by surface.

**The detail page heading.** A deployment renamed to `checkout-api` on another device used to read
`old-laptop-name` here forever; it now settles on the name the API holds. The two lines per case
are deliberate: the heading paints this browser's record first and swaps when the API answers, so
a deployment named before names reached the API never flickers through a blank heading, and one
named nowhere still reads `Deployment #4211337` rather than an empty heading or the literal
`null`.

**Requesting quotes.** The typed name now travels in the create request — trimmed, so
`"  checkout-api  "` is stored as `checkout-api`. A name left blank is **absent from the payload**
rather than sent as `""`: the API's schema is `trim().min(1)`, so an empty string would fail the
whole create instead of meaning "unnamed". Omitting it is what asks the API to name the deployment
after its services.

**The bid screening field.** Reopening a live quoting session in a browser that holds no draft of
it used to show an empty field. It now shows the name the deployment actually carries.

**Renaming.** The rename leaves the browser as `PATCH /v1/deployments/{dseq}` carrying nothing but
the name — the API path that records a name without broadcasting or pushing a manifest, so it
works on a deployment the console holds no SDL for. It then refreshes the exact query the heading
reads, which is why the new name appears without a reload.

One behaviour was **removed**, visible in the last line: an empty name is now refused instead of
clearing the name. `PATCH` rejects a blank name and rejects a patch that assigns nothing, so
clear-by-emptying cannot survive the move to the API. A user who wants the `Deployment #4211337`
placeholder back no longer has a way to ask for it.

No browser screenshot accompanies this: the sandbox has no Playwright browsers installed
(`~/.cache/ms-playwright` is empty) and the deployment pages cannot be reached without a wallet,
the console API and a chain. The strings above are read out of the same DOM a browser would paint,
from the same components.


</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployment names are retrieved from the API when available, with local fallback.
  - Deployment names are included in creation quote requests after trimming; blank names are omitted.
  - Deployment names are limited to 256 characters.

- **Bug Fixes**
  - Improved consistency when switching deployments and reopening edited names.
  - Renaming now prevents duplicate submissions, safely persists updates, refreshes deployment data, and reports failures.

- **Tests**
  - Expanded coverage for name resolution, validation, persistence, quote requests, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->