### PR TITLE
feat(auth): refuse accounts and trials from blocked email domains

### DIFF
--- a/apps/api/drizzle/0054_blocked_email_domains.sql
+++ b/apps/api/drizzle/0054_blocked_email_domains.sql
@@ -1,0 +1,16 @@
+CREATE TYPE "public"."blocked_email_domain_source" AS ENUM('auto', 'manual');--> statement-breakpoint
+CREATE TYPE "public"."blocked_email_domain_status" AS ENUM('blocked', 'allowed');--> statement-breakpoint
+CREATE TABLE "blocked_email_domains" (
+	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v4() NOT NULL,
+	"domain" varchar(253) NOT NULL,
+	"status" "blocked_email_domain_status" DEFAULT 'blocked' NOT NULL,
+	"source" "blocked_email_domain_source" DEFAULT 'manual' NOT NULL,
+	"reason" varchar(255),
+	"triggered_by_user_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "blocked_email_domains_domain_normalized" CHECK ("blocked_email_domains"."domain" = lower("blocked_email_domains"."domain") AND "blocked_email_domains"."domain" NOT LIKE '%@%' AND "blocked_email_domains"."domain" LIKE '%.%' AND btrim("blocked_email_domains"."domain") = "blocked_email_domains"."domain")
+);
+--> statement-breakpoint
+ALTER TABLE "blocked_email_domains" ADD CONSTRAINT "blocked_email_domains_triggered_by_user_id_userSetting_id_fk" FOREIGN KEY ("triggered_by_user_id") REFERENCES "public"."userSetting"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "blocked_email_domains_domain_unique" ON "blocked_email_domains" USING btree ("domain");

