### PR TITLE
test(deployment): cover container-vm ssh deployments on the configure page

### DIFF
--- a/apps/deploy-web/tests/ui/configure-deployment-container-vm.spec.ts
+++ b/apps/deploy-web/tests/ui/configure-deployment-container-vm.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "./fixture/base-test";
+import { ConfigureDeploymentPage } from "./pages/ConfigureDeploymentPage";
+
+test.describe("Configure deployment — Container-VM (SSH)", () => {
+  test.use({ userType: "existing" });
+
+  test("seeds an SSH VM, gates submission on the public key, and generates a key pair", async ({ page }) => {
+    test.setTimeout(2 * 60 * 1000);
+
+    const configure = new ConfigureDeploymentPage(page);
+    const createAttempts = await configure.blockDeploymentCreation();
+
+    await test.step("the Container-VM card opens configure seeded as a VM", async () => {
+      await configure.openContainerVm();
+
+      await expect(page).toHaveURL(/\/new-deployment\/configure\?.*vm=true/);
+      await expect(configure.operatingSystemCard()).toBeVisible();
+      await expect(configure.dockerImageInput()).toHaveCount(0);
+      await expect(configure.exposeSshCheckbox()).toBeChecked();
+      await expect(configure.exposeSshCheckbox()).toBeDisabled();
+    });
+
+    await test.step("the managed distributions are selectable", async () => {
+      await expect(configure.distributionSelect()).toContainText("Ubuntu 24.04");
+
+      await configure.selectDistro("Debian 11");
+      await expect(configure.distributionSelect()).toContainText("Debian 11");
+
+      await configure.selectDistro("Ubuntu 24.04");
+      await expect(configure.distributionSelect()).toContainText("Ubuntu 24.04");
+    });
+
+    await test.step("requesting quotes without a key is rejected before any deployment is created", async () => {
+      await configure.requestQuotes();
+
+      await expect(configure.sshKeyRequiredError()).toBeVisible();
+      expect(createAttempts).toHaveLength(0);
+    });
+
+    await test.step("generating a key pair downloads it and fills the key field", async () => {
+      const download = await configure.generateSshKeys();
+
+      expect(download.suggestedFilename()).toBe("keypair.zip");
+      await expect(configure.sshPublicKeyInput()).toHaveValue(/^ssh-rsa /);
+      await expect(configure.sshKeyRequiredError()).toHaveCount(0);
+    });
+
+    await test.step("the generated key and the VM image reach the submitted spec", async () => {
+      await configure.requestQuotes();
+
+      await expect.poll(() => createAttempts.length, { timeout: 15_000 }).toBe(1);
+      expect(createAttempts[0]).toContain("SSH_PUBKEY");
+      expect(createAttempts[0]).toContain("ubuntu-2404-ssh");
+    });
+  });
+
+  test("redirects a direct /deploy-linux visit into the container-VM flow", async ({ page }) => {
+    const configure = new ConfigureDeploymentPage(page);
+
+    await configure.gotoDeployLinux();
+
+    await expect(page).toHaveURL(/\/new-deployment\/configure\?.*vm=true/);
+    await expect(configure.operatingSystemCard()).toBeVisible();
+  });
+});

--- a/apps/deploy-web/tests/ui/pages/ConfigureDeploymentPage.ts
+++ b/apps/deploy-web/tests/ui/pages/ConfigureDeploymentPage.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import type { Download, Page } from "@playwright/test";
 
 import { testEnvConfig } from "../fixture/test-env.config";
 import { AppNav } from "./AppNav";
