### PR TITLE
feat(deployment): re-wrap data keys onto the target key version

### DIFF
--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -14,6 +14,7 @@ import { ExecutionContextService } from "@src/core/services/execution-context/ex
 import { TopUpDeploymentsController } from "@src/deployment/controllers/deployment/top-up-deployments.controller";
 import { GpuBotController } from "@src/deployment/controllers/gpu-bot/gpu-bot.controller";
 import { ProviderController } from "@src/provider/controllers/provider/provider.controller";
+import { DataKeyRotationController } from "@src/secret/controllers/data-key-rotation/data-key-rotation.controller";
 import { WorkloadAbuseController } from "@src/workload-abuse/controllers/workload-abuse.controller";
 import { APP_INITIALIZER, ON_APP_START } from "../core/providers/app-initializer";
 
@@ -119,6 +120,18 @@ program
   .action(async (options, command) => {
     await executeCliHandler(command.name(), async () => {
       await container.resolve(GpuBotController).createGpuBids();
+    });
+  });
+
+program
+  .command("rotate-data-keys")
+  .description("Re-wrap every user's data key onto the configured KMS key version, proving no stored secret changed")
+  .requiredOption("-t, --target-version <version>", "The key version to move data keys onto, which must be the one this console is configured to wrap under")
+  .option("-b, --batch-size <number>", "How many data keys are written per transaction", value => z.number({ coerce: true }).parse(value))
+  .option("-d, --dry-run", "Log what would be re-wrapped without opening or writing anything", false)
+  .action(async (options, command) => {
+    await executeCliHandler(command.name(), async () => {
+      return container.resolve(DataKeyRotationController).rotate(options);
     });
   });
 

