### PR TITLE
fix(deployment): dry-run rewrap counts only rows a real run can open

### DIFF
--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.integration.ts
@@ -164,12 +164,32 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
     expect(real.dataKeysRewrapped).toBe(rehearsal.dataKeysRewrapped);
   });
 
+  it("excludes from a dry run's count the row a real run could not open, and flags it", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { seedUser, seedCorruptedDataKey, attemptRewrapOnto, readDataKeys, logger } = setup();
+    await seedUser(oldVersion, "alpha-plaintext");
+    await seedCorruptedDataKey(oldVersion);
+    const before = await readDataKeys();
+
+    const rehearsal = await attemptRewrapOnto(newVersion, { dryRun: true });
+
+    expect(rehearsal.err).toBe(true);
+    expect(await readDataKeys()).toEqual(before);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "DATA_KEY_REWRAP_END",
+        report: expect.objectContaining({ dryRun: true, dataKeysRewrapped: 1, dataKeysFailed: 1 })
+      })
+    );
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   function setup() {
-    const createLogger: CreateLogger = () => mock<ReturnType<CreateLogger>>();
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger: CreateLogger = () => logger;
     const dataKeyRepository = container.resolve(DataKeyRepository);
     const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
     const userRepository = container.resolve(UserRepository);
@@ -223,7 +243,7 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
       return { userId: user.id, dseq };
     }
 