@@ -19,12 +19,47 @@ export class ConfigureDeploymentPage {
   /**
    * Reaches the configure screen the way a user does — from the app home, opening the Deploy entry in whichever
    * nav is rendered (the classic deployment-type/template picker), then choosing "Run Custom Container" (bring
-   * your own image), which routes on to configure under the onboarding redesign — rather than deep-linking to the URL.
+   * your own image), which routes on to configure — rather than deep-linking to the URL.
    */
   async open() {
+    await this.openFromPicker("Run Custom Container");
+  }
+
+  /** The Container-VM entry: the same picker walk through the card that seeds an SSH-accessible linux VM. */
+  async openContainerVm() {
+    await this.openFromPicker("Launch Container-VM");
+  }
+
+  /** The legacy Container-VM URL, kept alive for old links and bookmarks; it redirects onto configure. */
+  async gotoDeployLinux() {
+    await this.page.goto(`${testEnvConfig.BASE_URL}/deploy-linux`);
+    await this.page.getByRole("heading", { name: "Configure your deployment" }).waitFor({ state: "visible", timeout: 30_000 });
+  }
+
+  /**
+   * Answers deployment creation locally and records every attempt, so a submit can be driven against a deployed
+   * environment with no chance of putting a deployment on chain even if the form's own guards regress.
+   */
+  async blockDeploymentCreation(): Promise<string[]> {
+    const attempts: string[] = [];
+
+    await this.page.route(/\/api\/proxy\/v1\/deployments(\?|$)/, async route => {
+      if (route.request().method() !== "POST") {
+        return route.fallback();
+      }
+
+      attempts.push(route.request().postData() ?? "");
+      await route.fulfill({ status: 503, contentType: "application/json", body: JSON.stringify({ error: "blocked by e2e" }) });
+    });
+
+    return attempts;
+  }
+
+  /** The picker cards are divs carrying only an aria-label, so getByLabel is the locator that reaches them. */
+  private async openFromPicker(cardLabel: string) {
     await this.page.goto(`${testEnvConfig.BASE_URL}/`, { waitUntil: "commit" });
     await new AppNav(this.page).openDeploy();
-    await this.page.getByLabel("Run Custom Container").click({ timeout: 60_000 });
+    await this.page.getByLabel(cardLabel).click({ timeout: 60_000 });
     await this.page.getByRole("heading", { name: "Configure your deployment" }).waitFor({ state: "visible", timeout: 30_000 });
   }
 
@@ -35,6 +70,18 @@ export class ConfigureDeploymentPage {
 
   async fillImageName(image: string) {
     await this.dockerImageInput().fill(image);
+  }
+
+  async selectDistro(distro: string) {
+    await this.distributionSelect().click();
+    await this.page.getByRole("option", { name: distro }).click();
+  }
+
+  /** Arms the download listener before the click, since the zip is saved synchronously once the key pair exists. */
+  async generateSshKeys(): Promise<Download> {
+    const download = this.page.waitForEvent("download", { timeout: 30_000 });
+    await this.page.getByRole("button", { name: "Generate new key" }).click();
+    return download;
   }
 
   /** The SDL persisted for the active configure draft, or null when none has been written yet. */
@@ -55,6 +102,27 @@ export class ConfigureDeploymentPage {
 
   dockerImageInput() {
     return this.page.getByRole("textbox", { name: "Docker image" });
+  }
+
+  /** The image card, which is titled "Operating System" instead of "Docker" for a Container-VM service. */
+  operatingSystemCard() {
+    return this.page.getByRole("button", { name: /(Collapse|Expand) Operating System/ });
+  }
+
+  distributionSelect() {
+    return this.page.getByRole("combobox", { name: "Distribution" });
+  }
+
+  exposeSshCheckbox() {
+    return this.page.getByRole("checkbox", { name: "Expose SSH" });
+  }
+
+  sshPublicKeyInput() {
+    return this.page.getByRole("textbox", { name: "SSH public key" });
+  }
+
+  sshKeyRequiredError() {
+    return this.page.getByText("SSH Public key is required.");
   }
 
   cpuInput() {

--- a/doc/e2e-manual-qa-checklist.md
+++ b/doc/e2e-manual-qa-checklist.md
@@ -29,10 +29,11 @@ The following flows are already covered by automated E2E tests:
   - Template selection and customization
   - Wallet connection verification
 
-- ✅ **Linux Deployment** (`deploy-linux.spec.ts`)
-  - SSH key generation and download
-  - Ubuntu 24.04 distribution selection
-  - Key pair validation
+- ✅ **Container-VM (SSH) Deployment** (`configure-deployment-container-vm.spec.ts`)
+  - Container-VM entry on the Configure page, seeded as a VM
+  - Managed distribution selection (Ubuntu 24.04, Debian 11)
+  - SSH key generation, download and the required-key gate on submission
+  - `/deploy-linux` redirect into the Container-VM flow
 
 #### 2. **Wallet Management**
 


### PR DESCRIPTION
## Why

Closes CON-685

The Container-VM (SSH) path has had no end-to-end coverage since #3458. That PR removed the `onboarding_redesign_v1` flag and, with it, `tests/ui/deploy-linux.spec.ts`, its `PlainLinuxPage` page object and the `skipIfOnboardingRedesign` helper. The feature itself moved to the Configure page in #3443 (CON-675), which deferred its Playwright test as a follow-up. This is that follow-up.

Because the redesign is now unconditional, the spec runs everywhere — there is no flag to probe and no legacy spec left to conflict with. CON-685's original "skip where the redesign is off" criterion no longer applies; I've updated the issue to match.

## What

A new `configure-deployment-container-vm.spec.ts` drives the flow the deleted spec used to cover, on the page that now owns it:

- Enters through the **Launch Container-VM** card and checks the VM seeding — the image card reads "Operating System", there's no Docker image field, and **Expose SSH** is checked and disabled.
- Picks a managed distribution (Ubuntu 24.04 is seeded, so it switches to Debian 11 and back to prove the selector drives form state).
- Requests quotes with a blank key and asserts the required-key gate rejects it.
- Generates a key pair, asserting the `keypair.zip` download and the `ssh-rsa …` value.
- Requests quotes again and asserts the posted spec carries both `SSH_PUBKEY` and the Ubuntu VM image ref.

A second test covers a direct `/deploy-linux` visit landing on the Container-VM flow — the SSR stub plus the client redirect together, which the existing unit spec can't exercise.

`ConfigureDeploymentPage` grows the VM interactions. Its existing `open()` and the new `openContainerVm()` now share one private picker walk instead of duplicating it.

### No on-chain writes

Per the scope agreed on the issue, this stops at submission rather than repeating the deploy lifecycle that `configure-deployment-flow.spec.ts` already covers for nginx. Rather than trusting the form's validation to hold, the spec routes `POST /api/proxy/v1/deployments` to a local handler for its whole duration. That's both the guard rail — no deployment can reach the chain even if validation regresses — and what makes the two submission assertions real: zero attempts while the key is missing, and a captured body once it isn't.

## Verification

E2E never runs in PR CI, so I verified the spec's locators and assertions against a local dev server driven headlessly (mocked session/wallet, SSR gate bypassed). All 21 probes pass: every locator resolves, the required-key gate fires, the key generation downloads `keypair.zip` and fills the field, and the captured POST body carries `SSH_PUBKEY` and `ubuntu-2404-ssh`. The entry paths check out too — the card routes to `configure?vm=true`, `vm=true` survives the draft-id write-back, and `/deploy-linux` redirects into VM mode.

What that does **not** cover is the real login fixture and the deployed environment, since there's no local `env/.env.test`. That needs a beta run. Because the deploy pipeline checks out specs from the dispatched branch, it can be confirmed after merge without cutting a release:

```
gh workflow run reusable-deploy-app.yml --repo akash-network/console --ref main \
  -f app=console-web -f image_tag=console-web/v<current version>
```

`tsc --noEmit`, `eslint --quiet` and `prettier --check` are clean on the changed files.

## Notes

`doc/e2e-manual-qa-checklist.md` gets its `deploy-linux.spec.ts` bullet swapped for the new spec. The rest of that file is stale well beyond this change — it still lists `deploy-hello-world.spec.ts`, `deploy-custom-template.spec.ts`, `change-wallets.spec.ts` and `disconnect-wallet.spec.ts`, none of which exist — but that cleanup is out of scope here.
