### PR TITLE
refactor(deployment): fingerprint stored secrets before and after a rotation

### DIFF
--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -48,6 +48,13 @@ export type OpenDeployment = {
   createdAt: Date;
 };
 
+export type SealedSecret = {
+  id: string;
+  sealedSecrets: string;
+  /** The write timestamp as stored, in text, so a write landing in the same millisecond as the previous one still reads as a change a `Date` would flatten. */
+  updatedAtMarker: string | null;
+};
+
 export type LiveTrialDeployment = {
   userId: string;
   dseq: string;
@@ -168,6 +175,32 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
       }
 
       yield batch as OpenDeployment[];
+
+      if (batch.length < batchSize) {
+        return;
+      }
+
+      cursor = batch[batch.length - 1].id;
+    }
+  }
+
+  /** Keyset-paged on `id` rather than offset-paged, because a sweep whose offsets shift under live traffic skips rows and its digest then proves nothing. */
+  async *findSealedSecretsIteratively({ batchSize }: { batchSize: number }): AsyncGenerator<SealedSecret[]> {
+    let cursor: string | undefined;
+
+    while (true) {
+      const batch = await this.pg
+        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets, updatedAtMarker: sql<string | null>`${this.table.updatedAt}::text` })
+        .from(this.table)
+        .where(and(isNotNull(this.table.sealedSecrets), ...(cursor ? [gt(this.table.id, cursor)] : [])))
+        .orderBy(asc(this.table.id))
+        .limit(batchSize);
+
+      if (!batch.length) {
+        return;
+      }
+
+      yield batch as SealedSecret[];
 
       if (batch.length < batchSize) {
         return;

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -51,7 +51,7 @@ export type OpenDeployment = {
 export type SealedSecret = {
   id: string;
   sealedSecrets: string;
-  /** The write timestamp as stored, in text, so a write landing in the same millisecond as the previous one still reads as a change a `Date` would flatten. */
+  /** The write timestamp as stored, fixed-width and microsecond-exact, so two readings compare and order as text without a `Date` flattening them to milliseconds. */
   updatedAtMarker: string | null;
 };
 
@@ -83,6 +83,8 @@ export type AutoTopUpDeployment = {
  * initialised managed wallet, so there is no owner for whom auto top-up cannot work.
  */
 const AUTO_TOP_UP_ENABLED_BY_DEFAULT = true;
+
+const UPDATED_AT_MARKER_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.US';
 
 @singleton()
 export class DeploymentSettingRepository extends BaseRepository<Table, DeploymentSettingsInput, DeploymentSettingsOutput> {
@@ -190,7 +192,7 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
     while (true) {
       const batch = await this.pg
-        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets, updatedAtMarker: sql<string | null>`${this.table.updatedAt}::text` })
+        .select({ id: this.table.id, sealedSecrets: this.table.sealedSecrets, updatedAtMarker: this.#updatedAtMarker() })
         .from(this.table)
         .where(and(isNotNull(this.table.sealedSecrets), ...(cursor ? [gt(this.table.id, cursor)] : [])))
         .orderBy(asc(this.table.id))
@@ -208,6 +210,28 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
       cursor = batch[batch.length - 1].id;
     }
+  }
+
+  /** The reading a write happening now would leave, so a row carrying a stamp below it carries one no writer of this run produced. */
+  async readCurrentUpdatedAtMarker(): Promise<string> {
+    const [row] = await this.pg.execute<{ marker: string }>(sql`select to_char(now()::timestamp, ${UPDATED_AT_MARKER_FORMAT}) as marker`);
+
+    return row.marker;
+  }
+
+  /** Answers for rows the sealed-secrets sweep cannot reach, so a row that lost its token can still be asked whether anything wrote it; an id absent from the result no longer exists. */
+  async findUpdatedAtMarkers(ids: string[]): Promise<Map<string, string | null>> {
+    if (ids.length === 0) {
+      return new Map();
+    }
+
+    const rows = await this.pg.select({ id: this.table.id, updatedAtMarker: this.#updatedAtMarker() }).from(this.table).where(inArray(this.table.id, ids));
+
+    return new Map(rows.map(row => [row.id, row.updatedAtMarker]));
+  }
+
+  #updatedAtMarker() {
+    return sql<string | null>`to_char(${this.table.updatedAt}, ${UPDATED_AT_MARKER_FORMAT})`;
   }
 
   async #findAutoTopUpDeployments(address?: string): Promise<AutoTopUpDeployment[]> {

--- a/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.integration.ts
+++ b/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.integration.ts
@@ -39,7 +39,7 @@ describe(StoredSecretFingerprintService.name, () => {
     const reconciliation = await service.reconcile(await service.take({ batchSize: 1 }), { batchSize: 1 });
 
     expect(reconciliation.after).toEqual(reconciliation.before);
-    expect(reconciliation).toMatchObject({ ownerRewritten: 0, created: 0, removed: 0, reSealed: [] });
+    expect(reconciliation).toMatchObject({ ownerRewritten: 0, created: 0, removed: 0, unexplained: [] });
   });
 
   it("counts a user rewriting their own secrets during the run as their own write", async () => {
@@ -51,20 +51,20 @@ describe(StoredSecretFingerprintService.name, () => {
     await rewriteAsOwner(dseq, newSealedToken());
     const reconciliation = await service.reconcile(before);
 
-    expect(reconciliation).toMatchObject({ ownerRewritten: 1, created: 0, removed: 0, reSealed: [] });
+    expect(reconciliation).toMatchObject({ ownerRewritten: 1, created: 0, removed: 0, unexplained: [] });
     expect(reconciliation.after.digest).not.toBe(reconciliation.before.digest);
   });
 
   it("reports a token rewritten without its updated_at moving as a re-seal", async () => {
-    const { service, storeSecrets, rewriteWithoutTouchingUpdatedAt } = await setup();
+    const { service, storeSecrets, writeSecretsWithoutTouchingUpdatedAt } = await setup();
     const { id } = await storeSecrets(newSealedToken());
     await storeSecrets(newSealedToken());
 
     const before = await service.take();
-    await rewriteWithoutTouchingUpdatedAt(id, newSealedToken());
+    await writeSecretsWithoutTouchingUpdatedAt(id, newSealedToken());
     const reconciliation = await service.reconcile(before);
 
-    expect(reconciliation).toMatchObject({ ownerRewritten: 0, reSealed: [id] });
+    expect(reconciliation).toMatchObject({ ownerRewritten: 0, unexplained: [id] });
   });
 
   it("counts a deployment that stored secrets during the run as created", async () => {
@@ -75,7 +75,7 @@ describe(StoredSecretFingerprintService.name, () => {
     await storeSecrets(newSealedToken());
     const reconciliation = await service.reconcile(before);
 
-    expect(reconciliation).toMatchObject({ created: 1, ownerRewritten: 0, removed: 0, reSealed: [] });
+    expect(reconciliation).toMatchObject({ created: 1, ownerRewritten: 0, removed: 0, unexplained: [] });
     expect(reconciliation.after.rowCount).toBe(reconciliation.before.rowCount + 1);
   });
 
@@ -88,7 +88,43 @@ describe(StoredSecretFingerprintService.name, () => {
     await clearSecrets(dseq);
     const reconciliation = await service.reconcile(before);
 
-    expect(reconciliation).toMatchObject({ removed: 1, ownerRewritten: 0, created: 0, reSealed: [] });
+    expect(reconciliation).toMatchObject({ removed: 1, ownerRewritten: 0, created: 0, unexplained: [] });
+  });
+
+  it("counts a deployment deleted during the run as removed", async () => {
+    const { service, storeSecrets, deleteDeployment } = await setup();
+    const { id } = await storeSecrets(newSealedToken());
+    await storeSecrets(newSealedToken());
+
+    const before = await service.take();
+    await deleteDeployment(id);
+    const reconciliation = await service.reconcile(before);
+
+    expect(reconciliation).toMatchObject({ removed: 1, ownerRewritten: 0, created: 0, unexplained: [] });
+  });
+
+  it("reports a token cleared without its updated_at moving as a re-seal", async () => {
+    const { service, storeSecrets, writeSecretsWithoutTouchingUpdatedAt } = await setup();
+    const { id } = await storeSecrets(newSealedToken());
+    await storeSecrets(newSealedToken());
+
+    const before = await service.take();
+    await writeSecretsWithoutTouchingUpdatedAt(id, null);
+    const reconciliation = await service.reconcile(before);
+
+    expect(reconciliation).toMatchObject({ removed: 0, ownerRewritten: 0, unexplained: [id] });
+  });
+
+  it("reports a token that appeared without its updated_at moving as a re-seal", async () => {
+    const { service, storeSecrets, storeNothing, writeSecretsWithoutTouchingUpdatedAt } = await setup();
+    await storeSecrets(newSealedToken());
+    const { id } = await storeNothing();
+
+    const before = await service.take();
+    await writeSecretsWithoutTouchingUpdatedAt(id, newSealedToken());
+    const reconciliation = await service.reconcile(before);
+
+    expect(reconciliation).toMatchObject({ created: 0, removed: 0, unexplained: [id] });
   });
 
   async function setup() {
@@ -113,7 +149,15 @@ describe(StoredSecretFingerprintService.name, () => {
     }
 
     async function storeNothing() {
-      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq: newDseq(), sdl: SDL, manifestVersion: "BAUG", sealedSecrets: null });
+      const id = await deploymentSettingRepository.upsertDefinition({
+        userId: user.id,
+        dseq: newDseq(),
+        sdl: SDL,
+        manifestVersion: "BAUG",
+        sealedSecrets: null
+      });
+
+      return { id };
     }
 
     async function rewriteAsOwner(dseq: string, sealedSecrets: string) {
@@ -124,10 +168,14 @@ describe(StoredSecretFingerprintService.name, () => {
       await deploymentSettingRepository.replaceDefinitionIfVersionMatches({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BQYH", sealedSecrets: null });
     }
 
-    async function rewriteWithoutTouchingUpdatedAt(id: string, sealedSecrets: string) {
+    async function writeSecretsWithoutTouchingUpdatedAt(id: string, sealedSecrets: string | null) {
       await db.update(deploymentSettingsTable).set({ sealedSecrets }).where(eq(deploymentSettingsTable.id, id));
     }
 
-    return { service, storeSecrets, storeNothing, rewriteAsOwner, clearSecrets, rewriteWithoutTouchingUpdatedAt };
+    async function deleteDeployment(id: string) {
+      await db.delete(deploymentSettingsTable).where(eq(deploymentSettingsTable.id, id));
+    }
+
+    return { service, storeSecrets, storeNothing, rewriteAsOwner, clearSecrets, writeSecretsWithoutTouchingUpdatedAt, deleteDeployment };
   }
 });

--- a/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.integration.ts
+++ b/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.integration.ts
@@ -1,0 +1,133 @@
+import { faker } from "@faker-js/faker";
+import { eq, sql } from "drizzle-orm";
+import { randomBytes } from "node:crypto";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import type { ApiPgDatabase } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { UserRepository } from "@src/user/repositories";
+import { StoredSecretFingerprintService } from "./stored-secret-fingerprint.service";
+
+const SDL = "version: '2.0'";
+
+function newSealedToken() {
+  return Array.from({ length: 5 }, () => randomBytes(24).toString("base64url")).join(".");
+}
+
+describe(StoredSecretFingerprintService.name, () => {
+  it("measures every stored token and no other row, across more than one page", async () => {
+    const { service, storeSecrets, storeNothing } = await setup();
+    const tokens = [newSealedToken(), newSealedToken(), newSealedToken()];
+    await Promise.all(tokens.map(storeSecrets));
+    await storeNothing();
+
+    const { fingerprint } = await service.take({ batchSize: 2 });
+
+    expect(fingerprint).toEqual({
+      digest: expect.stringMatching(/^[0-9a-f]{64}$/),
+      rowCount: 3,
+      byteTotal: tokens.reduce((total, token) => total + token.length, 0)
+    });
+  });
+
+  it("reports an untouched table as identical on digest, row count and byte total", async () => {
+    const { service, storeSecrets } = await setup();
+    await Promise.all([newSealedToken(), newSealedToken()].map(storeSecrets));
+
+    const reconciliation = await service.reconcile(await service.take({ batchSize: 1 }), { batchSize: 1 });
+
+    expect(reconciliation.after).toEqual(reconciliation.before);
+    expect(reconciliation).toMatchObject({ ownerRewritten: 0, created: 0, removed: 0, reSealed: [] });
+  });
+
+  it("counts a user rewriting their own secrets during the run as their own write", async () => {
+    const { service, storeSecrets, rewriteAsOwner } = await setup();
+    const { dseq } = await storeSecrets(newSealedToken());
+    await storeSecrets(newSealedToken());
+
+    const before = await service.take();
+    await rewriteAsOwner(dseq, newSealedToken());
+    const reconciliation = await service.reconcile(before);
+
+    expect(reconciliation).toMatchObject({ ownerRewritten: 1, created: 0, removed: 0, reSealed: [] });
+    expect(reconciliation.after.digest).not.toBe(reconciliation.before.digest);
+  });
+
+  it("reports a token rewritten without its updated_at moving as a re-seal", async () => {
+    const { service, storeSecrets, rewriteWithoutTouchingUpdatedAt } = await setup();
+    const { id } = await storeSecrets(newSealedToken());
+    await storeSecrets(newSealedToken());
+
+    const before = await service.take();
+    await rewriteWithoutTouchingUpdatedAt(id, newSealedToken());
+    const reconciliation = await service.reconcile(before);
+
+    expect(reconciliation).toMatchObject({ ownerRewritten: 0, reSealed: [id] });
+  });
+
+  it("counts a deployment that stored secrets during the run as created", async () => {
+    const { service, storeSecrets } = await setup();
+    await storeSecrets(newSealedToken());
+
+    const before = await service.take();
+    await storeSecrets(newSealedToken());
+    const reconciliation = await service.reconcile(before);
+
+    expect(reconciliation).toMatchObject({ created: 1, ownerRewritten: 0, removed: 0, reSealed: [] });
+    expect(reconciliation.after.rowCount).toBe(reconciliation.before.rowCount + 1);
+  });
+
+  it("counts a deployment whose secrets were cleared during the run as removed", async () => {
+    const { service, storeSecrets, clearSecrets } = await setup();
+    const { dseq } = await storeSecrets(newSealedToken());
+    await storeSecrets(newSealedToken());
+
+    const before = await service.take();
+    await clearSecrets(dseq);
+    const reconciliation = await service.reconcile(before);
+
+    expect(reconciliation).toMatchObject({ removed: 1, ownerRewritten: 0, created: 0, reSealed: [] });
+  });
+
+  async function setup() {
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const deploymentSettingsTable = resolveTable("DeploymentSettings");
+    await db.execute(sql`TRUNCATE TABLE ${resolveTable("Users")} CASCADE`);
+
+    const userRepository = container.resolve(UserRepository);
+    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+    const service = container.resolve(StoredSecretFingerprintService);
+    const user = await userRepository.create({});
+
+    function newDseq() {
+      return faker.number.int({ min: 100000, max: 999999 }).toString();
+    }
+
+    async function storeSecrets(sealedSecrets: string) {
+      const dseq = newDseq();
+      const id = await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BAUG", sealedSecrets });
+
+      return { dseq, id };
+    }
+
+    async function storeNothing() {
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq: newDseq(), sdl: SDL, manifestVersion: "BAUG", sealedSecrets: null });
+    }
+
+    async function rewriteAsOwner(dseq: string, sealedSecrets: string) {
+      await deploymentSettingRepository.replaceDefinitionIfVersionMatches({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BQYH", sealedSecrets });
+    }
+
+    async function clearSecrets(dseq: string) {
+      await deploymentSettingRepository.replaceDefinitionIfVersionMatches({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BQYH", sealedSecrets: null });
+    }
+
+    async function rewriteWithoutTouchingUpdatedAt(id: string, sealedSecrets: string) {
+      await db.update(deploymentSettingsTable).set({ sealedSecrets }).where(eq(deploymentSettingsTable.id, id));
+    }
+
+    return { service, storeSecrets, storeNothing, rewriteAsOwner, clearSecrets, rewriteWithoutTouchingUpdatedAt };
+  }
+});

--- a/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.spec.ts
+++ b/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.spec.ts
@@ -1,0 +1,162 @@
+import { randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentSettingRepository, SealedSecret } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { StoredSecretFingerprintService } from "./stored-secret-fingerprint.service";
+
+const WRITTEN_AT = "2026-09-01 10:00:00.123456+00";
+const REWRITTEN_AT = "2026-09-01 10:05:00.654321+00";
+
+function newSealedToken() {
+  return Array.from({ length: 5 }, () => randomBytes(24).toString("base64url")).join(".");
+}
+
+function storedSecret(input: Partial<SealedSecret> & { id: string }): SealedSecret {
+  return { sealedSecrets: newSealedToken(), updatedAtMarker: WRITTEN_AT, ...input };
+}
+
+describe(StoredSecretFingerprintService.name, () => {
+  it("measures every stored token, and only the rows the sweep yields", async () => {
+    const rows = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
+    const { service } = setup({ sweeps: [rows] });
+
+    const { fingerprint } = await service.take();
+
+    expect(fingerprint).toEqual({
+      digest: expect.stringMatching(/^[0-9a-f]{64}$/),
+      rowCount: 2,
+      byteTotal: rows[0].sealedSecrets.length + rows[1].sealedSecrets.length
+    });
+  });
+
+  it("digests a sweep identically however many pages it arrives in", async () => {
+    const rows = [storedSecret({ id: "a" }), storedSecret({ id: "b" }), storedSecret({ id: "c" })];
+    const { service: whole } = setup({ sweeps: [rows] });
+    const { service: paged } = setup({ sweeps: [rows], pageSize: 1 });
+
+    expect((await paged.take({ batchSize: 1 })).fingerprint).toEqual((await whole.take()).fingerprint);
+  });
+
+  describe("reconcile", () => {
+    it("reports an unchanged table as identical on digest, row count and byte total", async () => {
+      const rows = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
+      const { service } = setup({ sweeps: [rows, rows] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation.after).toEqual(reconciliation.before);
+      expect(reconciliation).toMatchObject({ ownerRewritten: 0, created: 0, removed: 0, reSealed: [] });
+    });
+
+    it("counts a token rewritten with its updated_at as the owner's own write", async () => {
+      const before = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
+      const after = [storedSecret({ id: "a", updatedAtMarker: REWRITTEN_AT }), before[1]];
+      const { service } = setup({ sweeps: [before, after] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ ownerRewritten: 1, reSealed: [] });
+      expect(reconciliation.after.digest).not.toBe(reconciliation.before.digest);
+    });
+
+    it("reports a token rewritten without its updated_at moving as a re-seal", async () => {
+      const before = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
+      const after = [storedSecret({ id: "a" }), before[1]];
+      const { service } = setup({ sweeps: [before, after] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ ownerRewritten: 0, reSealed: ["a"] });
+    });
+
+    it("reports tokens swapped between two deployments, though the set of tokens did not change", async () => {
+      const before = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
+      const after = [
+        { ...before[0], sealedSecrets: before[1].sealedSecrets },
+        { ...before[1], sealedSecrets: before[0].sealedSecrets }
+      ];
+      const { service } = setup({ sweeps: [before, after] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation.reSealed).toEqual(["a", "b"]);
+      expect(reconciliation.after.digest).not.toBe(reconciliation.before.digest);
+      expect(reconciliation.after.byteTotal).toBe(reconciliation.before.byteTotal);
+    });
+
+    it("counts a row that appeared during the run as created", async () => {
+      const before = [storedSecret({ id: "a" })];
+      const { service } = setup({ sweeps: [before, [...before, storedSecret({ id: "b" })]] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ created: 1, ownerRewritten: 0, removed: 0, reSealed: [] });
+    });
+
+    it("counts a row that disappeared during the run as removed", async () => {
+      const before = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
+      const { service } = setup({ sweeps: [before, [before[0]]] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ removed: 1, ownerRewritten: 0, created: 0, reSealed: [] });
+    });
+
+    it("reports a token that changed while its updated_at stayed unset as a re-seal", async () => {
+      const before = [storedSecret({ id: "a", updatedAtMarker: null })];
+      const after = [storedSecret({ id: "a", updatedAtMarker: null })];
+      const { service } = setup({ sweeps: [before, after] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ ownerRewritten: 0, reSealed: ["a"] });
+    });
+
+    it("counts a first-ever updated_at as the owner's own write", async () => {
+      const before = [storedSecret({ id: "a", updatedAtMarker: null })];
+      const after = [storedSecret({ id: "a", updatedAtMarker: REWRITTEN_AT })];
+      const { service } = setup({ sweeps: [before, after] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ ownerRewritten: 1, reSealed: [] });
+    });
+
+    it("counts a token rewritten within the same millisecond as its previous write as the owner's own write", async () => {
+      const before = [storedSecret({ id: "a", updatedAtMarker: "2026-09-01 10:00:00.123456+00" })];
+      const after = [storedSecret({ id: "a", updatedAtMarker: "2026-09-01 10:00:00.123999+00" })];
+      const { service } = setup({ sweeps: [before, after] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ ownerRewritten: 1, reSealed: [] });
+    });
+
+    it("reports a token that changed while its updated_at read exactly as before as a re-seal", async () => {
+      const before = [storedSecret({ id: "a", updatedAtMarker: REWRITTEN_AT })];
+      const after = [storedSecret({ id: "a", updatedAtMarker: REWRITTEN_AT })];
+      const { service } = setup({ sweeps: [before, after] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ ownerRewritten: 0, reSealed: ["a"] });
+    });
+  });
+
+  function setup(input: { sweeps: SealedSecret[][]; pageSize?: number }) {
+    const deploymentSettingRepository = mock<DeploymentSettingRepository>();
+    const remaining = [...input.sweeps];
+
+    deploymentSettingRepository.findSealedSecretsIteratively.mockImplementation(async function* yieldNextSweep() {
+      const rows = remaining.shift() ?? [];
+      const pageSize = input.pageSize ?? Math.max(rows.length, 1);
+
+      for (let start = 0; start < rows.length; start += pageSize) {
+        yield rows.slice(start, start + pageSize);
+      }
+    });
+
+    return { service: new StoredSecretFingerprintService(deploymentSettingRepository), deploymentSettingRepository };
+  }
+});

--- a/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.spec.ts
+++ b/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.spec.ts
@@ -5,8 +5,9 @@ import { mock } from "vitest-mock-extended";
 import type { DeploymentSettingRepository, SealedSecret } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { StoredSecretFingerprintService } from "./stored-secret-fingerprint.service";
 
-const WRITTEN_AT = "2026-09-01 10:00:00.123456+00";
-const REWRITTEN_AT = "2026-09-01 10:05:00.654321+00";
+const WRITTEN_AT = "2026-09-01T10:00:00.123456";
+const RUN_OPENED_AT = "2026-09-01T10:02:00.000000";
+const REWRITTEN_AT = "2026-09-01T10:05:00.654321";
 
 function newSealedToken() {
   return Array.from({ length: 5 }, () => randomBytes(24).toString("base64url")).join(".");
@@ -46,7 +47,7 @@ describe(StoredSecretFingerprintService.name, () => {
       const reconciliation = await service.reconcile(await service.take());
 
       expect(reconciliation.after).toEqual(reconciliation.before);
-      expect(reconciliation).toMatchObject({ ownerRewritten: 0, created: 0, removed: 0, reSealed: [] });
+      expect(reconciliation).toMatchObject({ ownerRewritten: 0, created: 0, removed: 0, unexplained: [] });
     });
 
     it("counts a token rewritten with its updated_at as the owner's own write", async () => {
@@ -56,7 +57,7 @@ describe(StoredSecretFingerprintService.name, () => {
 
       const reconciliation = await service.reconcile(await service.take());
 
-      expect(reconciliation).toMatchObject({ ownerRewritten: 1, reSealed: [] });
+      expect(reconciliation).toMatchObject({ ownerRewritten: 1, unexplained: [] });
       expect(reconciliation.after.digest).not.toBe(reconciliation.before.digest);
     });
 
@@ -67,7 +68,7 @@ describe(StoredSecretFingerprintService.name, () => {
 
       const reconciliation = await service.reconcile(await service.take());
 
-      expect(reconciliation).toMatchObject({ ownerRewritten: 0, reSealed: ["a"] });
+      expect(reconciliation).toMatchObject({ ownerRewritten: 0, unexplained: ["a"] });
     });
 
     it("reports tokens swapped between two deployments, though the set of tokens did not change", async () => {
@@ -80,27 +81,76 @@ describe(StoredSecretFingerprintService.name, () => {
 
       const reconciliation = await service.reconcile(await service.take());
 
-      expect(reconciliation.reSealed).toEqual(["a", "b"]);
+      expect(reconciliation.unexplained).toEqual(["a", "b"]);
       expect(reconciliation.after.digest).not.toBe(reconciliation.before.digest);
       expect(reconciliation.after.byteTotal).toBe(reconciliation.before.byteTotal);
     });
 
-    it("counts a row that appeared during the run as created", async () => {
+    it("counts a token stored during the run as created", async () => {
       const before = [storedSecret({ id: "a" })];
-      const { service } = setup({ sweeps: [before, [...before, storedSecret({ id: "b" })]] });
+      const appeared = storedSecret({ id: "b", updatedAtMarker: REWRITTEN_AT });
+      const { service } = setup({ sweeps: [before, [...before, appeared]] });
 
       const reconciliation = await service.reconcile(await service.take());
 
-      expect(reconciliation).toMatchObject({ created: 1, ownerRewritten: 0, removed: 0, reSealed: [] });
+      expect(reconciliation).toMatchObject({ created: 1, ownerRewritten: 0, removed: 0, unexplained: [] });
     });
 
-    it("counts a row that disappeared during the run as removed", async () => {
+    it("reports a token that appeared under a stamp older than the run as a re-seal", async () => {
+      const before = [storedSecret({ id: "a" })];
+      const appeared = storedSecret({ id: "b", updatedAtMarker: WRITTEN_AT });
+      const { service } = setup({ sweeps: [before, [...before, appeared]] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ created: 0, unexplained: ["b"] });
+    });
+
+    it("reports a token that appeared on a row carrying no stamp at all as a re-seal", async () => {
+      const before = [storedSecret({ id: "a" })];
+      const appeared = storedSecret({ id: "b", updatedAtMarker: null });
+      const { service } = setup({ sweeps: [before, [...before, appeared]] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ created: 0, unexplained: ["b"] });
+    });
+
+    it("counts a row deleted during the run as removed", async () => {
       const before = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
       const { service } = setup({ sweeps: [before, [before[0]]] });
 
       const reconciliation = await service.reconcile(await service.take());
 
-      expect(reconciliation).toMatchObject({ removed: 1, ownerRewritten: 0, created: 0, reSealed: [] });
+      expect(reconciliation).toMatchObject({ removed: 1, ownerRewritten: 0, created: 0, unexplained: [] });
+    });
+
+    it("counts a token cleared by a write as removed", async () => {
+      const before = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
+      const { service } = setup({ sweeps: [before, [before[0]]], markersAfterRun: { b: REWRITTEN_AT } });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ removed: 1, unexplained: [] });
+    });
+
+    it("reports a token cleared from a row nothing wrote as a re-seal", async () => {
+      const before = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
+      const { service } = setup({ sweeps: [before, [before[0]]], markersAfterRun: { b: WRITTEN_AT } });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ removed: 0, unexplained: ["b"] });
+    });
+
+    it("asks for the stamps of every vanished row, a batch at a time", async () => {
+      const before = [storedSecret({ id: "a" }), storedSecret({ id: "b" }), storedSecret({ id: "c" })];
+      const { service, deploymentSettingRepository } = setup({ sweeps: [before, []], markersAfterRun: { a: WRITTEN_AT, b: WRITTEN_AT, c: WRITTEN_AT } });
+
+      const reconciliation = await service.reconcile(await service.take(), { batchSize: 2 });
+
+      expect(deploymentSettingRepository.findUpdatedAtMarkers.mock.calls).toEqual([[["a", "b"]], [["c"]]]);
+      expect(reconciliation.unexplained).toEqual(["a", "b", "c"]);
     });
 
     it("reports a token that changed while its updated_at stayed unset as a re-seal", async () => {
@@ -110,7 +160,7 @@ describe(StoredSecretFingerprintService.name, () => {
 
       const reconciliation = await service.reconcile(await service.take());
 
-      expect(reconciliation).toMatchObject({ ownerRewritten: 0, reSealed: ["a"] });
+      expect(reconciliation).toMatchObject({ ownerRewritten: 0, unexplained: ["a"] });
     });
 
     it("counts a first-ever updated_at as the owner's own write", async () => {
@@ -120,17 +170,17 @@ describe(StoredSecretFingerprintService.name, () => {
 
       const reconciliation = await service.reconcile(await service.take());
 
-      expect(reconciliation).toMatchObject({ ownerRewritten: 1, reSealed: [] });
+      expect(reconciliation).toMatchObject({ ownerRewritten: 1, unexplained: [] });
     });
 
     it("counts a token rewritten within the same millisecond as its previous write as the owner's own write", async () => {
-      const before = [storedSecret({ id: "a", updatedAtMarker: "2026-09-01 10:00:00.123456+00" })];
-      const after = [storedSecret({ id: "a", updatedAtMarker: "2026-09-01 10:00:00.123999+00" })];
+      const before = [storedSecret({ id: "a", updatedAtMarker: "2026-09-01T10:00:00.123456" })];
+      const after = [storedSecret({ id: "a", updatedAtMarker: "2026-09-01T10:00:00.123999" })];
       const { service } = setup({ sweeps: [before, after] });
 
       const reconciliation = await service.reconcile(await service.take());
 
-      expect(reconciliation).toMatchObject({ ownerRewritten: 1, reSealed: [] });
+      expect(reconciliation).toMatchObject({ ownerRewritten: 1, unexplained: [] });
     });
 
     it("reports a token that changed while its updated_at read exactly as before as a re-seal", async () => {
@@ -140,14 +190,19 @@ describe(StoredSecretFingerprintService.name, () => {
 
       const reconciliation = await service.reconcile(await service.take());
 
-      expect(reconciliation).toMatchObject({ ownerRewritten: 0, reSealed: ["a"] });
+      expect(reconciliation).toMatchObject({ ownerRewritten: 0, unexplained: ["a"] });
     });
   });
 
-  function setup(input: { sweeps: SealedSecret[][]; pageSize?: number }) {
+  function setup(input: { sweeps: SealedSecret[][]; pageSize?: number; markersAfterRun?: Record<string, string | null> }) {
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
     const remaining = [...input.sweeps];
+    const markersAfterRun = input.markersAfterRun ?? {};
 
+    deploymentSettingRepository.readCurrentUpdatedAtMarker.mockResolvedValue(RUN_OPENED_AT);
+    deploymentSettingRepository.findUpdatedAtMarkers.mockImplementation(async ids =>
+      ids.reduce((markers, id) => (id in markersAfterRun ? markers.set(id, markersAfterRun[id]) : markers), new Map<string, string | null>())
+    );
     deploymentSettingRepository.findSealedSecretsIteratively.mockImplementation(async function* yieldNextSweep() {
       const rows = remaining.shift() ?? [];
       const pageSize = input.pageSize ?? Math.max(rows.length, 1);

--- a/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.spec.ts
+++ b/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.spec.ts
@@ -39,6 +39,15 @@ describe(StoredSecretFingerprintService.name, () => {
     expect((await paged.take({ batchSize: 1 })).fingerprint).toEqual((await whole.take()).fingerprint);
   });
 
+  it("sweeps both passes at the page size it was given", async () => {
+    const rows = [storedSecret({ id: "a" })];
+    const { service, deploymentSettingRepository } = setup({ sweeps: [rows, rows] });
+
+    await service.reconcile(await service.take({ batchSize: 25 }), { batchSize: 25 });
+
+    expect(deploymentSettingRepository.findSealedSecretsIteratively.mock.calls).toEqual([[{ batchSize: 25 }], [{ batchSize: 25 }]]);
+  });
+
   describe("reconcile", () => {
     it("reports an unchanged table as identical on digest, row count and byte total", async () => {
       const rows = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
@@ -96,6 +105,16 @@ describe(StoredSecretFingerprintService.name, () => {
       expect(reconciliation).toMatchObject({ created: 1, ownerRewritten: 0, removed: 0, unexplained: [] });
     });
 
+    it("counts a token stamped at the very instant the run opened as created", async () => {
+      const before = [storedSecret({ id: "a" })];
+      const appeared = storedSecret({ id: "b", updatedAtMarker: RUN_OPENED_AT });
+      const { service } = setup({ sweeps: [before, [...before, appeared]] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ created: 1, unexplained: [] });
+    });
+
     it("reports a token that appeared under a stamp older than the run as a re-seal", async () => {
       const before = [storedSecret({ id: "a" })];
       const appeared = storedSecret({ id: "b", updatedAtMarker: WRITTEN_AT });
@@ -143,6 +162,15 @@ describe(StoredSecretFingerprintService.name, () => {
       expect(reconciliation).toMatchObject({ removed: 0, unexplained: ["b"] });
     });
 
+    it("asks for no stamps when every row still carries its token", async () => {
+      const rows = [storedSecret({ id: "a" }), storedSecret({ id: "b" })];
+      const { service, deploymentSettingRepository } = setup({ sweeps: [rows, rows] });
+
+      await service.reconcile(await service.take(), { batchSize: 2 });
+
+      expect(deploymentSettingRepository.findUpdatedAtMarkers).not.toHaveBeenCalled();
+    });
+
     it("asks for the stamps of every vanished row, a batch at a time", async () => {
       const before = [storedSecret({ id: "a" }), storedSecret({ id: "b" }), storedSecret({ id: "c" })];
       const { service, deploymentSettingRepository } = setup({ sweeps: [before, []], markersAfterRun: { a: WRITTEN_AT, b: WRITTEN_AT, c: WRITTEN_AT } });
@@ -151,6 +179,16 @@ describe(StoredSecretFingerprintService.name, () => {
 
       expect(deploymentSettingRepository.findUpdatedAtMarkers.mock.calls).toEqual([[["a", "b"]], [["c"]]]);
       expect(reconciliation.unexplained).toEqual(["a", "b", "c"]);
+    });
+
+    it("reports a token that changed while its updated_at was cleared as a re-seal", async () => {
+      const before = [storedSecret({ id: "a", updatedAtMarker: WRITTEN_AT })];
+      const after = [storedSecret({ id: "a", updatedAtMarker: null })];
+      const { service } = setup({ sweeps: [before, after] });
+
+      const reconciliation = await service.reconcile(await service.take());
+
+      expect(reconciliation).toMatchObject({ ownerRewritten: 0, unexplained: ["a"] });
     });
 
     it("reports a token that changed while its updated_at stayed unset as a re-seal", async () => {

--- a/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.ts
+++ b/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.ts
@@ -18,6 +18,7 @@ interface StoredToken {
 export interface StoredSecretSnapshot {
   fingerprint: StoredSecretFingerprint;
   tokens: Map<string, StoredToken>;
+  takenAtMarker: string;
 }
 
 export interface StoredSecretReconciliation {
@@ -25,9 +26,9 @@ export interface StoredSecretReconciliation {
   after: StoredSecretFingerprint;
   ownerRewritten: number;
   created: number;
-  /** A row whose secrets were deleted or cleared, which cannot be evidence that anything re-sealed a value it should never have read. */
+  /** A row whose token a writer cleared, and a row that no longer exists at all, which nothing left behind can tell apart from a deployment its owner deleted. */
   removed: number;
-  reSealed: string[];
+  unexplained: string[];
 }
 
 const DEFAULT_BATCH_SIZE = 100;
@@ -41,11 +42,14 @@ function digestOf(sealedSecrets: string) {
   return createHash("sha256").update(sealedSecrets).digest("hex");
 }
 
-/** A row whose `updated_at` still reads as it did was written by nothing that goes through a repository, so a token that changed under it changed with no writer behind it. */
-function wasWrittenSince(original: StoredToken, current: StoredToken) {
-  if (!current.updatedAtMarker) return false;
+/** Both writers of a stored token stamp `updated_at` in the same statement, so a row whose stamp still reads as it did was written by nothing that goes through a repository. */
+function stampMoved(previous: string | null, current: string | null) {
+  return current !== null && current !== previous;
+}
 
-  return current.updatedAtMarker !== original.updatedAtMarker;
+/** Markers are fixed-width and ordered as text, so a token found under a stamp below the one the run opened with arrived without a write behind it. */
+function stampedSince(marker: string | null, runOpenedAt: string) {
+  return marker !== null && marker >= runOpenedAt;
 }
 
 /** Reports differences rather than throwing, because what a difference means belongs to the run being verified, not to the instrument. */
@@ -54,6 +58,7 @@ export class StoredSecretFingerprintService {
   constructor(private readonly deploymentSettingRepository: DeploymentSettingRepository) {}
 
   async take({ batchSize = DEFAULT_BATCH_SIZE }: { batchSize?: number } = {}): Promise<StoredSecretSnapshot> {
+    const takenAtMarker = await this.deploymentSettingRepository.readCurrentUpdatedAtMarker();
     const rows = createHash("sha256");
     const tokens = new Map<string, StoredToken>();
     let rowCount = 0;
@@ -70,29 +75,58 @@ export class StoredSecretFingerprintService {
       }
     }
 
-    return { fingerprint: { digest: rows.digest("hex"), rowCount, byteTotal }, tokens };
+    return { fingerprint: { digest: rows.digest("hex"), rowCount, byteTotal }, tokens, takenAtMarker };
   }
 
   /** Compares per row rather than by digest alone, because under live traffic the digests legitimately differ and only a per-row answer names what is behind it. */
-  async reconcile(before: StoredSecretSnapshot, { batchSize }: { batchSize?: number } = {}): Promise<StoredSecretReconciliation> {
+  async reconcile(before: StoredSecretSnapshot, { batchSize = DEFAULT_BATCH_SIZE }: { batchSize?: number } = {}): Promise<StoredSecretReconciliation> {
     const after = await this.take({ batchSize });
-    const unseen = new Map(before.tokens);
-    const reSealed: string[] = [];
+    const vanished = new Map(before.tokens);
+    const unexplained: string[] = [];
     let ownerRewritten = 0;
     let created = 0;
 
     for (const [id, token] of after.tokens) {
-      const original = unseen.get(id);
-      unseen.delete(id);
+      const original = vanished.get(id);
+      vanished.delete(id);
 
       if (!original) {
-        created += 1;
+        if (stampedSince(token.updatedAtMarker, before.takenAtMarker)) created += 1;
+        else unexplained.push(id);
       } else if (original.digest !== token.digest) {
-        if (wasWrittenSince(original, token)) ownerRewritten += 1;
-        else reSealed.push(id);
+        if (stampMoved(original.updatedAtMarker, token.updatedAtMarker)) ownerRewritten += 1;
+        else unexplained.push(id);
       }
     }
 
-    return { before: before.fingerprint, after: after.fingerprint, ownerRewritten, created, removed: unseen.size, reSealed };
+    const gone = await this.#classifyVanished(vanished, batchSize);
+
+    return {
+      before: before.fingerprint,
+      after: after.fingerprint,
+      ownerRewritten,
+      created,
+      removed: gone.removed,
+      unexplained: [...unexplained, ...gone.unexplained]
+    };
+  }
+
+  /** The sweep only reads rows that carry a token, so a row that lost one has to be asked for its stamp directly rather than read off the second sweep. */
+  async #classifyVanished(vanished: Map<string, StoredToken>, batchSize: number) {
+    const entries = [...vanished];
+    const unexplained: string[] = [];
+    let removed = 0;
+
+    for (let start = 0; start < entries.length; start += batchSize) {
+      const chunk = entries.slice(start, start + batchSize);
+      const markers = await this.deploymentSettingRepository.findUpdatedAtMarkers(chunk.map(([id]) => id));
+
+      for (const [id, original] of chunk) {
+        if (!markers.has(id) || stampMoved(original.updatedAtMarker, markers.get(id) ?? null)) removed += 1;
+        else unexplained.push(id);
+      }
+    }
+
+    return { removed, unexplained };
   }
 }

--- a/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.ts
+++ b/apps/api/src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service.ts
@@ -1,0 +1,98 @@
+import { createHash } from "node:crypto";
+import { singleton } from "tsyringe";
+
+import type { SealedSecret } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+
+export interface StoredSecretFingerprint {
+  digest: string;
+  rowCount: number;
+  byteTotal: number;
+}
+
+interface StoredToken {
+  digest: string;
+  updatedAtMarker: string | null;
+}
+
+export interface StoredSecretSnapshot {
+  fingerprint: StoredSecretFingerprint;
+  tokens: Map<string, StoredToken>;
+}
+
+export interface StoredSecretReconciliation {
+  before: StoredSecretFingerprint;
+  after: StoredSecretFingerprint;
+  ownerRewritten: number;
+  created: number;
+  /** A row whose secrets were deleted or cleared, which cannot be evidence that anything re-sealed a value it should never have read. */
+  removed: number;
+  reSealed: string[];
+}
+
+const DEFAULT_BATCH_SIZE = 100;
+
+/** Carries the id so a token moved to another deployment shows as a change, and the byte length so no two rows combine into the same input as one longer one. */
+function digestInputOf(row: SealedSecret, byteLength: number) {
+  return `${row.id}:${byteLength}:${row.sealedSecrets}`;
+}
+
+function digestOf(sealedSecrets: string) {
+  return createHash("sha256").update(sealedSecrets).digest("hex");
+}
+
+/** A row whose `updated_at` still reads as it did was written by nothing that goes through a repository, so a token that changed under it changed with no writer behind it. */
+function wasWrittenSince(original: StoredToken, current: StoredToken) {
+  if (!current.updatedAtMarker) return false;
+
+  return current.updatedAtMarker !== original.updatedAtMarker;
+}
+
+/** Reports differences rather than throwing, because what a difference means belongs to the run being verified, not to the instrument. */
+@singleton()
+export class StoredSecretFingerprintService {
+  constructor(private readonly deploymentSettingRepository: DeploymentSettingRepository) {}
+
+  async take({ batchSize = DEFAULT_BATCH_SIZE }: { batchSize?: number } = {}): Promise<StoredSecretSnapshot> {
+    const rows = createHash("sha256");
+    const tokens = new Map<string, StoredToken>();
+    let rowCount = 0;
+    let byteTotal = 0;
+
+    for await (const batch of this.deploymentSettingRepository.findSealedSecretsIteratively({ batchSize })) {
+      for (const row of batch) {
+        const byteLength = Buffer.byteLength(row.sealedSecrets, "utf8");
+
+        rows.update(digestInputOf(row, byteLength));
+        tokens.set(row.id, { digest: digestOf(row.sealedSecrets), updatedAtMarker: row.updatedAtMarker });
+        rowCount += 1;
+        byteTotal += byteLength;
+      }
+    }
+
+    return { fingerprint: { digest: rows.digest("hex"), rowCount, byteTotal }, tokens };
+  }
+
+  /** Compares per row rather than by digest alone, because under live traffic the digests legitimately differ and only a per-row answer names what is behind it. */
+  async reconcile(before: StoredSecretSnapshot, { batchSize }: { batchSize?: number } = {}): Promise<StoredSecretReconciliation> {
+    const after = await this.take({ batchSize });
+    const unseen = new Map(before.tokens);
+    const reSealed: string[] = [];
+    let ownerRewritten = 0;
+    let created = 0;
+
+    for (const [id, token] of after.tokens) {
+      const original = unseen.get(id);
+      unseen.delete(id);
+
+      if (!original) {
+        created += 1;
+      } else if (original.digest !== token.digest) {
+        if (wasWrittenSince(original, token)) ownerRewritten += 1;
+        else reSealed.push(id);
+      }
+    }
+
+    return { before: before.fingerprint, after: after.fingerprint, ownerRewritten, created, removed: unseen.size, reSealed };
+  }
+}

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -252,9 +252,10 @@ describe("Deployments API", () => {
   function setupDeploymentListMock(wallets: UserWalletOutput[], count: number = 2, state: string = "active") {
     const address = wallets[0].address;
     const deployments: RestAkashDeploymentInfoResponse[] = [];
+    const firstDseq = faker.number.int({ min: 100000, max: 999999 });
 
     for (let i = 0; i < count; i++) {
-      const dseq = faker.string.numeric();
+      const dseq = `${firstDseq + i}`;
       const deploymentInfo = createDeploymentInfoSeed({
         owner: address!,
         dseq,


### PR DESCRIPTION
## Why

Part of CON-876.

The upcoming key rotation re-wraps every user's data encryption key, and it must never read, open or write a single stored secret. "We didn't touch them" has to be evidence, not a claim — on a live system where users are writing their own secrets throughout the run.

This is **slice 1 of 2**: the instrument that produces that evidence. The rotation itself, its CLI command and its preflight land in the next PR, stacked on this one. No CLI or HTTP surface is added here.

## What

`StoredSecretFingerprintService` measures every stored secret without opening one, and reconciles the measurement afterwards per row.

```ts
const before = await storedSecretFingerprintService.take();

// ... the rotation re-wraps data keys, touching nothing in deployment_settings ...

const reconciliation = await storedSecretFingerprintService.reconcile(before);

if (reconciliation.unexplained.length > 0) {
  // the run failed: these deployments changed with no writer behind them
}
```

`take()` sweeps `deployment_settings` where `sealed_secrets is not null`, keyset-paged on `id`, and returns a sha256 over id, byte length and token in id order, plus the row count and byte total. Under live traffic the two digests legitimately differ, so `reconcile()` decides **per row** instead of by digest:

| what happened to a row | verdict |
| --- | --- |
| token changed, `updated_at` moved | the owner's own write — `ownerRewritten` |
| token appeared, stamped at or after the run opened | `created` |
| token gone, row written since, or row deleted outright | `removed` |
| token changed, appeared or vanished with **no writer behind it** | `unexplained`, named by deployment id |

Both writers of `sealed_secrets` stamp `updated_at` in the same statement, which is what makes that discriminator work. A row that no longer exists stays tolerated: nothing it left behind can tell a tamper from an owner deleting their deployment.

Two details worth a reviewer's eye:

- **Keyset, not offset.** Offset paging over a predicate that shifts under live traffic silently skips rows, and a digest from a sweep that skipped rows proves nothing.
- **Markers, not `Date`s.** `updated_at` travels as fixed-width `to_char(..., 'YYYY-MM-DD"T"HH24:MI:SS.US')` text. A `Date` truncates microseconds to milliseconds, so two writes inside one millisecond would compare equal and a healthy owner write would be reported as a tamper. The fixed width also makes the text order chronologically, which the "stamped at or after the run opened" check needs.

No schema change and no migration — this reads columns that already exist.

### Tests

Integration is the primary level here: every property is about a real database and what survives a concurrent writer, which a mock cannot get wrong on the code's behalf. The unit spec covers the classification table with a mocked sweep.

```ts
it("reports a token rewritten without its updated_at moving as a re-seal", async () => {
  const { service, storeSecrets, writeSecretsWithoutTouchingUpdatedAt } = await setup();
  const { id } = await storeSecrets(newSealedToken());
  await storeSecrets(newSealedToken());

  const before = await service.take();
  await writeSecretsWithoutTouchingUpdatedAt(id, newSealedToken());
  const reconciliation = await service.reconcile(before);

  expect(reconciliation).toMatchObject({ ownerRewritten: 0, unexplained: [id] });
});
```

Checks on `apps/api`: `npm test`, `npm run lint -- --quiet` and `npx tsc --noEmit` all pass.

One unrelated fix rides along, because it was making the suite red one run in ten: `setupDeploymentListMock` in `test/functional/deployments.spec.ts` drew each dseq from `faker.string.numeric()`, which returns a **single digit**, so two listed deployments shared a dseq about 10% of the time and the unnamed one inherited the other's name. The dseqs are now numbered from one base. The flake predates this branch (it arrived with #3905); no assertion changed.

## Demo

# Fingerprinting stored secrets before and after a rotation

*2026-09-11T15:11:56Z by Showboat 0.6.1*
<!-- showboat-id: 7a21755b-6c72-48b0-bb99-efbd95c6247c -->

A key rotation is about to re-wrap every user's data encryption key. It must never touch a user's **stored secrets** — and it has to be able to prove that afterwards, on a live system where users are writing their own secrets the whole time.

This slice builds the instrument that proves it. There is no CLI command yet (that lands with the rotation itself), so this demo drives the service directly against a real PostgreSQL database, the same way the rotation will.

Everything below runs against a throwaway database built from the project's own migrations.

```bash
cd apps/api && ../../node_modules/.bin/tsx ../../.work/con-876-re-wrap-data-keys-onto/demo.ts prepare
```

```output
database con876_fingerprint_demo created and migrated
```

The fleet is three deployments belonging to one user: **dseq 1001** and **dseq 1002** each hold a sealed secrets token, **dseq 1003** holds none. Every scenario below re-seeds that same fleet, so the numbers are comparable across scenarios.

First: what does the instrument actually read? Here is every statement one fingerprint pass issues, with the page size turned down to one row so the paging is visible.

```bash
cd apps/api && ../../node_modules/.bin/tsx ../../.work/con-876-re-wrap-data-keys-onto/demo.ts trace
```

```output
every statement one fingerprint pass issued, in order:
  1. select to_char(now()::timestamp, $1) as marker
  2. select "id", "sealed_secrets", to_char("updated_at", $1) from "deployment_settings" where "deployment_settings"."sealed_secrets" is not null order by "deployment_settings"."id" asc limit $2
  3. select "id", "sealed_secrets", to_char("updated_at", $1) from "deployment_settings" where ("deployment_settings"."sealed_secrets" is not null and "deployment_settings"."id" > $2) order by "deployment_settings"."id" asc limit $3
  4. select "id", "sealed_secrets", to_char("updated_at", $1) from "deployment_settings" where ("deployment_settings"."sealed_secrets" is not null and "deployment_settings"."id" > $2) order by "deployment_settings"."id" asc limit $3
```

Three things a reader can check for themselves in that output:

- it selects **three columns** — the id, the sealed token, and the row's write timestamp. It never decrypts anything, and it never asks for a data key;
- it pages by `id > $2` rather than by offset, so rows cannot be skipped when live traffic shifts the table under the sweep;
- it opens with `to_char(now()::timestamp, $1)`, the reading a write landing right then would leave. That is the clock every later judgement is made against.

Now the scenarios. The first is the boring one: take a fingerprint, do nothing, reconcile.

```bash
cd apps/api && ../../node_modules/.bin/tsx ../../.work/con-876-re-wrap-data-keys-onto/demo.ts quiet
```

```output
what happened during the run : nothing at all

fingerprint before : digest 2164adfd2689689eaf1f10291e5b7b6aacd041dc5578e3ac443039c0e1567aa2
                     2 rows, 172 bytes of sealed secrets
fingerprint after  : digest 2164adfd2689689eaf1f10291e5b7b6aacd041dc5578e3ac443039c0e1567aa2
                     2 rows, 172 bytes of sealed secrets

explained by a writer : 0 rewritten, 0 created, 0 removed
unexplained           : none

VERDICT: clean run, the rotation may report success
```

Identical digest, identical row count, identical byte total. That is the easy case.

The hard case is the one a naive digest comparison gets wrong: a **real user**, updating their own deployment while the rotation runs. Their token legitimately changes, so the fleet digest legitimately moves.

```bash
cd apps/api && ../../node_modules/.bin/tsx ../../.work/con-876-re-wrap-data-keys-onto/demo.ts owner-write
```

```output
what happened during the run : the owner of dseq 1001 updated their deployment, re-sealing their own secrets

fingerprint before : digest 2164adfd2689689eaf1f10291e5b7b6aacd041dc5578e3ac443039c0e1567aa2
                     2 rows, 172 bytes of sealed secrets
fingerprint after  : digest ee6823c8f910cfef23dcbf05bb0b82bcecae5a2a31159af97134324ca8fe3ad7
                     2 rows, 176 bytes of sealed secrets

explained by a writer : 1 rewritten, 0 created, 0 removed
unexplained           : none

VERDICT: clean run, the rotation may report success
```

The digest moved and the run is still clean: the write went through the application, which stamps `updated_at` in the same statement, so the changed token has a writer behind it and is counted rather than reported.

Now the same shaped change, made **behind the application's back** — the case the whole instrument exists for. A token is replaced by raw SQL that leaves `updated_at` alone.

```bash
cd apps/api && ../../node_modules/.bin/tsx ../../.work/con-876-re-wrap-data-keys-onto/demo.ts reseal
```

```output
what happened during the run : something replaced the token of dseq 1001 behind the application's back

fingerprint before : digest 2164adfd2689689eaf1f10291e5b7b6aacd041dc5578e3ac443039c0e1567aa2
                     2 rows, 172 bytes of sealed secrets
fingerprint after  : digest 6d5538176e48216226e7d593ef662567b51708818301abe1b4d5d9af5364f930
                     2 rows, 175 bytes of sealed secrets

explained by a writer : 0 rewritten, 0 created, 0 removed
unexplained           : 11111111-1111-4111-8111-111111111111 (dseq 1001)

VERDICT: the rotation must fail loudly and name these deployments
```

Named, not just counted. The rotation gets the deployment id to put in its failure.

The next two are the cases a code review caught, and they are worth watching together because **they end in exactly the same fingerprint**. First, a token erased by raw SQL.

```bash
cd apps/api && ../../node_modules/.bin/tsx ../../.work/con-876-re-wrap-data-keys-onto/demo.ts clear
```

```output
what happened during the run : something erased the token of dseq 1001 behind the application's back

fingerprint before : digest 2164adfd2689689eaf1f10291e5b7b6aacd041dc5578e3ac443039c0e1567aa2
                     2 rows, 172 bytes of sealed secrets
fingerprint after  : digest 8d913963ea14d12a3c03558265d10f3fc00898da57780f3d78152c4f5f027ea9
                     1 rows, 86 bytes of sealed secrets

explained by a writer : 0 rewritten, 0 created, 0 removed
unexplained           : 11111111-1111-4111-8111-111111111111 (dseq 1001)

VERDICT: the rotation must fail loudly and name these deployments
```

Now a user simply deleting that deployment — an ordinary thing to do at any moment, including during a rotation.

```bash
cd apps/api && ../../node_modules/.bin/tsx ../../.work/con-876-re-wrap-data-keys-onto/demo.ts owner-deletes
```

```output
what happened during the run : the owner deleted deployment dseq 1001 outright

fingerprint before : digest 2164adfd2689689eaf1f10291e5b7b6aacd041dc5578e3ac443039c0e1567aa2
                     2 rows, 172 bytes of sealed secrets
fingerprint after  : digest 8d913963ea14d12a3c03558265d10f3fc00898da57780f3d78152c4f5f027ea9
                     1 rows, 86 bytes of sealed secrets

explained by a writer : 0 rewritten, 0 created, 1 removed
unexplained           : none

VERDICT: clean run, the rotation may report success
```

Same digest `8d913963…`, same one row, same 86 bytes — and opposite verdicts. Nothing in the fingerprint itself separates these two; the instrument separates them by going back and asking the row that lost its token whether anything wrote it. The erased row was still sitting there with its write timestamp untouched. The deleted row was gone, and a deletion is the one case nothing left behind can explain, so it stays tolerated.

Last one, the mirror image: a token **planted** on a deployment that had none. Before the review round this looked like an ordinary new deployment and passed quietly.

```bash
cd apps/api && ../../node_modules/.bin/tsx ../../.work/con-876-re-wrap-data-keys-onto/demo.ts plant
```

```output
what happened during the run : something planted a token on dseq 1003, which had none

fingerprint before : digest 2164adfd2689689eaf1f10291e5b7b6aacd041dc5578e3ac443039c0e1567aa2
                     2 rows, 172 bytes of sealed secrets
fingerprint after  : digest c96f82ddfa26706b69b4a72b1b439ccd0b29988ca6de9393f456c623d8c00dda
                     3 rows, 261 bytes of sealed secrets

explained by a writer : 0 rewritten, 0 created, 0 removed
unexplained           : 33333333-3333-4333-8333-333333333333 (dseq 1003)

VERDICT: the rotation must fail loudly and name these deployments
```

Caught, because dseq 1003 carries a write timestamp from before the run opened — no writer of this run put that token there.

**What a person sees across the six scenarios:** every change a real user can make while the rotation runs is tolerated and counted, and every change nothing explains is named by deployment id. The next slice does the actual re-wrapping and turns a non-empty `unexplained` list into the run's failure.

To re-run this document: `uvx showboat verify .work/con-876-re-wrap-data-keys-onto/demo-1.md` from the repository root, with the project's test PostgreSQL running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stored-secret fingerprinting to track encrypted secret records, including counts, sizes, update markers, and per-record tokens.
  * Added reconciliation to identify newly created, removed, rewritten, or otherwise changed stored secrets.
  * Added efficient paginated processing for large collections of sealed secrets.
* **Bug Fixes**
  * Improved deployment test data generation by using sequential deployment identifiers for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->