--- a/apps/api/src/deployment/providers/kms.provider.ts
+++ b/apps/api/src/deployment/providers/kms.provider.ts
@@ -12,6 +12,7 @@ const CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
 
 /** The Cloud KMS operations the console performs on the SDL secrets key, narrowed so they can be doubled in tests. */
 export interface SdlSecretsKmsClient {
+  getCryptoKeyVersion(request: { name: string }, options?: CallOptions): Promise<[protos.google.cloud.kms.v1.ICryptoKeyVersion, ...unknown[]]>;
   getPublicKey(request: { name: string }, options?: CallOptions): Promise<[protos.google.cloud.kms.v1.IPublicKey, ...unknown[]]>;
   asymmetricDecrypt(request: {
     name: string;
@@ -28,6 +29,7 @@ export interface SdlSecretsKmsClient {
  */
 export interface SdlSecretsKmsTarget {
   client: SdlSecretsKmsClient;
+  version: string;
   versionName: string;
   kid: string;
   resolveVersionName(kid: unknown): string | undefined;
@@ -53,6 +55,7 @@ export function createSdlSecretsKmsTarget(input: {
 
   return {
     client,
+    version,
     versionName: versionPath(version),
     kid: `${key}.v${version}`,
     resolveVersionName(kid) {

--- a/apps/api/src/secret/config/key-rotation.config.ts
+++ b/apps/api/src/secret/config/key-rotation.config.ts
@@ -1,0 +1,4 @@
+/** Cloud KMS answers a version's state as the enum's name over REST and as its ordinal over gRPC, and both reach here unchanged. */
+export const ENABLED_CRYPTO_KEY_VERSION_STATES: ReadonlySet<unknown> = new Set(["ENABLED", 1]);
+
+export const DEFAULT_KEY_ROTATION_BATCH_SIZE = 100;

--- a/apps/api/src/secret/controllers/data-key-rotation/data-key-rotation.controller.ts
+++ b/apps/api/src/secret/controllers/data-key-rotation/data-key-rotation.controller.ts
@@ -1,0 +1,13 @@
+import { singleton } from "tsyringe";
+
+import type { RotateDataKeysOptions } from "@src/secret/services/data-key-rotation/data-key-rotation.service";
+import { DataKeyRotationService } from "@src/secret/services/data-key-rotation/data-key-rotation.service";
+
+@singleton()
+export class DataKeyRotationController {
+  constructor(private readonly dataKeyRotationService: DataKeyRotationService) {}
+
+  async rotate(options: RotateDataKeysOptions) {
+    return this.dataKeyRotationService.rotate(options);
+  }
+}

--- a/apps/api/src/secret/repositories/data-key/data-key.repository.ts
+++ b/apps/api/src/secret/repositories/data-key/data-key.repository.ts
@@ -1,3 +1,4 @@
+import { and, asc, count, eq, gt, ne, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -50,5 +51,58 @@ export class DataKeyRepository extends BaseRepository<Table, DataKeyInput, DataK
   /** Answers whether a KMS key version may still be destroyed without making stored data keys unrecoverable. */
   async countWrappedUnder(wrappedByKid: DataKeyOutput["wrappedByKid"]): Promise<number> {
     return this.count({ wrappedByKid });
+  }
+
+  /** Where the fleet stands across every version at once, so an operator reads what is left behind without asking version by version. */
+  async countByWrappingVersion(): Promise<Record<string, number>> {
+    const rows = await this.cursor
+      .select({ wrappedByKid: this.table.wrappedByKid, total: count() })
+      .from(this.table)
+      .groupBy(this.table.wrappedByKid)
+      .orderBy(asc(this.table.wrappedByKid));
+
+    return Object.fromEntries(rows.map(row => [row.wrappedByKid, row.total]));
+  }
+
+  /**
+   * Keyset rather than offset, because every committed batch removes its own rows from this
+   * predicate: an offset walked forward over the shrinking remainder would step over as many rows
+   * as it moved. A row this run cannot move keeps its wrapping, so it is read again on the next
+   * pass — which is the whole of the rotation's resumability.
+   */
+  async *findNotWrappedUnderIteratively({ wrappedByKid, batchSize }: { wrappedByKid: string; batchSize: number }): AsyncGenerator<DataKeyOutput[]> {
+    let cursor: string | undefined;
+
+    while (true) {
+      const batch = await this.cursor
+        .select()
+        .from(this.table)
+        .where(and(ne(this.table.wrappedByKid, wrappedByKid), ...(cursor ? [gt(this.table.id, cursor)] : [])))
+        .orderBy(asc(this.table.id))
+        .limit(batchSize);
+
+      if (!batch.length) return;
+
+      yield this.toOutputList(batch);
+
+      if (batch.length < batchSize) return;
+
+      cursor = batch[batch.length - 1].id;
+    }
+  }
+
+  /**
+   * The wrapping this re-wrap opened is compared inside the statement's own WHERE, so a row another
+   * writer moved first is left as that writer wrote it rather than overwritten with a key wrapped
+   * from a reading that is no longer current.
+   */
+  async rewrapIfStillWrappedUnder(input: { id: string; wrappedUnder: string; wrappedKey: string; wrappedByKid: string }): Promise<boolean> {
+    const [rewrapped] = await this.cursor
+      .update(this.table)
+      .set({ wrappedKey: input.wrappedKey, wrappedByKid: input.wrappedByKid, updatedAt: sql`now()` })
+      .where(and(eq(this.table.id, input.id), eq(this.table.wrappedByKid, input.wrappedUnder)))
+      .returning({ id: this.table.id });
+
+    return !!rewrapped;
   }
 }

--- a/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.integration.ts
+++ b/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.integration.ts
@@ -1,0 +1,285 @@
+import { faker } from "@faker-js/faker";
+import type { KeyManagementServiceClient } from "@google-cloud/kms";
+import { eq, sql } from "drizzle-orm";
+import { decodeProtectedHeader } from "jose";
+import { randomUUID } from "node:crypto";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ApiPgDatabase } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import { TxService } from "@src/core/services";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import { createSdlSecretsKmsTarget, KMS_CLIENT } from "@src/deployment/providers/kms.provider";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import { StoredSecretFingerprintService } from "@src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service";
+import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyService } from "@src/secret/services/data-key/data-key.service";
+import { DataKeyUnwrapperService } from "@src/secret/services/data-key-unwrapper/data-key-unwrapper.service";
+import { SecretCipherService } from "@src/secret/services/secret-cipher/secret-cipher.service";
+import { UserRepository } from "@src/user/repositories";
+import { DataKeyRotationService } from "./data-key-rotation.service";
+
+const PROJECT = "console-dev-mock";
+const LOCATION = "global";
+const KEY_RING = "console-api";
+const KEY = "sdl-secrets";
+const SDL = "version: '2.0'";
+
+const kmsClient = container.resolve<KeyManagementServiceClient>(KMS_CLIENT);
+
+function versionPath(version: string) {
+  return kmsClient.cryptoKeyVersionPath(PROJECT, LOCATION, KEY_RING, KEY, version);
+}
+
+async function createEnabledVersion() {
+  const [created] = await kmsClient.createCryptoKeyVersion({
+    parent: kmsClient.cryptoKeyPath(PROJECT, LOCATION, KEY_RING, KEY),
+    cryptoKeyVersion: {}
+  });
+
+  return created.name!.split("/").pop()!;
+}
+
+/** Provisioned once: every RSA-3072 keypair the emulator mints costs real CPU on the same host the database runs on, and no test mutates the pair. */
+let rotationPair: Promise<{ oldVersion: string; newVersion: string }> | undefined;
+
+function enabledRotationPair() {
+  rotationPair ??= Promise.all([createEnabledVersion(), createEnabledVersion()]).then(([oldVersion, newVersion]) => ({ oldVersion, newVersion }));
+
+  return rotationPair;
+}
+
+describe(DataKeyRotationService.name, () => {
+  it("refuses a target version that is not enabled, before any secret is measured or any row touched", async () => {
+    const disabledVersion = await createEnabledVersion();
+    const { storeUserWithSecrets, rotationAt, sweepSealedSecrets, storedDataKeys } = await setup();
+    await storeUserWithSecrets((await enabledRotationPair()).oldVersion);
+    const before = await storedDataKeys();
+    const asymmetricDecrypt = vi.spyOn(kmsClient, "asymmetricDecrypt");
+    await kmsClient.updateCryptoKeyVersion({ cryptoKeyVersion: { name: versionPath(disabledVersion), state: "DISABLED" }, updateMask: { paths: ["state"] } });
+
+    const result = await rotationAt(disabledVersion).rotate({ targetVersion: disabledVersion, dryRun: false });
+
+    expect(result.err).toBe(true);
+    expect(sweepSealedSecrets).not.toHaveBeenCalled();
+    expect(asymmetricDecrypt).not.toHaveBeenCalled();
+    expect(await storedDataKeys()).toEqual(before);
+  });
+
+  it("moves every data key onto the target version in id order and in batches, leaving every stored secret as it was", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { storeUserWithSecrets, rotationAt, dataKeyRepository, storedSecretsOf, loggedEvents } = await setup();
+    const users = [];
+    for (let index = 0; index < 5; index++) users.push(await storeUserWithSecrets(oldVersion));
+    const secretsBefore = await storedSecretsOf(users);
+    const wrapBefore = (await dataKeyRepository.findByUserId(users[0].id))!;
+    const keyBefore = await users[0].unwrapDataKeyAt(oldVersion);
+
+    const result = await rotationAt(newVersion).rotate({ targetVersion: newVersion, batchSize: 2, dryRun: false });
+
+    const report = result.unwrap();
+    expect(report).toMatchObject({
+      usersReWrapped: 5,
+      secretsReEncrypted: 0,
+      concurrentSecretWrites: 0,
+      fromVersions: { [`${KEY}.v${oldVersion}`]: 5 },
+      toVersion: `${KEY}.v${newVersion}`,
+      dataKeysByVersion: { [`${KEY}.v${newVersion}`]: 5 }
+    });
+    expect(report.fingerprintAfter).toEqual(report.fingerprintBefore);
+    expect(report.bytesRewritten).toBeGreaterThan(0);
+    const batches = loggedEvents("KEY_ROTATION_BATCH");
+    expect(batches.map(batch => batch.rowCount)).toEqual([2, 2, 1]);
+    expect(batches.map(batch => batch.firstId)).toEqual([...batches.map(batch => batch.firstId)].sort());
+    expect(await dataKeyRepository.countWrappedUnder(`${KEY}.v${oldVersion}`)).toBe(0);
+    expect(await storedSecretsOf(users)).toEqual(secretsBefore);
+
+    for (const user of users) {
+      expect(await user.openStoredSecretsAt(newVersion)).toEqual(user.secrets);
+      expect(decodeProtectedHeader((await storedSecretsOf([user]))[0].sealedSecrets!)).toEqual(user.sealedHeader);
+    }
+
+    const wrapAfter = (await dataKeyRepository.findByUserId(users[0].id))!;
+    expect(wrapAfter.id).toBe(wrapBefore.id);
+    expect(wrapAfter.wrappedKey).not.toBe(wrapBefore.wrappedKey);
+    expect(decodeProtectedHeader(wrapAfter.wrappedKey)).toEqual({ ...decodeProtectedHeader(wrapBefore.wrappedKey), kid: `${KEY}.v${newVersion}` });
+    expect((await users[0].unwrapDataKeyAt(newVersion)).equals(keyBefore)).toBe(true);
+  });
+
+  it("continues an interrupted run and spends nothing on a fleet already rotated", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { storeUserWithSecrets, rotationAt, dataKeyRepository } = await setup();
+    for (let index = 0; index < 3; index++) await storeUserWithSecrets(oldVersion);
+    const rotation = rotationAt(newVersion);
+    const rewrapRow = dataKeyRepository.rewrapIfStillWrappedUnder.bind(dataKeyRepository);
+    const interrupted = vi
+      .spyOn(dataKeyRepository, "rewrapIfStillWrappedUnder")
+      .mockImplementationOnce(rewrapRow)
+      .mockImplementationOnce(async () => {
+        throw new Error("connection lost");
+      });
+
+    const first = await rotation.rotate({ targetVersion: newVersion, batchSize: 1, dryRun: false });
+    interrupted.mockRestore();
+    const asymmetricDecrypt = vi.spyOn(kmsClient, "asymmetricDecrypt");
+    const second = await rotation.rotate({ targetVersion: newVersion, batchSize: 1, dryRun: false });
+    const unwrapsOfSecondRun = asymmetricDecrypt.mock.calls.length;
+    const third = await rotation.rotate({ targetVersion: newVersion, dryRun: false });
+
+    expect(first.err).toBe(true);
+    expect(second.unwrap().usersReWrapped).toBe(2);
+    expect(unwrapsOfSecondRun).toBe(2);
+    expect(third.unwrap().usersReWrapped).toBe(0);
+    expect(asymmetricDecrypt.mock.calls.length).toBe(unwrapsOfSecondRun);
+    expect(await dataKeyRepository.countWrappedUnder(`${KEY}.v${oldVersion}`)).toBe(0);
+  });
+
+  it("steps over an unreadable wrapped key and moves the rest of the fleet anyway", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { storeUserWithSecrets, rotationAt, dataKeyRepository, corruptWrappedKey } = await setup();
+    const [corrupted] = [await storeUserWithSecrets(oldVersion), await storeUserWithSecrets(oldVersion), await storeUserWithSecrets(oldVersion)];
+    await corruptWrappedKey(corrupted);
+    const rotation = rotationAt(newVersion);
+
+    const first = await rotation.rotate({ targetVersion: newVersion, batchSize: 3, dryRun: false });
+    const rotatedRows = await dataKeyRepository.countWrappedUnder(`${KEY}.v${newVersion}`);
+    const second = await rotation.rotate({ targetVersion: newVersion, batchSize: 3, dryRun: false });
+
+    expect(first.val).toMatchObject({ report: { failed: 1, usersReWrapped: 2, secretsReEncrypted: 0 } });
+    expect(rotatedRows).toBe(2);
+    expect(second.val).toMatchObject({ report: { failed: 1, usersReWrapped: 0 } });
+    expect(await dataKeyRepository.countWrappedUnder(`${KEY}.v${newVersion}`)).toBe(2);
+  });
+
+  it("serves a read of the same data key while it is being re-wrapped", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { storeUserWithSecrets, rotationAt, dataKeyRepository } = await setup();
+    const user = await storeUserWithSecrets(oldVersion);
+
+    const [rotated, readConcurrently] = await Promise.all([
+      rotationAt(newVersion).rotate({ targetVersion: newVersion, dryRun: false }),
+      user.unwrapDataKeyAt(oldVersion)
+    ]);
+
+    expect(rotated.unwrap().usersReWrapped).toBe(1);
+    expect((await user.unwrapDataKeyAt(newVersion)).equals(readConcurrently)).toBe(true);
+    expect((await dataKeyRepository.findByUserId(user.id))!.wrappedByKid).toBe(`${KEY}.v${newVersion}`);
+  });
+
+  it("counts what a run would move without opening or writing anything", async () => {
+    const { oldVersion, newVersion } = await enabledRotationPair();
+    const { storeUserWithSecrets, rotationAt, storedDataKeys } = await setup();
+    for (let index = 0; index < 2; index++) await storeUserWithSecrets(oldVersion);
+    const before = await storedDataKeys();
+    const asymmetricDecrypt = vi.spyOn(kmsClient, "asymmetricDecrypt");
+
+    const result = await rotationAt(newVersion).rotate({ targetVersion: newVersion, dryRun: true });
+
+    expect(result.unwrap()).toMatchObject({ wouldReWrap: 2, usersReWrapped: 0 });
+    expect(asymmetricDecrypt).not.toHaveBeenCalled();
+    expect(await storedDataKeys()).toEqual(before);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function setup() {
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    await db.execute(sql`TRUNCATE TABLE ${resolveTable("Users")} CASCADE`);
+
+    const userRepository = container.resolve(UserRepository);
+    const dataKeyRepository = container.resolve(DataKeyRepository);
+    const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
+    const fingerprintService = container.resolve(StoredSecretFingerprintService);
+    const executionContextService = container.resolve(ExecutionContextService);
+    const txService = container.resolve(TxService);
+    const sweepSealedSecrets = vi.spyOn(deploymentSettingRepository, "findSealedSecretsIteratively");
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger: CreateLogger = (options = {}) => (options.context === DataKeyRotationService.name ? logger : mock<ReturnType<CreateLogger>>());
+
+    const consoleAt = (version: string) => {
+      const target = createSdlSecretsKmsTarget({ client: kmsClient, versionPath, key: KEY, version });
+      const wrappedJwe = new KmsWrappedJweService(target);
+      const sealingKeyService = new SdlSecretsSealingKeyService(target, createLogger);
+      const dataKeyService = new DataKeyService(dataKeyRepository, sealingKeyService, createLogger);
+      const unwrapper = new DataKeyUnwrapperService(dataKeyService, executionContextService, wrappedJwe, target, createLogger);
+
+      return {
+        target,
+        sealingKeyService,
+        wrappedJwe,
+        dataKeyService,
+        cipher: new SecretCipherService(unwrapper, createLogger),
+        unwrapFor: async (userId: string) => await executionContextService.runWithContext(async () => await (await unwrapper.getDataKey(userId)).unwrap())
+      };
+    };
+
+    const rotationAt = (version: string) => {
+      const { target, sealingKeyService, wrappedJwe } = consoleAt(version);
+
+      return new DataKeyRotationService(dataKeyRepository, fingerprintService, wrappedJwe, sealingKeyService, txService, target, createLogger);
+    };
+
+    async function storeUserWithSecrets(version: string) {
+      const consoleApi = consoleAt(version);
+      await consoleApi.sealingKeyService.getSealingKey();
+      const user = await userRepository.create({});
+      await consoleApi.dataKeyService.ensureDataKey(user.id);
+
+      const dseq = faker.number.int({ min: 100000, max: 999999 }).toString();
+      const secrets = { DB_URL: `postgres://app:${randomUUID()}@db.internal/app` };
+      const sealedSecrets = await executionContextService.runWithContext(
+        async () => await consoleApi.cipher.encrypt(user.id, JSON.stringify(secrets), { sub: user.id, dseq })
+      );
+      await deploymentSettingRepository.upsertDefinition({ userId: user.id, dseq, sdl: SDL, manifestVersion: "BAUG", sealedSecrets });
+
+      return {
+        id: user.id,
+        dseq,
+        secrets,
+        sealedHeader: decodeProtectedHeader(sealedSecrets),
+        unwrapDataKeyAt: async (readAt: string) => await consoleAt(readAt).unwrapFor(user.id),
+        openStoredSecretsAt: async (readAt: string) => {
+          const stored = (await storedSecretsOf([{ id: user.id }]))[0].sealedSecrets!;
+
+          return JSON.parse(
+            await executionContextService.runWithContext(async () => await consoleAt(readAt).cipher.decrypt(user.id, stored, { sub: user.id, dseq }))
+          );
+        }
+      };
+    }
+
+    async function storedSecretsOf(users: Array<{ id: string }>) {
+      const rows = await Promise.all(users.map(async user => await deploymentSettingRepository.find({ userId: user.id })));
+
+      return rows.flat().map(row => ({ id: row.id, sealedSecrets: row.sealedSecrets, updatedAt: row.updatedAt }));
+    }
+
+    async function storedDataKeys() {
+      const rows = await dataKeyRepository.find({});
+
+      return rows.map(row => ({ id: row.id, wrappedKey: row.wrappedKey, wrappedByKid: row.wrappedByKid })).sort((left, right) => left.id.localeCompare(right.id));
+    }
+
+    async function corruptWrappedKey(user: { id: string }) {
+      const row = (await dataKeyRepository.findByUserId(user.id))!;
+      const dataKeysTable = resolveTable("DataKeys");
+      await db
+        .update(dataKeysTable)
+        .set({ wrappedKey: row.wrappedKey.slice(0, -20) })
+        .where(eq(dataKeysTable.id, row.id));
+    }
+
+    function loggedEvents(name: string) {
+      return (logger.info.mock.calls as Array<[Record<string, unknown>]>).map(([payload]) => payload).filter(payload => payload.event === name);
+    }
+
+    return { storeUserWithSecrets, rotationAt, dataKeyRepository, storedSecretsOf, storedDataKeys, corruptWrappedKey, sweepSealedSecrets, loggedEvents };
+  }
+});

--- a/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.integration.ts
+++ b/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.integration.ts
@@ -111,7 +111,7 @@ describe(DataKeyRotationService.name, () => {
     expect((await users[0].unwrapDataKeyAt(newVersion)).equals(keyBefore)).toBe(true);
   });
 
-  it("continues an interrupted run and spends nothing on a fleet already rotated", async () => {
+  it("rolls a failed batch back whole, continues on the next run and spends nothing on a rotated fleet", async () => {
     const { oldVersion, newVersion } = await enabledRotationPair();
     const { storeUserWithSecrets, rotationAt, dataKeyRepository } = await setup();
     for (let index = 0; index < 3; index++) await storeUserWithSecrets(oldVersion);
@@ -124,16 +124,18 @@ describe(DataKeyRotationService.name, () => {
         throw new Error("connection lost");
       });
 
-    const first = await rotation.rotate({ targetVersion: newVersion, batchSize: 1, dryRun: false });
+    const first = await rotation.rotate({ targetVersion: newVersion, batchSize: 2, dryRun: false });
+    const rotatedAfterTheFailedBatch = await dataKeyRepository.countWrappedUnder(`${KEY}.v${newVersion}`);
     interrupted.mockRestore();
     const asymmetricDecrypt = vi.spyOn(kmsClient, "asymmetricDecrypt");
-    const second = await rotation.rotate({ targetVersion: newVersion, batchSize: 1, dryRun: false });
+    const second = await rotation.rotate({ targetVersion: newVersion, batchSize: 2, dryRun: false });
     const unwrapsOfSecondRun = asymmetricDecrypt.mock.calls.length;
     const third = await rotation.rotate({ targetVersion: newVersion, dryRun: false });
 
     expect(first.err).toBe(true);
-    expect(second.unwrap().usersReWrapped).toBe(2);
-    expect(unwrapsOfSecondRun).toBe(2);
+    expect(rotatedAfterTheFailedBatch).toBe(0);
+    expect(second.unwrap().usersReWrapped).toBe(3);
+    expect(unwrapsOfSecondRun).toBe(3);
     expect(third.unwrap().usersReWrapped).toBe(0);
     expect(asymmetricDecrypt.mock.calls.length).toBe(unwrapsOfSecondRun);
     expect(await dataKeyRepository.countWrappedUnder(`${KEY}.v${oldVersion}`)).toBe(0);

--- a/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.spec.ts
@@ -1,5 +1,6 @@
 import type { protos } from "@google-cloud/kms";
 import crc32c from "fast-crc32c";
+import { grpc } from "google-gax";
 import { compactDecrypt, CompactEncrypt, decodeProtectedHeader } from "jose";
 import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
@@ -29,24 +30,64 @@ function keyPairOf(version: string) {
 
 describe(DataKeyRotationService.name, () => {
   it("refuses a target version that is not the one the console wraps under", async () => {
-    const { service, fingerprintService, kmsClient } = setup();
+    const { service, fingerprintService, kmsClient, logger } = setup();
 
     const result = await service.rotate({ targetVersion: "3", dryRun: false });
 
-    expect(result.err).toBe(true);
+    expect(result.val).toMatchObject({ reason: `Requested target version 3 is not the configured one, ${TARGET_VERSION}` });
+    expect(logger.error).toHaveBeenCalledWith({ event: "KEY_ROTATION_TARGET_VERSION_MISMATCH", requested: "3", configured: TARGET_VERSION });
     expect(fingerprintService.take).not.toHaveBeenCalled();
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
   });
 
   it("refuses a target version the key service reports as anything but enabled", async () => {
-    const { service, fingerprintService, kmsClient, dataKeyRepository } = setup({ targetVersionState: "DISABLED" });
+    const { service, fingerprintService, kmsClient, dataKeyRepository, kmsTarget, logger } = setup({ targetVersionState: "DISABLED" });
 
     const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
 
-    expect(result.err).toBe(true);
+    expect(result.val).toMatchObject({ reason: `Target key version ${TARGET_KID} is DISABLED rather than enabled` });
+    expect(logger.error).toHaveBeenCalledWith({ event: "KEY_ROTATION_TARGET_VERSION_UNUSABLE", versionName: kmsTarget.versionName, state: "DISABLED" });
     expect(fingerprintService.take).not.toHaveBeenCalled();
     expect(dataKeyRepository.rewrapIfStillWrappedUnder).not.toHaveBeenCalled();
     expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the key service cannot read the target version's state", async () => {
+    const { service, fingerprintService, logger } = setup({ targetVersionError: rejectionWithStatus(grpc.status.NOT_FOUND) });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.val).toMatchObject({ reason: `Target key version ${TARGET_KID} could not be read from the key service` });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_TARGET_VERSION_UNREADABLE" }));
+    expect(fingerprintService.take).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the key service rejects with something it cannot read a status from", async () => {
+    const { service, fingerprintService } = setup({ targetVersionError: { code: grpc.status.UNIMPLEMENTED } });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.val).toMatchObject({ reason: `Target key version ${TARGET_KID} could not be read from the key service` });
+    expect(fingerprintService.take).not.toHaveBeenCalled();
+  });
+
+  it("carries on when the key service cannot answer the state at all, leaving the refusal to the key fetch", async () => {
+    const { service, logger } = setup({ rows: [await storedKey()], targetVersionError: rejectionWithStatus(grpc.status.UNIMPLEMENTED) });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.unwrap().usersReWrapped).toBe(1);
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_TARGET_VERSION_STATE_UNAVAILABLE" }));
+  });
+
+  it("refuses when the target version publishes no usable key", async () => {
+    const { service, fingerprintService, logger } = setup({ rows: [await storedKey()], sealingKeyUnavailable: true });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.val).toMatchObject({ reason: `Target key version ${TARGET_KID} did not publish a usable key` });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_TARGET_KEY_UNAVAILABLE" }));
+    expect(fingerprintService.take).not.toHaveBeenCalled();
   });
 
   it("re-wraps the same key bytes onto the target version, carrying every other claim", async () => {
@@ -67,25 +108,84 @@ describe(DataKeyRotationService.name, () => {
 
   it("spends one key-service unwrap per row and one public key fetch for the whole run", async () => {
     const rows = await Promise.all([storedKey(), storedKey(), storedKey()]);
-    const { service, kmsClient } = setup({ rows });
+    const { service, kmsClient, kmsTarget, fingerprintService, writtenRows } = setup({ rows });
+    const startedAt = Date.now();
 
     const result = await service.rotate({ targetVersion: TARGET_VERSION, batchSize: 2, dryRun: false });
 
-    expect(result.unwrap().usersReWrapped).toBe(3);
+    const report = result.unwrap();
+    expect(report).toMatchObject({ usersReWrapped: 3, fromVersions: { [PREVIOUS_KID]: 3 } });
+    expect(report.bytesRewritten).toBe(writtenRows.reduce((total, row) => total + row.wrappedKey.length, 0));
+    expect(report.elapsedMs).toBeLessThanOrEqual(Date.now() - startedAt);
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(3);
     expect(kmsClient.getPublicKey).toHaveBeenCalledTimes(1);
+    expect(kmsClient.getCryptoKeyVersion).toHaveBeenCalledWith({ name: kmsTarget.versionName }, expect.objectContaining({ timeout: expect.any(Number) }));
+    expect(fingerprintService.take).toHaveBeenCalledWith({ batchSize: 2 });
+    expect(fingerprintService.reconcile).toHaveBeenCalledWith(expect.anything(), { batchSize: 2 });
   });
 
   it("leaves a wrap naming a key version the console does not control untouched", async () => {
     const foreign = await storedKey(randomBytes(32), {}, "other-key.v1");
     const ours = await storedKey();
-    const { service, kmsClient, writtenRows } = setup({ rows: [foreign, ours] });
+    const { service, kmsClient, writtenRows, logger } = setup({ rows: [foreign, ours] });
 
     const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
 
     expect(result.unwrap()).toMatchObject({ skippedForeignWrap: 1, usersReWrapped: 1 });
     expect(writtenRows.map(row => row.id)).toEqual([ours.id]);
     expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith({ event: "KEY_ROTATION_FOREIGN_WRAP_SKIPPED", dataKeyId: foreign.id, wrappedByKid: "other-key.v1" });
+  });
+
+  it("steps over an unreadable wrapped key, moves its batch mates and fails the run", async () => {
+    const corrupted = { ...(await storedKey()), wrappedKey: "not-a-jwe" };
+    const { service, writtenRows, logger } = setup({ rows: [corrupted, await storedKey()] });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.val).toMatchObject({ reason: "1 data keys could not be re-wrapped", report: { failed: 1, usersReWrapped: 1 } });
+    expect(writtenRows.map(row => row.id)).not.toContain(corrupted.id);
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_DATA_KEY_FAILED", dataKeyId: corrupted.id }));
+  });
+
+  it("states both refusals when a key could not be re-wrapped and a stored secret changed", async () => {
+    const { service } = setup({ rows: [{ ...(await storedKey()), wrappedKey: "not-a-jwe" }], unexplained: ["deployment-setting-7"] });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.val).toMatchObject({
+      reason: "1 stored secrets changed with no write of their own behind them; 1 data keys could not be re-wrapped"
+    });
+  });
+
+  it("counts what a run would move without opening or writing anything", async () => {
+    const { service, kmsClient, writtenRows, txService } = setup({ rows: await Promise.all([storedKey(), storedKey()]) });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: true });
+
+    expect(result.unwrap()).toMatchObject({ wouldReWrap: 2, usersReWrapped: 0, bytesRewritten: 0 });
+    expect(writtenRows).toEqual([]);
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+    expect(txService.transaction).not.toHaveBeenCalled();
+  });
+
+  it("stops after a batch that could not be written, and reports it rolled back whole", async () => {
+    const { service, logger, txService } = setup({ rows: await Promise.all([storedKey(), storedKey()]), writeFailsOnCall: 1 });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, batchSize: 1, dryRun: false });
+
+    expect(result.val).toMatchObject({ reason: "A batch of data keys could not be written, and was rolled back whole" });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_BATCH_FAILED" }));
+    expect(txService.transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not count a data key another writer moved onto the target first", async () => {
+    const { service, logger } = setup({ rows: [await storedKey()], writeMovesNothing: true });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.unwrap()).toMatchObject({ usersReWrapped: 0, bytesRewritten: 0, fromVersions: {} });
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_BATCH", reWrapped: 0 }));
   });
 
   it("fails the run and names the deployment when a stored secret changed with no write behind it", async () => {
@@ -119,8 +219,11 @@ describe(DataKeyRotationService.name, () => {
       "KEY_ROTATION_FINGERPRINT_TAKEN",
       "KEY_ROTATION_COMPLETED"
     ]);
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_FINGERPRINT_TAKEN", phase: "before" }));
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_FINGERPRINT_TAKEN", phase: "after" }));
     expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_BATCH", rowCount: 2, reWrapped: 2 }));
     expect(logger.info).toHaveBeenCalledWith({ event: "KEY_ROTATION_COMPLETED", report: result.unwrap() });
+    expect(logger.error).not.toHaveBeenCalled();
   });
 
   async function storedKey(dataKey = randomBytes(32), claims: Record<string, string> = {}, kid = PREVIOUS_KID): Promise<DataKeyOutput> {
@@ -131,22 +234,41 @@ describe(DataKeyRotationService.name, () => {
     return { id: randomUUID(), userId: randomUUID(), wrappedKey, wrappedByKid: kid, createdAt: new Date(), updatedAt: new Date() };
   }
 
+  function rejectionWithStatus(code: number) {
+    return Object.assign(new Error("rejected by the key service"), { code });
+  }
+
   async function openUnderTarget(wrappedKey: string) {
     const { plaintext } = await compactDecrypt(wrappedKey, keyPairs.get(TARGET_VERSION)!.privateKey);
 
     return Buffer.from(plaintext);
   }
 
-  function setup(input?: { rows?: DataKeyOutput[]; targetVersionState?: "DISABLED" | "DESTROYED"; unexplained?: string[]; ownerRewritten?: number }) {
+  function setup(input?: {
+    rows?: DataKeyOutput[];
+    targetVersionState?: "DISABLED" | "DESTROYED";
+    targetVersionError?: unknown;
+    sealingKeyUnavailable?: boolean;
+    writeFailsOnCall?: number;
+    writeMovesNothing?: boolean;
+    unexplained?: string[];
+    ownerRewritten?: number;
+  }) {
     const rows = input?.rows ?? [];
     const writtenRows: Array<{ id: string; wrappedKey: string; wrappedByKid: string; wrappedUnder: string }> = [];
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger: CreateLogger = (options = {}) => (options.context === DataKeyRotationService.name ? logger : mock<ReturnType<CreateLogger>>());
     const kmsClient = mock<SdlSecretsKmsClient>();
 
-    kmsClient.getCryptoKeyVersion.mockImplementation(async ({ name }) => [{ name, state: input?.targetVersionState ?? "ENABLED" }]);
+    kmsClient.getCryptoKeyVersion.mockImplementation(async ({ name }) => {
+      if (input?.targetVersionError) throw input.targetVersionError;
+
+      return [{ name, state: input?.targetVersionState ?? "ENABLED" }];
+    });
 
     kmsClient.getPublicKey.mockImplementation(async ({ name }) => {
+      if (input?.sealingKeyUnavailable) throw new Error("key service unreachable");
+
       const pem = keyPairOf(name).publicKey.export({ type: "spki", format: "pem" }).toString();
 
       return [{ name, pem, pemCrc32c: { value: String(crc32c.calculate(pem)) }, algorithm: "RSA_DECRYPT_OAEP_3072_SHA256" }];
@@ -170,7 +292,13 @@ describe(DataKeyRotationService.name, () => {
         yield remaining.slice(start, start + batchSize);
       }
     });
+    let writes = 0;
     dataKeyRepository.rewrapIfStillWrappedUnder.mockImplementation(async rewrap => {
+      writes += 1;
+
+      if (writes === input?.writeFailsOnCall) throw new Error("connection lost");
+      if (input?.writeMovesNothing) return false;
+
       writtenRows.push(rewrap);
 
       return true;
@@ -202,6 +330,6 @@ describe(DataKeyRotationService.name, () => {
       createLogger
     );
 
-    return { service, dataKeyRepository, fingerprintService, kmsClient, writtenRows, logger };
+    return { service, dataKeyRepository, fingerprintService, kmsClient, kmsTarget, txService, writtenRows, logger };
   }
 });

--- a/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.spec.ts
@@ -98,6 +98,14 @@ describe(DataKeyRotationService.name, () => {
     expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_FINGERPRINT_MISMATCH", deploymentSettingIds: ["deployment-setting-7"] }));
   });
 
+  it("tolerates a user rewriting their own secrets while the run is in flight", async () => {
+    const { service } = setup({ rows: [await storedKey()], ownerRewritten: 1 });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.unwrap()).toMatchObject({ concurrentSecretWrites: 1, secretsReEncrypted: 0, usersReWrapped: 1 });
+  });
+
   it("emits a start, both fingerprints, a batch event per batch and a completion carrying the report", async () => {
     const { service, logger } = setup({ rows: await Promise.all([storedKey(), storedKey(), storedKey()]) });
 
@@ -129,7 +137,7 @@ describe(DataKeyRotationService.name, () => {
     return Buffer.from(plaintext);
   }
 
-  function setup(input?: { rows?: DataKeyOutput[]; targetVersionState?: "DISABLED" | "DESTROYED"; unexplained?: string[] }) {
+  function setup(input?: { rows?: DataKeyOutput[]; targetVersionState?: "DISABLED" | "DESTROYED"; unexplained?: string[]; ownerRewritten?: number }) {
     const rows = input?.rows ?? [];
     const writtenRows: Array<{ id: string; wrappedKey: string; wrappedByKid: string; wrappedUnder: string }> = [];
     const logger = mock<ReturnType<CreateLogger>>();
@@ -175,7 +183,7 @@ describe(DataKeyRotationService.name, () => {
     fingerprintService.reconcile.mockResolvedValue({
       before: fingerprint,
       after: fingerprint,
-      ownerRewritten: 0,
+      ownerRewritten: input?.ownerRewritten ?? 0,
       created: 0,
       removed: 0,
       unexplained: input?.unexplained ?? []

--- a/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.spec.ts
+++ b/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.spec.ts
@@ -1,0 +1,199 @@
+import type { protos } from "@google-cloud/kms";
+import crc32c from "fast-crc32c";
+import { compactDecrypt, CompactEncrypt, decodeProtectedHeader } from "jose";
+import { constants, generateKeyPairSync, privateDecrypt, randomBytes, randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import type { TxService } from "@src/core/services";
+import type { SdlSecretsKmsClient } from "@src/deployment/providers/kms.provider";
+import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import type { StoredSecretFingerprintService } from "@src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service";
+import type { DataKeyOutput } from "@src/secret/repositories/data-key/data-key.repository";
+import type { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyRotationService } from "./data-key-rotation.service";
+
+import { createTestSdlSecretsKmsTarget } from "@test/mocks/sdl-secrets-kms.mock";
+
+const TARGET_VERSION = "2";
+const TARGET_KID = "sdl-secrets.v2";
+const PREVIOUS_KID = "sdl-secrets.v1";
+
+const keyPairs = new Map(["1", TARGET_VERSION].map(version => [version, generateKeyPairSync("rsa", { modulusLength: 3072 })]));
+
+function keyPairOf(version: string) {
+  return keyPairs.get(version.split("/").pop()!)!;
+}
+
+describe(DataKeyRotationService.name, () => {
+  it("refuses a target version that is not the one the console wraps under", async () => {
+    const { service, fingerprintService, kmsClient } = setup();
+
+    const result = await service.rotate({ targetVersion: "3", dryRun: false });
+
+    expect(result.err).toBe(true);
+    expect(fingerprintService.take).not.toHaveBeenCalled();
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("refuses a target version the key service reports as anything but enabled", async () => {
+    const { service, fingerprintService, kmsClient, dataKeyRepository } = setup({ targetVersionState: "DISABLED" });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.err).toBe(true);
+    expect(fingerprintService.take).not.toHaveBeenCalled();
+    expect(dataKeyRepository.rewrapIfStillWrappedUnder).not.toHaveBeenCalled();
+    expect(kmsClient.asymmetricDecrypt).not.toHaveBeenCalled();
+  });
+
+  it("re-wraps the same key bytes onto the target version, carrying every other claim", async () => {
+    const dataKey = randomBytes(32);
+    const stored = await storedKey(dataKey, { sub: "user-42" });
+    const { service, writtenRows } = setup({ rows: [stored] });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    const rewrapped = writtenRows[0];
+    expect(result.ok).toBe(true);
+    expect(rewrapped.wrappedByKid).toBe(TARGET_KID);
+    expect(rewrapped.wrappedUnder).toBe(PREVIOUS_KID);
+    expect(rewrapped.wrappedKey).not.toBe(stored.wrappedKey);
+    expect(decodeProtectedHeader(rewrapped.wrappedKey)).toEqual({ ...decodeProtectedHeader(stored.wrappedKey), kid: TARGET_KID });
+    expect(await openUnderTarget(rewrapped.wrappedKey)).toEqual(dataKey);
+  });
+
+  it("spends one key-service unwrap per row and one public key fetch for the whole run", async () => {
+    const rows = await Promise.all([storedKey(), storedKey(), storedKey()]);
+    const { service, kmsClient } = setup({ rows });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, batchSize: 2, dryRun: false });
+
+    expect(result.unwrap().usersReWrapped).toBe(3);
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(3);
+    expect(kmsClient.getPublicKey).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves a wrap naming a key version the console does not control untouched", async () => {
+    const foreign = await storedKey(randomBytes(32), {}, "other-key.v1");
+    const ours = await storedKey();
+    const { service, kmsClient, writtenRows } = setup({ rows: [foreign, ours] });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.unwrap()).toMatchObject({ skippedForeignWrap: 1, usersReWrapped: 1 });
+    expect(writtenRows.map(row => row.id)).toEqual([ours.id]);
+    expect(kmsClient.asymmetricDecrypt).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails the run and names the deployment when a stored secret changed with no write behind it", async () => {
+    const { service, logger } = setup({ rows: [await storedKey()], unexplained: ["deployment-setting-7"] });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, dryRun: false });
+
+    expect(result.err).toBe(true);
+    expect(result.val).toMatchObject({ report: { secretsReEncrypted: 1, usersReWrapped: 1 } });
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_FINGERPRINT_MISMATCH", deploymentSettingIds: ["deployment-setting-7"] }));
+  });
+
+  it("emits a start, both fingerprints, a batch event per batch and a completion carrying the report", async () => {
+    const { service, logger } = setup({ rows: await Promise.all([storedKey(), storedKey(), storedKey()]) });
+
+    const result = await service.rotate({ targetVersion: TARGET_VERSION, batchSize: 2, dryRun: false });
+
+    expect((logger.info.mock.calls as Array<[{ event: string }]>).map(([payload]) => payload.event)).toEqual([
+      "KEY_ROTATION_STARTED",
+      "KEY_ROTATION_FINGERPRINT_TAKEN",
+      "KEY_ROTATION_BATCH",
+      "KEY_ROTATION_BATCH",
+      "KEY_ROTATION_FINGERPRINT_TAKEN",
+      "KEY_ROTATION_COMPLETED"
+    ]);
+    expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ event: "KEY_ROTATION_BATCH", rowCount: 2, reWrapped: 2 }));
+    expect(logger.info).toHaveBeenCalledWith({ event: "KEY_ROTATION_COMPLETED", report: result.unwrap() });
+  });
+
+  async function storedKey(dataKey = randomBytes(32), claims: Record<string, string> = {}, kid = PREVIOUS_KID): Promise<DataKeyOutput> {
+    const wrappedKey = await new CompactEncrypt(dataKey)
+      .setProtectedHeader({ alg: "RSA-OAEP-256", enc: "A256GCM", ...claims, kid })
+      .encrypt(keyPairOf(kid.endsWith(TARGET_VERSION) ? TARGET_VERSION : "1").publicKey);
+
+    return { id: randomUUID(), userId: randomUUID(), wrappedKey, wrappedByKid: kid, createdAt: new Date(), updatedAt: new Date() };
+  }
+
+  async function openUnderTarget(wrappedKey: string) {
+    const { plaintext } = await compactDecrypt(wrappedKey, keyPairs.get(TARGET_VERSION)!.privateKey);
+
+    return Buffer.from(plaintext);
+  }
+
+  function setup(input?: { rows?: DataKeyOutput[]; targetVersionState?: "DISABLED" | "DESTROYED"; unexplained?: string[] }) {
+    const rows = input?.rows ?? [];
+    const writtenRows: Array<{ id: string; wrappedKey: string; wrappedByKid: string; wrappedUnder: string }> = [];
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger: CreateLogger = (options = {}) => (options.context === DataKeyRotationService.name ? logger : mock<ReturnType<CreateLogger>>());
+    const kmsClient = mock<SdlSecretsKmsClient>();
+
+    kmsClient.getCryptoKeyVersion.mockImplementation(async ({ name }) => [{ name, state: input?.targetVersionState ?? "ENABLED" }]);
+
+    kmsClient.getPublicKey.mockImplementation(async ({ name }) => {
+      const pem = keyPairOf(name).publicKey.export({ type: "spki", format: "pem" }).toString();
+
+      return [{ name, pem, pemCrc32c: { value: String(crc32c.calculate(pem)) }, algorithm: "RSA_DECRYPT_OAEP_3072_SHA256" }];
+    });
+
+    kmsClient.asymmetricDecrypt.mockImplementation(async ({ name, ciphertext }) => {
+      const plaintext = privateDecrypt({ key: keyPairOf(name).privateKey, padding: constants.RSA_PKCS1_OAEP_PADDING, oaepHash: "sha256" }, ciphertext);
+
+      return [
+        { plaintext, plaintextCrc32c: { value: String(crc32c.calculate(plaintext)) }, verifiedCiphertextCrc32c: true } satisfies protos.google.cloud.kms.v1.IAsymmetricDecryptResponse
+      ];
+    });
+
+    const kmsTarget = createTestSdlSecretsKmsTarget({ client: kmsClient, version: TARGET_VERSION });
+    const dataKeyRepository = mock<DataKeyRepository>();
+
+    dataKeyRepository.findNotWrappedUnderIteratively.mockImplementation(async function* ({ batchSize }) {
+      const remaining = rows.filter(row => !writtenRows.some(written => written.id === row.id));
+
+      for (let start = 0; start < remaining.length; start += batchSize) {
+        yield remaining.slice(start, start + batchSize);
+      }
+    });
+    dataKeyRepository.rewrapIfStillWrappedUnder.mockImplementation(async rewrap => {
+      writtenRows.push(rewrap);
+
+      return true;
+    });
+    dataKeyRepository.countByWrappingVersion.mockResolvedValue({ [TARGET_KID]: rows.length });
+
+    const fingerprintService = mock<StoredSecretFingerprintService>();
+    const fingerprint = { digest: "d", rowCount: 0, byteTotal: 0 };
+    fingerprintService.take.mockResolvedValue({ fingerprint, tokens: new Map(), takenAtMarker: "marker" });
+    fingerprintService.reconcile.mockResolvedValue({
+      before: fingerprint,
+      after: fingerprint,
+      ownerRewritten: 0,
+      created: 0,
+      removed: 0,
+      unexplained: input?.unexplained ?? []
+    });
+
+    const txService = mock<TxService>();
+    txService.transaction.mockImplementation(async run => await run());
+
+    const service = new DataKeyRotationService(
+      dataKeyRepository,
+      fingerprintService,
+      new KmsWrappedJweService(kmsTarget),
+      new SdlSecretsSealingKeyService(kmsTarget, createLogger),
+      txService,
+      kmsTarget,
+      createLogger
+    );
+
+    return { service, dataKeyRepository, fingerprintService, kmsClient, writtenRows, logger };
+  }
+});

--- a/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.ts
+++ b/apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.ts
@@ -1,0 +1,316 @@
+import { grpc } from "google-gax";
+import type { CompactJWEHeaderParameters } from "jose";
+import { CompactEncrypt } from "jose";
+import { Err, Ok, Result } from "ts-results";
+import { inject, singleton } from "tsyringe";
+
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { TxService } from "@src/core/services";
+import type { DryRunOptions } from "@src/core/types/console";
+import type { SdlSecretsKmsTarget } from "@src/deployment/providers/kms.provider";
+import { SDL_SECRETS_KMS_TARGET } from "@src/deployment/providers/kms.provider";
+import { KmsWrappedJweService } from "@src/deployment/services/kms-wrapped-jwe/kms-wrapped-jwe.service";
+import type { SdlSecretsSealingKey } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import { SdlSecretsSealingKeyService } from "@src/deployment/services/sdl-secrets-sealing-key/sdl-secrets-sealing-key.service";
+import type { StoredSecretFingerprint, StoredSecretSnapshot } from "@src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service";
+import { StoredSecretFingerprintService } from "@src/deployment/services/stored-secret-fingerprint/stored-secret-fingerprint.service";
+import { DEFAULT_KEY_ROTATION_BATCH_SIZE, ENABLED_CRYPTO_KEY_VERSION_STATES } from "@src/secret/config/key-rotation.config";
+import type { DataKeyOutput } from "@src/secret/repositories/data-key/data-key.repository";
+import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
+
+export interface RotateDataKeysOptions extends DryRunOptions {
+  targetVersion: string;
+  batchSize?: number;
+}
+
+export interface DataKeyRotationReport {
+  usersReWrapped: number;
+  wouldReWrap: number;
+  secretsReEncrypted: number;
+  concurrentSecretWrites: number;
+  skippedForeignWrap: number;
+  failed: number;
+  bytesRewritten: number;
+  elapsedMs: number;
+  fingerprintBefore: StoredSecretFingerprint;
+  fingerprintAfter: StoredSecretFingerprint;
+  fromVersions: Record<string, number>;
+  toVersion: string;
+  dataKeysByVersion: Record<string, number>;
+}
+
+/** Carries the report alongside the reason, because a run that ends in a refusal is exactly the run whose numbers an operator has to read. */
+export interface DataKeyRotationFailure {
+  reason: string;
+  report?: DataKeyRotationReport;
+}
+
+interface RotationProgress {
+  usersReWrapped: number;
+  wouldReWrap: number;
+  skippedForeignWrap: number;
+  failed: number;
+  bytesRewritten: number;
+  fromVersions: Record<string, number>;
+}
+
+interface PreparedRewrap {
+  row: DataKeyOutput;
+  wrappedKey: string;
+}
+
+function getGrpcStatus(error: unknown) {
+  return error instanceof Error && "code" in error ? error.code : undefined;
+}
+
+/**
+ * Moves every user's data encryption key onto the version the console is configured to wrap under,
+ * by opening each wrap with the version its own header names and sealing the same key bytes to the
+ * target's public key. Nothing a deployment stores is opened or rewritten: a stored secret is sealed
+ * under the data key's identity rather than its wrapping, and the fingerprint taken on either side
+ * of the run is what proves it.
+ */
+@singleton()
+export class DataKeyRotationService {
+  readonly #loggerService: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly dataKeyRepository: DataKeyRepository,
+    private readonly fingerprintService: StoredSecretFingerprintService,
+    private readonly wrappedJweService: KmsWrappedJweService,
+    private readonly sealingKeyService: SdlSecretsSealingKeyService,
+    private readonly txService: TxService,
+    @inject(SDL_SECRETS_KMS_TARGET) private readonly kmsTarget: SdlSecretsKmsTarget,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.#loggerService = createLogger({ context: DataKeyRotationService.name });
+  }
+
+  async rotate(options: RotateDataKeysOptions): Promise<Result<DataKeyRotationReport, DataKeyRotationFailure>> {
+    const startedAt = Date.now();
+    const batchSize = options.batchSize ?? DEFAULT_KEY_ROTATION_BATCH_SIZE;
+
+    this.#loggerService.info({
+      event: "KEY_ROTATION_STARTED",
+      targetVersion: options.targetVersion,
+      toVersion: this.kmsTarget.kid,
+      batchSize,
+      dryRun: options.dryRun
+    });
+
+    const sealingKey = await this.#preflight(options.targetVersion);
+
+    if (sealingKey.err) return Err({ reason: sealingKey.val });
+
+    const before = await this.#takeFingerprint("before", batchSize);
+    const progress: RotationProgress = { usersReWrapped: 0, wouldReWrap: 0, skippedForeignWrap: 0, failed: 0, bytesRewritten: 0, fromVersions: {} };
+    const walked = await this.#reWrapEveryDataKey({ sealingKey: sealingKey.val, batchSize, dryRun: options.dryRun, progress });
+    const report = await this.#reportOn({ before, batchSize, progress, startedAt });
+
+    this.#loggerService.info({ event: "KEY_ROTATION_COMPLETED", report });
+
+    const reason = walked.err ? walked.val : this.#refusalFor(report);
+
+    return reason ? Err({ reason, report }) : Ok(report);
+  }
+
+  /** Reads the target's state and warms its public key before anything is measured or written, so an operator pointed at a version that cannot receive a wrap is refused rather than half-served. */
+  async #preflight(targetVersion: string): Promise<Result<SdlSecretsSealingKey, string>> {
+    if (targetVersion !== this.kmsTarget.version) {
+      this.#loggerService.error({ event: "KEY_ROTATION_TARGET_VERSION_MISMATCH", requested: targetVersion, configured: this.kmsTarget.version });
+
+      return Err(`Requested target version ${targetVersion} is not the configured one, ${this.kmsTarget.version}`);
+    }
+
+    const state = await this.#readTargetVersionState();
+
+    if (state.err) return state;
+
+    if (state.val !== undefined && !ENABLED_CRYPTO_KEY_VERSION_STATES.has(state.val)) {
+      this.#loggerService.error({ event: "KEY_ROTATION_TARGET_VERSION_UNUSABLE", versionName: this.kmsTarget.versionName, state: state.val });
+
+      return Err(`Target key version ${this.kmsTarget.kid} is ${state.val} rather than enabled`);
+    }
+
+    return await this.#warmSealingKey();
+  }
+
+  /** An emulator or a future transport that cannot answer the state at all leaves the refusal to the public key fetch below, which no version that cannot receive a wrap survives either. */
+  async #readTargetVersionState(): Promise<Result<unknown, string>> {
+    try {
+      const [version] = await this.kmsTarget.client.getCryptoKeyVersion({ name: this.kmsTarget.versionName }, { timeout: 5000 });
+
+      return Ok(version.state ?? undefined);
+    } catch (error) {
+      if (getGrpcStatus(error) === grpc.status.UNIMPLEMENTED) {
+        this.#loggerService.warn({ event: "KEY_ROTATION_TARGET_VERSION_STATE_UNAVAILABLE", versionName: this.kmsTarget.versionName });
+
+        return Ok(undefined);
+      }
+
+      this.#loggerService.error({ event: "KEY_ROTATION_TARGET_VERSION_UNREADABLE", versionName: this.kmsTarget.versionName, error });
+
+      return Err(`Target key version ${this.kmsTarget.kid} could not be read from the key service`);
+    }
+  }
+
+  async #warmSealingKey(): Promise<Result<SdlSecretsSealingKey, string>> {
+    try {
+      return Ok(await this.sealingKeyService.getSealingKey());
+    } catch (error) {
+      this.#loggerService.error({ event: "KEY_ROTATION_TARGET_KEY_UNAVAILABLE", versionName: this.kmsTarget.versionName, error });
+
+      return Err(`Target key version ${this.kmsTarget.kid} did not publish a usable key`);
+    }
+  }
+
+  async #takeFingerprint(phase: "before" | "after", batchSize: number): Promise<StoredSecretSnapshot> {
+    const snapshot = await this.fingerprintService.take({ batchSize });
+
+    this.#loggerService.info({ event: "KEY_ROTATION_FINGERPRINT_TAKEN", phase, ...snapshot.fingerprint });
+
+    return snapshot;
+  }
+
+  async #reWrapEveryDataKey(input: {
+    sealingKey: SdlSecretsSealingKey;
+    batchSize: number;
+    dryRun: boolean;
+    progress: RotationProgress;
+  }): Promise<Result<void, string>> {
+    const { sealingKey, batchSize, dryRun, progress } = input;
+
+    for await (const batch of this.dataKeyRepository.findNotWrappedUnderIteratively({ wrappedByKid: this.kmsTarget.kid, batchSize })) {
+      const prepared: PreparedRewrap[] = [];
+
+      for (const row of batch) {
+        const rewrap = await this.#prepareRewrap(row, sealingKey, dryRun, progress);
+
+        if (rewrap) prepared.push(rewrap);
+      }
+
+      const committed = await this.#commitBatch(prepared, progress);
+
+      this.#loggerService.info({
+        event: "KEY_ROTATION_BATCH",
+        rowCount: batch.length,
+        firstId: batch[0].id,
+        lastId: batch[batch.length - 1].id,
+        reWrapped: committed.ok ? committed.val : 0
+      });
+
+      if (committed.err) return committed;
+    }
+
+    return Ok.EMPTY;
+  }
+
+  /** A row that cannot be moved is left out of the write set rather than aborting its batch, so one unreadable key cannot pin its neighbours to the old version on every run from now on. */
+  async #prepareRewrap(row: DataKeyOutput, sealingKey: SdlSecretsSealingKey, dryRun: boolean, progress: RotationProgress): Promise<PreparedRewrap | undefined> {
+    try {
+      const parsed = this.wrappedJweService.parse(row.wrappedKey);
+      const versionName = this.kmsTarget.resolveVersionName(parsed.header.kid);
+
+      if (!versionName) {
+        progress.skippedForeignWrap += 1;
+        this.#loggerService.info({ event: "KEY_ROTATION_FOREIGN_WRAP_SKIPPED", dataKeyId: row.id, wrappedByKid: parsed.header.kid });
+
+        return undefined;
+      }
+
+      if (dryRun) {
+        progress.wouldReWrap += 1;
+
+        return undefined;
+      }
+
+      const dataKey = await this.wrappedJweService.open(parsed, versionName);
+      const wrappedKey = await new CompactEncrypt(dataKey)
+        .setProtectedHeader({ ...parsed.header, kid: this.kmsTarget.kid } as CompactJWEHeaderParameters)
+        .encrypt(sealingKey.publicKey);
+
+      return { row, wrappedKey };
+    } catch (error) {
+      progress.failed += 1;
+      this.#loggerService.error({ event: "KEY_ROTATION_DATA_KEY_FAILED", dataKeyId: row.id, wrappedByKid: row.wrappedByKid, error });
+
+      return undefined;
+    }
+  }
+
+  async #commitBatch(prepared: PreparedRewrap[], progress: RotationProgress): Promise<Result<number, string>> {
+    if (prepared.length === 0) return Ok(0);
+
+    try {
+      const rewrapped = await this.txService.transaction(async () => {
+        const written: PreparedRewrap[] = [];
+
+        for (const rewrap of prepared) {
+          const moved = await this.dataKeyRepository.rewrapIfStillWrappedUnder({
+            id: rewrap.row.id,
+            wrappedUnder: rewrap.row.wrappedByKid,
+            wrappedKey: rewrap.wrappedKey,
+            wrappedByKid: this.kmsTarget.kid
+          });
+
+          if (moved) written.push(rewrap);
+        }
+
+        return written;
+      });
+
+      for (const { row, wrappedKey } of rewrapped) {
+        progress.usersReWrapped += 1;
+        progress.bytesRewritten += Buffer.byteLength(wrappedKey, "utf8");
+        progress.fromVersions[row.wrappedByKid] = (progress.fromVersions[row.wrappedByKid] ?? 0) + 1;
+      }
+
+      return Ok(rewrapped.length);
+    } catch (error) {
+      this.#loggerService.error({ event: "KEY_ROTATION_BATCH_FAILED", firstId: prepared[0].row.id, error });
+
+      return Err("A batch of data keys could not be written, and was rolled back whole");
+    }
+  }
+
+  async #reportOn(input: {
+    before: StoredSecretSnapshot;
+    batchSize: number;
+    progress: RotationProgress;
+    startedAt: number;
+  }): Promise<DataKeyRotationReport> {
+    const reconciliation = await this.fingerprintService.reconcile(input.before, { batchSize: input.batchSize });
+
+    this.#loggerService.info({ event: "KEY_ROTATION_FINGERPRINT_TAKEN", phase: "after", ...reconciliation.after });
+
+    if (reconciliation.unexplained.length > 0) {
+      this.#loggerService.error({ event: "KEY_ROTATION_FINGERPRINT_MISMATCH", deploymentSettingIds: reconciliation.unexplained });
+    }
+
+    return {
+      ...input.progress,
+      secretsReEncrypted: reconciliation.unexplained.length,
+      concurrentSecretWrites: reconciliation.ownerRewritten,
+      elapsedMs: Date.now() - input.startedAt,
+      fingerprintBefore: reconciliation.before,
+      fingerprintAfter: reconciliation.after,
+      toVersion: this.kmsTarget.kid,
+      dataKeysByVersion: await this.dataKeyRepository.countByWrappingVersion()
+    };
+  }
+
+  /** Both refusals are stated, because a run can have stepped over an unreadable key and found a stored secret changed, and the second is what the whole procedure exists to catch. */
+  #refusalFor(report: DataKeyRotationReport) {
+    const refusals: string[] = [];
+
+    if (report.secretsReEncrypted > 0) {
+      refusals.push(`${report.secretsReEncrypted} stored secrets changed with no write of their own behind them`);
+    }
+
+    if (report.failed > 0) {
+      refusals.push(`${report.failed} data keys could not be re-wrapped`);
+    }
+
+    return refusals.length > 0 ? refusals.join("; ") : undefined;
+  }
+}