-    async function rewrapOnto(targetVersion: string, options: { batchSize?: number; dryRun?: boolean } = {}) {
+    async function attemptRewrapOnto(targetVersion: string, options: { batchSize?: number; dryRun?: boolean } = {}) {
       const service = new DataKeyRewrapService(
         dataKeyRepository,
         deploymentSettingRepository,
@@ -233,7 +253,11 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
         createLogger
       );
 
-      return (await service.rewrapDataKeys({ targetVersion, dryRun: options.dryRun ?? false, batchSize: options.batchSize })).unwrap();
+      return await service.rewrapDataKeys({ targetVersion, dryRun: options.dryRun ?? false, batchSize: options.batchSize });
+    }
+
+    async function rewrapOnto(targetVersion: string, options: { batchSize?: number; dryRun?: boolean } = {}) {
+      return (await attemptRewrapOnto(targetVersion, options)).unwrap();
     }
 
     async function seedUserWithoutDataKey() {
@@ -241,6 +265,12 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
       createdUserIds.push(user.id);
 
       return user;
+    }
+
+    async function seedCorruptedDataKey(version: string) {
+      const user = await seedUserWithoutDataKey();
+
+      return await dataKeyRepository.create({ userId: user.id, wrappedKey: "not-a-jwe", wrappedByKid: `${KEY}.v${version}` });
     }
 
     async function countDataKeys() {
@@ -278,7 +308,19 @@ describe(`${DataKeyRewrapService.name} against Cloud KMS`, () => {
       });
     }
 
-    return { consoleAt, seedUser, seedUserWithoutDataKey, rewrapOnto, readDataKeys, countDataKeys, readStoredSecrets, failWriteOf };
+    return {
+      consoleAt,
+      seedUser,
+      seedUserWithoutDataKey,
+      seedCorruptedDataKey,
+      attemptRewrapOnto,
+      rewrapOnto,
+      readDataKeys,
+      countDataKeys,
+      readStoredSecrets,
+      failWriteOf,
+      logger
+    };
   }
 });
 

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
@@ -253,6 +253,15 @@ describe(DataKeyRewrapService.name, () => {
   });
 
   describe("dry run", () => {
+    it("marks each audited batch with the same progress event a real run emits", async () => {
+      const { service, logger } = setup({ rows: [aRow({}), aRow({}), aRow({})] });
+
+      await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, batchSize: 2, dryRun: true });
+
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_BATCH", rewrapped: 2, failed: 0 }));
+      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_BATCH", rewrapped: 3, failed: 0 }));
+    });
+
     it("writes nothing and reports what a real run would move", async () => {
       const { service, report, dataKeyRepository, txService, wrappedJweService } = setup({
         rows: [aRow({ wrappedByKid: SOURCE_KID }), aRow({ wrappedByKid: SOURCE_KID })],

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.spec.ts
@@ -10,7 +10,7 @@ import type { TxService } from "@src/core/services";
 import type { SdlSecretsKmsClient, SdlSecretsKmsTargetFactory } from "@src/deployment/providers/kms.provider";
 import { createSdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
-import type { KmsWrappedJweService,ParsedKmsWrappedJwe  } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import type { KmsWrappedJweService, ParsedKmsWrappedJwe } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
 import { KmsWrappedJweError } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
 import type { DataKeyOutput, DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
 import { DataKeyRewrapService } from "./data-key-rewrap.service";
@@ -227,7 +227,9 @@ describe(DataKeyRewrapService.name, () => {
       await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: false });
 
       expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_START", toVersion: TARGET_KID, dryRun: false }));
-      expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_END", report: expect.objectContaining({ toVersion: TARGET_KID }) }));
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "DATA_KEY_REWRAP_END", report: expect.objectContaining({ toVersion: TARGET_KID }) })
+      );
     });
 
     it("names itself as the context every one of those events carries", () => {
@@ -252,7 +254,8 @@ describe(DataKeyRewrapService.name, () => {
 
   describe("dry run", () => {
     it("writes nothing and reports what a real run would move", async () => {
-      const { service, report, dataKeyRepository, txService } = setup({
+      const { service, report, dataKeyRepository, txService, wrappedJweService } = setup({
+        rows: [aRow({ wrappedByKid: SOURCE_KID }), aRow({ wrappedByKid: SOURCE_KID })],
         census: [
           { wrappedByKid: SOURCE_KID, count: 2 },
           { wrappedByKid: TARGET_KID, count: 1 }
@@ -262,9 +265,38 @@ describe(DataKeyRewrapService.name, () => {
       const summary = report(await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true }));
 
       expect(dataKeyRepository.updateById).not.toHaveBeenCalled();
-      expect(dataKeyRepository.findWrappedUnderOtherVersionsIteratively).not.toHaveBeenCalled();
       expect(txService.transaction).not.toHaveBeenCalled();
-      expect(summary).toMatchObject({ dryRun: true, dataKeysRewrapped: 2, census: { [SOURCE_KID]: 2, [TARGET_KID]: 1 } });
+      expect(wrappedJweService.open).not.toHaveBeenCalled();
+      expect(summary).toMatchObject({ dryRun: true, dataKeysRewrapped: 2, dataKeysFailed: 0, census: { [SOURCE_KID]: 2, [TARGET_KID]: 1 } });
+    });
+
+    it("excludes a row naming another crypto key from the count, flags it and reports the run as failed", async () => {
+      const foreign = aRow({ wrappedByKid: "someone-elses-key.v1" });
+      const { service, logger } = setup({ rows: [foreign, aRow({ wrappedByKid: SOURCE_KID })] });
+
+      const result = await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true });
+
+      expect(result.err).toBe(true);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "DATA_KEY_REWRAP_ROW_FAILED", dataKeyId: foreign.id, wrappedByKid: "someone-elses-key.v1" })
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "DATA_KEY_REWRAP_END", report: expect.objectContaining({ dataKeysRewrapped: 1, dataKeysFailed: 1 }) })
+      );
+    });
+
+    it("excludes a row whose header cannot be read, without spending a call on the key service", async () => {
+      const garbled = aRow({ wrappedByKid: SOURCE_KID });
+      const { service, logger, wrappedJweService } = setup({ rows: [garbled], unparseableIds: [garbled.id] });
+
+      const result = await service.rewrapDataKeys({ targetVersion: TARGET_VERSION, dryRun: true });
+
+      expect(result.err).toBe(true);
+      expect(wrappedJweService.open).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "DATA_KEY_REWRAP_ROW_FAILED", dataKeyId: garbled.id }));
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ event: "DATA_KEY_REWRAP_END", report: expect.objectContaining({ dataKeysRewrapped: 0, dataKeysFailed: 1 }) })
+      );
     });
 
     it("fingerprints the fleet once and reports no after, since nothing happened between", async () => {
@@ -360,6 +392,7 @@ describe(DataKeyRewrapService.name, () => {
     storedSecrets?: Array<{ id: string; sealedSecrets: string; updatedAt?: Date | null }>;
     storedSecretsAfter?: Array<{ id: string; sealedSecrets: string; updatedAt?: Date | null }>;
     unopenableIds?: string[];
+    unparseableIds?: string[];
     versionState?: protos.google.cloud.kms.v1.ICryptoKeyVersion["state"];
   }) {
     const rows = input.rows ?? [];
@@ -380,6 +413,11 @@ describe(DataKeyRewrapService.name, () => {
     const wrappedJweService = mock<KmsWrappedJweService>();
     wrappedJweService.parse.mockImplementation(serialized => {
       const row = rows.find(candidate => candidate.wrappedKey === serialized)!;
+
+      if (input.unparseableIds?.includes(row.id)) {
+        throw new KmsWrappedJweError("HEADER_UNREADABLE");
+      }
+
       const header = { alg: "RSA-OAEP-256", enc: "A256GCM", cty: "application/octet-stream", kid: row.wrappedByKid };
       rowByHeader.set(header, row);
 
@@ -404,7 +442,7 @@ describe(DataKeyRewrapService.name, () => {
     let scans = 0;
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     deploymentSettingRepository.findStoredSecretsIteratively.mockImplementation(async function* () {
-      const scanned = scans++ === 0 ? (input.storedSecrets ?? []) : (input.storedSecretsAfter ?? input.storedSecrets ?? []);
+      const scanned = scans++ === 0 ? input.storedSecrets ?? [] : input.storedSecretsAfter ?? input.storedSecrets ?? [];
 
       if (scanned.length) yield scanned.map(row => ({ ...row, updatedAt: row.updatedAt ?? null }));
     });

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -145,7 +145,7 @@ export class DataKeyRewrapService {
     return Object.fromEntries(census.map(({ wrappedByKid, count }) => [wrappedByKid, count]));
   }
 
-  /** Counts only rows a real run could move, so the dry-run promise holds for corrupted and foreign rows too — without spending a KMS unwrap on any of them. */
+  /** Parsing and version resolution are every check a dry run can make without spending a KMS unwrap, so the count stays an upper bound: the unwrap itself can still refuse a row. */
   #auditBatch(batch: DataKeyOutput[], target: SdlSecretsKmsTarget, errors: unknown[]): number {
     let resolvable = 0;
 

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -78,19 +78,19 @@ export class DataKeyRewrapService {
     for await (const batch of this.dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: target.kid, batchSize: pageSize })) {
       if (dryRun) {
         rewrapped += this.#auditBatch(batch, target, errors);
-        continue;
+      } else {
+        const wrappings = await this.#rewrapBatch(batch, target, sealingKey, errors);
+
+        await this.txService.transaction(async () => {
+          for (const { id, wrappedKey } of wrappings) {
+            await this.dataKeyRepository.updateById(id, { wrappedKey, wrappedByKid: target.kid });
+          }
+        });
+
+        rewrapped += wrappings.length;
+        bytesRewritten += wrappings.reduce((total, { wrappedKey }) => total + Buffer.byteLength(wrappedKey), 0);
       }
 
-      const wrappings = await this.#rewrapBatch(batch, target, sealingKey, errors);
-
-      await this.txService.transaction(async () => {
-        for (const { id, wrappedKey } of wrappings) {
-          await this.dataKeyRepository.updateById(id, { wrappedKey, wrappedByKid: target.kid });
-        }
-      });
-
-      rewrapped += wrappings.length;
-      bytesRewritten += wrappings.reduce((total, { wrappedKey }) => total + Buffer.byteLength(wrappedKey), 0);
       this.logger.info({ event: "DATA_KEY_REWRAP_BATCH", rewrapped, failed: errors.length, bytesRewritten });
     }
 

--- a/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
+++ b/apps/api/src/secret/services/data-key-rewrap/data-key-rewrap.service.ts
@@ -10,6 +10,7 @@ import { TxService } from "@src/core/services";
 import type { SdlSecretsKmsTarget, SdlSecretsKmsTargetFactory } from "@src/deployment/providers/kms.provider";
 import { SDL_SECRETS_KMS_TARGET_FACTORY } from "@src/deployment/providers/kms.provider";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { ParsedKmsWrappedJwe } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
 import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
 import type { SdlSecretsSealingKey } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
 import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
@@ -71,23 +72,26 @@ export class DataKeyRewrapService {
     const before = await this.#fingerprintStoredSecrets(pageSize);
     const census = await this.#censusByVersion();
     const errors: unknown[] = [];
-    let rewrapped = dryRun ? countAwayFrom(census, target.kid) : 0;
+    let rewrapped = 0;
     let bytesRewritten = 0;
 
-    if (!dryRun) {
-      for await (const batch of this.dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: target.kid, batchSize: pageSize })) {
-        const wrappings = await this.#rewrapBatch(batch, target, sealingKey, errors);
-
-        await this.txService.transaction(async () => {
-          for (const { id, wrappedKey } of wrappings) {
-            await this.dataKeyRepository.updateById(id, { wrappedKey, wrappedByKid: target.kid });
-          }
-        });
-
-        rewrapped += wrappings.length;
-        bytesRewritten += wrappings.reduce((total, { wrappedKey }) => total + Buffer.byteLength(wrappedKey), 0);
-        this.logger.info({ event: "DATA_KEY_REWRAP_BATCH", rewrapped, failed: errors.length, bytesRewritten });
+    for await (const batch of this.dataKeyRepository.findWrappedUnderOtherVersionsIteratively({ targetKid: target.kid, batchSize: pageSize })) {
+      if (dryRun) {
+        rewrapped += this.#auditBatch(batch, target, errors);
+        continue;
       }
+
+      const wrappings = await this.#rewrapBatch(batch, target, sealingKey, errors);
+
+      await this.txService.transaction(async () => {
+        for (const { id, wrappedKey } of wrappings) {
+          await this.dataKeyRepository.updateById(id, { wrappedKey, wrappedByKid: target.kid });
+        }
+      });
+
+      rewrapped += wrappings.length;
+      bytesRewritten += wrappings.reduce((total, { wrappedKey }) => total + Buffer.byteLength(wrappedKey), 0);
+      this.logger.info({ event: "DATA_KEY_REWRAP_BATCH", rewrapped, failed: errors.length, bytesRewritten });
     }
 
     const after = dryRun ? undefined : await this.#fingerprintStoredSecrets(pageSize);
@@ -141,6 +145,22 @@ export class DataKeyRewrapService {
     return Object.fromEntries(census.map(({ wrappedByKid, count }) => [wrappedByKid, count]));
   }
 
+  /** Counts only rows a real run could move, so the dry-run promise holds for corrupted and foreign rows too — without spending a KMS unwrap on any of them. */
+  #auditBatch(batch: DataKeyOutput[], target: SdlSecretsKmsTarget, errors: unknown[]): number {
+    let resolvable = 0;
+
+    for (const row of batch) {
+      try {
+        this.#parseWrapping(row, target);
+        resolvable += 1;
+      } catch (error) {
+        this.#recordRowFailure(row, error, errors);
+      }
+    }
+
+    return resolvable;
+  }
+
   /** A row nothing can open is recorded and stepped over, because keyset selection would hand it to every re-run first and the fleet would never move off the retiring version. */
   async #rewrapBatch(
     batch: DataKeyOutput[],
@@ -154,16 +174,19 @@ export class DataKeyRewrapService {
       try {
         wrappings.push({ id: row.id, wrappedKey: await this.#rewrap(row, target, sealingKey) });
       } catch (error) {
-        errors.push(error);
-        this.logger.error({ event: "DATA_KEY_REWRAP_ROW_FAILED", dataKeyId: row.id, userId: row.userId, wrappedByKid: row.wrappedByKid, error });
+        this.#recordRowFailure(row, error, errors);
       }
     }
 
     return wrappings;
   }
 
-  /** The unwrap is the only call the key service sees; wrapping again spends only the public half already in memory. */
-  async #rewrap(row: DataKeyOutput, target: SdlSecretsKmsTarget, sealingKey: SdlSecretsSealingKey): Promise<string> {
+  #recordRowFailure(row: DataKeyOutput, error: unknown, errors: unknown[]) {
+    errors.push(error);
+    this.logger.error({ event: "DATA_KEY_REWRAP_ROW_FAILED", dataKeyId: row.id, userId: row.userId, wrappedByKid: row.wrappedByKid, error });
+  }
+
+  #parseWrapping(row: DataKeyOutput, target: SdlSecretsKmsTarget): { parsed: ParsedKmsWrappedJwe; versionName: string } {
     const parsed = this.wrappedJweService.parse(row.wrappedKey);
     const versionName = target.resolveVersionName(parsed.header.kid);
 
@@ -171,6 +194,12 @@ export class DataKeyRewrapService {
       throw new Error(`Data key ${row.id} names a key version this console cannot resolve`);
     }
 
+    return { parsed, versionName };
+  }
+
+  /** The unwrap is the only call the key service sees; wrapping again spends only the public half already in memory. */
+  async #rewrap(row: DataKeyOutput, target: SdlSecretsKmsTarget, sealingKey: SdlSecretsSealingKey): Promise<string> {
+    const { parsed, versionName } = this.#parseWrapping(row, target);
     const dataKey = await this.wrappedJweService.open(parsed, versionName);
 
     return await new CompactEncrypt(dataKey)
@@ -198,8 +227,4 @@ export class DataKeyRewrapService {
 
     throw new Error(`Stored secrets changed while re-wrapping onto ${report.toVersion}`);
   }
-}
-
-function countAwayFrom(census: Record<string, number>, targetKid: string): number {
-  return Object.entries(census).reduce((total, [kid, count]) => (kid === targetKid ? total : total + count), 0);
 }


### PR DESCRIPTION
## Why

Part of CON-875.

The `rewrap-data-keys` command promises its dry run reports "what would be re-wrapped", but it computed `dataKeysRewrapped` straight from the census: every row whose `wrappedByKid` differs from the target, without opening any of them. Rows a real run would fail on — a kid of a foreign crypto key, an unreadable header — were counted as if they would succeed, which is exactly the corrupted-row class the design cares about.

## What

- A dry run now walks the same selection a real run uses and parses/resolves each row's header, without spending a KMS unwrap on any row. Rows that don't resolve are excluded from `dataKeysRewrapped`, flagged with the same `DATA_KEY_REWRAP_ROW_FAILED` event, counted in `dataKeysFailed`, and fail the run the way a real run would.
- The parse/resolve step is extracted (`#parseWrapping`) and shared by the dry-run audit and the real re-wrap, so the two paths cannot drift.
- Unit specs cover a foreign-kid row and an unparseable row in dry run; the integration test seeds a genuinely corrupted row and pins that the dry run excludes it from the count, flags it, and writes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dry-run data-key rewrapping to validate all eligible records consistently with live processing.
  - Added clear, row-level failure reporting for corrupted or unreadable key data.
  - Ensured dry runs do not decrypt data, start transactions, or modify stored records.
  - Excluded unrelated foreign-key records from dry-run results.
- **Tests**
  - Expanded coverage for corrupted key data, unreadable headers, failure reporting, and preservation of stored data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->