### PR TITLE
fix(dx): stamp updatedAt with the schema key in BaseRepository updates

### DIFF
--- a/apps/api/src/core/repositories/base.repository.spec.ts
+++ b/apps/api/src/core/repositories/base.repository.spec.ts
@@ -1,0 +1,125 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ApiPgDatabase } from "@src/core/providers";
+import { BaseRepository } from "@src/core/repositories/base.repository";
+import { TxService } from "@src/core/services";
+import { DataKeys } from "@src/secret/model-schemas";
+import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+import { Users } from "@src/user/model-schemas";
+import { UserRepository } from "@src/user/repositories";
+
+const DATA_KEY_ID = "6e4c9a2c-0f1d-4a3b-9c5e-7d8f0a1b2c3d";
+const OTHER_DATA_KEY_ID = "f1a2b3c4-d5e6-4789-9abc-def012345678";
+const USER_ID = "1b2c3d4e-5f60-4718-9a2b-3c4d5e6f7081";
+
+describe(BaseRepository.name, () => {
+  describe("updateBy", () => {
+    it("stamps updated_at on a table that declares the column", async () => {
+      const { dataKeyRepository, executedQueries } = setup();
+
+      await executeWithoutDriver(() => dataKeyRepository.updateBy({ userId: USER_ID }, { wrappedByKid: "kms-v2" }));
+
+      expect(executedQueries).toEqual([
+        {
+          query: 'update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = now() where "data_keys"."user_id" = $2',
+          params: ["kms-v2", USER_ID]
+        }
+      ]);
+    });
+
+    it("keeps an updatedAt supplied by the caller", async () => {
+      const { dataKeyRepository, executedQueries } = setup();
+      const updatedAt = new Date("2026-03-04T05:06:07.000Z");
+
+      await executeWithoutDriver(() => dataKeyRepository.updateBy({ id: DATA_KEY_ID }, { wrappedByKid: "kms-v2", updatedAt }));
+
+      expect(executedQueries).toEqual([
+        {
+          query: 'update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = $2 where "data_keys"."id" = $3',
+          params: ["kms-v2", updatedAt.toISOString(), DATA_KEY_ID]
+        }
+      ]);
+    });
+
+    it("touches updated_at when the payload holds nothing else", async () => {
+      const { dataKeyRepository, executedQueries } = setup();
+
+      await executeWithoutDriver(() => dataKeyRepository.updateBy({ id: DATA_KEY_ID }, {}));
+
+      expect(executedQueries).toEqual([
+        {
+          query: 'update "data_keys" set "updated_at" = now() where "data_keys"."id" = $1',
+          params: [DATA_KEY_ID]
+        }
+      ]);
+    });
+
+    it("leaves out updated_at on a table that has no such column", async () => {
+      const { userRepository, executedQueries } = setup();
+
+      await executeWithoutDriver(() => userRepository.updateBy({ id: USER_ID }, { bio: "hello" }));
+
+      expect(executedQueries).toEqual([
+        {
+          query: 'update "userSetting" set "bio" = $1 where "userSetting"."id" = $2',
+          params: ["hello", USER_ID]
+        }
+      ]);
+    });
+  });
+
+  describe("updateById", () => {
+    it("stamps updated_at", async () => {
+      const { dataKeyRepository, executedQueries } = setup();
+
+      await executeWithoutDriver(() => dataKeyRepository.updateById(DATA_KEY_ID, { wrappedByKid: "kms-v2" }));
+
+      expect(executedQueries).toEqual([
+        {
+          query: 'update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = now() where "data_keys"."id" = $2',
+          params: ["kms-v2", DATA_KEY_ID]
+        }
+      ]);
+    });
+  });
+
+  describe("updateManyById", () => {
+    it("stamps updated_at on every matched row", async () => {
+      const { dataKeyRepository, executedQueries } = setup();
+
+      await executeWithoutDriver(() => dataKeyRepository.updateManyById([DATA_KEY_ID, OTHER_DATA_KEY_ID], { wrappedByKid: "kms-v2" }));
+
+      expect(executedQueries).toEqual([
+        {
+          query: 'update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = now() where "data_keys"."id" in ($2, $3)',
+          params: ["kms-v2", DATA_KEY_ID, OTHER_DATA_KEY_ID]
+        }
+      ]);
+    });
+  });
+
+  async function executeWithoutDriver(run: () => Promise<unknown>) {
+    await expect(run()).rejects.toThrow();
+  }
+
+  function setup() {
+    const executedQueries: Array<{ query: string; params: unknown[] }> = [];
+    const driverlessDb = drizzle.mock({
+      logger: {
+        logQuery: (query, params) => {
+          executedQueries.push({ query, params });
+        }
+      }
+    });
+    const pg = mock<ApiPgDatabase>({ update: driverlessDb.update.bind(driverlessDb) });
+    const txManager = mock<TxService>();
+
+    return {
+      executedQueries,
+      dataKeyRepository: new DataKeyRepository(pg, DataKeys, txManager),
+      userRepository: new UserRepository(pg, Users, txManager)
+    };
+  }
+});