### PR DESCRIPTION
## Why

Part of CON-876 — https://linear.app/ovrclk/issue/CON-876/re-wrap-data-keys-onto-the-target-key-version-verified-by-fingerprint

Adding a KMS key version buys nothing on its own: every existing data key stays wrapped under the old version, so that version can never be retired. This is the step that makes retiring one possible.

It is also the step with the most dangerous neighbours — re-wrapping opens a wrapped key and writes a new one, right next to the sealed secrets it must never read or rewrite. So the command proves it did not touch them, by a fingerprint taken before and after and reconciled per row, rather than by design argument.

Slice 2 of 2, stacked on `fix/user-re-wrap-data-keys-onto` (the fingerprint instrument). Not `Closes`, because the issue is done only once the whole stack reaches `main`.

## What

An operator-only console command. No HTTP route, by design: rotation must not be reachable from the internet-facing surface.

```bash
# the console is already configured at GCP_KMS_KEY_VERSION=2
node dist/console.js rotate-data-keys --target-version 2 --batch-size 200
```

It refuses before reading anything unless `--target-version` is the version this console itself wraps under **and** the key service reports that version as `ENABLED`. Then it walks `data_keys` in id order, opens each wrap under the version its own header names, and seals the identical key bytes to the target's cached public key — every header claim carried across except `kid`. One key-service call per row (the unwrap); the re-wrap is local.