--- a/apps/api/drizzle/meta/0054_snapshot.json
+++ b/apps/api/drizzle/meta/0054_snapshot.json
@@ -1,0 +1,1875 @@
+{
+  "id": "42c76360-7c9c-403e-9bba-31c9e5e2c876",
+  "prevId": "ac23eb43-aae2-4886-bc9e-754d7776ba29",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "activated_at": {
+          "name": "activated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_notified_at": {
+          "name": "credits_low_notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_sufficient_since": {
+          "name": "credits_sufficient_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credits_low_since": {
+          "name": "credits_low_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abuse_locked_at": {
+          "name": "abuse_locked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abuse_locked_reason": {
+          "name": "abuse_locked_reason",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_idempotency_key": {
+          "name": "stripe_idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_idempotency_key_unique": {
+          "name": "stripe_transactions_stripe_idempotency_key_unique",
+          "columns": [
+            {
+              "expression": "stripe_idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_idempotency_key\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "auto_reload_mode": {
+          "name": "auto_reload_mode",
+          "type": "auto_reload_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'prediction'"
+        },
+        "auto_reload_threshold": {
+          "name": "auto_reload_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 2000
+        },
+        "auto_reload_amount": {
+          "name": "auto_reload_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "last_auto_charge_at": {
+          "name": "last_auto_charge_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_reload_failure_count": {
+          "name": "auto_reload_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_reload_paused_at": {
+          "name": "auto_reload_paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboardingSkippedAt": {
+          "name": "onboardingSkippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fair_use_policy_accepted_at": {
+          "name": "fair_use_policy_accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_funded_at": {
+          "name": "last_funded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_limit_hours": {
+          "name": "runtime_limit_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sealed_secrets": {
+          "name": "sealed_secrets",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "manifest_version": {
+          "name": "manifest_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ends_at": {
+          "name": "runtime_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_ending_notified_for": {
+          "name": "runtime_ending_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_unreachable_notified_for": {
+          "name": "provider_unreachable_notified_for",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.data_keys": {
+      "name": "data_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_key": {
+          "name": "wrapped_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wrapped_by_kid": {
+          "name": "wrapped_by_kid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "data_keys_wrapped_by_kid_idx": {
+          "name": "data_keys_wrapped_by_kid_idx",
+          "columns": [
+            {
+              "expression": "wrapped_by_kid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "data_keys_user_id_userSetting_id_fk": {
+          "name": "data_keys_user_id_userSetting_id_fk",
+          "tableFrom": "data_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "data_keys_user_id_unique": {
+          "name": "data_keys_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_email_domains": {
+      "name": "blocked_email_domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(253)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "blocked_email_domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'blocked'"
+        },
+        "source": {
+          "name": "source",
+          "type": "blocked_email_domain_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocked_email_domains_domain_unique": {
+          "name": "blocked_email_domains_domain_unique",
+          "columns": [
+            {
+              "expression": "domain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocked_email_domains_triggered_by_user_id_userSetting_id_fk": {
+          "name": "blocked_email_domains_triggered_by_user_id_userSetting_id_fk",
+          "tableFrom": "blocked_email_domains",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "blocked_email_domains_domain_normalized": {
+          "name": "blocked_email_domains_domain_normalized",
+          "value": "\"blocked_email_domains\".\"domain\" = lower(\"blocked_email_domains\".\"domain\") AND \"blocked_email_domains\".\"domain\" NOT LIKE '%@%' AND \"blocked_email_domains\".\"domain\" LIKE '%.%' AND btrim(\"blocked_email_domains\".\"domain\") = \"blocked_email_domains\".\"domain\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workload_abuse_detections": {
+      "name": "workload_abuse_detections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "workload_abuse_verdict",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probe_status": {
+          "name": "probe_status",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signals": {
+          "name": "signals",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_excerpt": {
+          "name": "evidence_excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "workload_abuse_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "enforcement_error": {
+          "name": "enforcement_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "workload_abuse_detections_user_id_idx": {
+          "name": "workload_abuse_detections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workload_abuse_detections_dseq_idx": {
+          "name": "workload_abuse_detections_dseq_idx",
+          "columns": [
+            {
+              "expression": "dseq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workload_abuse_detections_user_id_userSetting_id_fk": {
+          "name": "workload_abuse_detections_user_id_userSetting_id_fk",
+          "tableFrom": "workload_abuse_detections",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    },
+    "public.auto_reload_mode": {
+      "name": "auto_reload_mode",
+      "schema": "public",
+      "values": [
+        "prediction",
+        "threshold"
+      ]
+    },
+    "public.blocked_email_domain_source": {
+      "name": "blocked_email_domain_source",
+      "schema": "public",
+      "values": [
+        "auto",
+        "manual"
+      ]
+    },
+    "public.blocked_email_domain_status": {
+      "name": "blocked_email_domain_status",
+      "schema": "public",
+      "values": [
+        "blocked",
+        "allowed"
+      ]
+    },
+    "public.workload_abuse_action": {
+      "name": "workload_abuse_action",
+      "schema": "public",
+      "values": [
+        "detected",
+        "enforcing",
+        "enforced",
+        "enforcement_failed"
+      ]
+    },
+    "public.workload_abuse_verdict": {
+      "name": "workload_abuse_verdict",
+      "schema": "public",
+      "values": [
+        "hard",
+        "soft",
+        "proxy"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -379,6 +379,13 @@
       "when": 1789051951342,
       "tag": "0053_deployment_name",
       "breakpoints": true
+    },
+    {
+      "idx": 54,
+      "version": "7",
+      "when": 1789221053185,
+      "tag": "0054_blocked_email_domains",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
@@ -1,6 +1,6 @@
 import { ManagementApiError, ResponseError } from "auth0";
 import { container as rootContainer } from "tsyringe";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";
@@ -8,6 +8,7 @@ import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
 import { AUTH0_DB_CONNECTION } from "@src/auth/services/auth0/auth0.service";
 import type { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import type { UserService } from "@src/user/services/user/user.service";
+import type { BlockedEmailDomainService } from "@src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service";
 import { AuthController } from "./auth.controller";
 
 import { createUser } from "@test/seeders/user.seeder";
@@ -35,6 +36,16 @@ describe(AuthController.name, () => {
         password: "StrongPassword123!",
         connection: AUTH0_DB_CONNECTION
       });
+    });
+
+    it("refuses a blocked email domain with the same response as an existing account, without reaching auth0", async () => {
+      const { controller, auth0Service } = setup({ isBlockedEmail: true });
+
+      await expect(controller.signup({ email: "miner@attacker.com", password: "StrongPassword123!" })).rejects.toMatchObject({
+        status: 422,
+        message: "Unable to create account. Please try again or use a different email."
+      });
+      expect(auth0Service.createUser).not.toHaveBeenCalled();
     });
 
     it("converts 409 (user exists) to a 422 that does not confirm the email is registered", async () => {
@@ -132,6 +143,7 @@ describe(AuthController.name, () => {
   function setup(
     input: {
       user?: ReturnType<typeof createUser>;
+      isBlockedEmail?: boolean;
     } = {}
   ) {
     const user = input.user ?? createUser();
@@ -146,9 +158,16 @@ describe(AuthController.name, () => {
     const auth0Service = mock<Auth0Service>();
     const emailVerificationCodeService = mock<EmailVerificationCodeService>();
     const userService = mock<UserService>();
+    const blockedEmailDomainService = mock<BlockedEmailDomainService>({ isBlockedEmail: vi.fn().mockResolvedValue(input.isBlockedEmail ?? false) });
 
-    const controller = new AuthController(rootContainer.resolve(AuthService), auth0Service, userService, emailVerificationCodeService);
+    const controller = new AuthController(
+      rootContainer.resolve(AuthService),
+      auth0Service,
+      userService,
+      emailVerificationCodeService,
+      blockedEmailDomainService
+    );
 
-    return { controller, auth0Service, emailVerificationCodeService, userService };
+    return { controller, auth0Service, emailVerificationCodeService, userService, blockedEmailDomainService };
   }
 });

--- a/apps/api/src/auth/controllers/auth/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth/auth.controller.ts
@@ -3,6 +3,7 @@ import { singleton } from "tsyringe";
 
 import type { SendVerificationEmailRequestInput } from "@src/auth";
 import { VerifyEmailRequest } from "@src/auth/http-schemas/verify-email.schema";
+import { ACCOUNT_UNAVAILABLE_MESSAGE } from "@src/auth/lib/account-unavailable/account-unavailable";
 import type { SignupInput } from "@src/auth/routes/signup/signup.router";
 import type { VerifyEmailCodeRequest } from "@src/auth/routes/verify-email-code/verify-email-code.router";
 import { AuthService, Protected } from "@src/auth/services/auth.service";
@@ -10,9 +11,7 @@ import { AUTH0_DB_CONNECTION, Auth0Service } from "@src/auth/services/auth0/auth
 import { extractAuth0ErrorMessage, isAuth0ApiError } from "@src/auth/services/auth0/auth0-error";
 import { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import { UserService } from "@src/user/services/user/user.service";
-
-/** Deliberately vague so a failed signup cannot be used to confirm whether an email is already registered. */
-const ACCOUNT_UNAVAILABLE_MESSAGE = "Unable to create account. Please try again or use a different email.";
+import { BlockedEmailDomainService } from "@src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service";
 
 /** Auth0 being down is not the caller's fault, and its internal message is not useful to them. */
 const AUTH_PROVIDER_UNAVAILABLE_MESSAGE = "Unable to create the account right now. Please try again.";
@@ -23,10 +22,15 @@ export class AuthController {
     private readonly authService: AuthService,
     private readonly auth0: Auth0Service,
     private readonly userService: UserService,
-    private readonly emailVerificationCodeService: EmailVerificationCodeService
+    private readonly emailVerificationCodeService: EmailVerificationCodeService,
+    private readonly blockedEmailDomainService: BlockedEmailDomainService
   ) {}
 
   async signup(input: SignupInput) {
+    if (await this.blockedEmailDomainService.isBlockedEmail(input.email)) {
+      throw createError(422, ACCOUNT_UNAVAILABLE_MESSAGE);
+    }
+
     try {
       await this.auth0.createUser({
         email: input.email,

--- a/apps/api/src/auth/lib/account-unavailable/account-unavailable.ts
+++ b/apps/api/src/auth/lib/account-unavailable/account-unavailable.ts
@@ -1,0 +1,4 @@
+/** Deliberately vague so a failed signup cannot be used to confirm whether an email is already registered, or whether its domain is blocked. */
+export const ACCOUNT_UNAVAILABLE_MESSAGE = "Unable to create account. Please try again or use a different email.";
+
+export const ACCOUNT_UNAVAILABLE_ERROR_CODE = "account_unavailable";

--- a/apps/api/src/billing/services/activate-trial/trial-activation-instrumentation.service.spec.ts
+++ b/apps/api/src/billing/services/activate-trial/trial-activation-instrumentation.service.spec.ts
@@ -15,6 +15,7 @@ import createError from "http-errors";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { TRIAL_BLOCKED_DOMAIN_MESSAGE } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
 import type { MetricsService } from "@src/core";
 import { TrialActivationInstrumentationService } from "./trial-activation-instrumentation.service";
 
@@ -48,6 +49,7 @@ describe(TrialActivationInstrumentationService.name, () => {
       { error: createError(404, "wallet not found"), reason: "user_or_wallet_not_found" },
       { error: createError(400, "Email not verified"), reason: "email_not_verified" },
       { error: createError(400, "Unable to start trial for this user"), reason: "fingerprint_block" },
+      { error: createError(400, TRIAL_BLOCKED_DOMAIN_MESSAGE), reason: "blocked_domain" },
       { error: createError(400, "some other bad request"), reason: "grant_failed" },
       { error: new Error("chain grant reverted"), reason: "grant_failed" }
     ])("classifies a $reason failure", ({ error, reason }) => {

--- a/apps/api/src/billing/services/activate-trial/trial-activation-instrumentation.service.ts
+++ b/apps/api/src/billing/services/activate-trial/trial-activation-instrumentation.service.ts
@@ -17,6 +17,7 @@ function classifyFailure(error: unknown): string {
     if (error.status === 404) return "user_or_wallet_not_found";
     if (error.status === 400 && /email not verified/i.test(error.message)) return "email_not_verified";
     if (error.status === 400 && /unable to start trial/i.test(error.message)) return "fingerprint_block";
+    if (error.status === 400 && /not available for this email domain/i.test(error.message)) return "blocked_domain";
   }
   return "grant_failed";
 }

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -13,13 +13,14 @@ import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-fl
 import { ProviderJwtTokenService } from "@src/provider/services/provider-jwt-token/provider-jwt-token.service";
 import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
+import { BlockedEmailDomainService } from "@src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service";
 import { UserWalletRepository } from "../../repositories/user-wallet/user-wallet.repository";
 import { TrialActivationInstrumentationService } from "../activate-trial/trial-activation-instrumentation.service";
 import { ManagedSignerService } from "../managed-signer/managed-signer.service";
 import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
 import { StripeService } from "../stripe/stripe.service";
 import { TrialValidationService } from "../trial-validation/trial-validation.service";
-import { WalletInitializerService } from "./wallet-initializer.service";
+import { TRIAL_BLOCKED_DOMAIN_MESSAGE, WalletInitializerService } from "./wallet-initializer.service";
 
 import { createChainWallet } from "@test/seeders/chain-wallet.seeder";
 import { createUser } from "@test/seeders/user.seeder";
@@ -39,6 +40,23 @@ describe(WalletInitializerService.name, () => {
       const di = setup({ user, isProduction: true, hasDuplicateFingerprint: true });
 
       await expect(di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(user.id)).rejects.toThrow(/Unable to start trial/i);
+    });
+
+    it("throws 400 when the email domain is blocked", async () => {
+      const user = createUser({ emailVerified: true });
+      const di = setup({ user, isBlockedEmailDomain: true, getOrCreateWallet: vi.fn().mockResolvedValue({ wallet: createUserWallet({ activatedAt: null }) }) });
+
+      await expect(di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(user.id)).rejects.toThrow(TRIAL_BLOCKED_DOMAIN_MESSAGE);
+    });
+
+    it("returns an already-activated wallet even when the email domain is blocked", async () => {
+      const user = createUser({ emailVerified: true });
+      const activatedWallet = createUserWallet({ userId: user.id, activatedAt: new Date() });
+      const di = setup({ user, isBlockedEmailDomain: true, getOrCreateWallet: vi.fn().mockResolvedValue({ wallet: activatedWallet, isNew: false }) });
+
+      const result = await di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(user.id);
+
+      expect(result.address).toBe(activatedWallet.address);
     });
 
     it("derives and saves the address when the wallet is missing one", async () => {
@@ -210,6 +228,7 @@ describe(WalletInitializerService.name, () => {
     user?: UserOutput;
     isProduction?: boolean;
     hasDuplicateFingerprint?: boolean;
+    isBlockedEmailDomain?: boolean;
   }) {
     const di = container.createChildContainer();
     di.registerInstance(TYPE_REGISTRY, new Registry());
@@ -268,6 +287,10 @@ describe(WalletInitializerService.name, () => {
     );
     di.registerInstance(TrialActivationInstrumentationService, mock<TrialActivationInstrumentationService>());
     di.registerInstance(TrialValidationService, mock<TrialValidationService>());
+    di.registerInstance(
+      BlockedEmailDomainService,
+      mock<BlockedEmailDomainService>({ isBlockedEmail: vi.fn().mockResolvedValue(input?.isBlockedEmailDomain ?? false) })
+    );
 
     container.clearInstances();
 

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -11,7 +11,11 @@ import { DomainEventsService } from "@src/core/services/domain-events/domain-eve
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { UserOutput, UserRepository } from "@src/user/repositories";
+import { BlockedEmailDomainService } from "@src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service";
 import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
+
+/** Names the domain, unlike the registration refusal: only a verified account holder sees it, and support needs to be able to act on it. */
+export const TRIAL_BLOCKED_DOMAIN_MESSAGE = "Trial is not available for this email domain. Please contact support for assistance.";
 
 @singleton()
 export class WalletInitializerService {
@@ -24,7 +28,8 @@ export class WalletInitializerService {
     private readonly stripeService: StripeService,
     private readonly userRepository: UserRepository,
     private readonly trialActivationInstrumentation: TrialActivationInstrumentationService,
-    private readonly trialValidationService: TrialValidationService
+    private readonly trialValidationService: TrialValidationService,
+    private readonly blockedEmailDomainService: BlockedEmailDomainService
   ) {}
 
   async #assertNoDuplicateFingerprint(user: UserOutput): Promise<void> {
@@ -34,6 +39,11 @@ export class WalletInitializerService {
 
     const usersWithSameFingerprint = await this.userRepository.findTrialUsersByFingerprint(user.lastFingerprint, user.id);
     assert(usersWithSameFingerprint.length === 0, 400, "Unable to start trial. Please contact support for assistance.");
+  }
+
+  async #assertEmailDomainNotBlocked(user: UserOutput): Promise<void> {
+    const blocked = await this.blockedEmailDomainService.isBlockedEmail(user.email);
+    assert(!blocked, 400, TRIAL_BLOCKED_DOMAIN_MESSAGE);
   }
 
   /**
@@ -55,6 +65,8 @@ export class WalletInitializerService {
 
     const userWallet = await this.ensureWallet(userId);
     if (userWallet.activatedAt) return this.#toPublic(userWallet);
+
+    await this.#assertEmailDomainNotBlocked(user);
 
     const chainWallet = await this.walletManager.createAndAuthorizeTrialSpending(this.managedSignerService, { addressIndex: userWallet.id });
     const activatedWallet = await this.userWalletRepository.updateById(

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -3,7 +3,8 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
   TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check",
-  FAIR_USE_POLICY_GATE: "fair_use_policy_gate"
+  FAIR_USE_POLICY_GATE: "fair_use_policy_gate",
+  BLOCKED_EMAIL_DOMAIN_ENFORCEMENT: "blocked_email_domain_enforcement"
 } as const;
 
 export type FeatureFlagValue = (typeof FeatureFlags)[keyof typeof FeatureFlags];

--- a/apps/api/src/user/services/user/user.service.integration.ts
+++ b/apps/api/src/user/services/user/user.service.integration.ts
@@ -16,6 +16,7 @@ import type { NotificationService } from "@src/notifications/services/notificati
 import { DataKeyRepository } from "@src/secret/repositories/data-key/data-key.repository";
 import { DataKeyService } from "@src/secret/services/data-key/data-key.service";
 import { UserRepository } from "@src/user/repositories/user/user.repository";
+import type { BlockedEmailDomainService } from "@src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service";
 import type { RegisterUserInput } from "./user.service";
 import { UserService } from "./user.service";
 
@@ -449,7 +450,11 @@ describe(UserService.name, () => {
     };
   }
 
-  function setup(input?: { createDefaultNotificationChannel?: NotificationService["createDefaultChannel"]; ensureDataKey?: DataKeyService["ensureDataKey"] }) {
+  function setup(input?: {
+    createDefaultNotificationChannel?: NotificationService["createDefaultChannel"];
+    ensureDataKey?: DataKeyService["ensureDataKey"];
+    isBlockedEmail?: boolean;
+  }) {
     const analyticsService = mock<AnalyticsService>();
     const logger = mock<ReturnType<CreateLogger>>();
     const createLogger: CreateLogger = () => logger;
@@ -477,7 +482,8 @@ describe(UserService.name, () => {
       }),
       walletInitializerService,
       mock<TrialActivationJobService>({ schedule: vi.fn().mockResolvedValue(undefined) }),
-      input?.ensureDataKey ? mock<DataKeyService>({ ensureDataKey: input.ensureDataKey }) : dataKeyService
+      input?.ensureDataKey ? mock<DataKeyService>({ ensureDataKey: input.ensureDataKey }) : dataKeyService,
+      mock<BlockedEmailDomainService>({ isBlockedEmail: vi.fn().mockResolvedValue(input?.isBlockedEmail ?? false) })
     );
 
     return { service, analyticsService, logger, auth0Service, userRepository, walletInitializerService, dataKeyRepository };

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { ACCOUNT_UNAVAILABLE_ERROR_CODE, ACCOUNT_UNAVAILABLE_MESSAGE } from "@src/auth/lib/account-unavailable/account-unavailable";
 import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
 import type { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import type { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
@@ -11,6 +12,7 @@ import type { AnalyticsService } from "@src/core/services/analytics/analytics.se
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import type { DataKeyService } from "@src/secret/services/data-key/data-key.service";
 import type { UserRepository } from "@src/user/repositories/user/user.repository";
+import type { BlockedEmailDomainService } from "@src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service";
 import type { RegisterUserInput } from "./user.service";
 import { UserService } from "./user.service";
 
@@ -20,6 +22,45 @@ import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(UserService.name, () => {
   describe("registerUser", () => {
+    describe("when the email domain is blocked", () => {
+      it("refuses an account that does not exist yet", async () => {
+        const { service, userRepository, blockedEmailDomainService } = setup();
+        blockedEmailDomainService.isBlockedEmail.mockResolvedValue(true);
+        userRepository.findByUserId.mockResolvedValue(undefined);
+
+        await expect(service.registerUser(createRegisterInput())).rejects.toMatchObject({
+          status: 403,
+          message: ACCOUNT_UNAVAILABLE_MESSAGE,
+          errorCode: ACCOUNT_UNAVAILABLE_ERROR_CODE
+        });
+        expect(userRepository.upsertOnExternalIdConflict).not.toHaveBeenCalled();
+      });
+
+      it("registers an account that already exists, so a later block never locks an established user out", async () => {
+        const user = createUser({ emailVerified: true });
+        const { service, userRepository, notificationService, blockedEmailDomainService } = setup();
+        blockedEmailDomainService.isBlockedEmail.mockResolvedValue(true);
+        userRepository.findByUserId.mockResolvedValue(user);
+        userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: false });
+        notificationService.createDefaultChannel.mockResolvedValue(undefined);
+
+        const result = await service.registerUser(createRegisterInput({ emailVerified: true }));
+
+        expect(result.id).toBe(user.id);
+      });
+    });
+
+    it("registers without looking the user up when the email domain is not blocked", async () => {
+      const user = createUser({ emailVerified: true });
+      const { service, userRepository, notificationService } = setup();
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
+      notificationService.createDefaultChannel.mockResolvedValue(undefined);
+
+      await service.registerUser(createRegisterInput({ emailVerified: true }));
+
+      expect(userRepository.findByUserId).not.toHaveBeenCalled();
+    });
+
     it("sends verification code when email is not verified", async () => {
       const user = createUser({ emailVerified: false, email: "test@example.com" });
       const { service, emailVerificationCodeService, userRepository, notificationService } = setup();
@@ -180,6 +221,7 @@ describe(UserService.name, () => {
     });
     const trialActivationJobService = mock<TrialActivationJobService>({ schedule: vi.fn().mockResolvedValue(undefined) });
     const dataKeyService = mock<DataKeyService>({ ensureDataKey: vi.fn().mockResolvedValue(createDataKey()) });
+    const blockedEmailDomainService = mock<BlockedEmailDomainService>({ isBlockedEmail: vi.fn().mockResolvedValue(false) });
 
     const service = new UserService(
       userRepository,
@@ -190,10 +232,12 @@ describe(UserService.name, () => {
       emailVerificationCodeService,
       walletInitializerService,
       trialActivationJobService,
-      dataKeyService
+      dataKeyService,
+      blockedEmailDomainService
     );
 
     return {
+      blockedEmailDomainService,
       service,
       userRepository,
       analyticsService,

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -1,7 +1,9 @@
 import assert from "http-assert";
+import createError from "http-errors";
 import randomInt from "lodash/random";
 import { inject, singleton } from "tsyringe";
 
+import { ACCOUNT_UNAVAILABLE_ERROR_CODE, ACCOUNT_UNAVAILABLE_MESSAGE } from "@src/auth/lib/account-unavailable/account-unavailable";
 import { Auth0Service } from "@src/auth/services/auth0/auth0.service";
 import { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import { TrialActivationJobService } from "@src/billing/services/trial-activation-job/trial-activation-job.service";
@@ -11,6 +13,7 @@ import { getPostgresError, isUniqueViolation } from "@src/core/repositories/base
 import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { DataKeyService } from "@src/secret/services/data-key/data-key.service";
+import { BlockedEmailDomainService } from "@src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service";
 import { UserInput, type UserOutput, UserRepository } from "../../repositories/user/user.repository";
 
 @singleton()
@@ -26,7 +29,8 @@ export class UserService {
     private readonly emailVerificationCodeService: EmailVerificationCodeService,
     private readonly walletInitializer: WalletInitializerService,
     private readonly trialActivationJobService: TrialActivationJobService,
-    private readonly dataKeyService: DataKeyService
+    private readonly dataKeyService: DataKeyService,
+    private readonly blockedEmailDomainService: BlockedEmailDomainService
   ) {
     this.logger = createLogger({ context: UserService.name });
   }
@@ -45,6 +49,8 @@ export class UserService {
     githubUsername: string | null;
     isNewUser: boolean;
   }> {
+    await this.assertDomainNotBlockedForNewUser(data);
+
     const userDetails = {
       userId: data.userId,
       email: data.email,
@@ -107,6 +113,20 @@ export class UserService {
       githubUsername,
       isNewUser: wasInserted
     } as Awaited<ReturnType<this["registerUser"]>>;
+  }
+
+  /**
+   * Refuses only an account that does not exist yet. This endpoint runs on every login, so refusing
+   * unconditionally would ban an established user whose domain was blocked for somebody else's abuse —
+   * and the Auth0 callback swallows this error, so they would get a session with no account behind it.
+   */
+  private async assertDomainNotBlockedForNewUser(data: RegisterUserInput): Promise<void> {
+    if (!(await this.blockedEmailDomainService.isBlockedEmail(data.email))) return;
+    if (await this.userRepository.findByUserId(data.userId)) return;
+
+    this.logger.warn({ event: "REGISTRATION_BLOCKED_EMAIL_DOMAIN", userId: data.userId });
+
+    throw createError(403, ACCOUNT_UNAVAILABLE_MESSAGE, { errorCode: ACCOUNT_UNAVAILABLE_ERROR_CODE });
   }
 
   /**

--- a/apps/api/src/workload-abuse/config/env.config.ts
+++ b/apps/api/src/workload-abuse/config/env.config.ts
@@ -89,7 +89,15 @@ export const envSchema = z.object({
   /** Long enough for a shell round trip through the proxy, short enough that a leaked token is worthless minutes later. */
   WORKLOAD_ABUSE_PROVIDER_JWT_TTL_SECONDS: z.number({ coerce: true }).int().positive().default(120),
   /** How far back the reconcile sweep looks for live trial deployments without a pending probe. */
-  WORKLOAD_ABUSE_RECONCILE_MAX_AGE_HOURS: z.number({ coerce: true }).int().positive().default(26)
+  WORKLOAD_ABUSE_RECONCILE_MAX_AGE_HOURS: z.number({ coerce: true }).int().positive().default(26),
+  /** `detect` runs every guardrail and records the verdict without writing a block or wiping a sibling. */
+  WORKLOAD_ABUSE_DOMAIN_BLOCK_MODE: z.enum(["detect", "enforce"]).default("detect"),
+  /** The admin console writes the table out of band, so an operator un-blocking a domain waits at most this long. */
+  WORKLOAD_ABUSE_BLOCKED_DOMAIN_CACHE_TTL_SECONDS: z.number({ coerce: true }).int().positive().default(60),
+  /** Bounds the damage of a domain match that turns out to be too broad. */
+  WORKLOAD_ABUSE_DOMAIN_BLOCK_MAX_SIBLINGS: z.number({ coerce: true }).int().positive().default(200),
+  /** A domain with an account older than this predates the attack, so it is somebody's real domain. */
+  WORKLOAD_ABUSE_DOMAIN_BLOCK_MIN_ACCOUNT_AGE_DAYS: z.number({ coerce: true }).int().positive().default(30)
 });
 
 export type WorkloadAbuseConfig = z.infer<typeof envSchema>;

--- a/apps/api/src/workload-abuse/lib/email-domain/email-domain.spec.ts
+++ b/apps/api/src/workload-abuse/lib/email-domain/email-domain.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { extractEmailDomain, normalizeEmailDomain } from "./email-domain";
+
+describe("extractEmailDomain", () => {
+  it.each([
+    ["user@example.com", "example.com"],
+    ["  user@example.com  ", "example.com"],
+    ["User@Example.COM", "example.com"],
+    ["user@example.com.", "example.com"],
+    ["user+tag@example.com", "example.com"],
+    ['"user@internal"@example.com', "example.com"],
+    ["user@mail.example.co.uk", "mail.example.co.uk"],
+    [`user@${"a".repeat(249)}.com`, `${"a".repeat(249)}.com`]
+  ])("extracts %s as %s", (email, expected) => {
+    expect(extractEmailDomain(email)).toBe(expected);
+  });
+
+  it.each([
+    ["", "empty string"],
+    ["   ", "whitespace only"],
+    ["noatsign", "no separator"],
+    ["@example.com", "empty local part"],
+    ["user@", "empty domain"],
+    ["user@example.com..", "two trailing dots"],
+    ["user@localhost", "no dot"],
+    ["user@[192.168.0.1]", "address literal"],
+    ["user@-example.com", "leading hyphen"],
+    ["user@example-.com", "trailing hyphen"],
+    ["user@exa mple.com", "embedded space"],
+    ["user@exam_ple.com", "underscore"],
+    [`user@${"a".repeat(250)}.com`, "over the length limit"]
+  ])("returns null for %s (%s)", email => {
+    expect(extractEmailDomain(email)).toBeNull();
+  });
+
+  it.each([[null], [undefined]])("returns null for %s", email => {
+    expect(extractEmailDomain(email)).toBeNull();
+  });
+});
+
+describe("normalizeEmailDomain", () => {
+  it.each([
+    ["Example.COM", "example.com"],
+    [" example.com ", "example.com"],
+    ["example.com.", "example.com"]
+  ])("normalizes %s to %s", (domain, expected) => {
+    expect(normalizeEmailDomain(domain)).toBe(expected);
+  });
+
+  it.each([[""], ["localhost"], ["exa mple.com"], [null], [undefined]])("returns null for %s", domain => {
+    expect(normalizeEmailDomain(domain)).toBeNull();
+  });
+});

--- a/apps/api/src/workload-abuse/lib/email-domain/email-domain.ts
+++ b/apps/api/src/workload-abuse/lib/email-domain/email-domain.ts
@@ -1,0 +1,31 @@
+import { MAX_EMAIL_DOMAIN_LENGTH } from "@src/workload-abuse/model-schemas/blocked-email-domain/blocked-email-domain.schema";
+
+const DOMAIN_LABEL = "[a-z0-9](?:[a-z0-9-]*[a-z0-9])?";
+const DOMAIN_PATTERN = new RegExp(`^${DOMAIN_LABEL}(?:\\.${DOMAIN_LABEL})+$`);
+
+/**
+ * Returns the normalized domain of an email address, or null when there isn't one to act on. Every caller
+ * treats null as "not blocked", so an address we cannot parse can never be refused by mistake.
+ */
+export function extractEmailDomain(email: string | null | undefined): string | null {
+  if (!email) return null;
+
+  const trimmed = email.trim();
+  const separatorIndex = trimmed.lastIndexOf("@");
+
+  if (separatorIndex <= 0) return null;
+
+  return normalizeEmailDomain(trimmed.slice(separatorIndex + 1));
+}
+
+/** Matching is exact, so a domain only ever matches a stored row when both went through this. */
+export function normalizeEmailDomain(domain: string | null | undefined): string | null {
+  if (!domain) return null;
+
+  const withoutRootLabel = domain.trim().toLowerCase().replace(/\.$/, "");
+
+  if (withoutRootLabel.length > MAX_EMAIL_DOMAIN_LENGTH) return null;
+  if (!DOMAIN_PATTERN.test(withoutRootLabel)) return null;
+
+  return withoutRootLabel;
+}

--- a/apps/api/src/workload-abuse/lib/email-domain/public-email-providers.spec.ts
+++ b/apps/api/src/workload-abuse/lib/email-domain/public-email-providers.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { isPublicEmailProvider } from "./public-email-providers";
+
+describe("isPublicEmailProvider", () => {
+  it.each([["gmail.com"], ["outlook.com"], ["proton.me"], ["yandex.ru"], ["cox.net"]])("recognizes %s", domain => {
+    expect(isPublicEmailProvider(domain)).toBe(true);
+  });
+
+  it.each([["attacker.com"], ["notgmail.com"], ["gmail.com.attacker.net"], ["mail.gmail.com"], ["akash.network"]])("does not recognize %s", domain => {
+    expect(isPublicEmailProvider(domain)).toBe(false);
+  });
+});

--- a/apps/api/src/workload-abuse/lib/email-domain/public-email-providers.ts
+++ b/apps/api/src/workload-abuse/lib/email-domain/public-email-providers.ts
@@ -1,0 +1,63 @@
+/**
+ * Kept in code rather than rows so it survives an empty or unreachable database and cannot be deleted by the
+ * admin console, where the cost of a mistake is auto-blocking every account on a provider like gmail.com.
+ */
+const PUBLIC_EMAIL_PROVIDERS: ReadonlySet<string> = new Set([
+  "gmail.com",
+  "googlemail.com",
+  "outlook.com",
+  "outlook.fr",
+  "outlook.de",
+  "hotmail.com",
+  "hotmail.co.uk",
+  "hotmail.fr",
+  "live.com",
+  "live.co.uk",
+  "msn.com",
+  "yahoo.com",
+  "yahoo.co.uk",
+  "yahoo.fr",
+  "ymail.com",
+  "rocketmail.com",
+  "aol.com",
+  "proton.me",
+  "protonmail.com",
+  "pm.me",
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "gmx.com",
+  "gmx.de",
+  "gmx.net",
+  "mail.com",
+  "mail.ru",
+  "zoho.com",
+  "yandex.com",
+  "yandex.ru",
+  "qq.com",
+  "163.com",
+  "126.com",
+  "sina.com",
+  "naver.com",
+  "daum.net",
+  "fastmail.com",
+  "hey.com",
+  "tutanota.com",
+  "tuta.io",
+  "duck.com",
+  "web.de",
+  "t-online.de",
+  "free.fr",
+  "orange.fr",
+  "laposte.net",
+  "comcast.net",
+  "verizon.net",
+  "bellsouth.net",
+  "sbcglobal.net",
+  "cox.net"
+]);
+
+/** Expects an already normalized domain, as produced by normalizeEmailDomain. */
+export function isPublicEmailProvider(domain: string): boolean {
+  return PUBLIC_EMAIL_PROVIDERS.has(domain);
+}

--- a/apps/api/src/workload-abuse/model-schemas/blocked-email-domain/blocked-email-domain.schema.ts
+++ b/apps/api/src/workload-abuse/model-schemas/blocked-email-domain/blocked-email-domain.schema.ts
@@ -1,0 +1,37 @@
+import { sql } from "drizzle-orm";
+import { check, pgEnum, pgTable, timestamp, uniqueIndex, uuid, varchar } from "drizzle-orm/pg-core";
+
+import { Users } from "@src/user/model-schemas";
+
+export const blockedEmailDomainStatusEnum = pgEnum("blocked_email_domain_status", ["blocked", "allowed"]);
+
+export const blockedEmailDomainSourceEnum = pgEnum("blocked_email_domain_source", ["auto", "manual"]);
+
+export const MAX_EMAIL_DOMAIN_LENGTH = 253;
+
+export const BlockedEmailDomains = pgTable(
+  "blocked_email_domains",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .notNull()
+      .default(sql`uuid_generate_v4()`),
+    domain: varchar("domain", { length: MAX_EMAIL_DOMAIN_LENGTH }).notNull(),
+    status: blockedEmailDomainStatusEnum("status").notNull().default("blocked"),
+    /** Defaults to manual so a row written straight into the table by the admin console is labelled correctly without it having to say so. */
+    source: blockedEmailDomainSourceEnum("source").notNull().default("manual"),
+    reason: varchar("reason", { length: 255 }),
+    /** Set null rather than cascade: cascading would silently un-block a domain when the abusive user row is deleted. */
+    triggeredByUserId: uuid("triggered_by_user_id").references(() => Users.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull()
+  },
+  table => ({
+    domainUnique: uniqueIndex("blocked_email_domains_domain_unique").on(table.domain),
+    /** The admin console writes this table directly, and a row stored unnormalized would never match a lookup — a blocklist that silently stops blocking. */
+    domainNormalized: check(
+      "blocked_email_domains_domain_normalized",
+      sql`${table.domain} = lower(${table.domain}) AND ${table.domain} NOT LIKE '%@%' AND ${table.domain} LIKE '%.%' AND btrim(${table.domain}) = ${table.domain}`
+    )
+  })
+);

--- a/apps/api/src/workload-abuse/model-schemas/index.ts
+++ b/apps/api/src/workload-abuse/model-schemas/index.ts
@@ -1,1 +1,2 @@
+export * from "./blocked-email-domain/blocked-email-domain.schema";
 export * from "./workload-abuse-detection/workload-abuse-detection.schema";

--- a/apps/api/src/workload-abuse/repositories/blocked-email-domain/blocked-email-domain.repository.integration.ts
+++ b/apps/api/src/workload-abuse/repositories/blocked-email-domain/blocked-email-domain.repository.integration.ts
@@ -1,0 +1,82 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import { getPostgresError } from "@src/core/repositories/base.repository";
+import { UserRepository } from "@src/user/repositories";
+import { BlockedEmailDomainRepository } from "./blocked-email-domain.repository";
+
+describe(BlockedEmailDomainRepository.name, () => {
+  describe("findByDomain", () => {
+    it("matches the domain exactly", async () => {
+      const { repository, domain, userId } = await setup();
+      await repository.blockIfAbsent({ domain, reason: "workload_abuse", triggeredByUserId: userId });
+
+      const [exact, subdomain, suffix, prefix] = await Promise.all([
+        repository.findByDomain(domain),
+        repository.findByDomain(`mail.${domain}`),
+        repository.findByDomain(`x${domain}`),
+        repository.findByDomain(`${domain}.attacker.net`)
+      ]);
+
+      expect(exact?.domain).toBe(domain);
+      expect([subdomain, suffix, prefix]).toEqual([undefined, undefined, undefined]);
+    });
+  });
+
+  describe("blockIfAbsent", () => {
+    it("records an auto block with the wallet owner that triggered it", async () => {
+      const { repository, domain, userId } = await setup();
+
+      const blocked = await repository.blockIfAbsent({ domain, reason: "workload_abuse", triggeredByUserId: userId });
+
+      expect(blocked).toMatchObject({ domain, status: "blocked", source: "auto", reason: "workload_abuse", triggeredByUserId: userId });
+    });
+
+    it("returns nothing to the second caller, so only one of two concurrent blocks owns the row", async () => {
+      const { repository, domain, userId } = await setup();
+      await repository.blockIfAbsent({ domain, reason: "workload_abuse", triggeredByUserId: userId });
+
+      const second = await repository.blockIfAbsent({ domain, reason: "workload_abuse", triggeredByUserId: userId });
+
+      expect(second).toBeUndefined();
+    });
+
+    it("leaves a domain an operator has allowed untouched", async () => {
+      const { repository, domain, userId } = await setup();
+      const allowed = await repository.create({ domain, status: "allowed", source: "manual", reason: "false positive" });
+
+      const result = await repository.blockIfAbsent({ domain, reason: "workload_abuse", triggeredByUserId: userId });
+
+      expect(result).toBeUndefined();
+      expect(await repository.findById(allowed.id)).toMatchObject({ status: "allowed", source: "manual", reason: "false positive" });
+    });
+  });
+
+  describe("the normalization constraint", () => {
+    it.each([["Attacker.com"], [" attacker.com"], ["attacker.com "], ["miner@attacker.com"], ["localhost"]])(
+      "rejects %s, so an unnormalized row can never sit in the table unmatched",
+      async domain => {
+        const { repository } = await setup();
+
+        const error = await repository.create({ domain }).catch((caught: unknown) => caught);
+
+        expect(getPostgresError(error)?.constraint_name).toBe("blocked_email_domains_domain_normalized");
+      }
+    );
+
+    it("accepts a normalized domain", async () => {
+      const { repository, domain } = await setup();
+
+      await expect(repository.create({ domain })).resolves.toMatchObject({ domain });
+    });
+  });
+
+  async function setup() {
+    const repository = container.resolve(BlockedEmailDomainRepository);
+    const userRepository = container.resolve(UserRepository);
+    const user = await userRepository.create({ userId: faker.string.uuid() });
+
+    return { repository, userId: user.id, domain: `${faker.string.alphanumeric(16).toLowerCase()}.com` };
+  }
+});

--- a/apps/api/src/workload-abuse/repositories/blocked-email-domain/blocked-email-domain.repository.ts
+++ b/apps/api/src/workload-abuse/repositories/blocked-email-domain/blocked-email-domain.repository.ts
@@ -1,0 +1,49 @@
+import { eq } from "drizzle-orm";
+import { singleton } from "tsyringe";
+
+import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
+import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
+import { TxService } from "@src/core/services";
+
+type Table = ApiPgTables["BlockedEmailDomains"];
+export type BlockedEmailDomainInput = Partial<Table["$inferInsert"]>;
+export type BlockedEmailDomainOutput = Table["$inferSelect"];
+
+export interface AutoBlockInput {
+  domain: string;
+  reason: string;
+  triggeredByUserId: string;
+}
+
+@singleton()
+export class BlockedEmailDomainRepository extends BaseRepository<Table, BlockedEmailDomainInput, BlockedEmailDomainOutput> {
+  constructor(
+    @InjectPg() protected readonly pg: ApiPgDatabase,
+    @InjectPgTable("BlockedEmailDomains") protected readonly table: Table,
+    protected readonly txManager: TxService
+  ) {
+    super(pg, table, txManager, "BlockedEmailDomain", "BlockedEmailDomains");
+  }
+
+  accessibleBy(...abilityParams: AbilityParams) {
+    return new BlockedEmailDomainRepository(this.pg, this.table, this.txManager).withAbility(...abilityParams) as this;
+  }
+
+  async findByDomain(domain: string): Promise<BlockedEmailDomainOutput | undefined> {
+    return await this.cursor.query.BlockedEmailDomains.findFirst({ where: eq(this.table.domain, domain) });
+  }
+
+  /**
+   * Returns a row only to the call whose insert created it, so the unique index — not a race-prone
+   * read-before-write — decides the winner, and a domain an operator has already ruled on keeps their row.
+   */
+  async blockIfAbsent(input: AutoBlockInput): Promise<BlockedEmailDomainOutput | undefined> {
+    const [inserted] = await this.cursor
+      .insert(this.table)
+      .values({ ...input, status: "blocked", source: "auto" })
+      .onConflictDoNothing({ target: this.table.domain })
+      .returning();
+
+    return inserted;
+  }
+}

--- a/apps/api/src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service.spec.ts
+++ b/apps/api/src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { cacheRegistry } from "@src/caching/cache-registry";
+import type { CreateLogger } from "@src/core/providers/logging.provider";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import type { BlockedEmailDomainRepository } from "@src/workload-abuse/repositories/blocked-email-domain/blocked-email-domain.repository";
+import type { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+import { BlockedEmailDomainService } from "./blocked-email-domain.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+import { createBlockedEmailDomain } from "@test/seeders/blocked-email-domain.seeder";
+
+describe(BlockedEmailDomainService.name, () => {
+  describe("isBlockedEmail", () => {
+    it("blocks an address whose domain has a blocked row", async () => {
+      const { service, blockedEmailDomainRepository } = setup({ row: createBlockedEmailDomain({ domain: "attacker.com", status: "blocked" }) });
+
+      await expect(service.isBlockedEmail("miner@attacker.com")).resolves.toBe(true);
+      expect(blockedEmailDomainRepository.findByDomain).toHaveBeenCalledWith("attacker.com");
+    });
+
+    it("allows an address whose domain an operator has explicitly allowed", async () => {
+      const { service } = setup({ row: createBlockedEmailDomain({ domain: "customer.com", status: "allowed" }) });
+
+      await expect(service.isBlockedEmail("someone@customer.com")).resolves.toBe(false);
+    });
+
+    it("allows an address whose domain has no row", async () => {
+      const { service } = setup();
+
+      await expect(service.isBlockedEmail("someone@unknown.com")).resolves.toBe(false);
+    });
+
+    it("looks up the normalized domain of a mixed-case address", async () => {
+      const { service, blockedEmailDomainRepository } = setup();
+
+      await service.isBlockedEmail("Miner@Attacker.COM");
+
+      expect(blockedEmailDomainRepository.findByDomain).toHaveBeenCalledWith("attacker.com");
+    });
+
+    it("allows an address it cannot parse without consulting the repository", async () => {
+      const { service, blockedEmailDomainRepository } = setup();
+
+      await expect(service.isBlockedEmail("not-an-address")).resolves.toBe(false);
+      expect(blockedEmailDomainRepository.findByDomain).not.toHaveBeenCalled();
+    });
+
+    it("allows every address without consulting the repository while the flag is off", async () => {
+      const { service, blockedEmailDomainRepository } = setup({
+        isFlagEnabled: false,
+        row: createBlockedEmailDomain({ domain: "attacker.com", status: "blocked" })
+      });
+
+      await expect(service.isBlockedEmail("miner@attacker.com")).resolves.toBe(false);
+      expect(blockedEmailDomainRepository.findByDomain).not.toHaveBeenCalled();
+    });
+
+    it("reads the enforcement flag", async () => {
+      const { service, featureFlagsService } = setup();
+
+      await service.isBlockedEmail("someone@unknown.com");
+
+      expect(featureFlagsService.isEnabled).toHaveBeenCalledWith(FeatureFlags.BLOCKED_EMAIL_DOMAIN_ENFORCEMENT);
+    });
+
+    it("answers a repeated lookup from the cache", async () => {
+      const { service, blockedEmailDomainRepository } = setup({ row: createBlockedEmailDomain({ domain: "attacker.com", status: "blocked" }) });
+
+      await service.isBlockedEmail("one@attacker.com");
+      await service.isBlockedEmail("two@attacker.com");
+
+      expect(blockedEmailDomainRepository.findByDomain).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches a negative so a legitimate domain does not reach the database on every login", async () => {
+      const { service, blockedEmailDomainRepository } = setup();
+
+      await service.isBlockedEmail("someone@customer.com");
+      await service.isBlockedEmail("someone.else@customer.com");
+
+      expect(blockedEmailDomainRepository.findByDomain).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("isBlockedDomain", () => {
+    it("blocks a bare domain that has a blocked row", async () => {
+      const { service } = setup({ row: createBlockedEmailDomain({ domain: "attacker.com", status: "blocked" }) });
+
+      await expect(service.isBlockedDomain("Attacker.com.")).resolves.toBe(true);
+    });
+
+    it("allows a domain it cannot normalize", async () => {
+      const { service, blockedEmailDomainRepository } = setup();
+
+      await expect(service.isBlockedDomain("localhost")).resolves.toBe(false);
+      expect(blockedEmailDomainRepository.findByDomain).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when the lookup fails", () => {
+    it("allows the address and records the failure", async () => {
+      const { service, logger } = setup({ lookupError: new Error("connection terminated") });
+
+      await expect(service.isBlockedEmail("miner@attacker.com")).resolves.toBe(false);
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "BLOCKED_EMAIL_DOMAIN_LOOKUP_FAILED", domain: "attacker.com" }));
+    });
+
+    it("retries the next lookup rather than caching the failure", async () => {
+      const { service, blockedEmailDomainRepository } = setup({ lookupError: new Error("connection terminated") });
+
+      await service.isBlockedEmail("miner@attacker.com");
+      await service.isBlockedEmail("miner@attacker.com");
+
+      expect(blockedEmailDomainRepository.findByDomain).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("rememberBlocked", () => {
+    it("answers a following lookup without reading the row it was just told about", async () => {
+      const { service, blockedEmailDomainRepository } = setup();
+
+      service.rememberBlocked("attacker.com");
+
+      await expect(service.isBlockedEmail("miner@attacker.com")).resolves.toBe(true);
+      expect(blockedEmailDomainRepository.findByDomain).not.toHaveBeenCalled();
+    });
+  });
+
+  it("registers itself so a registry-wide clear empties it", async () => {
+    const { service, blockedEmailDomainRepository } = setup();
+    service.rememberBlocked("attacker.com");
+
+    cacheRegistry.clearAll();
+    await service.isBlockedEmail("miner@attacker.com");
+
+    expect(cacheRegistry.getStats().some(stats => stats.name.startsWith(BlockedEmailDomainService.name))).toBe(true);
+    expect(blockedEmailDomainRepository.findByDomain).toHaveBeenCalledWith("attacker.com");
+  });
+
+  function setup(input?: { row?: ReturnType<typeof createBlockedEmailDomain>; isFlagEnabled?: boolean; lookupError?: Error; ttlSeconds?: number }) {
+    const findByDomain = input?.lookupError ? vi.fn().mockRejectedValue(input.lookupError) : vi.fn().mockResolvedValue(input?.row);
+    const blockedEmailDomainRepository = mock<BlockedEmailDomainRepository>({ findByDomain });
+    const featureFlagsService = mock<FeatureFlagsService>({ isEnabled: vi.fn().mockReturnValue(input?.isFlagEnabled ?? true) });
+    const workloadAbuseConfigService = mockConfigService<WorkloadAbuseConfigService>({
+      WORKLOAD_ABUSE_BLOCKED_DOMAIN_CACHE_TTL_SECONDS: input?.ttlSeconds ?? 60
+    });
+    const logger = mock<ReturnType<CreateLogger>>();
+    const createLogger = vi.fn<CreateLogger>(() => logger);
+
+    const service = new BlockedEmailDomainService(blockedEmailDomainRepository, featureFlagsService, workloadAbuseConfigService, createLogger);
+
+    return { service, blockedEmailDomainRepository, featureFlagsService, workloadAbuseConfigService, logger, createLogger };
+  }
+});

--- a/apps/api/src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service.ts
+++ b/apps/api/src/workload-abuse/services/blocked-email-domain/blocked-email-domain.service.ts
@@ -1,0 +1,69 @@
+import { LRUCache } from "lru-cache";
+import { inject, singleton } from "tsyringe";
+
+import { cacheRegistry, nominalEntrySizing } from "@src/caching/cache-registry";
+import { type CreateLogger, LOGGER_FACTORY } from "@src/core/providers/logging.provider";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { extractEmailDomain, normalizeEmailDomain } from "@src/workload-abuse/lib/email-domain/email-domain";
+import { BlockedEmailDomainRepository } from "@src/workload-abuse/repositories/blocked-email-domain/blocked-email-domain.repository";
+import { WorkloadAbuseConfigService } from "@src/workload-abuse/services/workload-abuse-config/workload-abuse-config.service";
+
+const MAX_TRACKED_DOMAINS = 20_000;
+/** A boolean under a domain string, so the registry ranks this cache far below the ones holding response payloads. */
+const ENTRY_BYTES = 64;
+
+/**
+ * Answers whether an address may create an account or start a trial. Negatives are cached as well as positives,
+ * because a legitimate address is the common case and it is the one that must not reach Postgres on every login.
+ */
+@singleton()
+export class BlockedEmailDomainService {
+  readonly #verdicts: LRUCache<string, boolean>;
+  private readonly logger: ReturnType<CreateLogger>;
+
+  constructor(
+    private readonly blockedEmailDomainRepository: BlockedEmailDomainRepository,
+    private readonly featureFlagsService: FeatureFlagsService,
+    workloadAbuseConfigService: WorkloadAbuseConfigService,
+    @inject(LOGGER_FACTORY) createLogger: CreateLogger
+  ) {
+    this.#verdicts = new LRUCache({
+      max: MAX_TRACKED_DOMAINS,
+      ttl: workloadAbuseConfigService.get("WORKLOAD_ABUSE_BLOCKED_DOMAIN_CACHE_TTL_SECONDS") * 1000,
+      ...nominalEntrySizing(MAX_TRACKED_DOMAINS, ENTRY_BYTES)
+    });
+    cacheRegistry.register(BlockedEmailDomainService.name, this.#verdicts);
+    this.logger = createLogger({ context: BlockedEmailDomainService.name });
+  }
+
+  async isBlockedEmail(email: string | null | undefined): Promise<boolean> {
+    return await this.#isBlocked(extractEmailDomain(email));
+  }
+
+  async isBlockedDomain(domain: string | null | undefined): Promise<boolean> {
+    return await this.#isBlocked(normalizeEmailDomain(domain));
+  }
+
+  /** Primes the verdict we just wrote so a sibling sweep on the same pod does not wait out a stale negative. */
+  rememberBlocked(domain: string): void {
+    this.#verdicts.set(domain, true);
+  }
+
+  async #isBlocked(domain: string | null): Promise<boolean> {
+    if (!domain) return false;
+    if (!this.featureFlagsService.isEnabled(FeatureFlags.BLOCKED_EMAIL_DOMAIN_ENFORCEMENT)) return false;
+
+    const cached = this.#verdicts.get(domain);
+    if (cached !== undefined) return cached;
+
+    try {
+      const blocked = (await this.blockedEmailDomainRepository.findByDomain(domain))?.status === "blocked";
+      this.#verdicts.set(domain, blocked);
+      return blocked;
+    } catch (error) {
+      this.logger.error({ event: "BLOCKED_EMAIL_DOMAIN_LOOKUP_FAILED", domain, error });
+      return false;
+    }
+  }
+}

--- a/apps/api/test/seeders/blocked-email-domain.seeder.ts
+++ b/apps/api/test/seeders/blocked-email-domain.seeder.ts
@@ -1,0 +1,16 @@
+import { faker } from "@faker-js/faker";
+
+import type { BlockedEmailDomainOutput } from "@src/workload-abuse/repositories/blocked-email-domain/blocked-email-domain.repository";
+
+export function createBlockedEmailDomain({
+  id = faker.string.uuid(),
+  domain = faker.internet.domainName().toLowerCase(),
+  status = "blocked",
+  source = "auto",
+  reason = "workload_abuse",
+  triggeredByUserId = faker.string.uuid(),
+  createdAt = faker.date.recent(),
+  updatedAt = faker.date.recent()
+}: Partial<BlockedEmailDomainOutput> = {}): BlockedEmailDomainOutput {
+  return { id, domain, status, source, reason, triggeredByUserId, createdAt, updatedAt };
+}


### PR DESCRIPTION
## Why

Signup and trial activation had no domain-level defence against automated abuse. The only list was maintained by hand in the Auth0 tenant.

## What

Adds the `blocked_email_domains` table (migration `0054`) and the three places that read it: registration, trial activation and password signup.

The admin console in console-private owns reads and writes. `apps/api` ships no CRUD for it, so the table is the contract, and a `CHECK` constraint keeps every row in the one shape a lookup can match. A row stored in some other shape is a blocklist that has quietly stopped blocking.

Refusals reuse the existing deliberately vague messages, so a caller cannot tell a refusal apart from the ordinary failure.

Everything here is gated on the `blocked_email_domain_enforcement` flag, which is off. Merging changes no behaviour.

## Notes for the reviewer

Matching rules, cache behaviour and what happens when a lookup fails are deliberately left out of this description. They are in the internal runbook.

**Companion change still needed in deploy-web:** `apps/deploy-web/src/pages/api/auth/[...auth0].ts` catches and ignores errors from `createLocalUser`. That is part of why this ships with the flag off.