--- a/apps/api/src/core/repositories/base.repository.spec.ts
+++ b/apps/api/src/core/repositories/base.repository.spec.ts
@@ -1,10 +1,12 @@
+import { DrizzleQueryError } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/postgres-js";
-import { describe, expect, it } from "vitest";
+import postgres from "postgres";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { ApiPgDatabase } from "@src/core/providers";
 import { BaseRepository } from "@src/core/repositories/base.repository";
-import { TxService } from "@src/core/services";
+import type { TxService } from "@src/core/services";
 import { DataKeys } from "@src/secret/model-schemas";
 import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
 import { Users } from "@src/user/model-schemas";
@@ -13,13 +15,14 @@ import { UserRepository } from "@src/user/repositories";
 const DATA_KEY_ID = "6e4c9a2c-0f1d-4a3b-9c5e-7d8f0a1b2c3d";
 const OTHER_DATA_KEY_ID = "f1a2b3c4-d5e6-4789-9abc-def012345678";
 const USER_ID = "1b2c3d4e-5f60-4718-9a2b-3c4d5e6f7081";
+const UNREACHABLE_DRIVER = "the driver is stubbed out in unit tests";
 
 describe(BaseRepository.name, () => {
   describe("updateBy", () => {
     it("stamps updated_at on a table that declares the column", async () => {
       const { dataKeyRepository, executedQueries } = setup();
 
-      await executeWithoutDriver(() => dataKeyRepository.updateBy({ userId: USER_ID }, { wrappedByKid: "kms-v2" }));
+      await executeAgainstStubbedDriver(() => dataKeyRepository.updateBy({ userId: USER_ID }, { wrappedByKid: "kms-v2" }));
 
       expect(executedQueries).toEqual([
         {
@@ -33,7 +36,7 @@ describe(BaseRepository.name, () => {
       const { dataKeyRepository, executedQueries } = setup();
       const updatedAt = new Date("2026-03-04T05:06:07.000Z");
 
-      await executeWithoutDriver(() => dataKeyRepository.updateBy({ id: DATA_KEY_ID }, { wrappedByKid: "kms-v2", updatedAt }));
+      await executeAgainstStubbedDriver(() => dataKeyRepository.updateBy({ id: DATA_KEY_ID }, { wrappedByKid: "kms-v2", updatedAt }));
 
       expect(executedQueries).toEqual([
         {
@@ -46,7 +49,7 @@ describe(BaseRepository.name, () => {
     it("touches updated_at when the payload holds nothing else", async () => {
       const { dataKeyRepository, executedQueries } = setup();
 
-      await executeWithoutDriver(() => dataKeyRepository.updateBy({ id: DATA_KEY_ID }, {}));
+      await executeAgainstStubbedDriver(() => dataKeyRepository.updateBy({ id: DATA_KEY_ID }, {}));
 
       expect(executedQueries).toEqual([
         {
@@ -59,7 +62,7 @@ describe(BaseRepository.name, () => {
     it("leaves out updated_at on a table that has no such column", async () => {
       const { userRepository, executedQueries } = setup();
 
-      await executeWithoutDriver(() => userRepository.updateBy({ id: USER_ID }, { bio: "hello" }));
+      await executeAgainstStubbedDriver(() => userRepository.updateBy({ id: USER_ID }, { bio: "hello" }));
 
       expect(executedQueries).toEqual([
         {
@@ -74,7 +77,7 @@ describe(BaseRepository.name, () => {
     it("stamps updated_at", async () => {
       const { dataKeyRepository, executedQueries } = setup();
 
-      await executeWithoutDriver(() => dataKeyRepository.updateById(DATA_KEY_ID, { wrappedByKid: "kms-v2" }));
+      await executeAgainstStubbedDriver(() => dataKeyRepository.updateById(DATA_KEY_ID, { wrappedByKid: "kms-v2" }));
 
       expect(executedQueries).toEqual([
         {
@@ -89,7 +92,7 @@ describe(BaseRepository.name, () => {
     it("stamps updated_at on every matched row", async () => {
       const { dataKeyRepository, executedQueries } = setup();
 
-      await executeWithoutDriver(() => dataKeyRepository.updateManyById([DATA_KEY_ID, OTHER_DATA_KEY_ID], { wrappedByKid: "kms-v2" }));
+      await executeAgainstStubbedDriver(() => dataKeyRepository.updateManyById([DATA_KEY_ID, OTHER_DATA_KEY_ID], { wrappedByKid: "kms-v2" }));
 
       expect(executedQueries).toEqual([
         {
@@ -100,19 +103,18 @@ describe(BaseRepository.name, () => {
     });
   });
 
-  async function executeWithoutDriver(run: () => Promise<unknown>) {
-    await expect(run()).rejects.toThrow();
+  async function executeAgainstStubbedDriver(run: () => Promise<unknown>) {
+    await expect(run()).rejects.toThrow(DrizzleQueryError);
   }
 
   function setup() {
     const executedQueries: Array<{ query: string; params: unknown[] }> = [];
-    const driverlessDb = drizzle.mock({
-      logger: {
-        logQuery: (query, params) => {
-          executedQueries.push({ query, params });
-        }
-      }
+    const client = postgres("postgres://localhost:5432/unused");
+    vi.spyOn(client, "unsafe").mockImplementation((query, params) => {
+      executedQueries.push({ query, params: params ?? [] });
+      throw new Error(UNREACHABLE_DRIVER);
     });
+    const driverlessDb = drizzle(client);
     const pg = mock<ApiPgDatabase>({ update: driverlessDb.update.bind(driverlessDb) });
     const txManager = mock<TxService>();
 

--- a/apps/api/src/core/repositories/base.repository.ts
+++ b/apps/api/src/core/repositories/base.repository.ts
@@ -150,10 +150,7 @@ export abstract class BaseRepository<
   async updateManyById(ids: Output["id"][], payload: Partial<Input>): Promise<void> {
     await this.cursor
       .update(this.table)
-      .set({
-        ...this.toInput(payload),
-        updated_at: sql`now()`
-      })
+      .set(this.toUpdateSet(payload))
       .where(inArray(this.table.id, ids));
   }
 
@@ -162,10 +159,7 @@ export abstract class BaseRepository<
   async updateBy(query: Partial<Output>, payload: Partial<Input>, options?: MutationOptions): Promise<void | Output> {
     const cursor = this.cursor
       .update(this.table)
-      .set({
-        ...this.toInput(payload),
-        updated_at: sql`now()`
-      })
+      .set(this.toUpdateSet(payload))
       .where(this.queryToWhere(query));
 
     if (options?.returning) {
@@ -217,6 +211,11 @@ export abstract class BaseRepository<
       : undefined;
 
     return this.whereAccessibleBy(where);
+  }
+
+  /** Drizzle builds the SET clause from schema property names, so a raw column key such as updated_at is dropped without an error. */
+  private toUpdateSet(payload: Partial<Input>) {
+    return { updatedAt: sql`now()`, ...this.toInput(payload) };
   }
 
   protected toInput(payload: Partial<Input>): Partial<T["$inferInsert"]> {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -642,12 +642,4 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
         set: { closed: true, updatedAt: sql`now()` }
       });
   }
-
-  protected toInput(payload: Partial<DeploymentSettingsInput>): Partial<DeploymentSettingsInput> {
-    if (!payload.updatedAt) {
-      payload.updatedAt = new Date();
-    }
-
-    return payload;
-  }
 }


### PR DESCRIPTION
## Why

Fixes bug

`BaseRepository.updateBy`, `updateById` and `updateManyById` refreshed a row's modification
timestamp by putting the **raw column key** `updated_at` into Drizzle's `.set()`. Drizzle builds an
UPDATE's SET clause from **schema property names** (`updatedAt`), and silently ignores a key it does
not recognise — so the stamp never reached the database and no error was raised.

Every row updated through those methods kept its creation-time timestamp. That matters most for
`data_keys`: a KMS rotation re-wraps thousands of rows through `updateById`, and each one kept its
pre-rotation `updated_at`, leaving operators no way to audit when a rotation actually touched a row.

## What

- `BaseRepository` now routes both update paths through one `toUpdateSet` helper that uses the
  schema key `updatedAt`, so the stamp is emitted as `"updated_at" = now()`.
- A caller-supplied `updatedAt` still wins — the spread order makes the stamp a default, not an
  override.
- Tables without an `updatedAt` column (e.g. `userSetting`) are unaffected: no clause, no crash.
- `DeploymentSettingRepository.toInput` is deleted. It was a per-repository workaround that injected
  a JavaScript `new Date()` to paper over the gap; the base class now covers it, and the stamp comes
  from the database clock instead of the API process's.
- New `base.repository.spec.ts` pins the emitted SQL for all four cases by stubbing the driver.

```typescript
it("stamps updated_at on a table that declares the column", async () => {
  const { dataKeyRepository, executedQueries } = setup();

  await executeAgainstStubbedDriver(() => dataKeyRepository.updateBy({ userId: USER_ID }, { wrappedByKid: "kms-v2" }));

  expect(executedQueries).toEqual([
    {
      query: 'update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = now() where "data_keys"."user_id" = $2',
      params: ["kms-v2", USER_ID]
    }
  ]);
});
```

No migration, no API contract change. `apps/api` is green on `npm test`, `npm run lint -- --quiet`
and `npx tsc --noEmit`.

## Demo

# BaseRepository stamps updated_at with the schema key

*2026-09-11T14:45:47Z by Showboat 0.6.1*
<!-- showboat-id: e77a781f-d148-4e32-8f58-5aa3be45c928 -->

`BaseRepository.updateBy` and `updateManyById` refreshed a row's modification timestamp by putting
the raw column key `updated_at` into Drizzle's `.set()` call. Drizzle builds an UPDATE's SET clause
from **schema property names**, not from database column names, and it silently ignores a key it
does not recognise. The column is `updated_at`; the schema property is `updatedAt`. So the stamp was
dropped on the floor, and the column kept whatever value it was given when the row was created.

This branch routes both methods through one `toUpdateSet` helper that uses the schema key, and drops
the per-repository workaround `DeploymentSettingRepository` had grown to paper over the gap.

What follows compiles the SQL that the real repository classes emit — first on this branch, then on
`main` — so the difference is visible as a statement rather than as a test result.

```bash
git -C /home/agent/workspace --no-pager diff --no-color main...HEAD -- \
  apps/api/src/core/repositories/base.repository.ts \
  apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts

```

```output
diff --git a/apps/api/src/core/repositories/base.repository.ts b/apps/api/src/core/repositories/base.repository.ts
index 550569fe1..345e0db25 100644
--- a/apps/api/src/core/repositories/base.repository.ts
+++ b/apps/api/src/core/repositories/base.repository.ts
@@ -150,10 +150,7 @@ export abstract class BaseRepository<
   async updateManyById(ids: Output["id"][], payload: Partial<Input>): Promise<void> {
     await this.cursor
       .update(this.table)
-      .set({
-        ...this.toInput(payload),
-        updated_at: sql`now()`
-      })
+      .set(this.toUpdateSet(payload))
       .where(inArray(this.table.id, ids));
   }
 
@@ -162,10 +159,7 @@ export abstract class BaseRepository<
   async updateBy(query: Partial<Output>, payload: Partial<Input>, options?: MutationOptions): Promise<void | Output> {
     const cursor = this.cursor
       .update(this.table)
-      .set({
-        ...this.toInput(payload),
-        updated_at: sql`now()`
-      })
+      .set(this.toUpdateSet(payload))
       .where(this.queryToWhere(query));
 
     if (options?.returning) {
@@ -219,6 +213,11 @@ export abstract class BaseRepository<
     return this.whereAccessibleBy(where);
   }
 
+  /** Drizzle builds the SET clause from schema property names, so a raw column key such as updated_at is dropped without an error. */
+  private toUpdateSet(payload: Partial<Input>) {
+    return { updatedAt: sql`now()`, ...this.toInput(payload) };
+  }
+
   protected toInput(payload: Partial<Input>): Partial<T["$inferInsert"]> {
     return payload as Partial<T["$inferSelect"]>;
   }
diff --git a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
index ee22e78b7..cd0d103ab 100644
--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -642,12 +642,4 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
         set: { closed: true, updatedAt: sql`now()` }
       });
   }
-
-  protected toInput(payload: Partial<DeploymentSettingsInput>): Partial<DeploymentSettingsInput> {
-    if (!payload.updatedAt) {
-      payload.updatedAt = new Date();
-    }
-
-    return payload;
-  }
 }
```

## The probe

There is no Postgres in this sandbox, so instead of asserting on a stored row the demo hands the
real repository classes a Drizzle instance whose driver is replaced by a recorder: every statement
Drizzle hands to the driver is captured verbatim and the call is then aborted. What gets printed is
the exact SQL that would have reached the database.

It exercises three tables on purpose — `data_keys` (has an `updatedAt` column), `userSetting` (has
none), and `deployment_settings` (the table whose repository carried the workaround).

```bash
cd /home/agent/workspace/apps/api

cat > .demo-update-sql.ts <<'PROBE'
import "reflect-metadata";

import { drizzle } from "drizzle-orm/postgres-js";
import postgres from "postgres";

import type { ApiPgDatabase, TxService } from "@src/core";
import { DeploymentSettings } from "@src/deployment/model-schemas";
import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
import { DataKeys } from "@src/secret/model-schemas";
import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
import { Users } from "@src/user/model-schemas";
import { UserRepository } from "@src/user/repositories";

const USER_ID = "1b2c3d4e-5f60-4718-9a2b-3c4d5e6f7081";
const DATA_KEY_ID = "6e4c9a2c-0f1d-4a3b-9c5e-7d8f0a1b2c3d";
const SUPPLIED_UPDATED_AT = new Date("2026-03-04T05:06:07.000Z");

const capturedQueries: string[] = [];
const client = postgres("postgres://localhost:5432/unused");
Object.assign(client, {
  unsafe(query: string) {
    capturedQueries.push(query);
    throw new Error("the driver is replaced by a recorder in this demo");
  }
});

const driverlessDb = drizzle(client);
const pg = { update: driverlessDb.update.bind(driverlessDb) } as unknown as ApiPgDatabase;
const txManager = { getPgTx: () => undefined } as unknown as TxService;

const dataKeyRepository = new DataKeyRepository(pg, DataKeys, txManager);
const userRepository = new UserRepository(pg, Users, txManager);
const deploymentSettingRepository = new DeploymentSettingRepository(pg, DeploymentSettings, txManager);

async function record(label: string, run: () => Promise<unknown>) {
  capturedQueries.length = 0;
  await run().catch(() => undefined);
  console.log(label);
  console.log("  " + (capturedQueries.join("\n  ") || "<no statement reached the driver>"));
  console.log("");
}

async function main() {
  await record("data_keys / updateBy", () => dataKeyRepository.updateBy({ userId: USER_ID }, { wrappedByKid: "kms-v2" }));
  await record("data_keys / updateById", () => dataKeyRepository.updateById(DATA_KEY_ID, { wrappedByKid: "kms-v2" }));
  await record("data_keys / updateManyById", () => dataKeyRepository.updateManyById([DATA_KEY_ID], { wrappedByKid: "kms-v2" }));
  await record("data_keys / updateBy, caller supplies updatedAt", () =>
    dataKeyRepository.updateBy({ id: DATA_KEY_ID }, { wrappedByKid: "kms-v2", updatedAt: SUPPLIED_UPDATED_AT })
  );
  await record("userSetting / updateBy, table has no updatedAt column", () => userRepository.updateBy({ id: USER_ID }, { bio: "hello" }));
  await record("deployment_settings / updateBy", () => deploymentSettingRepository.updateBy({ userId: USER_ID }, { autoTopUpEnabled: true }));
}

main().then(() => process.exit(0));
PROBE

/home/agent/workspace/node_modules/.bin/tsx --tsconfig ./tsconfig.json .demo-update-sql.ts

```

```output
data_keys / updateBy
  update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = now() where "data_keys"."user_id" = $2

data_keys / updateById
  update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = now() where "data_keys"."id" = $2

data_keys / updateManyById
  update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = now() where "data_keys"."id" in ($2)

data_keys / updateBy, caller supplies updatedAt
  update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = $2 where "data_keys"."id" = $3

userSetting / updateBy, table has no updatedAt column
  update "userSetting" set "bio" = $1 where "userSetting"."id" = $2

deployment_settings / updateBy
  update "deployment_settings" set "auto_top_up_enabled" = $1, "updated_at" = now() where "deployment_settings"."user_id" = $2

```

Every `data_keys` update carries `"updated_at" = now()`. A caller who passes an explicit `updatedAt`
still wins — the stamp is a default, not an override. `userSetting`, which has no such column, is
left alone rather than being handed a column it does not have.

## The same probe against `main`

Now the two files are replaced with their `main` contents and the identical probe is run again. The
probe itself is untouched, so any difference in output comes from the repository code.

```bash
cd /home/agent/workspace/apps/api

git show main:apps/api/src/core/repositories/base.repository.ts > src/core/repositories/base.repository.ts
git show main:apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts > src/deployment/repositories/deployment-setting/deployment-setting.repository.ts

/home/agent/workspace/node_modules/.bin/tsx --tsconfig ./tsconfig.json .demo-update-sql.ts
status=$?

git checkout HEAD -- src/core/repositories/base.repository.ts src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
exit $status

```

```output
data_keys / updateBy
  update "data_keys" set "wrapped_by_kid" = $1 where "data_keys"."user_id" = $2

data_keys / updateById
  update "data_keys" set "wrapped_by_kid" = $1 where "data_keys"."id" = $2

data_keys / updateManyById
  update "data_keys" set "wrapped_by_kid" = $1 where "data_keys"."id" in ($2)

data_keys / updateBy, caller supplies updatedAt
  update "data_keys" set "wrapped_by_kid" = $1, "updated_at" = $2 where "data_keys"."id" = $3

userSetting / updateBy, table has no updatedAt column
  update "userSetting" set "bio" = $1 where "userSetting"."id" = $2

deployment_settings / updateBy
  update "deployment_settings" set "auto_top_up_enabled" = $1, "updated_at" = $2 where "deployment_settings"."user_id" = $3

```

Three statements changed, and they are the bug:

- `data_keys / updateBy`, `updateById` and `updateManyById` emit **no `updated_at` at all** on
  `main`. Drizzle accepted the `updated_at` key, found no schema property by that name, and dropped
  it. Every row updated through these methods kept a stale modification timestamp, with no error
  anywhere to say so.
- `deployment_settings / updateBy` does carry a stamp on `main`, but as a bound parameter `$2`
  rather than `now()` — that is the `toInput` workaround inserting a JavaScript `new Date()`, so the
  value came from the API process's clock instead of the database's. On this branch it is `now()`,
  consistent with every other table, and the workaround is gone.
- The caller-supplied `updatedAt` case is identical on both sides, which is the point: the fix adds
  a default without taking the override away.

Finally, the probe is removed and the working tree is shown to be back where it started, so nothing
in this demo leaves a trace.

```bash
cd /home/agent/workspace
rm -f apps/api/.demo-update-sql.ts
git status --porcelain -- apps/api packages && echo "apps/ and packages/ are clean"
git log --oneline -1 --format='%s'

```

```output
apps/ and packages/ are clean
test(dx): stub the driver in the base repository spec
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Update operations now reliably set modification timestamps, including single-record and multi-record updates.
  - Caller-provided timestamps are preserved when supplied.
  - Updates now behave consistently for empty payloads and records without timestamp fields.

- **Tests**
  - Added coverage for timestamp handling, single- and multi-record updates, empty updates, and tables without modification timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->