```
{"event":"KEY_ROTATION_COMPLETED","report":{
  "usersReWrapped":5,"secretsReEncrypted":0,"concurrentSecretWrites":0,
  "skippedForeignWrap":0,"failed":0,"bytesRewritten":3395,
  "fromVersions":{"sdl-secrets.v1":5},"toVersion":"sdl-secrets.v2",
  "dataKeysByVersion":{"sdl-secrets.v2":5},
  "fingerprintBefore":{"digest":"…","rowCount":5,"byteTotal":1288},
  "fingerprintAfter":{"digest":"…","rowCount":5,"byteTotal":1288}}}
```

The same run, asserted against a real database and two enabled emulator key versions:

```ts
const result = await rotationAt(newVersion).rotate({ targetVersion: newVersion, batchSize: 2, dryRun: false });

const report = result.unwrap();
expect(report).toMatchObject({
  usersReWrapped: 5,
  secretsReEncrypted: 0,
  fromVersions: { "sdl-secrets.v1": 5 },
  toVersion: "sdl-secrets.v2",
  dataKeysByVersion: { "sdl-secrets.v2": 5 }
});
expect(report.fingerprintAfter).toEqual(report.fingerprintBefore);
expect(await storedSecretsOf(users)).toEqual(secretsBefore);
expect(await user.openStoredSecretsAt(newVersion)).toEqual(user.secrets);
```

**Decisions worth a reviewer's eye**

- **Keyset selection, not offset paging.** Every committed batch removes its own rows from the predicate, so an offset walked forward would step over as many rows as it moved — silently, while reporting success.
- **Row-level containment inside a per-batch transaction.** A row that cannot be parsed, opened, or whose `kid` names a key this console does not control, drops out of its batch's write set; the batch's healthy rows still commit and the run ends in `Err`. Under whole-batch rollback one corrupt row would pin up to `batchSize - 1` healthy keys to the old version on every future run — and the old version could never be destroyed, which is the whole point.
- **The write is guarded on the wrapping it opened** (`id = :id and wrapped_by_kid = :originalKid`), so a concurrent writer is never clobbered. It does not go through `BaseRepository.updateById`, which does not bump `updated_at` (drizzle drops the snake_case key — noted for a separate fix).
- **Unwraps go through `KmsWrappedJweService` directly, never `DataKeyUnwrapperService`**, which caches every unwrapped key on the execution context — and the CLI runs the whole command body in one context. A whole-fleet run would otherwise hold every user's plaintext data key in one map, on a command whose purpose is bounding key exposure.
- **A refused run still returns its report** (`Result<Report, { reason, report? }>`), because a run that ends in a refusal is exactly the one whose numbers an operator needs.
- **A dry run is a counting run**: preflight, both fingerprints, per-row classification, no unwrap and no write. The Spec does not say what `--dry-run` does; this follows every other `--dry-run` in `console.ts`.

**Files**

| | |
|---|---|
| `secret/services/data-key-rotation/` | the service, its unit spec and its integration suite |
| `secret/controllers/data-key-rotation/` | thin controller the CLI resolves |
| `secret/repositories/data-key/` | keyset sweep, guarded re-wrap, grouped count per version |
| `secret/config/key-rotation.config.ts` | default batch size, enabled-state set |
| `deployment/providers/kms.provider.ts` | `getCryptoKeyVersion` on the narrowed client; the target carries its own version |
| `app/console.ts` | the `rotate-data-keys` command |

No schema change and no migration: `data_keys.wrapped_by_kid` and its index already exist.

**Verified** — `apps/api`: `npm test` ✅, `npm run lint -- --quiet` ✅, `npx tsc --noEmit` ✅ (897 changes). The integration suite runs against the real PostgreSQL and the real Cloud KMS emulator with two enabled versions; the unit spec drives real RSA-3072 keypairs through a doubled KMS client.

## Demo

Every block below is executable and was re-verified end to end.

### Re-wrapping every data key onto a new KMS key version

*2026-09-11T20:18:38Z by Showboat 0.6.1*

An operator has added a new version to the console's Cloud KMS key and raised `GCP_KMS_KEY_VERSION` to it. Every user's data encryption key is still wrapped under the **old** version, so that version can never be retired. This slice adds the command that moves them.

The dangerous part is the neighbourhood: re-wrapping opens a wrapped key and writes a new one, right next to the sealed secrets of every deployment — which the rotation must never read or rewrite. So the command proves it rather than arguing it: it fingerprints every stored token before and after, and reconciles the two per row.

Everything below is the **real compiled console CLI** (`dist/console.js`, what `npm run console` runs) against a **real PostgreSQL database** and the **real Cloud KMS emulator** this repository already uses for its integration tests. Nothing is mocked.

```bash
cd apps/api && npm run build:app > /dev/null 2>&1 && ls dist/console.js
```

```output
dist/console.js
```

The command is reachable only through the console CLI — there is no HTTP route for it, by design. Here is its surface:

```bash
cd apps/api && node dist/console.js rotate-data-keys --help 2>&1 | grep -v "Failed to find Response" | grep -v "\"context\":\"ENV\""
```

```output
Usage: API Console rotate-data-keys [options]

Re-wrap every user's data key onto the configured KMS key version, proving no
stored secret changed

Options:
  -t, --target-version <version>  The key version to move data keys onto, which
                                  must be the one this console is configured to
                                  wrap under
  -b, --batch-size <number>       How many data keys are written per
                                  transaction
  -d, --dry-run                   Log what would be re-wrapped without opening
                                  or writing anything (default: false)
  -h, --help                      display help for command
```

### The fleet before the rotation

Five users, each holding one data encryption key wrapped under key version **1**, and each with one deployment whose secrets are sealed under that data key. The database is thrown away and rebuilt from the project's own migrations first.

```bash
cd apps/api && node --require reflect-metadata --import tsx ../../.work/con-876-re-wrap-data-keys-onto/demo-2.ts prepare 2>&1 | grep -v "Failed to find Response"
```

```output
database con876_rotation_demo created and migrated
```

```bash
cd apps/api && node --require reflect-metadata --import tsx ../../.work/con-876-re-wrap-data-keys-onto/demo-2.ts seed 2>&1 | grep -v "Failed to find Response"
```

```output
seeded 5 users, each holding one data key and one deployment whose secrets are sealed under it

the fleet as seeded:
  {"user":"alice","wrapped_by_kid":"sdl-secrets.v1","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v1"},"stored token unchanged":true,"secrets open to":{"TOKEN":"alice-token-value"},"same data key bytes":true}
  {"user":"bob","wrapped_by_kid":"sdl-secrets.v1","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v1"},"stored token unchanged":true,"secrets open to":{"TOKEN":"bob-token-value"},"same data key bytes":true}
  {"user":"carol","wrapped_by_kid":"sdl-secrets.v1","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v1"},"stored token unchanged":true,"secrets open to":{"TOKEN":"carol-token-value"},"same data key bytes":true}
  {"user":"dan","wrapped_by_kid":"sdl-secrets.v1","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v1"},"stored token unchanged":true,"secrets open to":{"TOKEN":"dan-token-value"},"same data key bytes":true}
  {"user":"erin","wrapped_by_kid":"sdl-secrets.v1","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v1"},"stored token unchanged":true,"secrets open to":{"TOKEN":"erin-token-value"},"same data key bytes":true}
```

Two things to notice already. Each wrapped key's own protected header names the version that wrapped it (`kid: sdl-secrets.v1`), and the denormalised `wrapped_by_kid` column agrees with it. And the secrets **open** — even though this console is already configured at version **2**: a read follows the header, never the configured version. That is what makes a half-finished rotation a working system.

### Two ways the run refuses before touching anything

First, a `--target-version` that is not the version this console wraps under. Moving the fleet onto a version the running API does not itself wrap new keys under would mean the fleet never converges, so the command refuses rather than half-serving.

```bash
cd apps/api && W=../../.work/con-876-re-wrap-data-keys-onto; node --env-file=$W/demo-2.env dist/console.js rotate-data-keys --target-version 1 > $W/run.log 2>&1; echo "exit code: $?"; grep "^{" $W/run.log | jq -s -c -f $W/events.jq
```

```output
exit code: 1
{"event":"KEY_ROTATION_STARTED","targetVersion":"1","toVersion":"sdl-secrets.v2","batchSize":100,"dryRun":false}
{"event":"KEY_ROTATION_TARGET_VERSION_MISMATCH","requested":"1","configured":"2"}
{"event":"COMMAND_ERROR","refused":"Requested target version 1 is not the configured one, 2"}
```

No fingerprint was taken and no row was read: the run stops at the first event. The exit code is 1, which is how a cron or an operator's shell finds out.

Second, a target version the key service does not report as enabled. A fresh version is minted on the emulator and disabled, and the console is pointed at it. That version's number differs on every run, so it is masked below — everything else is verbatim.

```bash
cd apps/api && node --require reflect-metadata --import tsx ../../.work/con-876-re-wrap-data-keys-onto/demo-2.ts disable-fresh-version 2>&1 | grep -v "Failed to find Response"
```

```output
minted a fresh key version and disabled it; the key service now reports it as DISABLED
```

```bash
cd apps/api && W=../../.work/con-876-re-wrap-data-keys-onto; V=$(cat $W/disabled.version); node --env-file=$W/demo-2-disabled.env dist/console.js rotate-data-keys --target-version "$V" > $W/run.log 2>&1; echo "exit code: $?"; grep "^{" $W/run.log | jq -s -c -f $W/events.jq | sed -e "s/\.v$V/.v<fresh>/g" -e "s/\b$V\b/<fresh>/g"
```

```output
exit code: 1
{"event":"KEY_ROTATION_STARTED","targetVersion":"<fresh>","toVersion":"sdl-secrets.v<fresh>","batchSize":100,"dryRun":false}
{"event":"KEY_ROTATION_TARGET_VERSION_UNUSABLE","versionName":"projects/console-dev-mock/locations/global/keyRings/console-api/cryptoKeys/sdl-secrets/cryptoKeyVersions/<fresh>","state":"DISABLED"}
{"event":"COMMAND_ERROR","refused":"Target key version sdl-secrets.v<fresh> is DISABLED rather than enabled"}
```

Again: refused before the first fingerprint, exit code 1. The state came from the key service itself — the emulator answers `GetCryptoKeyVersion` with `DISABLED`.

### A dry run first

`--dry-run` says what would move without opening or writing anything. It still takes both fingerprints and still walks the fleet in batches; it just never spends a key-service unwrap and never writes a row.

```bash
cd apps/api && W=../../.work/con-876-re-wrap-data-keys-onto; node --env-file=$W/demo-2.env dist/console.js rotate-data-keys --target-version 2 --batch-size 2 --dry-run > $W/run.log 2>&1; echo "exit code: $?"; grep "^{" $W/run.log | jq -s -c -f $W/events.jq
```

```output
exit code: 0
{"event":"KEY_ROTATION_STARTED","targetVersion":"2","toVersion":"sdl-secrets.v2","batchSize":2,"dryRun":true}
{"event":"KEY_ROTATION_FINGERPRINT_TAKEN","phase":"before","digest":"sha256#1","rowCount":5,"byteTotal":1288}
{"event":"KEY_ROTATION_BATCH","rowCount":2,"reWrapped":0}
{"event":"KEY_ROTATION_BATCH","rowCount":2,"reWrapped":0}
{"event":"KEY_ROTATION_BATCH","rowCount":1,"reWrapped":0}
{"event":"KEY_ROTATION_FINGERPRINT_TAKEN","phase":"after","digest":"sha256#1","rowCount":5,"byteTotal":1288}
{"event":"KEY_ROTATION_COMPLETED","report":{"usersReWrapped":0,"wouldReWrap":5,"skippedForeignWrap":0,"failed":0,"bytesRewritten":0,"fromVersions":{},"secretsReEncrypted":0,"concurrentSecretWrites":0,"fingerprintBefore":{"digest":"sha256#1","rowCount":5,"byteTotal":1288},"fingerprintAfter":{"digest":"sha256#1","rowCount":5,"byteTotal":1288},"toVersion":"sdl-secrets.v2","dataKeysByVersion":{"sdl-secrets.v1":5}}}
{"event":"COMMAND_END"}
```

`wouldReWrap: 5`, `usersReWrapped: 0`, `bytesRewritten: 0`, and `dataKeysByVersion` still shows all five on `sdl-secrets.v1`.

A note on reading the digests below: the sealed tokens are real ciphertext, so their sha256 differs on every seeding. The filter over the log replaces each distinct digest with a stable label, so `sha256#1` appearing twice means *the same digest twice*. Row counts and byte totals are printed as they are.

### The rotation

Five data keys, two per transaction.

```bash
cd apps/api && W=../../.work/con-876-re-wrap-data-keys-onto; node --env-file=$W/demo-2.env dist/console.js rotate-data-keys --target-version 2 --batch-size 2 > $W/run.log 2>&1; echo "exit code: $?"; grep "^{" $W/run.log | jq -s -c -f $W/events.jq
```

```output
exit code: 0
{"event":"KEY_ROTATION_STARTED","targetVersion":"2","toVersion":"sdl-secrets.v2","batchSize":2,"dryRun":false}
{"event":"KEY_ROTATION_FINGERPRINT_TAKEN","phase":"before","digest":"sha256#1","rowCount":5,"byteTotal":1288}
{"event":"KEY_ROTATION_BATCH","rowCount":2,"reWrapped":2}
{"event":"KEY_ROTATION_BATCH","rowCount":2,"reWrapped":2}
{"event":"KEY_ROTATION_BATCH","rowCount":1,"reWrapped":1}
{"event":"KEY_ROTATION_FINGERPRINT_TAKEN","phase":"after","digest":"sha256#1","rowCount":5,"byteTotal":1288}
{"event":"KEY_ROTATION_COMPLETED","report":{"usersReWrapped":5,"wouldReWrap":0,"skippedForeignWrap":0,"failed":0,"bytesRewritten":3395,"fromVersions":{"sdl-secrets.v1":5},"secretsReEncrypted":0,"concurrentSecretWrites":0,"fingerprintBefore":{"digest":"sha256#1","rowCount":5,"byteTotal":1288},"fingerprintAfter":{"digest":"sha256#1","rowCount":5,"byteTotal":1288},"toVersion":"sdl-secrets.v2","dataKeysByVersion":{"sdl-secrets.v2":5}}}
{"event":"COMMAND_END"}
```

Batches of 2, 2 and 1 — `--batch-size` is what partitions them, and each batch is its own transaction. Five users re-wrapped, `secretsReEncrypted: 0`, and the two fingerprints are the same digest over the same 5 rows and the same 1288 bytes. `dataKeysByVersion` has moved wholesale from `sdl-secrets.v1` to `sdl-secrets.v2`, which is the answer to "may I destroy version 1 now".

And the fleet itself:

```bash
cd apps/api && node --require reflect-metadata --import tsx ../../.work/con-876-re-wrap-data-keys-onto/demo-2.ts state "after the rotation" 2>&1 | grep -v "Failed to find Response"
```

```output

the fleet after the rotation:
  {"user":"alice","wrapped_by_kid":"sdl-secrets.v2","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v2"},"stored token unchanged":true,"secrets open to":{"TOKEN":"alice-token-value"},"same data key bytes":true}
  {"user":"bob","wrapped_by_kid":"sdl-secrets.v2","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v2"},"stored token unchanged":true,"secrets open to":{"TOKEN":"bob-token-value"},"same data key bytes":true}
  {"user":"carol","wrapped_by_kid":"sdl-secrets.v2","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v2"},"stored token unchanged":true,"secrets open to":{"TOKEN":"carol-token-value"},"same data key bytes":true}
  {"user":"dan","wrapped_by_kid":"sdl-secrets.v2","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v2"},"stored token unchanged":true,"secrets open to":{"TOKEN":"dan-token-value"},"same data key bytes":true}
  {"user":"erin","wrapped_by_kid":"sdl-secrets.v2","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v2"},"stored token unchanged":true,"secrets open to":{"TOKEN":"erin-token-value"},"same data key bytes":true}
```

Every row now names `sdl-secrets.v2` in both its header and its column, and the rest of the header — `alg` and `enc` — came across unchanged. `same data key bytes` is the interesting one: the demo recorded a digest of each user's *unwrapped* data key before the run, unwrapped it again afterwards under the new version, and compared. The wrapping changed; the key did not. That is why no stored secret had to be touched, and `stored token unchanged` says none was.

### Running it again

Resumability is not a progress table — it falls out of the selection. A run over a fleet already on the target version selects no rows at all:

```bash
cd apps/api && W=../../.work/con-876-re-wrap-data-keys-onto; node --env-file=$W/demo-2.env dist/console.js rotate-data-keys --target-version 2 > $W/run.log 2>&1; echo "exit code: $?"; grep "^{" $W/run.log | jq -s -c -f $W/events.jq
```

```output
exit code: 0
{"event":"KEY_ROTATION_STARTED","targetVersion":"2","toVersion":"sdl-secrets.v2","batchSize":100,"dryRun":false}
{"event":"KEY_ROTATION_FINGERPRINT_TAKEN","phase":"before","digest":"sha256#1","rowCount":5,"byteTotal":1288}
{"event":"KEY_ROTATION_FINGERPRINT_TAKEN","phase":"after","digest":"sha256#1","rowCount":5,"byteTotal":1288}
{"event":"KEY_ROTATION_COMPLETED","report":{"usersReWrapped":0,"wouldReWrap":0,"skippedForeignWrap":0,"failed":0,"bytesRewritten":0,"fromVersions":{},"secretsReEncrypted":0,"concurrentSecretWrites":0,"fingerprintBefore":{"digest":"sha256#1","rowCount":5,"byteTotal":1288},"fingerprintAfter":{"digest":"sha256#1","rowCount":5,"byteTotal":1288},"toVersion":"sdl-secrets.v2","dataKeysByVersion":{"sdl-secrets.v2":5}}}
{"event":"COMMAND_END"}
```

Not one `KEY_ROTATION_BATCH` event, so not one row was read and not one unwrap was spent on the key service. The same thing makes an interrupted run resumable: whatever moved stays moved, whatever did not is selected again next time.

### The proof firing

The fingerprint is only worth having if it catches something. Here a rogue writer re-seals one deployment's secrets **while the run is in flight**, leaving `updated_at` exactly as it was — the signature of a write that did not go through the application.

Timing that from outside is not possible on a run this fast, so this one scenario drives `DataKeyRotationService` in process and performs the rogue write the moment the first fingerprint returns. Everything else — the database, the key service, the rotation itself — is the same code the CLI runs.

```bash
cd apps/api && node --require reflect-metadata --import tsx ../../.work/con-876-re-wrap-data-keys-onto/demo-2.ts rogue-run 2>&1 | grep -v "Failed to find Response"
```

```output
the run refused: 1 stored secrets changed with no write of their own behind them
  users re-wrapped     : 5
  secrets re-encrypted : 1
  owner writes counted : 0
  named by the mismatch: dseq 1001
  fingerprint unchanged: false
```

The rogue write re-encrypted the *same* plaintext under the *same* data key, so nothing about the value gives it away — it still opens, to the same secrets. What gives it away is the fingerprint: the token changed and the row's write stamp did not. The run reports `secretsReEncrypted: 1`, names the deployment by id (shown here as its dseq) and refuses. The five data keys were still re-wrapped; the refusal is about the evidence, not about the work.

A user re-sealing their own secrets through the application in the same window moves `updated_at` in the same statement, and is counted under `owner writes counted` instead — a healthy run, not a failed one.

### One bad row does not hold the fleet back

Last scenario, on a freshly seeded fleet: one data key wrapped under `other-key.v1` — a key this console does not control, which is what a future client-held wrap would look like — and one wrapped key truncated in place, standing in for corruption at rest.

```bash
cd apps/api && node --require reflect-metadata --import tsx ../../.work/con-876-re-wrap-data-keys-onto/demo-2.ts plant-odd-rows 2>&1 | grep -v "Failed to find Response"
```

```output
planted one data key wrapped under other-key.v1, and truncated alice's wrapped key in place
```

```bash
cd apps/api && W=../../.work/con-876-re-wrap-data-keys-onto; node --env-file=$W/demo-2.env dist/console.js rotate-data-keys --target-version 2 > $W/run.log 2>&1; echo "exit code: $?"; grep "^{" $W/run.log | jq -s -c -f $W/events.jq
```

```output
exit code: 1
{"event":"KEY_ROTATION_STARTED","targetVersion":"2","toVersion":"sdl-secrets.v2","batchSize":100,"dryRun":false}
{"event":"KEY_ROTATION_FINGERPRINT_TAKEN","phase":"before","digest":"sha256#1","rowCount":5,"byteTotal":1288}
{"event":"KEY_ROTATION_DATA_KEY_FAILED","wrappedByKid":"sdl-secrets.v1","error":"KmsWrappedJweError: TAG_INVALID"}
{"event":"KEY_ROTATION_FOREIGN_WRAP_SKIPPED","wrappedByKid":"other-key.v1"}
{"event":"KEY_ROTATION_BATCH","rowCount":6,"reWrapped":4}
{"event":"KEY_ROTATION_FINGERPRINT_TAKEN","phase":"after","digest":"sha256#1","rowCount":5,"byteTotal":1288}
{"event":"KEY_ROTATION_COMPLETED","report":{"usersReWrapped":4,"wouldReWrap":0,"skippedForeignWrap":1,"failed":1,"bytesRewritten":2716,"fromVersions":{"sdl-secrets.v1":4},"secretsReEncrypted":0,"concurrentSecretWrites":0,"fingerprintBefore":{"digest":"sha256#1","rowCount":5,"byteTotal":1288},"fingerprintAfter":{"digest":"sha256#1","rowCount":5,"byteTotal":1288},"toVersion":"sdl-secrets.v2","dataKeysByVersion":{"other-key.v1":1,"sdl-secrets.v1":1,"sdl-secrets.v2":4}}}
{"event":"COMMAND_ERROR","refused":"1 data keys could not be re-wrapped"}
```

All six rows were in one batch. The unreadable one and the foreign one dropped out of that batch's write set; the other four committed. `usersReWrapped: 4`, `failed: 1`, `skippedForeignWrap: 1`, and the run still exits 1 so nobody mistakes it for a clean sweep. Had the batch rolled back whole, one damaged row would pin its four neighbours to the old version on every future run — and the old version could never be destroyed, which is the entire point of the command.

```bash
cd apps/api && node --require reflect-metadata --import tsx ../../.work/con-876-re-wrap-data-keys-onto/demo-2.ts state "after the contained failure" 2>&1 | grep -v "Failed to find Response"
```

```output

the fleet after the contained failure:
  {"user":"alice","wrapped_by_kid":"sdl-secrets.v1","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v1"},"stored token unchanged":true,"secrets open to":"UNREADABLE","same data key bytes":false}
  {"user":"bob","wrapped_by_kid":"sdl-secrets.v2","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v2"},"stored token unchanged":true,"secrets open to":{"TOKEN":"bob-token-value"},"same data key bytes":true}
  {"user":"carol","wrapped_by_kid":"sdl-secrets.v2","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v2"},"stored token unchanged":true,"secrets open to":{"TOKEN":"carol-token-value"},"same data key bytes":true}
  {"user":"dan","wrapped_by_kid":"sdl-secrets.v2","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v2"},"stored token unchanged":true,"secrets open to":{"TOKEN":"dan-token-value"},"same data key bytes":true}
  {"user":"erin","wrapped_by_kid":"sdl-secrets.v2","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"sdl-secrets.v2"},"stored token unchanged":true,"secrets open to":{"TOKEN":"erin-token-value"},"same data key bytes":true}
  {"user":"frank","wrapped_by_kid":"other-key.v1","wrapped key header":{"alg":"RSA-OAEP-256","enc":"A256GCM","kid":"other-key.v1"},"secrets open to":"nothing stored"}
```

Alice's row is the one whose wrapped key was deliberately truncated: it still names `sdl-secrets.v1` and her secrets no longer open — the damage was done to it before the run, and the rotation neither repaired it nor made it worse. Frank's row still names `other-key.v1`, byte for byte as it was planted: a wrap the console does not own is left for whoever does. The other four moved, and their stored secrets still open to exactly what was sealed.

---

**How this demo runs.** The CLI above is the compiled console (`dist/console.js`), pointed at a throwaway `con876_rotation_demo` database built from the project's own migrations, and at the Cloud KMS emulator on `localhost:9090`. Key versions **1** and **2** are two real RSA-3072 key versions on that emulator; the disabled one is minted fresh per run, which is why its number is masked. The seeding, inspection and rogue-write steps are driven by a script under `.work/`, which is deliberately never committed, so a reader outside this sandbox sees the captured output rather than a re-runnable command.

The secret values (`alice-token-value` and friends) are fixtures invented for the demo. Nothing here prints a connection string, a credential, or any real ciphertext.

The same properties are asserted in `apps/api/src/secret/services/data-key-rotation/data-key-rotation.service.integration.ts` against the same database and the same emulator, and in `data-key-rotation.service.spec.ts` at unit level.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line workflow to rotate data-encryption keys to a selected KMS key version.
  * Supports batching, dry-run previews, progress reporting, validation, and safe handling of concurrent updates or unreadable keys.
  * Rotation preserves encrypted data and secrets while providing detailed success or refusal reports.

* **Tests**
  * Added comprehensive unit and integration coverage for successful rotations, failures, rollback behavior, dry runs, batching, and repeat executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->